### PR TITLE
Bug 4668 - Librarian's Dream: unclosed div in profile module when opts a...

### DIFF
--- a/bin/upgrading/s2layers/librariansdream/layout.s2
+++ b/bin/upgrading/s2layers/librariansdream/layout.s2
@@ -182,34 +182,37 @@ function Page::print() {
 }
 
 
+## Enclose userpic and name in new DIV
+## Switch from DIV to SPAN for userpic and name
+
 function print_module_userprofile() {
     var Page p = get_page();
 
     open_module("userprofile", $*text_module_userprofile, $p.view_url{"userinfo"});
-    """<div class='userprofile-userinfo'>""";
-    if ($*module_userprofile_opts_userpic) {
-        if (defined $p.journal.default_pic) {
-            $p.journal.default_pic.width  = $p.journal.default_pic.width  / 4;
-            $p.journal.default_pic.height = $p.journal.default_pic.height / 4;
-            """<span class="userpic">""";
-            $p.journal->print_userpic();
-             """</span>""";
+
+    if ($*module_userprofile_opts_userpic or $*module_userprofile_opts_name) {
+        """<div class="userprofile-userinfo">""";
+        if ($*module_userprofile_opts_userpic) {
+            if (defined $p.journal.default_pic) {
+                $p.journal.default_pic.width  = $p.journal.default_pic.width  / 4;
+                $p.journal.default_pic.height = $p.journal.default_pic.height / 4;
+                """<span class="userpic">""";
+                $p.journal->print_userpic();
+                """</span>""";
+            }
         }
-    }
-    if ($*module_userprofile_opts_name or $*module_userprofile_opts_website) {
         if ($*module_userprofile_opts_name) {
-            println "<span class='journal-name'>"+$p.journal.name+"</span>";
+            println "<span class='journal-name'>" + $p.journal.name + "</span>";
         }
-    """</div>""";
-        if ($*module_userprofile_opts_website and $p.journal.website_url != "") {
-            var string website_name = ( $p.journal.website_name != "" ) ? $p.journal.website_name : $*text_website_default_name;
-            println "<div class='journal-website-name'><a href='$p.journal.website_url'>$website_name</a></div>";
-        }
+        "</div>";
+    }
+    if ($*module_userprofile_opts_website and $p.journal.website_url != "") {
+        var string website_name = ( $p.journal.website_name != "" ) ? $p.journal.website_name : $*text_website_default_name;
+        println "<div class='journal-website-name'><a href='$p.journal.website_url'>$website_name</a></div>";
     }
     $p.journal->print_interaction_links();
     close_module();
 }
-
 
 ##===============================
 ## Stylesheet
@@ -711,6 +714,10 @@ ul.userlite-interaction-links {
 ul.userlite-interaction-links li {
     display: block !important;
     padding: 0 !important;
+}
+
+.module-userprofile .journal-name {
+    padding-left: .5em;
 }
 
 .module-powered,


### PR DESCRIPTION
...re hidden

http://bugs.dwscoalition.org/show_bug.cgi?id=4668

Only display DIV if we have something to display in it (userpic or name)
Display website separately, as intended
Add space between name and border/userpic

Note: the function in Core2 has a strange if statement --if ($_module_userprofile_opts_name or $_module_userprofile_opts_website-- enclosing name and website. I don't really understand its purpose as these are printed in their own div, aren't related, and website isn't displayed when there's no URL. I've removed it here but tell me if I'm missing something.
