### PR TITLE
(Bug 4667) Add a second confirmation step for crossposts

### DIFF
--- a/htdocs/js/jquery.crosspost.js
+++ b/htdocs/js/jquery.crosspost.js
@@ -266,6 +266,17 @@ toggle: function(why, allowThisCrosspost, animate) {
         $("#crosspost_accounts, #crosspost_component h4").hide()
             .siblings("p").slideDown();
     }
+},
+
+confirmDelete: function( message ) {
+    var do_delete = true;
+
+    // check to see if we have any crossposts selected
+    if ( $("#crosspost_entry").is( ":checked" ) && $( "input[name=crosspost]" ).is( ":checked" ) ) {
+        do_delete = confirm( message );
+    }
+
+    return do_delete;
 }
 
 });

--- a/htdocs/js/jquery.postform.js
+++ b/htdocs/js/jquery.postform.js
@@ -420,11 +420,16 @@ init: function(formData) {
 
         $("#delete_entry").click(function(e) {
             $(this.form).data("skipchecks", "delete");
-            var conf = confirm(formData.strings.delete_confirm);
-            if ( ! conf ) {
+            var do_delete = confirm(formData.strings.delete_confirm);
+            if ( do_delete ) {
+                do_delete = $("#crosspost_component").crosspost( "confirmDelete", formData.strings.delete_xposts_confirm );
+            }
+
+            if ( ! do_delete ) {
                 e.preventDefault();
             }
         });
+
 
         $("#post_options").click(function(e){
             e.preventDefault();

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -123,7 +123,8 @@ postFormInitData.panels = {
 postFormInitData.minAnimation = [% min_animation ? "true" : "false" %];
 
 postFormInitData.strings = {
-  "delete_confirm" : [%- dw.ml("entryform.delete.confirm") | js -%],
+  "delete_confirm" : [%- "entryform.delete.confirm" | ml | js -%],
+  "delete_xposts_confirm": [%- "entryform.delete.xposts.confirm" | ml | js  -%]
 };
 
 </script>


### PR DESCRIPTION
Adds another confirmation popup if (and only if) we said we wanted to delete,
and we had a crosspost account checked.
