### PR TITLE
(bug4539) better priv checking for FAQ editing

### DIFF
--- a/htdocs/admin/faq/faqedit.bml
+++ b/htdocs/admin/faq/faqedit.bml
@@ -59,7 +59,7 @@ body<=
         $summary = $faq->summary_raw;
         $answer = $faq->answer_raw;
         $has_summary = $faq->has_summary;
-        unless ( $ac_edit{'*'} || $ac_edit{$faqcat} ) {
+        unless ( $ac_edit{'*'} || $ac_edit{''} || $ac_edit{$faqcat} ) {
             if ( %ac_edit ) {
                 return "<b>Error: </b> You do not have access to edit a FAQ question in the \"$faqcat\" category.";
             } else {


### PR DESCRIPTION
Kareila found a weird case where faqedit:\* worked but faqedit, no args,
didn't. On further investigation it looks like it's happening because
faqedit does priv checks weirdly. I pondered refactoring the priv
checks in the whole file but considering it's all going to TT soon, I
saved time and just threw in an explict check for faqedit: as well as
faqedit:*.

Bugzilla: http://bugs.dwscoalition.org/show_bug.cgi?id=4539

Patch by denise.
