### PR TITLE
Bug 4822 - Remove extra padding in inline lists

### DIFF
--- a/bin/upgrading/s2layers/basicboxes/layout.s2
+++ b/bin/upgrading/s2layers/basicboxes/layout.s2
@@ -283,7 +283,7 @@ margin: .5em 0; }
 .entry .footer > .inner:first-child { padding: 1px; } /*float uneveness fix */
 
 .entry .tag { margin-left: .25em; }
-.entry .tag li { margin-left: 0; padding: .25em .10em; }
+.entry .tag li { margin-left: 0; padding: .25em 0; }
 .entry .tag-text { font-weight: bold; }
 
 ul.entry-management-links { float: left;
@@ -433,7 +433,7 @@ text-align: center; }
 
 .icon-keywords ul li {
     margin-left: 0;
-    padding: .25em .10em;
+    padding: .25em 0;
 }
 
 /* sidebars */

--- a/bin/upgrading/s2layers/boxesandborders/layout.s2
+++ b/bin/upgrading/s2layers/boxesandborders/layout.s2
@@ -326,7 +326,7 @@ margin: .5em 0; }
 .entry .footer > .inner:first-child { padding: 1px; } /*float uneveness fix */
 
 .entry .tag { margin-left: .25em; }
-.entry .tag li { margin-left: 0; padding: .25em .10em; }
+.entry .tag li { margin-left: 0; padding: .25em 0; }
 .entry .tag-text { font-weight: bold; }
 
 ul.entry-management-links { float: left;
@@ -452,7 +452,7 @@ text-align: center; }
 
 .icon-keywords ul li {
     margin-left: 0;
-    padding: .25em .10em;
+    padding: .25em 0;
 }
 
 /* sidebars */

--- a/bin/upgrading/s2layers/brittle/layout.s2
+++ b/bin/upgrading/s2layers/brittle/layout.s2
@@ -579,9 +579,9 @@ h3.entry-title a { color: $*color_entry_title; }
     }
 
 .tag ul {
-    padding: 0 0 0 13px;
-    margin: 0;
     display: inline;
+    margin: 0;
+    padding: 0;
     }
 
 .tag ul li {
@@ -816,7 +816,7 @@ td.day {
 .icon-keywords ul {
     display: inline;
     margin: 0;
-    padding: 0 0 0 13px;
+    padding: 0;
     }
 
 .icon-keywords ul li {

--- a/bin/upgrading/s2layers/colorside/layout.s2
+++ b/bin/upgrading/s2layers/colorside/layout.s2
@@ -233,7 +233,7 @@ top: -1em; }
 .entry .footer > .inner:first-child { padding: 1px; } /*float uneveness fix */
 
 .entry .tag { margin-left: .25em; }
-.entry .tag li { margin-left: 0; padding: .25em .10em; }
+.entry .tag li { margin-left: 0; padding: .25em 0; }
 .entry .tag-text { font-weight: bold; }
 
 ul.entry-management-links { float: left;

--- a/bin/upgrading/s2layers/core2base/layout.s2
+++ b/bin/upgrading/s2layers/core2base/layout.s2
@@ -530,12 +530,12 @@ h2#pagetitle {
 
 .tag ul {
     display: inline;
-    margin-left: .5em;
+    margin-left: 0;
     padding-left: 0;
 }
+
 .tag ul li {
     display: inline;
-    padding: .25em;
 } /* same for month view */
 
 ul.entry-management-links {
@@ -654,13 +654,12 @@ table.month td p {
 
 .icon-keywords ul {
     display: inline;
-    margin-left: .5em;
+    margin-left: 0;
     padding-left: 0;
 }
 
 .icon-keywords ul li {
     display: inline;
-    padding: .25em;
 }
 
 /* modules */

--- a/bin/upgrading/s2layers/drifting/layout.s2
+++ b/bin/upgrading/s2layers/drifting/layout.s2
@@ -746,7 +746,7 @@ function Page::print_default_stylesheet()
         display: inline;
         margin 0px;
         padding: 0px;
-        padding-left: 5px;
+        padding-left: 0;
     }
 
     .entry-management-links,
@@ -1016,7 +1016,7 @@ function Page::print_default_stylesheet()
     .icon-keywords ul {
         display: inline;
         margin 0;
-        padding-left: 5px;
+        padding-left: 0;
     }
 
     .icon-keywords ul li {

--- a/bin/upgrading/s2layers/lineup/layout.s2
+++ b/bin/upgrading/s2layers/lineup/layout.s2
@@ -379,7 +379,6 @@ h3.entry-title {
 
 .tag ul li {
     font-weight: normal;
-    margin: 5px 5px 0 0;
     padding: 0;
     }
 
@@ -737,7 +736,6 @@ table.month td {
     }
 
 .icon-keywords ul li {
-    margin-right: 5px;
     padding: 0;
     }
 

--- a/bin/upgrading/s2layers/modish/layout.s2
+++ b/bin/upgrading/s2layers/modish/layout.s2
@@ -124,7 +124,7 @@ margin: .5em 0; }
 .entry .footer > .inner:first-child { padding: 1px; } /*float uneveness fix */
 
 .entry .tag { margin-left: .25em; }
-.entry .tag li { margin-left: 0; padding: .25em .10em; }
+.entry .tag li { margin-left: 0; padding: .25em 0; }
 .entry .tag-text { font-weight: bold; }
 
 ul.entry-management-links { float: left;
@@ -257,7 +257,7 @@ text-align: center; }
     text-decoration: underline;
     }
 
-.icon-keywords ul li { margin-left: 0; padding: .25em .10em; }
+.icon-keywords ul li { margin-left: 0; padding: .25em 0; }
 
 /* sidebars */
 

--- a/bin/upgrading/s2layers/steppingstones/layout.s2
+++ b/bin/upgrading/s2layers/steppingstones/layout.s2
@@ -296,7 +296,7 @@ dl dt { font-weight: bold; }
 
 .entry .tag li {
     margin-left: 0;
-    padding: .25em .10em;
+    padding: .25em 0;
     }
 
 ul.entry-management-links {
@@ -498,7 +498,7 @@ table.month th {
 
 .icon-info .default { text-decoration: underline; }
 
-.icon-keywords ul li { padding: .25em .10em; }
+.icon-keywords ul li { padding: .25em 0; }
 
 /* Sidebars
 ******************************/


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4822
-- Remove margin and padding in tags and icon keywords inline lists in various styles

N.B. Left it in PaperMe where it's quite big and therefore doesn't look as odd, imo.
