### PR TITLE
(bug 4436) Remove overlays for TheSchwartz* repos.

### DIFF
--- a/bin/checkconfig.pl
+++ b/bin/checkconfig.pl
@@ -234,6 +234,10 @@ my %modules = (
                  },
                "LWPx::ParanoidAgent" => { deb => 'liblwpx-paranoidagent-perl' },
                "MogileFS::Client" => {},
+               "TheSchwartz" => {
+                   deb => 'libtheschwartz-perl',
+               },
+               "TheSchwartz::Worker::SendEmail" => {},
               );
 
 

--- a/cvs/multicvs.conf
+++ b/cvs/multicvs.conf
@@ -16,18 +16,13 @@ HG(dw-free)               = http://hg.dwscoalition.org/dw-free @stable
 # stock/unchanged repositories pulled from external sources
 SVN(gearman)              = http://code.livejournal.org/svn/gearman/trunk/
 SVN(memcached)            = http://code.livejournal.org/svn/memcached/trunk/
-SVN(TheSchwartz)          = http://code.sixapart.com/svn/TheSchwartz/trunk/
 SVN(ddlockd)              = http://code.livejournal.org/svn/ddlockd/trunk/
 SVN(LJ-UserSearch)        = http://code.livejournal.org/svn/LJ-UserSearch/trunk/
-SVN(TheSchwartz-Worker-SendEmail) = http://code.sixapart.com/svn/TheSchwartz-Worker-SendEmail/trunk/
 SVN(hubbub)               = http://pubsubhubbub.googlecode.com/svn/trunk/publisher_clients/
 
 dw-free                                   .
 
 gearman/api/perl/Gearman/lib                  cgi-bin/
-TheSchwartz/lib                               cgi-bin
-TheSchwartz-Worker-SendEmail/lib              cgi-bin/
-TheSchwartz/bin/schwartzmon                   bin/schwartzmon
 
 memcached/server                              src/memcached
 memcached/api/perl/lib/                       cgi-bin


### PR DESCRIPTION
6a/SayMedia moved TheSchwartz to github but left the SendEmail one
somewhere in the void. Let's just use the CPAN versions.

Patch by exor674.

{ I am actually doing this as a pull request so I don't have to do weird things on my NoOverlays bit }
