### PR TITLE
(Bug 4386) Save the icon browser display state

### DIFF
--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -430,6 +430,22 @@ userproplist.icbm:
   multihomed: 0
   prettyname: ICBM Address
 
+userproplist.iconbrowser_metatext:
+  cldversion: 4
+  datatype: bool
+  des: Whether or not to show the meta text in the icon browser
+  indexed: 0
+  multihomed: 0
+  prettyname: Icon browser meta text
+
+userproplist.iconbrowser_smallicons:
+  cldversion: 4
+  datatype: bool
+  des: Whether to show small or large images in the icon browser
+  indexed: 0
+  multihomed: 0
+  prettyname: Icon browser small icons
+
 userproplist.icq:
   cldversion: 0
   datatype: char

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -408,6 +408,11 @@ sub _init {
         icons       => @icons ? [ { userpic => $defaulticon }, @icons ] : [],
         defaulticon => $defaulticon,
 
+        icon_browser => {
+                metatext => $u->iconbrowser_metatext,
+                smallicons => $u->iconbrowser_smallicons,
+        },
+
         moodtheme => \%moodtheme,
         moods     => \@moodlist,
 

--- a/cgi-bin/DW/Controller/RPC/IconBrowserOptions.pm
+++ b/cgi-bin/DW/Controller/RPC/IconBrowserOptions.pm
@@ -1,0 +1,44 @@
+#!/usr/bin/perl
+#
+# DW::Controller::RPC::IconBrowserOptions
+#
+# Remember options for the icon browser
+#
+# Authors:
+#      Afuna <coder.dw@afunamatata.com>
+#
+# Copyright (c) 2012 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+package DW::Controller::RPC::IconBrowserOptions;
+
+use strict;
+use DW::Routing;
+use JSON;
+
+DW::Routing->register_string( "/__rpc_iconbrowser_save", \&iconbrowser_save, app => 1,  format => 'json' );
+
+# saves the metatext / smallicons options (Y/N)
+sub iconbrowser_save {
+    # gets the request and args
+    my $r = DW::Request->get;
+    my $post = $r->post_args;
+
+    my $remote = LJ::get_remote();
+
+    if ( $post->{metatext} ) {
+        $remote->iconbrowser_metatext( $post->{metatext} eq "true" ? "Y" : "N" );
+    }
+
+    if ( $post->{smallicons} ) {
+        $remote->iconbrowser_smallicons( $post->{smallicons} eq "true" ? "Y" : "N" );
+    }
+
+    $r->print( objToJson( { success => 1 } ) );
+    return $r->OK;
+}
+
+1;

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -25,6 +25,7 @@ use LJ::EventLogRecord::NewComment;
 use LJ::OpenID;
 use LJ::S2;
 use DW::Captcha;
+use JSON;
 
 # dataversion for rate limit logging
 our $RATE_DATAVER = "1";
@@ -2203,13 +2204,18 @@ sub init_iconbrowser_js {
 
 # generate the javascript code for the icon browser
 sub js_iconbrowser_button {
-    return LJ::BetaFeatures->user_in_beta( LJ::get_remote() => "journaljquery" )
+    my $remote = LJ::get_remote();
+    my $iconbrowser_opts = JSON::objToJson({
+        selectorButtons => "#lj_userpicselect",
+        metatext => $remote->iconbrowser_metatext ? "true" : "false",
+        smallicons => $remote->iconbrowser_smallicons ? "true" : "false"
+    });
+
+    return LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" )
     ?   qq {
         <script type="text/javascript">
         jQuery(function(jQ){
-            jQ("#prop_picture_keyword").iconselector({
-                selectorButtons: "#lj_userpicselect"
-            });
+            jQ("#prop_picture_keyword").iconselector($iconbrowser_opts);
         })
         </script>
     } : qq {

--- a/cgi-bin/LJ/User.pm
+++ b/cgi-bin/LJ/User.pm
@@ -2510,6 +2510,47 @@ sub hide_join_post_link {
     return $u->prop( 'hide_join_post_link' );
 }
 
+=head3 C<< $self->iconbrowser_metatext( [ $arg ] ) >>
+
+If no argument, returns whether to show meta text in the icon browser or not.
+Default is to show meta text (true)
+
+If argument is passed in, acts as setter. Argument can be "Y" / "N"
+
+=cut
+
+sub iconbrowser_metatext {
+    my $u = $_[0];
+
+    if ( $_[1] ) {
+        my $newval = $_[1] eq "N" ? "N": undef;
+        $u->set_prop( iconbrowser_metatext => $newval );
+    }
+
+    return  ( $_[1] || $u->prop( 'iconbrowser_metatext' ) || "Y" ) eq 'Y' ? 1 : 0;
+}
+
+
+=head3 C<< $self->iconbrowser_smallicons( [ $small_icons ] ) >>
+
+If no argument, returns whether to show small icons in the icon browser or large.
+Default is large.
+
+If argument is passed in, acts as setter. Argument can be "Y" / "N"
+
+=cut
+
+sub iconbrowser_smallicons {
+    my $u = $_[0];
+
+    if ( $_[1] ) {
+        my $newval = $_[1] eq "Y" ? "Y" : undef;
+        $u->set_prop( iconbrowser_smallicons => $newval );
+    }
+
+    return  ( $_[1] || $u->prop( 'iconbrowser_smallicons' ) || "N" ) eq 'Y' ? 1 : 0;
+}
+
 # whether to respect cut tags in the inbox
 sub cut_inbox {
     my $u = $_[0];

--- a/htdocs/js/jquery.iconselector.js
+++ b/htdocs/js/jquery.iconselector.js
@@ -29,7 +29,11 @@
         height: $(window).height() * 0.8,
         selectedClass: "iconselector_selected",
         onSelect: function() {},
-        selectorButtons: null
+        selectorButtons: null,
+
+        // user options
+        metatext: true,
+        smallicons: false
     };
 
     function _dialogHTML() {
@@ -158,6 +162,14 @@
             _selectContainer($visible, null, true);
     };
 
+    function _persist( option, value ) {
+        var params = {};
+        params[option] = value;
+
+        // this is a best effort thing, so be silent about success/error
+        $.post( $.endpoint( "iconbrowser_save" ) , params );
+    }
+
     function _open () {
         if ( ! $.fn.iconselector.instance ) {
             $.fn.iconselector.instance = $(_dialogHTML());
@@ -175,31 +187,37 @@
             .keydown(_selectByEnter);
 
 
-            $("#iconselector_image_size_toggle a").click(function() {
+            $("#iconselector_image_size_toggle a").click(function(e, init) {
                 if ($(this).hasClass("half_image") ) {
                     $("#iconselector_icons, #iconselector_image_size_toggle, #iconselector_icons_list").addClass("half_icons");
+                    if ( ! init ) _persist( "smallicons", true );
                 } else {
                     $("#iconselector_icons, #iconselector_image_size_toggle, #iconselector_icons_list").removeClass("half_icons");
+                    if ( ! init ) _persist( "smallicons", false );
                 }
 
                 //refocus
                 $("#iconselector_image_size_toggle a:visible:first").focus();
 
                 return false;
-            });
+            }).filter( opts.smallicons ? ".half_image" : ":not(.half_image)" )
+                    .triggerHandler("click", true);
 
-            $("#iconselector_image_text_toggle a").click(function() {
+            $("#iconselector_image_text_toggle a").click(function(e, init) {
                 if ($(this).hasClass("no_meta_text") ) {
                     $("#iconselector_icons, #iconselector_image_text_toggle, #iconselector_icons_list").addClass("no_meta");
+                    if ( ! init ) _persist( "metatext", false );
                 } else {
                     $("#iconselector_icons, #iconselector_image_text_toggle, #iconselector_icons_list").removeClass("no_meta");
+                    if ( ! init ) _persist( "metatext", true );
                 }
 
                 // refocus because we just hid the link we clicked on
                 $("#iconselector_image_text_toggle a:visible:first").focus();
 
                 return false;
-            });
+            }).filter( opts.metatext ? ":not(.no_meta_text)" : ".no_meta_text" )
+                    .triggerHandler("click", true);
 
             $("#iconselector_icons").height(
                 $.fn.iconselector.instance.height() -

--- a/htdocs/js/jquery.postform.js
+++ b/htdocs/js/jquery.postform.js
@@ -34,7 +34,14 @@ init: function(formData) {
             }
         }
         if ( $.fn.iconselector ) {
-            $select.iconselector( { onSelect: update_icon_preview, selectorButtons: "#icon_preview .icon img, #icon_browser_link" } );
+            var browser_opts = formData.iconBrowser;
+            if ( ! browser_opts ) browser_opts = {};
+            $select.iconselector( {
+                onSelect: update_icon_preview,
+                selectorButtons: "#icon_preview .icon img, #icon_browser_link",
+                metatext: browser_opts.metatext,
+                smallicons: browser_opts.smallicons
+            } );
         } else {
             $("#icon_browser_link").remove();
         }

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -126,6 +126,13 @@ postFormInitData.strings = {
   "delete_confirm" : [%- dw.ml("entryform.delete.confirm") | js -%],
 };
 
+[%- IF remote && remote.can_use_userpic_select -%]
+    postFormInitData.iconBrowser = {
+        "metatext": [%- icon_browser.metatext ? "true" : "false" -%],
+        "smallicons": [%- icon_browser.smallicons ? "true": "false" -%]
+    };
+[%- END -%]
+
 </script>
 [% END  # sections.head %]
 


### PR DESCRIPTION
So that meta text vs no meta text / small icons vs large icons persists 
across page reloads.
