### PR TITLE
(Bug 4585) Differentiate singular and plural for poll requirements

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2086,11 +2086,11 @@ Password=Password
 
 poll.changevote=Change Your Vote
 
-poll.checkexact=You must choose exactly <b>[[options]]</b> responses.
+poll.checkexact2=You must choose exactly <b>[[options]]</b> [[?options|response|responses]].
 
-poll.checkmin=You must choose at least <b>[[options]]</b> responses.
+poll.checkmin2=You must choose at least <b>[[options]]</b> [[?options|response|responses]].
 
-poll.checkmax=You can choose up to <b>[[options]]</b> responses.
+poll.checkmax2=You can choose up to <b>[[options]]</b> [[?options|response|responses]].
 
 poll.clear=Clear Answers
 
@@ -2110,13 +2110,13 @@ poll.error.cantview=Error: you don't have access to these poll results.
 
 poll.error.cantvote=Sorry, you don't have permission to vote in this particular poll.
 
-poll.error.checkfewoptions2=You must select at least <b>[[options]]</b> responses in question <b>#[[question]]</b>, or you can choose to skip it.
+poll.error.checkfewoptions3=You must select at least <b>[[options]]</b> [[?options|response|responses]] in question <b>#[[question]]</b>, or you can choose to skip it.
 
 poll.error.checkmaxtoolow=Checkmax attribute must be higher than Checkmin attribute.
 
 poll.error.checkmintoolow=Checkmin attribute must be positive.
 
-poll.error.checktoomuchoptions2=You can only select up to <b>[[options]]</b> responses in question <b>#[[question]]</b>.
+poll.error.checktoomuchoptions3=You can only select up to <b>[[options]]</b> [[?options|response|responses]] in question <b>#[[question]]</b>.
 
 poll.error.deletedowner=Error: poll owner has been deleted
 

--- a/cgi-bin/LJ/Poll.pm
+++ b/cgi-bin/LJ/Poll.pm
@@ -1006,15 +1006,15 @@ sub render {
             $maxcheck ||= 255;
 
             if ($mincheck > 0 && $mincheck eq $maxcheck ) {
-                $results_table .= "<i>". LJ::Lang::ml( "poll.checkexact", { options => $mincheck } ). "</i><br />\n";
+                $results_table .= "<i>". LJ::Lang::ml( "poll.checkexact2", { options => $mincheck } ). "</i><br />\n";
             }
             else {
                 if ($mincheck > 0) {
-                    $results_table .= "<i>". LJ::Lang::ml( "poll.checkmin", { options => $mincheck } ). "</i><br />\n";
+                    $results_table .= "<i>". LJ::Lang::ml( "poll.checkmin2", { options => $mincheck } ). "</i><br />\n";
                 }
 
                 if ($maxcheck < 255) {
-                    $results_table .= "<i>". LJ::Lang::ml( "poll.checkmax", { options => $maxcheck } ). "</i><br />\n";
+                    $results_table .= "<i>". LJ::Lang::ml( "poll.checkmax2", { options => $maxcheck } ). "</i><br />\n";
                 }
             }
         }
@@ -1562,12 +1562,12 @@ sub process_submission {
                 $checkmax ||= 255;
 
                 if($num_opts < $checkmin) {
-                    $$error = LJ::Lang::ml( 'poll.error.checkfewoptions2', {'question' => $qid, 'options' => $checkmin} );
+                    $$error = LJ::Lang::ml( 'poll.error.checkfewoptions3', {'question' => $qid, 'options' => $checkmin} );
                     $error_code = 2;
                     $val = "";
                 }
                 if($num_opts > $checkmax) {
-                    $$error = LJ::Lang::ml( 'poll.error.checktoomuchoptions2', {'question' => $qid, 'options' => $checkmax} );
+                    $$error = LJ::Lang::ml( 'poll.error.checktoomuchoptions3', {'question' => $qid, 'options' => $checkmax} );
                     $error_code = 2;
                     $val = "";
                 }

--- a/cgi-bin/LJ/Poll/Question.pm
+++ b/cgi-bin/LJ/Poll/Question.pm
@@ -84,15 +84,15 @@ sub preview_as_html {
         $maxcheck ||= 255;
 
         if ($mincheck > 0 && $mincheck eq $maxcheck ) {
-            $ret .= "<i>". LJ::Lang::ml( "poll.checkexact", { options => $mincheck } ). "</i><br />\n";
+            $ret .= "<i>". LJ::Lang::ml( "poll.checkexact2", { options => $mincheck } ). "</i><br />\n";
         }
         else {
             if ($mincheck > 0) {
-                $ret .= "<i>". LJ::Lang::ml( "poll.checkmin", { options => $mincheck } ). "</i><br />\n";
+                $ret .= "<i>". LJ::Lang::ml( "poll.checkmin2", { options => $mincheck } ). "</i><br />\n";
             }
 
             if ($maxcheck < 255) {
-                $ret .= "<i>". LJ::Lang::ml( "poll.checkmax", { options => $maxcheck } ). "</i><br />\n";
+                $ret .= "<i>". LJ::Lang::ml( "poll.checkmax2", { options => $maxcheck } ). "</i><br />\n";
             }
         }
     }


### PR DESCRIPTION
This patch replaces several translation strings with new ones
that differentiate between singular "response" and plular "responses".
The new texts are used in poll creation and poll display as well
as in error messages.
