### PR TITLE
Bug #4298 - "Advanced Customization" link only showing up with custom la...

### DIFF
--- a/cgi-bin/LJ/Widget/CurrentTheme.pm
+++ b/cgi-bin/LJ/Widget/CurrentTheme.pm
@@ -73,7 +73,7 @@ sub render_body {
     } else {
         $ret .= "<li><a href='$LJ::SITEROOT/customize/options$getextra'>" . $class->ml('widget.currenttheme.options.change') . "</a></li>";
     }
-    if (! $no_layer_edit && $theme->is_custom && $theme->available_to($u)) {
+    if (! $no_layer_edit ) {
         $ret .= "<li><a href='$LJ::SITEROOT/customize/advanced'>" . $class->ml( 'widget.currenttheme.options.advancedcust' ) . "</a></li>";
         if ($theme->layoutid && !$theme->layout_uniq) {
             $ret .= "<li><a href='$LJ::SITEROOT/customize/advanced/layeredit?id=" . $theme->layoutid . "'>" . $class->ml('widget.currenttheme.options.editlayoutlayer') . "</a></li>";


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4298
Makes the "Advanced Customization" link show up in the current theme widget for all users with advanced customization access even if their current layout is not a custom layout.
