### PR TITLE
(Bug 105) Save getargs into $opts for subs we call

### DIFF
--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -1627,7 +1627,6 @@ sub customview_content
                    "styleid" => $styleid,
                    "saycharset" => $charset,
                    "args" => scalar $apache_r->args,
-                   "getargs" => \%FORM,
                    "r" => $apache_r,
                })
           || "<b>[$LJ::SITENAME: Bad username, styleid, or style definition]</b>");

--- a/cgi-bin/LJ/User.pm
+++ b/cgi-bin/LJ/User.pm
@@ -9478,6 +9478,7 @@ sub make_journal {
 
     my $r = DW::Request->get;
     my $geta = $r->get_args;
+    $opts->{getargs} = $geta;
 
     my $u = $opts->{'u'} || LJ::load_user($user);
     unless ($u) {


### PR DESCRIPTION
The things we call expected the get args to be passed along with the opts, so
let's put it into opts.
