### PR TITLE
(Bug 4564) Only escape the < and > symbols, not quotes, etc

### DIFF
--- a/htdocs/tools/endpoints/getuserpics.bml
+++ b/htdocs/tools/endpoints/getuserpics.bml
@@ -56,7 +56,10 @@ _c?>
             #        ( no code ref will be required )
             # we don't want the full version of alttext here, because the keywords, etc
             # will already likely be displayed by the icon
-            alt => sub { LJ::ehtml($upic->description)  . "" }, # force to string
+
+            # We don't want to use ehtml, because we want the JSON converter
+            # handle escaping ", ', etc. We just escape the < and > ourselves
+            alt => sub { LJ::etags($upic->description) . "" }, # force to string
 
             comment => LJ::strip_html($upic->comment),
             id => $id,


### PR DESCRIPTION
The JSON library handles escaping of characters that aren't valid in
JSON, including double quotes, so let it do its job. Previously, our
escaping the characters that the JSON library could handle was actually
breaking things.
