### PR TITLE
Bug 4690 - Librarian's Dream: fix module heading links colors

### DIFF
--- a/bin/upgrading/s2layers/librariansdream/layout.s2
+++ b/bin/upgrading/s2layers/librariansdream/layout.s2
@@ -635,6 +635,9 @@ table.month caption { display: none; }
 
 /* Extra specificity needed to override .module a */
 .module .module-header a { color: $*color_module_title; }
+.module .module-header a:visited { color: $*color_module_title; }
+.module .module-header a:hover { color: $*color_module_link_hover; }
+.module .module-header a:active { color: $*color_module_link_active; }
 
 .module-content ul,
 .module-list,


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4690
-- Restore original code
-- Make sure hover and visited colors are what they used to be too
