### PR TITLE
Bug4824/abstractia iconspage

### DIFF
--- a/bin/upgrading/s2layers/abstractia/layout.s2
+++ b/bin/upgrading/s2layers/abstractia/layout.s2
@@ -1507,15 +1507,15 @@ q {
     text-align: left;
 }
 
-.icon-image,
-.icon-info {
-    display: inline-block;
-    vertical-align: top;
-}
+.icon-image {
+    float: left;
+    clear: left;
+    margin-bottom: .25em;
+    min-width: 100px;
+    padding-right: .5em;
+    }
 
-.icon-info {
-    margin-left: .5em;
-}
+.icon-info { min-height: 100px; }
 
 .icon-info .label,
 .icon-info span {


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4824
-- Switch inline-block for float so text is always besides the icon
-- Use min-width and min-height for consistent vertical alignment
