### PR TITLE
(bug 4669) Fix FAQ category titles not showing up

### DIFF
--- a/htdocs/support/see_request.bml
+++ b/htdocs/support/see_request.bml
@@ -714,7 +714,7 @@ body<=
         my $altlang = $deflang ne $curlang;
         $altlang = 0 unless $mld and $mll;
         if ( $altlang ) {
-            my $sql = qq{SELECT fc.faqcat, t.text, fc.catorder
+            my $sql = qq{SELECT fc.faqcat, t.text as faqcatname, fc.catorder
                          FROM faqcat fc, ml_text t, ml_latest l, ml_items i
                          WHERE t.dmid=$mld->{'dmid'} AND l.dmid=$mld->{'dmid'}
                              AND i.dmid=$mld->{'dmid'} AND l.lnid=$mll->{'lnid'}


### PR DESCRIPTION
Category titles wern't showing up in the support request
dropdown.

I am not sure why this broke ( we've never used this code-path before, but now we are -- may be a good idea to look into why we are using this code path now, and if that is breaking anything else. )
