### PR TITLE
Bug 4728 - Paper Me: custom icons page is turned on by default

### DIFF
--- a/bin/upgrading/s2layers/paperme/layout.s2
+++ b/bin/upgrading/s2layers/paperme/layout.s2
@@ -6,7 +6,6 @@ layerinfo lang = "en";
 
 set layout_authors = [ { "name" => "cimorene", "type" => "user" } ];
 set layout_type = "two-columns-right";
-set use_journalstyle_icons_page = true; #FIXME: remove before commit
 
 ##===============================
 ## Presentation


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4728
-- Don't turn custom icons page on by default
