### PR TITLE
(Bug 4862) Don't lowercase POST args

### DIFF
--- a/cgi-bin/DW/Request/Apache2.pm
+++ b/cgi-bin/DW/Request/Apache2.pm
@@ -116,7 +116,7 @@ sub post_args {
     foreach my $key ( keys %$data ) {
         my @val = $data->get( $key );
         next unless @val;
-        push @out, map { lc $key => $_ } @val;
+        push @out, map { $key => $_ } @val;
     }
 
     return $self->{post_args} = Hash::MultiValue->new( @out );


### PR DESCRIPTION
We have an argument for lowercasing GET args (normalizing input, since this
can be so easily entered by hand, and we don't have anything that's 
case-sensitive). But we need to leave POST args alone. Widgets use 
case-sensitive names for their form elements, e.g., Widget[WidgetName]_...
