### PR TITLE
(Bug 2174) Reading filter options: public/order

### DIFF
--- a/htdocs/js/subfilters.js
+++ b/htdocs/js/subfilters.js
@@ -149,12 +149,18 @@ function cfPopulateLists(selectValue) {
     if ($.browser.msie && parseInt($.browser.version, 10) <= 8) $('#cf-in-list, #cf-notin-list').css('width', 'auto').css('width', '100%'); // set #cf-in-list and #cf-notin-list width (IE n..7 bug)
 }
 
+function cfPopulateOptions( ) {
+    $('#cf-visibility').val( cfFilters[cfSelectedFilterId]['public'] );
+    $('#cf-sortorder').val( String( cfFilters[cfSelectedFilterId]['sortorder'] ) );
+    $('#cf-foname').text( cfFilters[cfSelectedFilterId]['name'] );
+    $('#cf-filtopts').show();
+}
 
 function cfSelectedFilter() {
     // filter options are not implemented yet, so don't show that box :)
-    //$('#cf-filtopts').show();
 
     cfPopulateLists();
+    cfPopulateOptions();
 }
 
 
@@ -542,8 +548,23 @@ function cfRenameFilter() {
 
     // and now update the select dialog
     cfUpdateFilterSelect();
+    // and any labeling
+    $('#cf-foname').text( cfFilters[cfSelectedFilterId]['name'] );
 
     // kick off a saaaaaaaave!
+    cfSaveChanges();
+}
+
+function cfSortOrder() {
+    cfFilters[cfSelectedFilterId]['sortorder'] = parseInt( $('#cf-sortorder').val(), 10 );
+
+    cfSaveChanges();
+    cfUpdateFilterSelect();
+}
+
+function cfPublic( sel ) {
+    cfFilters[cfSelectedFilterId]['public'] = sel ? 1 : 0;
+
     cfSaveChanges();
 }
 
@@ -560,12 +581,30 @@ function cfViewFilter() {
     );
 }
 
+// function used for sorting filters -- compares based on sort order, then name
+function compareFilters( a, b ) {
+    if ( a.sortorder == b.sortorder ) {
+        return a.name > b.name ? 1 : a.name < b.name ? -1 : 0;
+    }
+
+    return a.sortorder > b.sortorder ? 1 : -1;
+}
+
 function cfUpdateFilterSelect() {
     // regenerate HTML for the Filter: dropdown
     var options = '<option value="0">( select filter )</option><option value="0"></option>';
+
+    // sort by sortorder, then name
+    var sortedFilters = [];
     for ( i in cfFilters ) {
-        cfFilters[i]['members'] = null;
-        options += '<option value="' + i + '">' + cfFilters[i].name + '</option>';
+        sortedFilters.push(cfFilters[i]);
+    }
+    sortedFilters.sort(compareFilters);
+
+    for ( var i = 0; i < sortedFilters.length; i++ ) {
+        var id = sortedFilters[i]['id'];
+        cfFilters[id]['members'] = null;
+        options += '<option value="' + id + '">' + cfFilters[id].name + '</option>';
     }
     $('#cf-filters').html( options );
 
@@ -634,6 +673,9 @@ jQuery( function($) {
     $('#cf-view').bind( 'click', function(e) { cfViewFilter(); } );
     $('#cf-delete').bind( 'click', function(e) { cfDeleteFilter(); } );
     $('#cf-showtypes').bind( 'change', function(e) { cfShowTypes( $(e.target).val() ); } );
+    $('#cf-public').bind( 'change', function(e) { cfPublic( $(e.target).val() ); } );
+    // not working on the input element? put the function in directly as onChange
+    //$('#cf-sortorder').bind( 'change', function(e) { cfSortOrder( $(e.target).val() ); } );
 
     // if the user is paid, we bind these.  note that even if someone goes through the
     // trouble of hacking up the form and submitting data, the server won't actually give

--- a/htdocs/manage/subscriptions/filters.bml
+++ b/htdocs/manage/subscriptions/filters.bml
@@ -64,9 +64,17 @@ body<=
 </div>
 
 <div id='cf-filtopts'>
-    Options for <span id='cf-foname'>selected filter</span>:<br /><br />
+    <h4>Options for "<span id='cf-foname'>selected filter</span>"</h4> 
 
-    (filter options are not implemented yet, sorry!)
+    <p><label for='cf-public'>Visibility:</label>
+    <select id='cf-public'>
+       <option value='0'>Private</option>
+       <option value='1'>Public</option>
+    </select></p>
+
+    <p><label for="cf-sortorder">Order:</label>
+    <input id="cf-sortorder" onchange="cfSortOrder()" size="2" /></p>
+
 </div>
 
 <div id='cf-intro'>

--- a/htdocs/stc/subfilters.css
+++ b/htdocs/stc/subfilters.css
@@ -31,3 +31,7 @@
 .cf-tag-on { font-weight: bold; }
 .cf-tag { text-decoration: underline; margin: 3px; }
 .cf-tag:hover { background-color: #ccc; }
+
+#cf-filtopts { padding: 5px; }
+#cf-filtopts h4, #cf-filtopts p, #cf-filtopts label { display: inline; margin-right: 1em;}
+#cf-filtopts input { text-align: right; }

--- a/htdocs/tools/endpoints/contentfilters.bml
+++ b/htdocs/tools/endpoints/contentfilters.bml
@@ -163,6 +163,10 @@
                 delete $data->{$uid} unless exists $filt->{members}->{$uid};
             }
 
+            # save public and sortorder preferences
+            $cf->_getset( 'sortorder', $filt->{sortorder} + 0 ) unless $filt->{sortorder} == $cf->{sortorder};
+            $cf->_getset( 'public', $filt->{public} ? 1 : 0 ) unless $filt->{public} == $cf->{public};
+
             # save the filter, very important...
             $cf->_save;
         }


### PR DESCRIPTION
I went in to do Bug4501 and found that Mark's excellent set up already
had this support in the backend, where it counted.  Public filters
and sortorder were already supported and just needed to be added
to the UI.  I know we want to overhaul this UI eventually, but in
the meantime, users will be able to set these filters as public
and order them how they wish.  This additionally satisfies
Bug4501--in the interface, the filters in the drop down are
sorted by sortorder first, and then name. Someone who hasn't set
any sortorder for any filters will see them ordered by name.
