### PR TITLE
(Bug 4702) Add styling to the list of comment pages on S2 siteviews, and...

### DIFF
--- a/bin/upgrading/s2layers/siteviews/layout.s2
+++ b/bin/upgrading/s2layers/siteviews/layout.s2
@@ -275,7 +275,7 @@ if ($p isa ReplyPage) {
 function EntryPage::print_entry_footer(Entry e) {
     """<hr class="above-entry-interaction-links" />""";
     $e->print_interaction_links("topcomment");
-   $.comment_pages->print({ "anchor" => "comments", "class" => "comment-pages toppages" });
+   $.comment_pages->print({ "anchor" => "comments", "class" => "comment-pages toppages comment-page-list" });
 }
 
 function EntryPage::print_comment_section(Entry e) {
@@ -295,7 +295,7 @@ function EntryPage::print_comment_section(Entry e) {
         $this->print_reply_container({ "target" => "bottomcomment" });
         "</div>";
    }
-   $.comment_pages->print({ "anchor" => "comments", "class" => "comment-pages bottompages" });
+   $.comment_pages->print({ "anchor" => "comments", "class" => "comment-pages bottompages comment-page-list" });
    if ($.comment_pages.total_subitems > 0) {
         $.comment_nav->print({ "class" => "comment-pages bottompages" });
         $this->print_multiform_actionline();

--- a/htdocs/stc/celerity/celerity.css
+++ b/htdocs/stc/celerity/celerity.css
@@ -365,7 +365,7 @@ footer { border-top: 4px double #999966;
     text-align: center;
     background-color: #EEEECC;
 }
-.action-box .inner {
+.action-box .inner, .comment-page-list {
     color: #000;
     border: 1px solid #555555;
     background-color: #DDDDAA;

--- a/htdocs/stc/entrypage.css
+++ b/htdocs/stc/entrypage.css
@@ -40,6 +40,7 @@ hr.above-entry-interaction-links, hr.below-entry-interaction-links {margin: 1em 
 .entry-interaction-links, .comment-pages {text-align: center; font-weight:bold; float:none;}
 .entry-interaction-links li {display:inline;}
 ul.entry-interaction-links {list-style: none outside none; display: inline; text-align: center; padding: 0.5em 0; margin:0;}
+.comment-page-list {max-width: 28em; margin-left:auto; margin-right: auto;}
 
 /* give talkread styling to management links without S2 overrides*/
 .entry-interaction-links li:before, .comment-interaction-links li:before, .view-flat:before, .view-threaded:before, .view-top-only:before, .expand_all:before {content:"(";}
@@ -69,6 +70,7 @@ ul.comment-interaction-links {display: inline; margin: 0; }
 /*Styling for end of comments section*/
 .bottompages { margin-bottom: 1em;}
 .bottomcomment {text-align: center;}
+
 
 /*Styling for collapsed comments*/
 .partial h4.comment-title {font-size: 1em; display:inline; font-weight:normal;}

--- a/htdocs/stc/gradation/gradation.css
+++ b/htdocs/stc/gradation/gradation.css
@@ -456,7 +456,7 @@ textarea, input {
     text-align: center;
     background-color: #666666;
 }
-.action-box .inner {
+.action-box .inner, .comment-page-list {
     color: #eee;
     border: 1px solid #555555;
     background-color: #333333;


### PR DESCRIPTION
... keep it from going full-width.

(Changes from the BML version - comment page count box is always 28em, as I can't think of a way to make it 'shrink' when content is narrower, and instead of line breaking every 10 items exactly it breaks every 28em, which is approximately ten items)
