### PR TITLE
Adds a message to be displayed on /manage/circle/add.bml when adding fee...

### DIFF
--- a/htdocs/manage/circle/add.bml
+++ b/htdocs/manage/circle/add.bml
@@ -286,7 +286,7 @@ _c?>
     # content filter buttons
     if ( $remote->can_watch( $u ) && @content_filters ) {
         $body .= "<div class='add_watch' style='float: left; width: 45%; padding: 1em;'><?p &nbsp;<br />";
-        $body .= "$ML{'.groups.reading'} p?>\n";
+        $body .= $u->is_syndicated ? "$ML{'.groups.reading.feed'} p?>\n" : "$ML{'.groups.reading'} p?>\n";
         my @sorted_content_filters = sort { $a->{sortorder} <=> $b->{sortorder} } @content_filters;
         foreach my $filter ( @sorted_content_filters ) {
             my $ck = ( $filter->contains_userid( $u->userid ) )

--- a/htdocs/manage/circle/add.bml.text
+++ b/htdocs/manage/circle/add.bml.text
@@ -87,6 +87,8 @@
 
 .groups.reading=<i>Optional:</i> Include in one or more subscription filters.  <strong>You must subscribe to the user by selecting the second box above in order to add them to any subscription filters.</strong>
 
+.groups.reading.feed=<i>Optional:</i>: Include in one or more subscription filters.
+
 .groups.text1=<em>Optional:</em> Include in one or more access filters.  <strong>You must grant access to this account by selecting the first box above in order to add them to any access filters.</strong>
 
 .optional=Optional


### PR DESCRIPTION
...d accounts, to avoid confusion by referencing a nonexistent checkbox. Patch by denise.

As the bug mentions, we can probably remove references to the "first
checkbox"/"second checkbox" on access granting/subscribing, since the
page now dynamically updates, but I'm not 100% convinced on that since
both messages will still be displayed to people browsing without JS.
So, for now, just deconfuse it for feed accounts.
