### PR TITLE
Warning when user object is undefined in get_remapped_userids.

### DIFF
--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
@@ -197,7 +197,7 @@ sub get_remapped_userids {
     # load this user and determine if they've been claimed. if so, we want to post
     # all content as from the claimant.
     my $ou = LJ::load_userid( $oid );
-    if ( my $cu = $ou->claimed_by ) {
+    if ( defined $ou && my $cu = $ou->claimed_by ) {
         $oid = $cu->id;
     }
 


### PR DESCRIPTION
This should fix the warning reported here:
 http://changelog.dreamwidth.org/1122817.html?thread=315393

It checks to make sure the user object is defined before attempting
to call the claimed_by method on it.

I haven't tested this, but it's a simple fix.
