### PR TITLE
(Bug 4844) Pass in a $log sub

### DIFF
--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
@@ -158,7 +158,11 @@ Remaps a remote user to local userids.
 =cut
 
 sub get_remapped_userids {
-    my ( $class, $data, $user ) = @_;
+    my ( $class, $data, $user, $log ) = @_;
+
+    $log ||= sub {
+        warn @_;
+    };
 
     # some users we can't map, because the process of loading their FOAF data or journal
     # does really weird things (DNS!)
@@ -176,18 +180,18 @@ sub get_remapped_userids {
     );
 
     unless ( defined $oid ) {
-        warn "[$$] Remapping identity userid of $data->{hostname}:$user\n";
+        $log->( "[$$] Remapping identity userid of $data->{hostname}:$user" );
         $oid = $class->remap_username_friend( $data, $user );
-        warn "     IDENTITY USERID IS STILL UNDEFINED\n"
+        $log->( "     IDENTITY USERID IS STILL UNDEFINED" )
             unless defined $oid;
     }
 
 # FIXME: this is temporarily disabled while we hash out exactly how we want
 # this functionality to work.
 #    unless ( defined $fid ) {
-#        warn "[$$] Remapping feed userid of $data->{hostname}:$user\n";
+#        $log->( "[$$] Remapping feed userid of $data->{hostname}:$user" );
 #        $fid = $class->remap_username_feed( $data, $user );
-#        warn "     FEED USERID IS STILL UNDEFINED\n"
+#        $log->( "     FEED USERID IS STILL UNDEFINED" )
 #            unless defined $fid;
 #    }
 

--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Comments.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Comments.pm
@@ -235,7 +235,7 @@ sub try_work {
             $meta{$temp{id}} = new_comment( $temp{id}, $temp{posterid}+0, $temp{state} || 'A' );
 
         } elsif ( $lasttag eq 'usermap' && ! exists $identity_map{$temp{id}} ) {
-            my ( $local_oid, $local_fid ) = $class->get_remapped_userids( $data, $temp{user} );
+            my ( $local_oid, $local_fid ) = $class->get_remapped_userids( $data, $temp{user}, $log );
             $identity_map{$temp{id}} = $local_oid;
             $was_external_user{$temp{id}} = 1
                 if $temp{user} =~ m/^ext_/; # If the remote username starts with ext_ flag it as external

--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Entries.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Entries.pm
@@ -214,7 +214,7 @@ sub try_work {
         # now try to determine if we need to post this as a user
         my $posteru;
         if ( $data->{usejournal} ) {
-            my ( $posterid, $fid ) = $class->get_remapped_userids( $data, $evt->{poster} );
+            my ( $posterid, $fid ) = $class->get_remapped_userids( $data, $evt->{poster}, $log );
 
             unless ( $posterid ) {
                 # FIXME: need a better way of totally dying...


### PR DESCRIPTION
So that context may determine where this warning should be printed.
