### PR TITLE
(Bug 4819) Reset width/height to auto to override HTML attribute

### DIFF
--- a/htdocs/stc/jquery.contextualhover.css
+++ b/htdocs/stc/jquery.contextualhover.css
@@ -29,6 +29,8 @@
 }
 
 .ContextualPopup .Userpic img {
+    height: auto;
+    width: auto;
     max-height: 75px;
     max-width: 75px;
     width:expression(this.width > 75 ? "75px" : this.width); /*IE Max-width */


### PR DESCRIPTION
Reset the width/height to auto first before applying a max-width/height. This
is to fix distortion of non-square images (where one dimension > 75px)
