### PR TITLE
(Bug 4331) Expose the correct options on Customize Journal

### DIFF
--- a/bin/upgrading/s2layers/abstractia/layout.s2
+++ b/bin/upgrading/s2layers/abstractia/layout.s2
@@ -371,6 +371,7 @@ propgroup text {
 
     property use text_view_recent;
     property use text_view_friends;
+    property use text_view_friends_comm;
     property use text_view_network;
     property use text_view_archive;
     property use text_view_userinfo;

--- a/bin/upgrading/s2layers/bases/layout.s2
+++ b/bin/upgrading/s2layers/bases/layout.s2
@@ -198,6 +198,7 @@ propgroup text {
     property use text_view_recent;
     property use text_view_archive;
     property use text_view_friends;
+    property use text_view_friends_comm;
     property use text_view_network;
     property use text_view_tags;
     property use text_view_memories;

--- a/bin/upgrading/s2layers/blanket/layout.s2
+++ b/bin/upgrading/s2layers/blanket/layout.s2
@@ -185,6 +185,7 @@ propgroup text {
     property use text_view_recent;
     property use text_view_archive;
     property use text_view_friends;
+    property use text_view_friends_comm;
     property use text_view_network;
     property use text_view_tags;
     property use text_view_memories;

--- a/bin/upgrading/s2layers/brittle/layout.s2
+++ b/bin/upgrading/s2layers/brittle/layout.s2
@@ -255,6 +255,7 @@ propgroup text {
     property use text_view_recent;
     property use text_view_archive;
     property use text_view_friends;
+    property use text_view_friends_comm;
     property use text_view_network;
     property use text_view_tags;
     property use text_view_memories;

--- a/bin/upgrading/s2layers/core2base/layout.s2
+++ b/bin/upgrading/s2layers/core2base/layout.s2
@@ -185,6 +185,7 @@ propgroup text {
     property use text_view_recent;
     property use text_view_archive;
     property use text_view_friends;
+    property use text_view_friends_comm;
     property use text_view_network;
     property use text_view_tags;
     property use text_view_memories;

--- a/bin/upgrading/s2layers/easyread/layout.s2
+++ b/bin/upgrading/s2layers/easyread/layout.s2
@@ -159,6 +159,7 @@ propgroup text {
 
     property use text_view_recent;
     property use text_view_friends;
+    property use text_view_friends_comm;
     property use text_view_network;
     property use text_view_archive;
     property use text_view_userinfo;

--- a/bin/upgrading/s2layers/zesty/layout.s2
+++ b/bin/upgrading/s2layers/zesty/layout.s2
@@ -189,6 +189,7 @@ propgroup Text {
     property use text_view_archive;
     property use text_view_recent;
     property use text_view_friends;
+    property use text_view_friends_comm;
     property use text_view_month;
     property use text_view_userinfo;
 

--- a/cgi-bin/LJ/Widget/S2PropGroup.pm
+++ b/cgi-bin/LJ/Widget/S2PropGroup.pm
@@ -319,6 +319,7 @@ sub skip_prop {
     if ( $opts{user}->is_community ) {
         return 1 if $prop_name eq "text_view_network";
         return 1 if $prop_name eq "text_view_friends";
+        return 1 if $prop_name eq "text_view_friends_filter";
     } else {
         return 1 if $prop_name eq "text_view_friends_comm"
     }


### PR DESCRIPTION
Certain text properties are not used for communities, like
text_view_network and text_view_friends, while others are only used for
communities, like text_view_friends_comm. Expose the correct ones
depending on whether a personal or community journal is being styled.
- Added section to the "skip" test for props to filter the
  personal/community-only options
- Always pass user object to the skip test for consistency
- Add the property to the text propgroup for all layouts that currently
  don't
