### PR TITLE
(Bug 4471) Do not use blobcache for dbnotes.

### DIFF
--- a/bin/moveucluster.pl
+++ b/bin/moveucluster.pl
@@ -689,8 +689,8 @@ sub moveUser {
                       "pendcomments" => 1,    # don't need to copy these
                       "active_user"  => 1,    # don't need to copy these
                       "random_user_set" => 1, # "
-                      "blobcache" => 1,       # No need to handle this, used for database migrations
-                      );
+                      "dbnotes" => 1,         # No need to handle this, used for database migrations
+                     );
 
     $skip_table{'inviterecv'} = 1 unless $u->is_person; # if not person, skip invites received
     $skip_table{'invitesent'} = 1 unless $u->is_community; # if not community, skip invites sent

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -3184,6 +3184,14 @@ CREATE TABLE `collection_items` (
 )
 EOC
 
+register_tablecreate("dbnotes", <<'EOC');
+CREATE TABLE dbnotes (
+    dbnote VARCHAR(40) NOT NULL,
+    PRIMARY KEY (dbnote),
+    value VARCHAR(255)
+)
+EOC
+
 # NOTE: new table declarations go ABOVE here ;)
 
 ### changes

--- a/bin/upgrading/update-db.pl
+++ b/bin/upgrading/update-db.pl
@@ -172,6 +172,8 @@ CLUSTER: foreach my $cluster (@clusters) {
         print "# Warning: unknown live table: $t\n";
     }
 
+    my $run_alter = $table_exists{dbnotes};
+
     ## create tables
     foreach my $t (keys %table_create)
     {
@@ -186,10 +188,14 @@ CLUSTER: foreach my $cluster (@clusters) {
         drop_table($t);
     }
 
-    ## do all the alters
-    foreach my $s (@alters)
-    {
-        $s->($dbh, $opt_sql);
+    if ( $run_alter ) {
+        ## do all the alters
+        foreach my $s (@alters)
+        {
+            $s->($dbh, $opt_sql);
+        }
+    } else {
+        print "## Skipping alters this pass, please re-run once the 'dbnotes' table exists."
     }
 
     $status{$cluster} = "OKAY";
@@ -964,7 +970,7 @@ sub set_dbnote
     my ($key, $value) = @_;
     return unless $opt_sql && $key && $value;
 
-    return $dbh->do("REPLACE INTO blobcache (bckey, dateupdate, value) VALUES (?,NOW(),?)",
+    return $dbh->do("REPLACE INTO dbnotes (dbnote, value) VALUES (?,?)",
                     undef, $key, $value);
 }
 
@@ -972,7 +978,7 @@ sub check_dbnote
 {
     my $key = shift;
 
-    return $dbh->selectrow_array("SELECT value FROM blobcache WHERE bckey=?",
+    return $dbh->selectrow_array("SELECT value FROM dbnotes WHERE dbnote=?",
                                  undef, $key);
 }
 

--- a/cgi-bin/LJ/DB.pm
+++ b/cgi-bin/LJ/DB.pm
@@ -54,7 +54,7 @@ $LJ::DBIRole = new DBI::Role {
                     "logtags", "logtagsrecent", "logkwsum",
                     "recentactions", "usertags", "pendcomments",
                     "loginlog", "active_user", "bannotes",
-                    "notifyqueue", "cprod", "blobcache",
+                    "notifyqueue", "cprod", "dbnotes",
                     "jabroster", "jablastseen", "random_user_set",
                     "poll2", "pollquestion2", "pollitem2",
                     "pollresult2", "pollsubmission2",


### PR DESCRIPTION
blobcache is a cache, and gets cleared.
Create a new table for dbnotes.

This will cause all migrations to re-run, but that happens all the time anyway because blobcache keeps getting cleared.
