### PR TITLE
(Bug 4783) Skip paid expiration warnings for deleted users.

### DIFF
--- a/bin/worker/paidstatus
+++ b/bin/worker/paidstatus
@@ -217,6 +217,7 @@ sub warn_user {
 
     my $u = LJ::load_userid( $uid )
         or return 0;
+    return 0 unless $u->is_visible;
 
     my $mail;
     if ( $timeleft < 86400*3 && ( ! defined $lastmail || $lastmail == 14 ) ) {


### PR DESCRIPTION
skip warn_user (14- and 3-day paidstatus warnings) for deleted users.
expire_user already skips sending email due to bug 2605.
