### PR TITLE
Bug 4690 - Librarian's Dream: module heading links not changing color in...

### DIFF
--- a/bin/upgrading/s2layers/librariansdream/layout.s2
+++ b/bin/upgrading/s2layers/librariansdream/layout.s2
@@ -633,6 +633,9 @@ table.month caption { display: none; }
     margin: 0;
 }
 
+/* Extra specificity needed to override .module a */
+.module .module-header a { color: $*color_module_title; }
+
 .module-content ul,
 .module-list,
 .module dl {


### PR DESCRIPTION
... original design

http://bugs.dwscoalition.org/show_bug.cgi?id=4690
-- Prevent module header links from changing color
