### PR TITLE
(Bug 4531): Group library JS/CSS separately from per-page JS/CSS

### DIFF
--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -328,7 +328,7 @@ no strict "vars";
     # default priority for libraries and resources in a sitescheme,
     # so that they come before any stylesheets declared by the page itself
     $LJ::LIB_RES_PRIORITY = 3;
-    $LJ::SCHEME_RES_PRIORITY = 2;
+    $LJ::SCHEME_RES_PRIORITY = 3;
 
     # FIXME: remove the need for this, it's a hack of a hack of a hack
     # it used to be that site scheme pages were called later than page-level CSS

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -2604,7 +2604,7 @@ sub res_includes {
         my %oldest; # type -> $oldest
         my %included = ();
         my $add = sub {
-            my ($type, $what, $modtime) = @_;
+            my ($type, $what, $modtime, $order) = @_;
 
             # the same file may have been included twice
             # if it was in two different groups and not JS
@@ -2617,15 +2617,19 @@ sub res_includes {
             # end, which is done later in the tags function.
             $what .= "?v=$modtime" unless $do_concat;
 
-            push @{$list{$type} ||= []}, $what;
-            $oldest{$type} = $modtime if $modtime > ( $oldest{$type} || 0 );
+            $list{$type} ||= [];
+            push @{$list{$type}[$order] ||= []}, $what;
+            $oldest{$type} ||= [];
+            $oldest{$type}[$order] = $modtime if $modtime > ( $oldest{$type}[$order] || 0 );
         };
 
         # we may not want to pull in the libraries again, say if we're pulling in elements via an ajax load
         delete $LJ::NEEDED_RES[$LJ::LIB_RES_PRIORITY] unless $include_libs;
 
+        my $order = 0;
         foreach my $by_priority ( reverse @LJ::NEEDED_RES ) {
             next unless $by_priority;
+            $order++;
 
             foreach my $resrow ( @$by_priority ) {
                 # determine if this resource is part of the resource group that is active;
@@ -2654,30 +2658,33 @@ sub res_includes {
                 }
 
                 if ($path =~ m!^js/(.+)!) {
-                    $add->('js', $1, $mtime);
+                    $add->("js", $1, $mtime, $order);
                 } elsif ($path =~ /\.css$/ && $path =~ m!^(w?)stc/(.+)!) {
-                    $add->("${1}stccss", $2, $mtime);
+                    $add->("${1}stccss", $2, $mtime, $order);
                 } elsif ($path =~ /\.js$/ && $path =~ m!^(w?)stc/(.+)!) {
-                    $add->("${1}stcjs", $2, $mtime);
+                    $add->("${1}stcjs", $2, $mtime, $order);
                 }
             }
         }
 
         my $tags = sub {
             my ($type, $template) = @_;
-            my $list;
-            return unless $list = $list{$type};
+            for my $o ( 0...$order ) {
+                my $list;
+                my $template_order = $template;
+                next unless $list = $list{$type}[$o];
 
-            if ($do_concat) {
-                my $csep = join(',', @$list);
-                $csep .= "?v=" . $oldest{$type};
-                $template =~ s/__+/??$csep/;
-                $ret .= $template;
-            } else {
-                foreach my $item (@$list) {
-                    my $inc = $template;
-                    $inc =~ s/__+/$item/;
-                    $ret .= $inc;
+                if ($do_concat) {
+                    my $csep = join(',', @$list);
+                    $csep .= "?v=" . $oldest{$type}[$o];
+                    $template_order =~ s/__+/??$csep/;
+                    $ret .= $template_order;
+                } else {
+                    foreach my $item (@$list) {
+                        my $inc = $template;
+                        $inc =~ s/__+/$item/;
+                        $ret .= $inc;
+                    }
                 }
             }
         };


### PR DESCRIPTION
...for better caching. Also set the scheme and library to have the same priority/ordering, so that they're grouped together when being printed
