### PR TITLE
(Bug 4294) JQuery cut-tags not remaining open after back

### DIFF
--- a/htdocs/js/jquery.cuttag-ajax.js
+++ b/htdocs/js/jquery.cuttag-ajax.js
@@ -62,7 +62,7 @@ $.widget("dw.cuttag", {
 
         self.element.css("display","inline");
 
-        if ( sessionStorage && sessionStorage.getItem(self.identifier) )
+        if ( window.sessionStorage && sessionStorage.getItem(self.identifier) )
             this.open();
 
         if ( isExpandingAll )
@@ -94,11 +94,11 @@ $.widget("dw.cuttag", {
                 self.handleError(error);
             }
         });
-        if (sessionStorage) sessionStorage.setItem(self.identifier, "open");
+        if (window.sessionStorage) sessionStorage.setItem(self.identifier, "open");
     },
     close: function() {
         var self = this;
-        if (sessionStorage) sessionStorage.removeItem(self.identifier);
+        if (window.sessionStorage) sessionStorage.removeItem(self.identifier);
 
         if ( ! this.isOpen() )
             return;


### PR DESCRIPTION
Possible fix. Uses sessionStorage to retain changes.

Note that this is only compatible to a certain extent. FF pre-3.5, or IE pre-8.0 for example, does not follow the sessionStorage standard. If we consider this to be important, there is some information on the MDN on workarounds, or we could possibly find a JQuery plugin that would manage all compatibility issues (www.jquerysdk.com has one, for example) for us.

(I think it's plenty of compatibility, personally, but you probably shouldn't listen to me.)

Hey look, I submitted a git pull request. Let's see whether this works, huh?
