### PR TITLE
(Bug 4860) Pre-fetch textcaptcha items and store them in the DB

### DIFF
--- a/bin/maint/captcha.pl
+++ b/bin/maint/captcha.pl
@@ -1,0 +1,74 @@
+#!/usr/bin/perl
+# TODO: check license
+#
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+
+use strict;
+
+use lib "$ENV{LJHOME}/cgi-bin";
+use DW::Captcha;
+use DW::Captcha::textCAPTCHA;
+
+our %maint;
+
+$maint{cache_textcaptcha} = sub {
+    return unless DW::Captcha->new( undef, want => "textcaptcha" )->site_enabled;
+    print " - I - Caching textcaptcha items.\n";
+
+    my $MAX_CACHED = $LJ::TEXTCAPTCHA_MAX_PREFETCH || 500;
+
+    my $count = DW::Captcha::textCAPTCHA::Logic->unused_count;
+    my $need;
+
+    if ( $count >= $MAX_CACHED ) {
+        print "already have enough textcaptcha items.\n";
+        return;
+    }
+
+    my $need = $MAX_CACHED - $count;
+    print "pre-fetching $need textcaptcha items.\n";
+
+    # pre-fetch. Gradually ease off the timer if we were unable to get a captcha
+    # if we failed totally, we can always try again next time we run maint tasks
+    my @backoff_timer = ( 1, 3, 5, 0 );
+    my $delay = 1;
+    my @fetched_captchas = ();
+    foreach my $i ( 1...$need ) {
+        my $captcha = DW::Captcha::textCAPTCHA::Logic->get_from_remote_server;
+
+        if ( $captcha ) {
+            push @fetched_captchas, $captcha;
+        } else {
+            $delay = shift @backoff_timer unless $captcha;
+            last unless $delay;
+        }
+
+        sleep $delay;
+    }
+
+    DW::Captcha::textCAPTCHA::Logic->save_multi( @fetched_captchas );
+    return 1;
+};
+
+$maint{clean_captchas} = sub {
+    print " - I - Cleaning captchas.\n";
+
+    my $count = DW::Captcha::textCAPTCHA::Logic->cleanup;
+
+    print "Done: deleted $count expired captchas.\n";
+
+    return 1;
+};
+
+1;

--- a/bin/maint/taskinfo.txt
+++ b/bin/maint/taskinfo.txt
@@ -19,3 +19,7 @@ generic.pl:
 
 comm_promo_list.pl:
   comm_promo_list - Generates data needed for community promos
+
+captcha.pl:
+  cache_textcaptcha - Generates textcaptcha instances
+  clean_captchas - Clean out captchas that have been used

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -3193,6 +3193,18 @@ CREATE TABLE dbnotes (
 )
 EOC
 
+register_tablecreate("captcha_cache", <<'EOC');
+CREATE TABLE captcha_cache (
+    `captcha_id` INT UNSIGNED NOT NULL auto_increment,
+    `question`   VARCHAR(255) NOT NULL,
+    `answer`     VARCHAR(255) NOT NULL,
+    `issuetime`  INT UNSIGNED NOT NULL DEFAULT 0,
+
+    PRIMARY KEY (`captcha_id`),
+    INDEX(`issuetime`)
+)
+EOC
+
 # NOTE: new table declarations go ABOVE here ;)
 
 ### changes

--- a/cgi-bin/DW/Captcha.pm
+++ b/cgi-bin/DW/Captcha.pm
@@ -60,15 +60,13 @@ foreach my $class ( @CLASSES ) {
 # class methods
 =head1 API
 
-=head2 C<< DW::Captcha->new( $implementation, $page, %opts ) >>
+=head2 C<< DW::Captcha->new( $page, %opts ) >>
 
 Arguments:
 
 =over
 
 =item page - the page we're going to display this CAPTCHA on
-
-=item implementation - which CAPTCHA implementation we'd like to use
 
 =item a hash of additional options, including the request/response from a form post
 

--- a/cgi-bin/DW/Controller/RPC/TextCAPTCHA.pm
+++ b/cgi-bin/DW/Controller/RPC/TextCAPTCHA.pm
@@ -34,7 +34,7 @@ DW::Routing->register_regex( '^/captcha/text/(.*)$', \&iframe_captcha_handler, a
 sub captcha_handler {
     my ( $call_opts, $auth ) = @_;
 
-    my $from_textcaptcha = DW::Captcha::textCAPTCHA::Logic->fetch;
+    my $from_textcaptcha = DW::Captcha::textCAPTCHA::Logic->get_captcha;
     my ( $captcha ) = DW::Captcha::textCAPTCHA::Logic::form_data( $from_textcaptcha,  $auth );
 
     if ( $call_opts->format eq "json" ) {
@@ -62,7 +62,7 @@ sub iframe_captcha_handler {
         return DW::Template->render_template( 'textcaptcha-response.tt', { response => DW::Captcha::textCAPTCHA::Logic::to_form_string( $captcha_object ) }, { fragment => 1 } );
     }
 
-    my $from_textcaptcha = DW::Captcha::textCAPTCHA::Logic->fetch;
+    my $from_textcaptcha = DW::Captcha::textCAPTCHA::Logic->get_captcha;
     my ( $captcha ) = DW::Captcha::textCAPTCHA::Logic::form_data( $from_textcaptcha,  $auth );
 
     return DW::Template->render_template( 'textcaptcha.tt', {

--- a/t/captcha-textcaptcha.t
+++ b/t/captcha-textcaptcha.t
@@ -11,7 +11,7 @@ use LJ::Test;
 
 my $fakeanswers_single = {
     question => 'The white bank is what colour?',
-    answer   => 'd508fe45cecaf653904a0e774084bb5c',
+    answer   => [ 'd508fe45cecaf653904a0e774084bb5c' ],
 };
 
 my $fakeanswers_multiple = {
@@ -46,7 +46,7 @@ sub _get_answers {
 note( "single answer" );
 {
     LJ::start_request();
-    my $content = XML::Simple::XMLout( $fakeanswers_single, NoAttr => 1 );
+    my $content = $fakeanswers_single;
     my $auth = LJ::form_auth( 1 );
     my $captcha = DW::Captcha::textCAPTCHA::Logic::form_data( $content, $auth );
 
@@ -76,7 +76,7 @@ note( "single answer" );
 note( "multiple valid answers" );
 {
     LJ::start_request();
-    my $content = XML::Simple::XMLout( $fakeanswers_multiple, NoAttr => 1 );
+    my $content = $fakeanswers_multiple;
     my $auth = LJ::form_auth( 1 );
     my $captcha = DW::Captcha::textCAPTCHA::Logic::form_data( $content, $auth );
 
@@ -100,7 +100,7 @@ note( "multiple valid answers" );
 
 note( "no form auth passed in" );
 {
-    my $content = XML::Simple::XMLout( $fakeanswers_single, NoAttr => 1 );
+    my $content = $fakeanswers_single;
     my $captcha = DW::Captcha::textCAPTCHA::Logic::form_data( $content, "" );
     my $captcha_auth = $captcha->{chal};
 
@@ -116,7 +116,7 @@ note( "no form auth passed in" );
 note( "tried to reuse captcha + form_auth" );
 {
     LJ::start_request();
-    my $content = XML::Simple::XMLout( $fakeanswers_single, NoAttr => 1 );
+    my $content = $fakeanswers_single;
     my $auth = LJ::form_auth( 1 );
     my $captcha = DW::Captcha::textCAPTCHA::Logic::form_data( $content, $auth );
     my $captcha_auth = $captcha->{chal};


### PR DESCRIPTION
We should be nice to both our users and the textcaptcha service. We
pre-fetch
several hundred items with a 1-second delay so we don't hammer the
textcaptcha service with too many requests too close together at active
hours.

When we need a captcha, we check our DB first. If we run out, then we do
a
remote fetch. This should also make the captcha show up more quickly to
users.

Pinging @xb95 to look over how hard this will hit us. It didn't seem to
be suitable for memcache since we only look up each captcha _once_, and
then never again, but this does mean a DB hit every time we need a 
captcha (lost info, long comment threads).
