### PR TITLE
Bug 4652 - update URL for FF.net userhead

### DIFF
--- a/cgi-bin/DW/External/Site/FanFiction.pm
+++ b/cgi-bin/DW/External/Site/FanFiction.pm
@@ -67,7 +67,7 @@ sub badge_image {
 
     # for lack of anything better, let's use the favicon
     return {
-        url => "http://b.fanfiction.net/static/images/favicon_2010_site.ico",
+        url => "http://www.fanfiction.net/static/images/favicon_2010_site.ico",
         width => 16,
         height => 16,
     }


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4652

Code sources gives me 'http://ffcdn2012.fictionpressllc.netdna-cdn.com/static/images/favicon_2010_site.ico' but this URL works and seems more reliable.
