### PR TITLE
(Bug 4721) Whitelist Goodreads updates widget

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -54,6 +54,8 @@ my %host_path_match = (
     "www.dailymotion.com"   => qr!^/embed/video/!,
     "dotsub.com"            => qr!^/media/!,
 
+    "www.goodreads.com"     => qr!^/widgets/!,
+
     "maps.google.com"       => qr!^/maps!,
     "www.google.com"        => qr!^/calendar/!,
 

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -1,7 +1,7 @@
 # -*-perl-*-
 use strict;
 
-use Test::More tests => 31;
+use Test::More tests => 32;
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { require 'ljlib.pl'; }
 
@@ -58,6 +58,8 @@ note( "misc" );
     test_good_url( "http://www.dailymotion.com/embed/video/x1xx11x" );
 
     test_good_url( "http://dotsub.com/media/9db493c6-6168-44b0-89ea-e33a31db48db/e/m" );
+
+    test_good_url( "http://www.goodreads.com/widgets/user_update_widget?height=400&num_updates=3&user=12345&width=250" );
 
     test_good_url( "http://maps.google.com/maps?f=q&source=s_q&hl=en&geocode=&q=somethingsomething&aq=0&sll=00.000,-00.0000&sspn=0.00,0.0&vpsrc=0&ie=UTF8&hq=&hnear=somethingsomething&z=0&ll=0,-00&output=embed" );
     test_good_url( "https://www.google.com/calendar/b/0/embed?showPrint=0&showTabs=0&showCalendars=0&showTz=0&height=600&wkst=1&bgcolor=%23FFFFFF&src=foo%40group.calendar.google.com" );


### PR DESCRIPTION
The Goodreads updates widget uses an iframe, which we're now whitelisting.

The Goodreads "my books" widget uses flash; this will work without further
effort on our part.

All other widgets we're aware of use JS, or are a mix of dynamic and 
non-dynamic content. The non-dynamic content will work fine, without any 
further action on our part.
