### PR TITLE
(Bug 4239) Mark deleted crosspost accounts as inactive

### DIFF
--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -2869,6 +2869,7 @@ CREATE table externalaccount (
     serviceurl varchar(128),
     xpostbydefault enum('1','0') NOT NULL default '0',
     recordlink enum('1','0') NOT NULL default '0',
+    active enum('1', '0') NOT NULL default '1',
     options blob,
     primary key (userid, acctid),
     index (userid)
@@ -4123,6 +4124,12 @@ EOF
 
     if ( column_type( "support", "timemodified" ) eq '' ) {
         do_alter( 'support', "ALTER TABLE support ADD COLUMN timemodified int(10) unsigned default NULL" );
+    }
+
+    if ( column_type( "externalaccount", "active" ) eq '' ) {
+        do_alter( 'externalaccount',
+            "ALTER TABLE externalaccount " .
+            "ADD COLUMN active enum('1', '0') NOT NULL default '1'" );
     }
 });
 

--- a/htdocs/admin/entryprops.bml
+++ b/htdocs/admin/entryprops.bml
@@ -84,7 +84,7 @@ body<=
             
             # render xpost prop into human readable form
             if ( $prop eq "xpost" || $prop eq "xpostdetail" ) {
-                my %external_accounts_map = map { $_->acctid => $_->servername } DW::External::Account->get_external_accounts( $pu );
+                my %external_accounts_map = map { $_->acctid => $_->servername . ( $_->active ? "" : " (deleted)" ) } DW::External::Account->get_external_accounts( $pu, show_inactive => 1 );
 
                 # FIXME: temporary; trying to figure out when this is undef
                 my $xpost_prop = $props{$prop};


### PR DESCRIPTION
Keep the metadata (sans sensitive info), so that we don't break importing,
and we can maybe adjust the crosspost link display settings later on.

Also adjusts the places where we load the External/Account info so that we
fetch the active status, and filter to only show active accounts in most
cases

Leaving this to stand for a bit. MySQL is making me wary.
