### PR TITLE
(bug4520) Lengthen rename field

### DIFF
--- a/cgi-bin/DW/User/Rename.pm
+++ b/cgi-bin/DW/User/Rename.pm
@@ -624,8 +624,8 @@ sub _rename_to_ex {
     my $tries = 0;
 
     while ( $tries < 10 ) {
-        # take the first ten characters of the old username + a random number
-        my $ex_user = substr( $u->user, 0, 10 ) . int( rand( 999 ) );
+        # take the first nineteen characters of the old username + a random number
+        my $ex_user = substr( $u->user, 0, 19 ) . int( rand( 999 ) );
 
         # do the rename if the user doesn't already exist
         return DW::User::Rename::_rename( $u, "ex_$ex_user", redirect => 0, token => DW::RenameToken->create_token( systemtoken => 1 ) )


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4520

This took a _ridiculous_ amount of testing for such a small patch, but
I did test it throroughly. Expands the length of the throwaway username
(ex_username123) from 10 characters to 19, which accounts for the extra
6 characters in the renamed-away account (the "ex_" and the "123").
Patch by denise.
