### PR TITLE
(Bug 3523) CSS tweaks for ContextualPopup

### DIFF
--- a/htdocs/stc/jquery.contextualhover.css
+++ b/htdocs/stc/jquery.contextualhover.css
@@ -21,14 +21,18 @@
 .ContextualPopup {
     width: 20em;
     text-align: left;
+    overflow: auto;
+}
+
+.ContextualPopup .Userpic {
+    float: right;
 }
 
 .ContextualPopup .Userpic img {
-    float: right;
     max-height: 75px;
     max-width: 75px;
     width:expression(this.width > 75 ? "75px" : this.width); /*IE Max-width */
-    border: 9;
+    border: 0;
 }
 
 .ContextualPopup a {


### PR DESCRIPTION
- apply float to .Userpic instead of .Userpic img, so that it looks
  right if we're applying color to .Userpic
- make sure .ContextualPopup can always contain .Userpic
- fix typo: 9 => 0
