### PR TITLE
(Bug 4627) Use canonical link on admin/recent_comments

### DIFF
--- a/htdocs/admin/recent_comments.bml
+++ b/htdocs/admin/recent_comments.bml
@@ -62,7 +62,8 @@ _c?>
 
         if ($lrow) {
             my $talkid = ($r->{'jtalkid'} << 8) + $lrow->{'anum'};
-            my $url = "$LJ::SITEROOT/users/$ju->{user}/$lrow->{ditemid}.html?thread=$talkid" . LJ::Talk::comment_anchor( $talkid );
+            my $talkurl = $ju->journal_base . "/$lrow->{ditemid}.html";
+            my $url = LJ::Talk::talkargs($talkurl, "thread=$talkid") . LJ::Talk::comment_anchor( $talkid );
             $ret .= "$hr_ago hr ago in " . LJ::ljuser($ju) . ": <a href='$url'>$url</a><br />\n";
         } else {
             $ret .= "$hr_ago hr ago in " . LJ::ljuser($ju) . ": link unavailable<br />";


### PR DESCRIPTION
The admin/recent_comments page was using old-style URLs
/dreamwidth.org/user/username/...) for linking to
comments instead of the newer canonical style
(user.dreamwidth.org/username). This patch updates the links to the new
style.
