### PR TITLE
'Frozen' comment text no longer gets the link class

### DIFF
--- a/bin/upgrading/s2layers/core2.s2
+++ b/bin/upgrading/s2layers/core2.s2
@@ -5007,7 +5007,7 @@ function Comment::print_interaction_links()
     """<ul class="comment-interaction-links">""";
     print safe """<li class="link commentpermalink"><a href="$this.permalink_url">$*text_comment_link</a></li>\n""";
     if ($this.frozen) {
-        print safe """<li class="link frozen first-item">$*text_comment_frozen</li>\n""";
+        print safe """<li class="frozen first-item">$*text_comment_frozen</li>\n""";
     } else {
         """<li class="link reply first-item">""";
         $this->print_reply_link({"linktext" => $*text_comment_reply});


### PR DESCRIPTION
Despite not being a link, the 'Frozen' text in the comment interaction list was being given the 'link' class. Now it's not!
