### PR TITLE
(Bug 4816) Use .prop instead of .attr

### DIFF
--- a/htdocs/js/jquery.iconrandom.js
+++ b/htdocs/js/jquery.iconrandom.js
@@ -5,11 +5,11 @@
         if ( opts.trigger ) {
             $(opts.trigger).click(
                 function() {
-                    var numicons = $selector.attr("length");
+                    var numicons = $selector.prop("length");
 
                     // we need to ignore the first option "(default)"
                     var randomnumber = Math.floor(Math.random() * (numicons - 1));
-                    $selector.attr("selectedIndex", randomnumber + 1);
+                    $selector.prop("selectedIndex", randomnumber + 1);
 
                     if ( opts.handler && $selector.get(0) )
                         opts.handler.apply($selector.get(0));


### PR DESCRIPTION
Adjustment for jQuery 1.6+, which makes .attr applicable only for HTML 
attributes and .prop the one to use for Javascript properties.
