### PR TITLE
Bug 1836

### DIFF
--- a/cgi-bin/DW/Template/Plugin/FormHTML.pm
+++ b/cgi-bin/DW/Template/Plugin/FormHTML.pm
@@ -88,7 +88,7 @@ sub checkbox {
     my $ret = "";
 
     if ( ! defined $args->{selected} && $self->{data} ) {
-        my %selected = map { $_ => 1 } $self->{data}->get_all( $args->{name} );
+        my %selected = map { $_ => 1 } ( $self->{data}->get_all( $args->{name} ) );
         $args->{selected} = $selected{$args->{value}};
     }
 


### PR DESCRIPTION
Fixes a bug with the FormHTML plugin, where it wouldn't display multiple checked items on a page reload.
