### PR TITLE
Bug 4785 - Background images not showing in Librarian's Dream

### DIFF
--- a/bin/upgrading/s2layers/librariansdream/layout.s2
+++ b/bin/upgrading/s2layers/librariansdream/layout.s2
@@ -333,7 +333,6 @@ dl dt { font-weight: bold; }
 a:hover { text-decoration: none; }
 
 body {
-    background:  $*color_page_background;
     padding: 0;
     margin: 0;
 }


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4785
-- Remove CSS override
