### PR TITLE
(Bug 2524) Only remember value if user did the selecting

### DIFF
--- a/htdocs/js/jquery.postform.js
+++ b/htdocs/js/jquery.postform.js
@@ -290,18 +290,23 @@ init: function(formData) {
     // access
     function initAccess() {
         $("#custom_access_groups").hide();
-        $("#security").change( function() {
-            if ( $(this).val() == "custom" )
+        $("#security").change( function(e, init) {
+            var $this = $(this);
+            if ( $this.val() == "custom" )
                 $("#custom_access_groups").slideDown();
             else
                 $("#custom_access_groups").slideUp();
-        }).triggerHandler("change");
+
+            if ( ! init ) {
+                $this.data("lastselected",$this.val())
+            }
+        }).triggerHandler("change", true)
 
         function adjustSecurityDropdown(data) {
             if ( ! data ) return;
 
             var $security = $("#security");
-            var oldval = $security.val();
+            var oldval = $security.data("lastselected");
             var rank = { "public": "0", "access": "1", "private": "2", "custom": "3" };
 
             $security.empty();


### PR DESCRIPTION
Handles this case:
- Set your journal to a minsecurity of "Private"
- Go to make a new post
- Pick any community that has a lesser minsecurity (anyone, members)
- Security of post will remain "Private" instead of that comm's
  minsecurity

This was better than the alternative of, if you'd selected "Private"
manually, it being switched to a lesser security, but honestly neither
was ideal.

So now instead of looking at the current value before adjusting things
for minsecurity, it becomes smarter and records a value when the user
themself has selected an option, and uses _that_ value (only) if it
exists.
