### PR TITLE
(Bug 4645) Make answer an arrayref instead of a string

### DIFF
--- a/t/captcha-textcaptcha.t
+++ b/t/captcha-textcaptcha.t
@@ -11,7 +11,7 @@ use LJ::Test;
 
 my $fakeanswers_single = {
     question => 'The white bank is what colour?',
-    answer   => 'd508fe45cecaf653904a0e774084bb5c',
+    answer   => [ 'd508fe45cecaf653904a0e774084bb5c' ],
 };
 
 my $fakeanswers_multiple = {


### PR DESCRIPTION
Expected input changed; the test did not. Fixed!
