### PR TITLE
Bug 4873 - Replace 'maintainer' with 'administrator'

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1519,4 +1519,7 @@ general esn.security_attribute_changed.account_deleted.email_text
 general esn.security_attribute_changed.account_renamed.email_subject
 general esn.security_attribute_changed.account_renamed.email_text
 
-
+general /manage/circle/edit.bml.circle.maintainer
+general /community/leave.bml.label.lastmaintainer.deletedcomm
+general entryform.comment.settings.nocomments.maintainer
+genereal talk.comments.disabled_maintainer

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -689,7 +689,7 @@ entryform.comment.settings.default5=Journal Default
 
 entryform.comment.settings.nocomments=Disabled
 
-entryform.comment.settings.nocomments.maintainer=Disabled by maintainer
+entryform.comment.settings.nocomments.admin=Disabled by administrator
 
 entryform.comment.settings.noemail=Don't Email
 
@@ -3944,7 +3944,7 @@ talk.comments.counted=[[replycount]] [[?replycount|comment|comments]]
 
 talk.comments.counted.screened=[[replycount]] visible | [[screenedcount]] screened [[?screenedcount|comment|comments]]
 
-talk.comments.disabled_maintainer=Comments disabled by a maintainer of this community
+talk.comments.disabled_admin=Comments disabled by an administrator of this community
 
 talk.commentsread=Read comments
 
@@ -4597,7 +4597,7 @@ widget.createaccountentercode.code=Code:
 
 widget.createaccountentercode.comm=If you'd like to <a [[aopts]]>create a community</a> instead, you don't need an account creation code.
 
-widget.createaccountentercode.comm.loggedout=You should create or log into a personal account to be the maintainer. If you don't have a personal account yet, you will need a code to create that account, but you don't need one for the community itself.
+widget.createaccountentercode.comm.loggedout2=You should create or log into a personal account to be the administrator. If you don't have a personal account yet, you will need a code to create that account, but you don't need one for the community itself.
 
 widget.createaccountentercode.error.invalidcode=Invite code is not valid or has already been used.
 

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -1658,7 +1658,7 @@ MOODS
             };
 
             my $nocomments_display = $opts->{prop_opt_nocomments_maintainer} ?
-                'entryform.comment.settings.nocomments.maintainer' : 'entryform.comment.settings.nocomments';
+                'entryform.comment.settings.nocomments.admin' : 'entryform.comment.settings.nocomments';
 
             my $comment_settings_default = BML::ml('entryform.comment.settings.default5', {'aopts' => $comment_settings_journaldefault->()});
             $out .= LJ::html_select({ 'name' => "comment_settings", 'id' => 'comment_settings', 'class' => 'select', 'selected' => $comment_settings_selected->(),

--- a/cgi-bin/LJ/Widget/CreateAccountEnterCode.pm
+++ b/cgi-bin/LJ/Widget/CreateAccountEnterCode.pm
@@ -77,7 +77,7 @@ sub render_body {
     }
     my $remote = LJ::get_remote(); 
     $ret .= " " . $class->ml( 'widget.createaccountentercode.comm', { aopts => "href='$LJ::SITEROOT/community/create'" } );
-    $ret .= " " . $class->ml( 'widget.createaccountentercode.comm.loggedout', { aopts => "href='$LJ::SITEROOT/community/create'" } ) unless $remote;
+    $ret .= " " . $class->ml( 'widget.createaccountentercode.comm.loggedout2', { aopts => "href='$LJ::SITEROOT/community/create'" } ) unless $remote;
         
     $ret .= "</p>";
 

--- a/htdocs/community/create.bml
+++ b/htdocs/community/create.bml
@@ -210,7 +210,7 @@ SUBMIT:
         $ret .= "<label for='postopen'> $ML{'.label.anybodycan'}</label></p><p>";
         $ret .= LJ::html_check({ type => 'radio', name => 'postlevel', id => 'postclosed',
                 value => 'select', selected => ($POST{postlevel} eq 'select' ? 1 : 0)});
-        $ret .= "<label for='postclosed'> $ML{'.label.selcan'}</label></p>";
+        $ret .= "<label for='postclosed'> $ML{'.label.selcan2'}</label></p>";
         $ret .= "</div></div></li>";
 
         # moderated options

--- a/htdocs/community/create.bml.text
+++ b/htdocs/community/create.bml.text
@@ -41,7 +41,7 @@
 
 .label.postaccess=Member Posting Restrictions
 
-.label.selcan=<b>Select Members</b><br />Only some members are able to post, once a maintainer gives them access.
+.label.selcan2=<b>Select Members</b><br />Only some members are able to post, once an administrator gives them access.
 
 .label.whocanpost=Do you want to allow only certain members the ability to post?
 

--- a/htdocs/community/join.bml
+++ b/htdocs/community/join.bml
@@ -64,7 +64,7 @@ body<=
     unless ($remote->can_join_adult_comm( comm => $cu, adultref => \$adult_content )) {
         my $adult_err;
         if ( $adult_content eq "explicit" ) {
-            $adult_err = BML::ml('.error.isminor', {'comm' => $cu->ljuser_display});
+            $adult_err = BML::ml('.error.isminor2', {'comm' => $cu->ljuser_display});
         }
 
         unless ($remote->best_guess_age) {

--- a/htdocs/community/join.bml.text
+++ b/htdocs/community/join.bml.text
@@ -7,7 +7,7 @@
 
 .error.closed=This community is closed to new members.  If you wish to join, please contact one of the administrators: [[admins]]
 
-.error.isminor=The maintainers of [[comm]] require that all members be over the age of 18.
+.error.isminor2=The administrators of [[comm]] require that all members be over the age of 18.
 
 .error.setage=Please <a [[aopts]]>edit your profile</a> to register your age.
 

--- a/htdocs/community/leave.bml
+++ b/htdocs/community/leave.bml
@@ -72,7 +72,7 @@ _c?>
     } else {
         # show a confirmation form
         $body .= "<?h1 $ML{'.sure'} h1?>";
-        $body .= "<?p $ML{'.label.lastmaintainer.deletedcomm'} p?>" if $cu->is_deleted && $remote->can_manage( $cu ) && length( $cu->maintainer_userids ) == 1;
+        $body .= "<?p $ML{'.label.lastadmin.deletedcomm'} p?>" if $cu->is_deleted && $remote->can_manage( $cu ) && length( $cu->maintainer_userids ) == 1;
         $body .= "<?p ";
         if ($watching && !$memberof) {
             $body .= BML::ml('.label.buttontostopwatch', { commname => $ecname });

--- a/htdocs/community/leave.bml.text
+++ b/htdocs/community/leave.bml.text
@@ -9,7 +9,7 @@
 
 .label.infoerror=The specified community information isn't valid.
 
-.label.lastmaintainer.deletedcomm=You are the last maintainer for this deleted community. If you leave now, it will not be possible to restore the community, should you change your mind in the future.
+.label.lastadmin.deletedcomm=You are the last administrator for this deleted community. If you leave now, it will not be possible to restore the community, should you change your mind in the future.
 
 .label.logoutfirst2=To leave a community you must first <a [[aopts]]>log in</a>.
 

--- a/htdocs/manage/circle/edit.bml
+++ b/htdocs/manage/circle/edit.bml
@@ -192,7 +192,7 @@ body<=
 
                         # check membership
                         if ( $is_member_of_userid{$uid} ) {
-                            $jointext = $ML{'.circle.maintainer'}
+                            $jointext = $ML{'.circle.admin'}
                                 if $u->can_manage( $other_u );
                             $joinvals->{selected} = 1;
                             $joinvals->{disabled} =

--- a/htdocs/manage/circle/edit.bml.text
+++ b/htdocs/manage/circle/edit.bml.text
@@ -25,6 +25,8 @@
 
 .circle.access.y=Gives you access
 
+.circle.admin=Administrator
+
 .circle.header=Current Relationships
 
 .circle.header.comms=Communities ([[num]])
@@ -46,8 +48,6 @@
 .circle.join.moderated=(Moderated)
 
 .circle.join.open=(Open)
-
-.circle.maintainer=Maintainer
 
 .circle.member=Member
 

--- a/htdocs/talkread.bml
+++ b/htdocs/talkread.bml
@@ -743,7 +743,7 @@ body<=
     # Display comment threads and commenting UI
     #
     if ( $nocomments ) {
-        $ret .= BML::ml( "talk.comments.disabled_maintainer" ) if $entry->comments_disabled_maintainer;
+        $ret .= BML::ml( "talk.comments.disabled_admin" ) if $entry->comments_disabled_maintainer;
     } else {
         $ret .= "<div id='Comments'>";
         $ret .= "<a name='comments'></a>";


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4873
-- replace maintainer with administrator in various text strings
-- edit or rename strings to prevent snafus
-- add dead strings to deadphrases
