### PR TITLE
Bug 3798 - Rename Group One/Two to Main Module Section/Second Module Sec...

### DIFF
--- a/bin/upgrading/s2layers/bases/layout.s2
+++ b/bin/upgrading/s2layers/bases/layout.s2
@@ -176,11 +176,11 @@ propgroup modules {
 }
 
 property string module_navlinks_section_override {
-    values = "none|(none)|header|Header|one|Group One";
+    values = "none|(none)|header|Header|one|Sidebar";
     grouped = 1;
 }
 
-set module_layout_sections = "none|(none)|one|Group One";
+set module_layout_sections = "none|(none)|one|Sidebar";
 set grouped_property_override = { "module_navlinks_section" => "module_navlinks_section_override" };
 set module_navlinks_section = "header";
 

--- a/bin/upgrading/s2layers/brittle/layout.s2
+++ b/bin/upgrading/s2layers/brittle/layout.s2
@@ -216,7 +216,7 @@ propgroup modules {
 }
 
 # explicitly define what sections the layout has available
-set module_layout_sections = "none|(none)|one|Group One|two|Group Two";
+set module_layout_sections = "none|(none)|one|Main Module Section|two|Second Module Section";
 
 set module_userprofile_section = "two";
 set module_userprofile_order = 3;


### PR DESCRIPTION
...tion

http://bugs.dwscoalition.org/show_bug.cgi?id=3798
-- rename module sections to Main/Second in Brittle
-- rename module section to Sidebar in Bases
