### PR TITLE
(Bug 4831) Remove one of the two colons after Diagnostics.

### DIFF
--- a/htdocs/support/see_request.bml
+++ b/htdocs/support/see_request.bml
@@ -407,7 +407,7 @@ body<=
         # special case: original request
         if ($le->{'type'} eq "req") {
             # insert support diagnostics from props
-            $message .= "<?hr?><strong>$ML{'.diagnostics'}:</strong> " . LJ::ehtml($props->{useragent}) if $props->{useragent};
+            $message .= "<?hr?><strong>$ML{'.diagnostics'}</strong> " . LJ::ehtml($props->{useragent}) if $props->{useragent};
 
             $ret .= "<div style='margin-top: 15px;'>\n";
             $ret .= "<b>$ML{'.original.request'}:</b><br />\n";


### PR DESCRIPTION
Remove the colon added in bml since it's already in the text string.
