### PR TITLE
(bug4544) Add quick needlogin for moodlist.bml

### DIFF
--- a/htdocs/moodlist.bml
+++ b/htdocs/moodlist.bml
@@ -44,6 +44,8 @@ body<=
     my $ret;
 
     my $remote = LJ::get_remote();
+    return "<?needlogin?>" unless $remote;
+
     my $journal = $GET{'journal'} || $remote->{'user'};
     my $u = LJ::load_user($journal);
 


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4544 -- exor674 mentioned
in comments to the bug that she's working on converting this to TT to
fix another bug, but since she's got so much on her plate I figured I'd
do a quick patch for the interim. This just adds a needlogin return at
the top of the page so logged-out users will be redirected. Patch by
denise.
