### PR TITLE
(Bug 4858) Fix detection of fully expanded comments

### DIFF
--- a/htdocs/js/jquery.threadexpander.js
+++ b/htdocs/js/jquery.threadexpander.js
@@ -145,7 +145,7 @@
                   LJ[cmtId].full = true;
                 }
               } else {
-                if (newComment.parent().hasClass("full")) {
+                if (newComment.find(".full")) {
                   LJ[cmtId].full = true;
                   setFull(cmtElement, true);
                 }


### PR DESCRIPTION
We changed the HTML structure, but not the way the JS was looking for whether
the element was expanded when it was copied over to the page. This broke our
ability to check that said comment had already been copied over (and thus did
not need to be recopied). Fixing should make that more efficient.

This also broke the quick reply(!) in the case where you expand a comment
deep in the thread, hit reply to that, change your mind and decide to read
more of the thread (expanding the comment). The unnecessary replacement
removes #qrdiv and breaks it for the entire page. This'll fix it.
