### PR TITLE
(Bug 4738) Don't always include the jquery-ui theme stylesheet

### DIFF
--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -77,7 +77,17 @@ sub EntryPage
 
     # quickreply js libs
     my $beta = LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" );
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( $beta, $beta ? 'stc/jquery/jquery.ui.theme.smoothness.css' : 'stc/lj_base.css' ) )
+
+    my @iconbrowser_extra_stylesheet;
+    if ( $beta ) {
+        # if we're using the site skin, don't override the jquery-ui theme, as that's already included
+        @iconbrowser_extra_stylesheet = ( 'stc/jquery/jquery.ui.theme.smoothness.css' )
+            unless $opts->{handle_with_siteviews_ref} && ${$opts->{handle_with_siteviews_ref}};
+    } else {
+        @iconbrowser_extra_stylesheet = ( 'stc/lj_base.css' );
+    }
+
+    LJ::need_res( LJ::Talk::init_iconbrowser_js( $beta, @iconbrowser_extra_stylesheet ) )
         if $remote && $remote->can_use_userpic_select;
 
     LJ::need_res(qw(

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -62,10 +62,19 @@ sub ReplyPage
 
     LJ::need_res('stc/display_none.css');
     LJ::need_res( LJ::S2::tracking_popup_js() );
-    
+
     # libs for userpicselect
     my $beta = LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" );
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( $beta, $beta ? 'stc/jquery/jquery.ui.theme.smoothness.css' : 'stc/lj_base.css' ) )
+    my @iconbrowser_extra_stylesheet;
+    if ( $beta ) {
+        # if we're using the site skin, don't override the jquery-ui theme, as that's already included
+        @iconbrowser_extra_stylesheet = ( 'stc/jquery/jquery.ui.theme.smoothness.css' )
+            unless $opts->{handle_with_siteviews_ref} && ${$opts->{handle_with_siteviews_ref}};
+    } else {
+        @iconbrowser_extra_stylesheet = ( 'stc/lj_base.css' );
+    }
+
+    LJ::need_res( LJ::Talk::init_iconbrowser_js( $beta, @iconbrowser_extra_stylesheet ) )
         if $remote && $remote->can_use_userpic_select;
 
     if ($u->should_block_robots || $entry->should_block_robots) {


### PR DESCRIPTION
We include a dark-on-light theme stylesheet so that our icon browser will 
have styling within layouts. However, we don't need it when we're in site
skin, because the site skin already includes the theme files (and in that
case, we'd be potentially overriding with the wrong colors)
