### PR TITLE
(Bug 4719) Coerce all false values to the numerical 0

### DIFF
--- a/cgi-bin/LJ/User.pm
+++ b/cgi-bin/LJ/User.pm
@@ -3104,7 +3104,9 @@ shop.  For adjusting points on a user, please see C<<$self->give_shop_points>>.
 =cut
 
 sub shop_points {
-    return $_[0]->prop( 'shop_points' ) // 0;
+    # force false value to be 0 instead of any other false value
+    # useful to make sure this gets printed out as "0" in the frontend
+    return $_[0]->prop( 'shop_points' ) || 0;
 }
 
 


### PR DESCRIPTION
We can't rely on defined-ness. The cached value is stored as an empty string
when there are no points, so it fails the defined test and doesn't get set to
0. Then in the frontend it gets printed as an empty string...

This means that on production, or anywhere else with memcache on, first time
you load the page you'll get "you have 0 points". On subsequent loads it
becomes "you have points". Misleading! Annoying! Weird.
