### PR TITLE
Bug4637. Keywords lacking padding in some styles

### DIFF
--- a/bin/upgrading/s2layers/bases/layout.s2
+++ b/bin/upgrading/s2layers/bases/layout.s2
@@ -947,15 +947,19 @@ div.ljtaglist {padding: 0.5em; }
     text-decoration: underline;
     }
 
+.icon-keywords {
+    padding-right: .5em;
+    }
+
 .icon-keywords ul {
     display: inline;
-    padding-left: 0;
+    margin: 0;
+    padding: 0;
     }
 
 .icon-keywords ul li {
     display: inline;
-    list-style: none;
-    padding: 0 .25em 0 0;
+    margin: 0;
     }
 
 .icons-container .manage-link {

--- a/bin/upgrading/s2layers/basicboxes/layout.s2
+++ b/bin/upgrading/s2layers/basicboxes/layout.s2
@@ -432,6 +432,11 @@ text-align: center; }
     text-decoration: underline;
     }
 
+.icon-keywords ul li {
+    margin-left: 0;
+    padding: .25em .10em;
+}
+
 /* sidebars */
 
 #secondary > .inner:first-child,

--- a/bin/upgrading/s2layers/blanket/layout.s2
+++ b/bin/upgrading/s2layers/blanket/layout.s2
@@ -961,13 +961,14 @@ td.day {
 
 .icon-keywords ul {
     display: inline;
-    padding-left: 0;
+    margin: 0;
+    padding: 0;
     }
 
 .icon-keywords ul li {
     display: inline;
     list-style: none;
-    padding: 0 .25em 0 0;
+    padding: 0;
     }
 
 $userpic_css

--- a/bin/upgrading/s2layers/boxesandborders/layout.s2
+++ b/bin/upgrading/s2layers/boxesandborders/layout.s2
@@ -451,6 +451,11 @@ text-align: center; }
     text-decoration: underline;
     }
 
+.icon-keywords ul li {
+    margin-left: 0;
+    padding: .25em .10em;
+}
+
 /* sidebars */
 
 #secondary > .inner:first-child,

--- a/bin/upgrading/s2layers/brittle/layout.s2
+++ b/bin/upgrading/s2layers/brittle/layout.s2
@@ -810,13 +810,14 @@ td.day {
 
 .icon-keywords ul {
     display: inline;
+    margin: 0;
     padding: 0 0 0 13px;
     }
 
 .icon-keywords ul li {
     display: inline;
     list-style: none;
-    padding: 0 .25em 0 0;
+    padding: 0;
     }
 
 /*--- comments ---*/

--- a/bin/upgrading/s2layers/core2.s2
+++ b/bin/upgrading/s2layers/core2.s2
@@ -6094,14 +6094,14 @@ function Icon::print {
     if ($.keywords) {
         """<div class="icon-keywords">""";
         var int keyword_count = 0;
-        print safe "<span class='keywords-label'>$*text_icons_keywords</span> ";
-        """<ul>""";
+        print safe "<span class='keywords-label'>$*text_icons_keywords</span>";
+        """<ul>\n""";
         foreach var string kw ($.keywords) {
             $keyword_count++;
             """<li>""";
             print safe $kw;
             if ($keyword_count < size $.keywords) { print $*text_icons_keyword_sep; }
-            """</li>""";
+            """</li>\n""";
         }
         """</ul></div>\n""";
     }

--- a/bin/upgrading/s2layers/core2base/layout.s2
+++ b/bin/upgrading/s2layers/core2base/layout.s2
@@ -654,7 +654,7 @@ table.month td p {
 
 .icon-keywords ul li {
     display: inline;
-    padding: 0 .25em 0 0;
+    padding: .25em;
 }
 
 /* modules */

--- a/bin/upgrading/s2layers/database/layout.s2
+++ b/bin/upgrading/s2layers/database/layout.s2
@@ -1927,8 +1927,6 @@ span.de {
 
 .icon-info .default { text-decoration: underline; }
 
-.icon-info .comment { margin-bottom: 0; }
-
 .icon-keywords ul {
     color: $*color_entry_link_hover;
     margin: 0;

--- a/bin/upgrading/s2layers/drifting/layout.s2
+++ b/bin/upgrading/s2layers/drifting/layout.s2
@@ -1004,12 +1004,13 @@ function Page::print_default_stylesheet()
     .icon-keywords ul {
         display: inline;
         list-style: none;
-        padding-left: 0;
+        display: inline;
+        margin 0;
+        padding-left: 5px;
     }
 
     .icon-keywords ul li {
         display: inline;
-        padding: 0 .25em 0 0;
     }
 
     /* Footer

--- a/bin/upgrading/s2layers/easyread/layout.s2
+++ b/bin/upgrading/s2layers/easyread/layout.s2
@@ -803,7 +803,6 @@ module-section-two ul.module-list li {
 
 .icon-keywords ul li {
     display: inline;
-    padding: 0 .25em 0 0;
     }
 
 $userpic_css

--- a/bin/upgrading/s2layers/fiveam/layout.s2
+++ b/bin/upgrading/s2layers/fiveam/layout.s2
@@ -954,11 +954,7 @@ h3.day-date {
     }
 
 .icon-keywords ul {
-    margin-left: 0;
-    }
-
-.icon-keywords ul li {
-    padding: 0 .25em 0 0;
+    margin: 0;
     }
 
 /* Modules

--- a/bin/upgrading/s2layers/lineup/layout.s2
+++ b/bin/upgrading/s2layers/lineup/layout.s2
@@ -736,6 +736,11 @@ table.month td {
     text-decoration: underline;
     }
 
+.icon-keywords ul li {
+    margin-right: 5px;
+    padding: 0;
+    }
+
 .icons-container .manage-link {
     text-align: right;
     text-transform: uppercase;

--- a/bin/upgrading/s2layers/modish/layout.s2
+++ b/bin/upgrading/s2layers/modish/layout.s2
@@ -257,6 +257,8 @@ text-align: center; }
     text-decoration: underline;
     }
 
+.icon-keywords ul li { margin-left: 0; padding: .25em .10em; }
+
 /* sidebars */
 
 #secondary > .inner:first-child,

--- a/bin/upgrading/s2layers/negatives/layout.s2
+++ b/bin/upgrading/s2layers/negatives/layout.s2
@@ -661,13 +661,13 @@ function Page::print_default_stylesheet()
 
     .icon-keywords ul {
         display: inline;
+        margin: 0;
         padding: 0;
         }
 
     .icon-keywords ul li {
         display: inline;
         list-style: none;
-        padding: 0 .25em 0 0;
         }
 
     .module-section-two .module,

--- a/bin/upgrading/s2layers/skittlishdreams/layout.s2
+++ b/bin/upgrading/s2layers/skittlishdreams/layout.s2
@@ -1065,12 +1065,13 @@ if ( $*use_action_links_images ) {
 .icon-keywords ul {
     display: inline;
     list-style: none;
-    padding-left: 0;
+    margin: 0;
+    padding: 0;
     }
 
 .icon-keywords ul li {
     display: inline;
-    padding: 0 .25em 0 0;
+    padding: 0;
     }
 
 $entryicon_css

--- a/bin/upgrading/s2layers/steppingstones/layout.s2
+++ b/bin/upgrading/s2layers/steppingstones/layout.s2
@@ -498,6 +498,8 @@ table.month th {
 
 .icon-info .default { text-decoration: underline; }
 
+.icon-keywords ul li { padding: .25em .10em; }
+
 /* Sidebars
 ******************************/
 

--- a/bin/upgrading/s2layers/wideopen/layout.s2
+++ b/bin/upgrading/s2layers/wideopen/layout.s2
@@ -946,6 +946,12 @@ $userpic_css
     text-decoration: underline;
     }
 
+.icon-keywords ul,
+.icon-keywords ul li {
+    margin: 0;
+    padding: 0;
+}
+
 /* Modules
 ******************************/
 

--- a/bin/upgrading/s2layers/zesty/layout.s2
+++ b/bin/upgrading/s2layers/zesty/layout.s2
@@ -1106,7 +1106,6 @@ h3 {
 .icon-keywords ul li {
     display: inline;
     list-style: none;
-    padding: 0 .25em 0 0;
     }
 
 /* ReplyPage reply box */


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4637

Add /n after UL and LI in icon keywords list to make sure there's always a space.
Remove now unneeded CSS padding.
Make styling for icon keywords match styling for entry tags.
Remove unneeded CSS in Database (dates back to when icons didn't have their own class for comments).
