### PR TITLE
(Bug 4708) Hide the first set of buttons, not the second

### DIFF
--- a/htdocs/js/jquery.circle-add.js
+++ b/htdocs/js/jquery.circle-add.js
@@ -4,8 +4,8 @@ $("#add_trust, #add_watch").click(function() {
     var $linked = $("."+$this.attr("id"))
     $this.is(":checked") ? $linked.fadeIn() : $linked.fadeOut();
     $("#add_trust, #add_watch").is(":checked")
-        ? $("#add_button_bottom").fadeIn()
-        : $("#add_button_bottom").fadeOut();
+        ? $("#add_button_extra").fadeIn()
+        : $("#add_button_extra").fadeOut();
 })
 $("#add_trust").triggerHandler("click");
 $("#add_watch").triggerHandler("click");

--- a/htdocs/manage/circle/add.bml
+++ b/htdocs/manage/circle/add.bml
@@ -250,7 +250,7 @@ _c?>
 
     if ( $remote->can_trust( $u ) && @trust_groups || $remote->can_watch( $u ) && @content_filters ) {
         # extra add and cancel buttons
-        $body .= "<br /><br />";
+        $body .= "<br /><br /><div id='add_button_extra'>\n";
         if ($u->is_visible) {
             my $btn = ( $watched || $trusted ) ? $ML{'.btn.modify'} :  BML::ml( '.btn.add', { user => $u->display_name } );
             $body .= "<input type='submit' value=\"$btn\"> ";
@@ -264,6 +264,7 @@ _c?>
        document.write(\"<input type='button' value='$cancel_btn' onclick='history.go(-1); return false;'>\");
         \n // -->\n ";
         $body .= '</script>';
+        $body .= '</div>';
     }
 
     # trust group buttons
@@ -566,7 +567,6 @@ _c?>
 
    } # end is_visible if statement
 
-    $body .= "<div id='add_button_bottom'>\n";
     $body .= "<br />\n <?p ";
     # Form submit buttons
     if ($u->is_visible) {
@@ -581,7 +581,7 @@ _c?>
     $body .= "<script type='text/javascript' language='Javascript'> \n <!-- \n
        document.write(\"<input type='button' value='$cancel_btn' onclick='history.go(-1); return false;'>\");
         \n // -->\n ";
-    $body .= '</script> p?></div>';
+    $body .= '</script> p?>';
 
     $body .= "</form>";
 


### PR DESCRIPTION
The first set of buttons are duplicates which only show if we have filters
for the account. The second set of buttons always show. What we want is to
have the first set of buttons show if there are filters, and in addition, if
the subscribe/etc are selected (that is, the filters could be visible)

Just changes which set of buttons are affected by the JS, logic otherwise
remains the same.
