### PR TITLE
Bug 4874 - Strata: 'keywords' label isn't bold on Icons pag

### DIFF
--- a/bin/upgrading/s2layers/strata/layout.s2
+++ b/bin/upgrading/s2layers/strata/layout.s2
@@ -467,7 +467,7 @@ table.month td.day-has-entries {
     word-wrap: break-word;
     }
 
-.label, .comment-text, .description-text, .default {
+.label, .icon-info span {
     font-weight: bold;
     }
 


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4874
-- Bold all labels
