### PR TITLE
(bug 4804) Swap dw_lounge for dw_volunteers on sitemap

### DIFF
--- a/htdocs/site/index.bml
+++ b/htdocs/site/index.bml
@@ -140,7 +140,7 @@ _code?>
   <dd><ul>
    <li><?ljuser news ljuser?></li>
    <li><?ljuser dw_maintenance ljuser?></li>
-   <li><?ljuser dw_lounge ljuser?></li>
+   <li><?ljuser dw_volunteers ljuser?></li>
    <li><?ljuser dw_suggestions ljuser?> - <a href='/site/suggest'><?_ml .maplinks.suggestion _ml?></li>
    <li><a href='/support/faqbrowse?faqid=65'><?_ml .maplinks.official-journals.list _ml?></a></li>
   </ul></dd></dl>


### PR DESCRIPTION
Taking the initiative to do this so it can be fixed this push. Swap-out per comments on http://dw-lounge.dreamwidth.org/80878.html

[ also, why is this page in -free? That bit at least is totally DWS-specific ]
