### PR TITLE
Bug 4590 - Confusing buttons in "save changes" confirmation in settings

### DIFF
--- a/htdocs/manage/settings/index.bml
+++ b/htdocs/manage/settings/index.bml
@@ -424,7 +424,7 @@ body<=
     $ret .= "</p></div>";
 
     if ($cats_with_settings{$given_cat}->{form}) {
-        my $confirm_msg = LJ::ejs($ML{'.form.confirm'});
+        my $confirm_msg = LJ::ejs($ML{'.form.confirm1'});
         $ret .= "<script>Settings.confirm_msg = \"$confirm_msg\";</script>";
         $ret .= "<form class='table-form' id='settings_form' action='$LJ::SITEROOT/manage/settings/$getextra${getsep}cat=$given_cat' method='post'>";
         $ret .= LJ::form_auth();

--- a/htdocs/manage/settings/index.bml.text
+++ b/htdocs/manage/settings/index.bml.text
@@ -88,6 +88,7 @@
 .fn.viewingadult=Viewing Age Limited Content
 
 .form.confirm=Save your changes?
+.form.confirm1=Save your changes? Click OK to save changes or Cancel to discard them.
 
 .imagelinks.size.custom=Custom: use placeholders for images larger than [[width]]x[[height]]
 


### PR DESCRIPTION
I've expanded the message text to make it more clear what the OK and Cancel buttons will do. This is probably only an interim fix - as discussed in bugzilla, I think changing the names of the buttons would be much better in the long run, but that will need somebody who knows javascript :-)
