### PR TITLE
(bug 4720) Changes error message when check_form_auth fails on search

### DIFF
--- a/htdocs/search.bml
+++ b/htdocs/search.bml
@@ -93,7 +93,7 @@ body<=
     ################################################################################
 
     # at this point, they have done a POST, which means they want to search something
-    return $error->( "Failauth." ) unless LJ::check_form_auth();
+    return $error->( "Did you leave this window open too long? Please refresh and try again." ) unless LJ::check_form_auth();
 
     # and make sure we got a query
     return $error->( "Query must be shorter than 255 characters, sorry!" )


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4720

Most common reason for check_form_auth to fail on search is because the tab's been open too long, so tell the user to try again.
