### PR TITLE
(Bug 4875) Specialcase %BML::ML for post-request cleanup

### DIFF
--- a/cgi-bin/Apache/BML.pm
+++ b/cgi-bin/Apache/BML.pm
@@ -670,9 +670,11 @@ sub deleteglob
     {
         undef @entry;
     }
-    if ($key ne "main::" && $key ne "DB::" && scalar(keys %entry)
-        && $key !~ /::$/
-        && $key !~ /^_</ && $val ne "*BML::COOKIE")
+
+    if ( $key eq "ML" ||
+        ( $key ne "main::" && $key ne "DB::" && scalar(keys %entry)
+            && $key !~ /::$/
+            && $key !~ /^_</ && $val ne "*BML::COOKIE" ) )
     {
         undef %entry;
     }


### PR DESCRIPTION
`keys %BML::ML` gets us this in the logs:

```
    Can't locate object method "FIRSTKEY" via package "BML::ML"
```

So we just specialcase BML::ML and clear it after each request (instead of
trying to detect if it contains anything, etc)
