### PR TITLE
(Bug 4661) Retitle link to "Fill out poll" when user hasn't voted yet

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2164,6 +2164,8 @@ poll.error.unknownpqtype=Unknown type on lj-pq tag.
 
 poll.error.unlockedtag=Unlocked [[tag]] tag.
 
+poll.vote=Fill out Poll
+
 poll.error.whoview=whoview must be 'all', 'friends', or 'none'.
 
 poll.error.whovote=whovote must be 'all' or 'friends'.

--- a/cgi-bin/LJ/Poll.pm
+++ b/cgi-bin/LJ/Poll.pm
@@ -981,7 +981,9 @@ sub render {
     } elsif ( $mode eq 'results' ) {
         $ret .= "<br />\n";
         # change vote link
-        $ret .= "[ <a href='$LJ::SITEROOT/poll/?id=$pollid&amp;mode=enter' class='LJ_PollChangeLink' id='LJ_PollChangeLink_${pollid}' lj_pollid='$pollid' >" . LJ::Lang::ml( 'poll.changevote' ) . "</a> ]" if $self->can_vote( $remote ) && !$self->is_closed;
+        my $pollvotetext = %preval ? "poll.changevote" : "poll.vote";
+        $ret .= "[ <a href='$LJ::SITEROOT/poll/?id=$pollid&amp;mode=enter' class='LJ_PollChangeLink' id='LJ_PollChangeLink_${pollid}' lj_pollid='$pollid' >" 
+            . LJ::Lang::ml( $pollvotetext ) . "</a> ]" if $self->can_vote( $remote ) && !$self->is_closed;
         if ( $self->can_view && $self->isanon ne "yes" ) {
             $ret .= "<br /><br /><div class='respondents'><a href='$LJ::SITEROOT/poll/?id=$pollid&amp;mode=ans_extended' class='LJ_PollRespondentsLink' " .
             "id='LJ_PollRespondentsLink_${pollid}' " .


### PR DESCRIPTION
This adds a new translation string poll.vote to the site
and uses it as a link text when the user has not yet voted
in a poll and is viewing the poll results.

The link text shown when the user has already voted is not changed.
