### PR TITLE
(Bug 4620) Update community account conversion page

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1509,3 +1509,5 @@ general /customize/options.bml.switcher.label
 
 general web.authas.label
 general web.authas.label.comm
+
+general /community/settings.bml.label.commheader

--- a/htdocs/community/settings.bml
+++ b/htdocs/community/settings.bml
@@ -16,7 +16,7 @@ _c?>
 title<=
 <?_code
  if ($GET{'mode'} eq 'create') {
-    return $ML{'.title.create'};
+    return $ML{'.title.create2'};
  }
  else {
     return $ML{'.title.modify'};
@@ -61,9 +61,12 @@ body<=
     my $mode = "modify";
     $mode = "create" if $GET{'mode'} eq 'create';
 
-    $ret .= "<form action='$LJ::SITEROOT/community/settings' method='get'>";
-    $ret .= LJ::make_authas_select($remote, { authas => $GET{authas}, type => "C" });
-    $ret .= "</form>";
+    # if we're changing rather than creating, show the work as menu
+    if ( $mode eq 'modify') {
+        $ret .= "<form action='$LJ::SITEROOT/community/settings' method='get'>";
+        $ret .= LJ::make_authas_select($remote, { authas => $GET{authas}, type => "C" });
+        $ret .= "</form>";
+    }
 
     if (LJ::did_post())
     {
@@ -264,14 +267,13 @@ body<=
 
     if ($mode eq 'create') {
         LJ::set_active_crumb('createcommunity');
-          $ret .= "<?h2 $ML{'.label.commheader'} h2?>" .
-              ($mode eq 'modify' ? "<?p $ML{'.label.commchange'} p?>" : "<?p " . BML::ml('.label.commcreate2', {'aopts' => "href='$LJ::SITEROOT/create'"}) . " p?>");
-          $ret .= "<div class='highlight-box'><table summary='' width='350' cellpadding='7'><tr valign='top'><td><b>$ML{'.label.maintainer'}</b></td>";
-          $ret .= "<td><?ljuser $remote->{'user'} ljuser?><br />" . BML::ml('.label.maintainer.login2', {'aopts' => "href='$LJ::SITEROOT/login?ret=1'"}) . "</td></tr>";
-          $ret .= "<tr valign='top'><td><b>$ML{'.label.community'}</b></td>";
+          $ret .= "<?p " . BML::ml('.label.commcreate3', {'aopts' => "href='$LJ::SITEROOT/create'"}) . " p?>";
+          $ret .= "<div class='highlight-box'><table summary='' cellpadding='7'><tr valign='top'><td><b>$ML{'.label.maintainer2'}</b></td>";
+          $ret .= "<td><?ljuser $remote->{'user'} ljuser?><br />" . BML::ml('.label.maintainer.login3', {'aopts' => "href='$LJ::SITEROOT/login?ret=1'"}) . "</td></tr>";
+          $ret .= "<tr valign='top'><td><b>$ML{'.label.community2'}</b></td>";
           $ret .= "<td>$ML{'.label.username'}<br /><input name='cuser' maxlength='25' value='$cname' /><br />";
           $ret .= "<?inerr $errors{'username'} inerr?><br />";
-          $ret .= "$ML{'.label.password'}<br /><input name='cpassword' type='password' /><br />";
+          $ret .= "$ML{'.label.password2'}<br /><input name='cpassword' type='password' /><br />";
           $ret .= "<?inerr $errors{'password'} inerr?></td></tr></table> </div>";
     } else {
         LJ::set_active_crumb('commsettings');

--- a/htdocs/community/settings.bml.text
+++ b/htdocs/community/settings.bml.text
@@ -43,11 +43,9 @@
 
 .label.commchanged=You've changed your community settings.
 
-.label.commcreate2=This is the account that you want to turn into a community. It must <a [[aopts]]>already be created</a>, but shouldn't already be in use by an individual, because after this many different people might be able to post in it.
+.label.commcreate3=Enter the name and password of the personal account you want to turn into a community in the fields below. This personal account must <a [[aopts]]>already be created</a>, but shouldn't already be in use because many different users might be able to post in it once it's become a community. It shouldn't have any entries in it either.
 
 .label.commcreated=You've successfully invited these people to this community and given them the listed privileges:
-
-.label.commheader=Community Account
 
 .label.comminfo=Community Information
 
@@ -55,7 +53,7 @@
 
 .label.commsite=Community Website
 
-.label.community=Community:
+.label.community2=Account to convert:
 
 .label.entrypostingguidelines=<strong>In an entry:</strong><br />The community posting guidelines can be found in an entry (details below).
 
@@ -63,9 +61,9 @@
 
 .label.howoperates=Choose the settings for your community journal.  You can make changes to these settings at any time you want.
 
-.label.maintainer=Administrator:
+.label.maintainer2=Community administrator:
 
-.label.maintainer.login2=If this isn't the adminstrator account, please <a [[aopts]]>log in</a> as somebody else.
+.label.maintainer.login3=If this isn't the administrator account, please <a [[aopts]]>log in</a> as another user.
 
 .label.managepage=<a [[aopts]]>Community Administration</a>: you can add members, grant posting access, appoint administrators, and perform other functions of community administration here.
 
@@ -81,7 +79,7 @@
 
 .label.openmemb=<STRONG>Open Membership</STRONG><br />Anyone can join this community.
 
-.label.password=Password:
+.label.password2=Account password:
 
 .label.postingaccess=Posting Access
 
@@ -117,7 +115,7 @@
 
 .success=Success.
 
-.title.create=Create Community
+.title.create2=Turn Personal Account Into Community
 
 .title.modify=Community Settings
 


### PR DESCRIPTION
Bug 4620 - Convert personal journal to community page is very confusing

http://bugs.dwscoalition.org/show_bug.cgi?id=4620

Change title in creation mode to reflect what this page is for.
Remove work-as menu in creation mode.
Remove useless H2.
Clarify intro text (also there was some weird ternary conditional there).
Clarify labels.
Remove width restriction on the table to improve readability.
Refer to users as users rather than people, etc.
