### PR TITLE
(Bug 4468) Use ?tag=TAG instead of /tag/TAG for tags with slashes

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -1908,11 +1908,16 @@ sub Tag
     my ($u, $kwid, $kw) = @_;
     return undef unless $u && $kwid && $kw;
 
+    my $url = LJ::eurl( $kw );
+    $url = ( $url =~ m![\\\/]! )
+            ? $u->journal_base . '?tag=' . $url
+            : $u->journal_base . '/tag/' . $url;
+
     my $t = {
         _type => 'Tag',
         _id => $kwid,
         name => LJ::ehtml( $kw ),
-        url => $u->journal_base . '/tag/' . LJ::eurl( $kw ),
+        url => $url,
     };
 
     return $t;


### PR DESCRIPTION
Tried escaping to various levels, but when I tested with the following
tags: \o/, /o\, / whee, whee \, I found that various levels of escape
would work for one tag but break the others.

This is the safest.
