### PR TITLE
Bug 2936 - Make reverse_sortorder options work

### DIFF
--- a/bin/upgrading/s2layers/abstractia/layout.s2
+++ b/bin/upgrading/s2layers/abstractia/layout.s2
@@ -17,6 +17,8 @@ propgroup presentation {
     property use num_items_reading;
     property use use_journalstyle_entry_page;
     property use layout_type;
+    property use reverse_sortorder_group;
+    property use reg_firstdayofweek;
     property use tags_page_type;
     property string sidebar_width {
         des = "Set the percentage width of a single sidebar, without the % symbol.";
@@ -42,7 +44,6 @@ propgroup presentation {
     property use userlite_interaction_links;
     property use entry_management_links;
     property use comment_management_links;
-    property use reg_firstdayofweek;
     property use entry_datetime_format_group;
     property use comment_datetime_format_group;
 }

--- a/bin/upgrading/s2layers/bases/layout.s2
+++ b/bin/upgrading/s2layers/bases/layout.s2
@@ -18,6 +18,8 @@ propgroup presentation {
     property use use_shared_pic;
     property use use_journalstyle_entry_page;
 
+    property use reverse_sortorder_group;
+    property use reg_firstdayofweek;
     property use tags_page_type;
     property use num_items_icons;
     property use icons_page_sort;
@@ -32,8 +34,6 @@ propgroup presentation {
     property use userlite_interaction_links;
     property use entry_management_links;
     property use comment_management_links;
-
-    property use reg_firstdayofweek;
 }
 
 set layout_type = "two-columns-right";

--- a/bin/upgrading/s2layers/blanket/layout.s2
+++ b/bin/upgrading/s2layers/blanket/layout.s2
@@ -18,6 +18,8 @@ propgroup presentation {
     property use use_shared_pic;
     property use use_journalstyle_entry_page;
 
+    property use reverse_sortorder_group;
+    property use reg_firstdayofweek;
     property use tags_page_type;
     property use num_items_icons;
     property use icons_page_sort;
@@ -32,8 +34,6 @@ propgroup presentation {
     property use userlite_interaction_links;
     property use entry_management_links;
     property use comment_management_links;
-
-    property use reg_firstdayofweek;
 }
 
 set layout_type = "one-column";

--- a/bin/upgrading/s2layers/brittle/layout.s2
+++ b/bin/upgrading/s2layers/brittle/layout.s2
@@ -20,6 +20,8 @@ propgroup presentation {
     property use margins_unit;
     property use sidebar_width;
 
+    property use reverse_sortorder_group;
+    property use reg_firstdayofweek;
     property use tags_page_type;
     property use num_items_icons;
     property use icons_page_sort;
@@ -37,8 +39,6 @@ propgroup presentation {
     property use userlite_interaction_links;
     property use entry_management_links;
     property use comment_management_links;
-
-    property use reg_firstdayofweek;
 }
 
 set layout_type = "two-columns-right";

--- a/bin/upgrading/s2layers/core2.s2
+++ b/bin/upgrading/s2layers/core2.s2
@@ -1217,8 +1217,35 @@ set sidebar_width_doubled = "";
 
 ##=======================================
 ## Display properties - Presentation
-## Tags page & Icons page
+## Specific pages
 ##=======================================
+
+property string[] reverse_sortorder_group {
+    des = "Display content in reverse-chronological order on:";
+    grouptype = "viewslist";
+}
+set reverse_sortorder_group = [ "reverse_sortorder_year", "reverse_sortorder_month", "reverse_sortorder_day"];
+property bool reverse_sortorder_year {
+    des = "Display months in reverse-chronological order on the archive page";
+    label = "the archive page";
+    grouped = 1;
+}
+property bool reverse_sortorder_month {
+    des = "Display days and entries in reverse-chronological order on the month page";
+    label = "the month page";
+    grouped = 1;
+}
+property bool reverse_sortorder_day {
+    des = "Display entries in reverse-chronological order on the day page";
+    label = "the day page";
+    grouped = 1;
+}
+
+property string reg_firstdayofweek {
+    des = "Day the calendar week starts on";
+    doc_flags = "[construct]";
+    values = "sunday|Sunday|monday|Monday";
+}
 
 property string tags_page_type {
     des = "Type of tags display on the tags page. For the tag module, see the Modules section.";
@@ -1234,9 +1261,13 @@ property string icons_page_sort {
     values="upload|Upload Order|keyword|Keyword Order";
 }
 
+set reverse_sortorder_year = false;
+set reverse_sortorder_month = false;
+set reverse_sortorder_day = false;
+set reg_firstdayofweek = "sunday";
+set tags_page_type = "multi";
 set num_items_icons = 0;
 set icons_page_sort = "upload";
-set tags_page_type = "multi";
 
 ##=======================================
 ## Display properties - Presentation
@@ -1356,14 +1387,6 @@ set comment_interaction_links = "text";
 set all_entrysubjects = true;
 set all_commentsubjects = false;
 
-property string reg_firstdayofweek {
-    des = "Day the calendar week starts on";
-    doc = "The day of the week the calendar weeks starts on.  Either 'sunday' or 'monday'. Not currently implemented";
-    doc_flags = "[construct]";
-    values = "sunday|Sunday|monday|Monday";
-}
-set reg_firstdayofweek = "sunday";
-
 ##=======================================
 ## Display properties - Presentation
 ## Misc. options - not exposed
@@ -1397,22 +1420,7 @@ set module_tags_opts_count_type = "";
 ## Misc. options - not implemented
 ##=======================================
 
-property string[] reverse_sortorder_group {
-    des = "Display entries in reverse-chronological order on my:";
-    grouptype = "viewslist";
-}
-set reverse_sortorder_group = [ "reverse_sortorder_day", "reverse_sortorder_year" ];
 property bool reverse_sortorder_recent    { des = "Display entries in reverse-chronological order on my recent entries page"; }
-property bool reverse_sortorder_day {
-    des = "Display entries in reverse-chronological order on my day page";
-    label = "Day Page";
-    grouped = 1;
-}
-property bool reverse_sortorder_year {
-    des = "Display entries in reverse-chronological order on my year archive";
-    label = "Year Archive";
-    grouped = 1;
-}
 property bool reverse_sortorder_reading   { des = "Display entries in reverse-chronological order on my reading page"; }
 
 property string[] show_userpics_group {
@@ -1442,8 +1450,6 @@ property bool show_userpics_comments {
 }
 
 set reverse_sortorder_recent = true;
-set reverse_sortorder_day = false;
-set reverse_sortorder_year = false;
 set reverse_sortorder_reading = true;
 
 set show_userpics_recent = true;
@@ -5466,6 +5472,7 @@ function Comment::edittime_display (string datefmt, string timefmt) : string {
 ### Year view
 
 function YearPage::print_body {
+var YearMonth[] months = $*reverse_sortorder_year ? reverse $.months : $.months;
     """
     <div id="archive-year">
         <div class="inner">
@@ -5475,7 +5482,7 @@ function YearPage::print_body {
             <div class="year">
                 <div class="inner">
                     """;
-                    foreach var YearMonth m ($.months) {
+                    foreach var YearMonth m ($months) {
                         $this->print_month($m);
                     }
                     """
@@ -5597,6 +5604,7 @@ function MonthPage::view_title : string {
 }
 
 function MonthPage::print_body {
+var MonthDay[] days = $*reverse_sortorder_month ? reverse $.days : $.days;
     """
     <div id="archive-month">
         <div class="inner">
@@ -5609,7 +5617,7 @@ function MonthPage::print_body {
                     <dl>
                     """;
 
-    foreach var MonthDay d ($.days) {
+    foreach var MonthDay d ($days) {
         if ($d.has_entries) {
             """<dt><a href="$d.url">""";
                 if ($*entry_date_format == "med" or $*entry_date_format == "med_day" or $*entry_date_format == "long" or $*entry_date_format == "long_day") {
@@ -5675,10 +5683,11 @@ function MonthPage::print_navigation( string{} opts ) [fixed] {
 }
 
 function MonthDay::print_subjectlist() {
+var Entry[] entries = $*reverse_sortorder_month ? reverse $.entries : $.entries;
     # Too many tables...
     var Page p = get_page();
 
-    foreach var Entry e ($.entries) {
+    foreach var Entry e ($entries) {
         $e->print_time("none", "");
         $e->print_poster();
         $e->print_metatypes();
@@ -5698,6 +5707,7 @@ function MonthDay::print_subjectlist() {
 ### Day view
 
 function DayPage::print_body() {
+var Entry[] entries = $*reverse_sortorder_day ? reverse $.entries : $.entries;
     """
     <div id="archive-day">
         <div class="inner">
@@ -5711,7 +5721,7 @@ function DayPage::print_body() {
                     """;
                     print "<h3 class='day-date'>" + $.date->date_format($*entry_date_format) + "</h3>";
                     if ($.has_entries) {
-                        foreach var Entry e ($.entries) {
+                        foreach var Entry e ($entries) {
                             $this->print_entry($e);
                         }
                     } else {

--- a/bin/upgrading/s2layers/core2base/layout.s2
+++ b/bin/upgrading/s2layers/core2base/layout.s2
@@ -18,6 +18,8 @@ propgroup presentation {
     property use sidebar_width;
     property use sidebar_width_doubled;
 
+    property use reverse_sortorder_group;
+    property use reg_firstdayofweek;
     property use tags_page_type;
     property use num_items_icons;
     property use icons_page_sort;
@@ -33,7 +35,6 @@ propgroup presentation {
     property use entry_management_links;
     property use comment_management_links;
 
-    property use reg_firstdayofweek;
 }
 
 set layout_type = "one-column";

--- a/bin/upgrading/s2layers/drifting/layout.s2
+++ b/bin/upgrading/s2layers/drifting/layout.s2
@@ -30,6 +30,8 @@ propgroup presentation
     property use use_journalstyle_entry_page;
     property use margins_size;
     property use margins_unit;
+    property use reverse_sortorder_group;
+    property use reg_firstdayofweek;
     property use icons_page_sort;
     property use userpics_style_group;
     property use userpics_position;
@@ -39,7 +41,6 @@ propgroup presentation
     property use userlite_interaction_links;
     property use entry_management_links;
     property use comment_management_links;
-    property use reg_firstdayofweek;
     property use entry_datetime_format_group;
     property use comment_datetime_format_group;
     property use all_entrysubjects;
@@ -1237,15 +1238,16 @@ function ReplyPage::print_comment (Comment c)
 
 ## Day Page
 ################################################################################
-function DayPage::print_body()
-{
+function DayPage::print_body() {
+var Entry[] entries = $*reverse_sortorder_day ? reverse $.entries : $.entries;
+
     $this->print_navigation();
 
     println "<h2 class=\"day-title\">" + $.date->date_format("long") + "</h2>";
 
     if ($.has_entries)
     {
-        foreach var Entry e ($.entries)
+        foreach var Entry e ($entries)
         {
             $this->print_entry($e);
         }
@@ -1260,11 +1262,12 @@ function DayPage::print_body()
 
 ## Year Page
 ################################################################################
-function YearPage::print_body
-{
+function YearPage::print_body {
+var YearMonth[] months = $*reverse_sortorder_year ? reverse $.months : $.months;
+
     $this->print_navigation();
 
-    foreach var YearMonth m ($.months)
+    foreach var YearMonth m ($months)
     {
         $this->print_month($m);
     }
@@ -1299,14 +1302,15 @@ function YearPage::print_month(YearMonth m)
 
 ## Month Page
 ################################################################################
-function MonthPage::print_body
-{
+function MonthPage::print_body {
+var MonthDay[] days = $*reverse_sortorder_month ? reverse $.days : $.days;
+
     $this->print_navigation();
 
     println "<h2 class=\"month-title\">" + $.date->date_format($*lang_fmt_month_long) + "</h2>";
 
     println "<div class=\"month-entries\">";
-        foreach var MonthDay d ($.days)
+        foreach var MonthDay d ($days)
         {
             if ($d.has_entries)
             {

--- a/bin/upgrading/s2layers/easyread/layout.s2
+++ b/bin/upgrading/s2layers/easyread/layout.s2
@@ -17,6 +17,8 @@ propgroup presentation {
     property use num_items_icons;
     property use use_journalstyle_entry_page;
     property use layout_type;
+    property use reverse_sortorder_group;
+    property use reg_firstdayofweek;
     property use tags_page_type;
     property use icons_page_sort;
     property use margins_size;
@@ -29,7 +31,6 @@ propgroup presentation {
     property use userlite_interaction_links;
     property use entry_management_links;
     property use comment_management_links;
-    property use reg_firstdayofweek;
     property use entry_datetime_format_group;
     property use comment_datetime_format_group;
     property use all_entrysubjects;

--- a/bin/upgrading/s2layers/negatives/layout.s2
+++ b/bin/upgrading/s2layers/negatives/layout.s2
@@ -21,6 +21,8 @@ propgroup presentation {
     property use margins_size;
     property use margins_unit;
 
+    property use reverse_sortorder_group;
+    property use reg_firstdayofweek;
     property use tags_page_type;
     property use num_items_icons;
     property use icons_page_sort;
@@ -35,8 +37,6 @@ propgroup presentation {
     property use userlite_interaction_links;
     property use entry_management_links;
     property use comment_management_links;
-
-    property use reg_firstdayofweek;
 }
 
 set layout_type = "two-columns-right";
@@ -821,8 +821,9 @@ var string raquo = (not $*all_entrysubjects and $e.subject == "" and $.view != "
 
 #######################################
 #Year Page
-function YearPage::print_body()
-{
+function YearPage::print_body() {
+var YearMonth[] months = $*reverse_sortorder_year ? reverse $.months : $.months;
+
     println "<div class=\"entry\">";
 
         "<div class=\"subject\">";
@@ -830,7 +831,7 @@ function YearPage::print_body()
         println "</div>";
 
         println "<center>";
-        foreach var YearMonth m ($.months) {
+        foreach var YearMonth m ($months) {
             $this->print_month($m);
         }
         println "</center>";
@@ -877,10 +878,9 @@ function YearWeek::print() {
     "</tr>";
 }
 
+function MonthPage::print_body {
+var MonthDay[] days = $*reverse_sortorder_month ? reverse $.days : $.days;
 
-
-function MonthPage::print_body
-{
     println "<div class=\"entry\">";
     println "<div class=\"subject\">" + $.date->date_format($*lang_fmt_month_long) + "</div>";
     "<form method='post' action='$.redir.url'><center>";
@@ -900,7 +900,7 @@ function MonthPage::print_body
     }
     if ($.next_url != "") { "\n[<a href='$.next_url'>&gt;&gt;&gt;</a>]\n"; }
     "</center></form>";
-    foreach var MonthDay d ($.days) {
+    foreach var MonthDay d ($days) {
         if ($d.has_entries) {
             println "<div class='subject'>";
             println "<a href=\"$d.url\">" + lang_ordinal($d.day) + " " + $.date->date_format($*lang_fmt_month_long) + "</a></div>";
@@ -912,12 +912,13 @@ function MonthPage::print_body
     println "</div>";
 }
 
-function DayPage::print_body()
-{
+function DayPage::print_body() {
+var Entry[] entries = $*reverse_sortorder_day ? reverse $.entries : $.entries;
+
     if (not $.has_entries) {
         println $*text_noentries_day;
     }
-    foreach var Entry e ($.entries) {
+    foreach var Entry e ($entries) {
         $this->print_entry($e);
     }
 }

--- a/bin/upgrading/s2layers/skittlishdreams/layout.s2
+++ b/bin/upgrading/s2layers/skittlishdreams/layout.s2
@@ -23,6 +23,8 @@ propgroup presentation {
     property use use_shared_pic;
     property use use_journalstyle_entry_page;
 
+    property use reverse_sortorder_group;
+    property use reg_firstdayofweek;
     property use tags_page_type;
     property use num_items_icons;
     property use icons_page_sort;
@@ -40,8 +42,6 @@ propgroup presentation {
     property use userlite_interaction_links;
     property use entry_management_links;
     property use comment_management_links;
-
-    property use reg_firstdayofweek;
 
     property bool use_action_links_images {
         des = "Theme has images for the entry/comment links";


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=2936

Allow display of content in reverse-chronological order
Implement options for Year page and Day page in Core2
Create and implement similar option for Month page in Core2
Expose options in all dw-free styles except Zesty
Move other archive option below it for more coherence
