### PR TITLE
(Bug 4826) Remember the previous security level after spellcheck

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -338,7 +338,6 @@ sub _init {
             foreach my $acct ( @accounts ) {
                 my $id = $acct->acctid;
 
-                # FIXME:  spellcheck
                 my $selected = $crosspost_selected{$id};
 
                 push @crosspost_list, {
@@ -791,7 +790,6 @@ sub _backend_to_form {
 #             my $entry = {
 #                 'usejournal' => $usejournal,
 #                 'auth' => $auth,
-#                 'spellcheck_html' => $spellcheck_html,
 #                 'richtext' => LJ::is_enabled('richtext'),
 #                 'suspended' => $suspend_msg,
 #                 'unsuspend_supportid' => $suspend_msg ? $entry_obj->prop("unsuspend_supportid") : 0,

--- a/htdocs/js/jquery.postform.js
+++ b/htdocs/js/jquery.postform.js
@@ -297,6 +297,8 @@ init: function(formData) {
     // access
     function initAccess() {
         $("#custom_access_groups").hide();
+
+        var rememberInitialValue = !formData.did_spellcheck;
         $("#security").change( function(e, init) {
             var $this = $(this);
             if ( $this.val() == "custom" )
@@ -307,7 +309,7 @@ init: function(formData) {
             if ( ! init ) {
                 $this.data("lastselected",$this.val())
             }
-        }).triggerHandler("change", true)
+        }).triggerHandler("change", rememberInitialValue);
 
         function adjustSecurityDropdown(data) {
             if ( ! data ) return;

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -128,6 +128,8 @@ postFormInitData.strings = {
   "delete_xposts_confirm": [%- "entryform.delete.xposts.confirm" | ml | js  -%]
 };
 
+postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false" %];
+
 [%- IF remote && remote.can_use_userpic_select -%]
     postFormInitData.iconBrowser = {
         "metatext": [%- icon_browser.metatext ? "true" : "false" -%],


### PR DESCRIPTION
- for reasons related to changing minsecurity, we rebuild the security
  level dropdown with JS. We go back to the dropdown's displayed
  value only if it the user had already explicitly selected that level,
  rather than us having adjusted it because of minsecurity.
  
  See SHA: d1b7b5fa for a detailed breakdown of this case.
  
  Because we wait until the user has explicitly chosen a security level
  from the dropdown, this means that the value of the dropdown on load
  is ignored. This is not an issue when making a new entry
  (minsecurity), and not an issue when editing (that code path is not
  triggered on edit), but is an issue when spellchecking (the initial
  value _has_ been explicitly selected by the user).
  
  This is much longer than the actual code, but the solution then is to
  mark the form as having been spell-checked, and then trust that
  initial value as being one the user chose deliberately.
- also removes a couple TODOs re: spellcheck which are no longer
  relevant since spellcheck is handled for those cases
