### PR TITLE
(Bug 4865) Temporary fail the import if we weren't able to load a user

### DIFF
--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Comments.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Comments.pm
@@ -221,6 +221,7 @@ sub try_work {
     # parameters for below
     my ( %meta, %identity_map, %was_external_user );
     my ( $maxid, $server_max_id, $server_next_id, $lasttag ) = ( 0, 0, 1, '' );
+    my @fail_errors;
 
     # setup our parsing function
     my $meta_handler = sub {
@@ -236,11 +237,17 @@ sub try_work {
 
         } elsif ( $lasttag eq 'usermap' && ! exists $identity_map{$temp{id}} ) {
             my ( $local_oid, $local_fid ) = $class->get_remapped_userids( $data, $temp{user}, $log );
+
+            # we want to fail if we weren't able to create a local user, because this would otherwise be mistakenly posted as anonymous
+            push @fail_errors, "Unable to map comment poster from $data->{hostname} user '$temp{user}' to local user"
+                unless $local_oid;
+
             $identity_map{$temp{id}} = $local_oid;
             $was_external_user{$temp{id}} = 1
                 if $temp{user} =~ m/^ext_/; # If the remote username starts with ext_ flag it as external
 
-            $log->( 'Mapped remote %s(%d) to local userid %d.', $temp{user}, $temp{id}, $local_oid );
+            $log->( 'Mapped remote %s(%d) to local userid %d.', $temp{user}, $temp{id}, $local_oid )
+                unless $local_oid;
         }
     };
     my $meta_closer = sub {
@@ -285,6 +292,9 @@ sub try_work {
             }
         );
         $parser->parse( $content );
+
+        return $temp_fail->( join( "\n", map { " * $_" } @fail_errors ) )
+            if @fail_errors;
 
         # this is the best place to test for too many comments. if this site is limiting
         # the comment imports for some reason or another, we can bail here.


### PR DESCRIPTION
- fail the import with a list of users we couldn't load, if we weren't
  able to load users from the remote site
- fix bug which prevented us from retrying users after they've timed out
  once

Based on discussion over at dreamwidth/dw-free#198:

The error is caused by the openid user ($ou) not actually existing. The most
common reason is that we timed out while fetching data on the $ou.

We can't just let the importer continue in this case, because that would make
the comment be posted (wrongly) as by an anonymous user. So we've decided to
make the import temp-fail with the list of users we failed on. We can pick it
up again on a retry.

Problem again: subtle bug meant that once we failed to fetch a particular
user, we never again retried. If it timed out, we returned
(and stored in the db) 0, instead of NULL. Later on, when retrieving the 
values, we check for defined-ness. Fix is to set an explicit return undef for
the future. For existing cases, we check for truth value of
$oid, instead of defined-ness. (This also means that we finally log data on
this user if something goes wrong)

Note that the temp-fail listed above means that a problem user which we 
somehow never fetch, could still cause all imports where they commented to
fail entirely. But now we know who they are, and we have a working retry
mechanism in place to guard against timeouts.

_If_ the retries don't work for some unforeseen reason, we have something to
work with once the repeated failure to import has been reported.

Ping @xb95 for feedback!
