### PR TITLE
(Bug 4855) Get the first non-DOOO entry when importing

### DIFF
--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Entries.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Entries.pm
@@ -113,19 +113,38 @@ sub try_work {
     my $last = $class->call_xmlrpc( $data, 'getevents',
         {
             ver         => 1,
-            selecttype  => 'one',
-            itemid      => -1,
+            selecttype  => 'lastn',
+            howmany     => 5,
             lineendings => 'unix',
         }
     );
+
     return $temp_fail->( 'XMLRPC failure: ' . $last->{faultString} )
         if ! $last || $last->{fault};
-    return $temp_fail->( 'Failed to fetch the most recent entry.' )
-        unless ref $last->{events} eq 'ARRAY' && scalar @{$last->{events}} == 1;
 
-    # extract the maximum jitemid from this event
-    my $maxid = $last->{events}->[0]->{itemid};
-    $log->( 'Discovered that the maximum jitemid on the remote is %d.', $maxid );
+    # we weren't able to get any data. Maybe weren't able to connect to remote server?
+    # we want to try again
+    return $temp_fail->( 'Failed to fetch the most recent entry.' )
+        unless ref $last->{events} eq 'ARRAY';
+
+    # look for the latest non-DOOO entry
+    my $maxid;
+    foreach my $event ( @{$last->{events}} ) {
+        unless ( $event->{props}->{opt_backdated} ) {
+            $maxid = $event->{itemid};
+            $log->( 'Discovered that the maximum jitemid on the remote is %d.', $maxid );
+            last;
+        }
+    }
+
+    # we got entries but weren't able to find a single *non*-DOOO entry.
+    # No idea what the actual latest entry is. Give up now, tell the user to fix it
+    unless ( $maxid ) {
+        $log->( 'Got %d entries but all were DOOO.', scalar @{$last->{events}} );
+        $fail->( "We weren't able to find your latest entry because you have several entries that are dated out of order (DOOO, or backdated). " .
+            "Please edit all the entries on %s that are DOOO and set their date to one that's earlier than your latest non-DOOO entry. " .
+            "Then try your import again." , $data->{hostname} );
+    }
 
     # this is an optimization.  since we never do an edit event (only post!) we will
     # never get changes anyway.  so let's remove from the list of things to sync any


### PR DESCRIPTION
Getting the latest entry via the protocol gives us the latest entry according
to eventtime (user-provided time) rather than logtime. Sometimse this could
be a DOOO entry, which then means that everything after that DOOO entry will
not be imported. So let's try to find the first non-DOOO entry, as that will
be the latest according to logtime.
