### PR TITLE
Bug 4840 - Librarian's Dream: header overlaps nav strip

### DIFF
--- a/bin/upgrading/s2layers/librariansdream/layout.s2
+++ b/bin/upgrading/s2layers/librariansdream/layout.s2
@@ -347,7 +347,6 @@ body {
 #header { padding: 1px; }
 
 #header .inner {
-    margin-top: -1px;
     padding: 1px 1em;
     }
 


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4840
-- Remove negative margin in header to prevent overlap
