### PR TITLE
(Bug 4679) Don't mark Recent Entries when browsing tags

### DIFF
--- a/cgi-bin/LJ/S2/RecentPage.pm
+++ b/cgi-bin/LJ/S2/RecentPage.pm
@@ -66,6 +66,7 @@ sub RecentPage
         $p->{filter_active} = 1;
         $p->{filter_name} = join(", ", @{$opts->{tags}});
         $p->{filter_tags} = 1;
+        $p->{view} = "";
     }
 
     if ( $opts->{securityfilter} ) {


### PR DESCRIPTION
When browsing entries in a journal by tags, the "Recent Entries"
part of the navigation menu was shown as the currently active one
by appliying the "current" CSS class. When browsing tags, the current
class should bot be applied to any of the menu items.

This tags sets the "view" attribute of the S2 page object to an empty
string if the user is browsing by tags. Thus the "current" class is not
applied to the "Recent Entries" div by the function
print_module_navlinks.
