### PR TITLE
(Bug 4660) Add explanation to username swap error

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2348,7 +2348,7 @@ rename.error.tokeninvalid=The provided token is not a valid token.
 
 rename.error.tokentoofew=Too few tokens; you need two to perform a swap.
 
-rename.error.unauthorized=[[to]] is not under your control.
+rename.error.unauthorized2=[[to]] is not under your control. Both accounts need to have the same verified email address and the same password for this operation.
 
 rename.error.unauthorized.forcomm=The community [[comm]] must have no members, and must be under your control.
 

--- a/cgi-bin/DW/User/Rename.pm
+++ b/cgi-bin/DW/User/Rename.pm
@@ -138,7 +138,7 @@ sub can_rename_to {
         # person-to-community (only under restricted circumstances for the community)
         return 1 if DW::User::Rename::_is_authorized_for_comm( $self, $tou );
 
-        push @$errref, LJ::Lang::ml( 'rename.error.unauthorized', { to => $tou->ljuser_display } );
+        push @$errref, LJ::Lang::ml( 'rename.error.unauthorized2', { to => $tou->ljuser_display } );
         return 0;
     } elsif ( $self->is_community && LJ::isu( $opts{user} ) ) {
         my $admin = $opts{user};


### PR DESCRIPTION
Adds a bit more explanation to the error that occurs when a username
swap fails because the two accounts do not have the same verified email
address and the same password.

The community error does not need to be changed because with communities
"under your control" is clearer than with personal jounals - it means
being the community maintainer.
