### PR TITLE
(Bug 4753) Add fallback for displaying icons in IE8 on new comment pages

### DIFF
--- a/htdocs/stc/entrypage.css
+++ b/htdocs/stc/entrypage.css
@@ -49,7 +49,10 @@ ul.entry-interaction-links {list-style: none outside none; display: inline; text
 
 /*Comment header and content styling*/
 .comment .userpic {display:table-cell; max-width:100px;}
-.comment .userpic img {display:table;}
+.comment .userpic img {
+    display:table;
+    display:inline-block\0/; /*Fix for IE8 display*/
+}
 .comment-info {display: table-cell; vertical-align: top; padding-left:10px;}
 .poster {display: block;}
 .commentpermalink, .comment .poster-ip  {margin-left:1em;}


### PR DESCRIPTION
This works as intended in Opera, Chromium, and Firefox for Linux (most recent versions) and IE8 on WinXP (via VirtualBox). It could probably use a quick look-see in Safari and IE9 and IE10 to make sure they inherit the cleaner line of code and not the hacky IE8 line of code.
