### PR TITLE
(bug 4634) Allow calling S2 constructors with new.

### DIFF
--- a/src/s2/S2/BackendJS/Codegen.pm
+++ b/src/s2/S2/BackendJS/Codegen.pm
@@ -690,6 +690,7 @@ sub asJS {
         return;
     }
 
+    # FIXME: Fix for S2 Constructors
     if ($type == $NEW) {
         $o->write("{\".type\": ".
                   $bp->quoteString($this->{'newClass'}->getIdent()) .


### PR DESCRIPTION
Okay! Here we go.
- All of S2 still compiles with this in place.
- I am requiring that all [ one of them! ] constructors be builtins -- this can be fixed later, but would require some design and it doesn't seem required at this point.

Future:
- I want the builtin constructor[s] to get $ctx passed in at some point ( no need to pass in $this, but having a dummy slot for it would make things more consistant with other builtin calling conventions, and won't cause things to blow up if you call it normally [ you can `$clr->Color("#f00")` ) -- but will require more work because of `var Color c = "#f00";` and me not able to find where that is handled )
- Variable declarations/assignment should also implicitly call S2 constructors when they exist [ this is special-cased for 'string', but should work in all cases ] -- or the empty one for declarations.
- Fix the other backends [ at least JS -- I think we should probably just rip the Lua one out at some point, but JS backend might be used in the future for a live-previewey like thing ]
