### PR TITLE
(Bug 3523) Turn on new JS implementation (jQuery) by default

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -4456,6 +4456,20 @@ Currently beta-testing the new JS behavior on journals.
 
 widget.betafeature.journaljquery.title=New JS on Journals
 
+widget.betafeature.journaljquery_optout.on<<
+Start using the new scripting behavior on journals.
+
+.
+
+widget.betafeature.journaljquery_optout.off<<
+<p>We're currently in the last stages of testing the new scripting behavior on journals, so you might notice that some things have changed.</p>
+
+<p>If you choose to stop using the new JS behavior, please leave a comment in <?ljuser dw_beta ljuser?>. Let us know why, so we can fix it before we switch over permanently.</p>
+
+.
+
+widget.betafeature.journaljquery_optout.title=New JS on Journals
+
 widget.betafeature.s2comments.off<<
 <p>Activate the testing version of the sitescheme comments and reply pages. This is a complete rewrite of the existing pages into S2, the scripting language we use for journalstyles, which is more modern and flexible than the old code. It should be complete and a close match to old reply pages, but some bugs may still remain.</p>
 

--- a/cgi-bin/LJ/BetaFeatures/default.pm
+++ b/cgi-bin/LJ/BetaFeatures/default.pm
@@ -98,6 +98,11 @@ sub is_expired {
     return 1;
 }
 
+# are we opt-in, or opt-out?
+sub is_optout {
+    return $_[0]->key =~ /_optout$/ ? 1 : 0;
+}
+
 # any arguments to pass to the translation string to describe this feature?
 sub args_list {
     return ();

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -172,7 +172,7 @@ sub make_journal
     # like print_stylesheet() won't run, which don't have an method invocant
     return $page if $page && ref $page ne 'HASH';
 
-    my $beta_jquery = LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" );
+    my $beta_jquery = ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" );
     LJ::set_active_resource_group( 'jquery' )
         if $beta_jquery;
 
@@ -3472,7 +3472,7 @@ sub _Comment__get_link
     if ($key eq "hide_comments") {
         ## show "Hide/Show" link if the comment has any children
         # only show hide/show comments if using jquery
-        if  ( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) && @{ $this->{replies} } > 0 ) {
+        if  ( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) && @{ $this->{replies} } > 0 ) {
             return LJ::S2::Link("#",        ## actual link is javascript: onclick='....'
                                 $ctx->[S2::PROPS]->{"text_comment_hide"});
         } else {
@@ -3482,7 +3482,7 @@ sub _Comment__get_link
     if ($key eq "unhide_comments") {
         ## show "Hide/Unhide" link if the comment has any children
         # only show hide/show comments if using jquery
-        if  ( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) && @{ $this->{replies} } > 0 ) {
+        if  ( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) && @{ $this->{replies} } > 0 ) {
             return LJ::S2::Link("#",        ## actual link is javascript: onclick='....'
                                 $ctx->[S2::PROPS]->{"text_comment_unhide"});
         } else {
@@ -3669,7 +3669,7 @@ sub Comment__expand_link
 
         # unhide only works with jquery; if the user isn't in the jquery
         # beta, drop back down to the no-javascript option
-        if  ( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) ) {
+        if  ( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) ) {
             $onclick = " onClick=\"Expander.make(this,'$this->{expand_url}','$this->{talkid}', false, true); return false;\"";
         }
     } else {

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -76,7 +76,7 @@ sub EntryPage
     $p->{head_content} .= LJ::canonical_link( $permalink, $get->{thread} );
 
     # quickreply js libs
-    my $beta = LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" );
+    my $beta = ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" );
 
     my @iconbrowser_extra_stylesheet;
     if ( $beta ) {

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -64,7 +64,7 @@ sub ReplyPage
     LJ::need_res( LJ::S2::tracking_popup_js() );
 
     # libs for userpicselect
-    my $beta = LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" );
+    my $beta = ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" );
     my @iconbrowser_extra_stylesheet;
     if ( $beta ) {
         # if we're using the site skin, don't override the jquery-ui theme, as that's already included

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2211,7 +2211,7 @@ sub js_iconbrowser_button {
         smallicons => $remote->iconbrowser_smallicons ? "true" : "false"
     });
 
-    return LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" )
+    return ! LJ::BetaFeatures->user_in_beta( LJ::get_remote() => "journaljquery_optout" )
     ?   qq {
         <script type="text/javascript">
         jQuery(function(jQ){
@@ -2294,7 +2294,7 @@ sub js_quote_button {
     }
 QUOTE
 
-    if ( LJ::BetaFeatures->user_in_beta( LJ::get_remote() => "journaljquery" ) ) {
+    if ( ! LJ::BetaFeatures->user_in_beta( LJ::get_remote() => "journaljquery_optout" ) ) {
         return <<"QQ";
 jQuery(function(jQ){
     $quote_func

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -916,7 +916,7 @@ sub create_qr_div {
     $qrhtml .= LJ::ljuser($remote->{'user'});
     $qrhtml .= "</td><td align='center'>";
 
-    my $beta_jquery = LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" );
+    my $beta_jquery = ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" );
     # Userpic selector
     {
         my %res;
@@ -1019,7 +1019,7 @@ sub create_qr_div {
                                       {'name' => 'saved_ptid', 'id' => 'saved_ptid'},
                                       ));
 
-    if ( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) ) {
+    if ( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) ) {
         # FIXME: figure out how to fix the saving of the qr entry stuff
         $ret .= qq{jQuery(function(jQ){
                 jQ("body").append(jQ("<div id='qrdiv'></div>").html("$qrhtml").hide());

--- a/cgi-bin/LJ/Widget/BetaFeature.pm
+++ b/cgi-bin/LJ/Widget/BetaFeature.pm
@@ -37,14 +37,16 @@ sub render_body {
         if $handler->is_active;
 
     if ($handler->is_active && $handler->user_can_add($u)) {
+        my @submit_actions = $handler->is_optout ? ( "on", "off" ) : ( "off", "on" );
+
         $ret .= "<div class='simple-form'>";
         $ret .= $class->start_form;
         if ($u->is_in_beta($feature)) {
             $ret .= "<?p " . $class->ml("widget.betafeature.$feature.on", { $handler->args_list } ) . " p?>";
-            $ret .= "<fieldset class='submit'>" . $class->html_submit("off", $class->ml('widget.betafeature.btn.off')) . "</fieldset>";
+            $ret .= "<fieldset class='submit'>" . $class->html_submit("off", $class->ml("widget.betafeature.btn.$submit_actions[0]")) . "</fieldset>";
         } else {
             $ret .= "<?p " . $class->ml("widget.betafeature.$feature.off", { $handler->args_list } ) . " p?>";
-            $ret .= "<fieldset class='submit'>" . $class->html_submit("on", $class->ml('widget.betafeature.btn.on')) . "</fieldset>";
+            $ret .= "<fieldset class='submit'>" . $class->html_submit("on", $class->ml("widget.betafeature.btn.$submit_actions[1]")) . "</fieldset>";
         }
         $ret .= $class->html_hidden( feature => $feature, user => $u->user );
         $ret .= $class->end_form;

--- a/htdocs/talkpost.bml
+++ b/htdocs/talkpost.bml
@@ -27,10 +27,10 @@ body<=
     my $errtxt;
 
     # libs for userpicselect
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) ) )
+    LJ::need_res( LJ::Talk::init_iconbrowser_js( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) ) )
         if $remote && $remote->can_use_userpic_select;
     LJ::set_active_resource_group( "jquery" )
-        if LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" );
+        if ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" );
 
 
     my $pics = LJ::Talk::get_subjecticons();

--- a/htdocs/talkpost_do.bml
+++ b/htdocs/talkpost_do.bml
@@ -114,10 +114,10 @@ body<=
 
     LJ::need_res('stc/display_none.css');
     # libs for userpicselect
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) ) )
+    LJ::need_res( LJ::Talk::init_iconbrowser_js( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) ) )
         if $remote && $remote->can_use_userpic_select;
     LJ::set_active_resource_group( "jquery" )
-        if LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" );
+        if ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" );
 
 
     # FIXME: this isn't entirely correct, if ecphash is present but ignored/incorrect

--- a/htdocs/talkread.bml
+++ b/htdocs/talkread.bml
@@ -214,7 +214,7 @@ body<=
                 ) );
 
     LJ::set_active_resource_group( "jquery" )
-        if LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" );
+        if ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" );
 
     if ( ( $remote && ! $remote->prop( "opt_no_quickreply" ) ) && ! $nocomments ) {
        # quickreply js libs
@@ -228,7 +228,7 @@ body<=
                         js/jquery.quickreply.js
                     ) );
 
-        LJ::need_res( LJ::Talk::init_iconbrowser_js( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ), 'stc/lj_base.css' ) )
+        LJ::need_res( LJ::Talk::init_iconbrowser_js( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ), 'stc/lj_base.css' ) )
             if $remote->can_use_userpic_select;
     }
 
@@ -441,7 +441,7 @@ body<=
                     # if we're in top-only mode, then we display the
                     # expand link as the unhide ('show x comments')
                     # message
-                    if ( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) ) {
+                    if ( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) ) {
                         $ret .= qq[(<a href='$url' onClick="Expander.make(this,'$url','$dtid',true,true);return false;">];
                         $ret .= BML::ml( 'talk.unhide', { num => $post->{'showable_children'} } );
                         $ret .= qq[</a>)</span>];
@@ -469,7 +469,7 @@ body<=
                     # if we're in top-only mode, then we display the
                     # expand link as the unhide ('show x comments')
                     # message
-                    if ( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) ) {
+                    if ( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) ) {
                         $ret .= qq[(<a href='$url' onClick="Expander.make(this,'$url','$dtid',true,true);return false;">];
                         $ret .= BML::ml( 'talk.unhide', { num => $post->{'showable_children'} } );
                         $ret .= qq[</a>)</span>];
@@ -672,7 +672,7 @@ body<=
                             # if we're in top-only mode, then we display the
                             # expand link as the unhide ('show x comments')
                             # message
-                            if ( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) ) {
+                            if ( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) ) {
                                 $ret .= qq[(<a href='$url' onClick="Expander.make(this,'$url','$dtid',true,true);return false;">];
                                 $ret .= BML::ml( 'talk.unhide', { num => $post->{'showable_children'} } );
                                 $ret .= qq[</a>)</span>];
@@ -689,7 +689,7 @@ body<=
                         }
                     }
                     if ( $show_thread_expander ) {
-                        if ( LJ::BetaFeatures->user_in_beta( $remote => "journaljquery" ) ) {
+                        if ( ! LJ::BetaFeatures->user_in_beta( $remote => "journaljquery_optout" ) ) {
                             my $hideclass = $post->{'hide_children'} ? "" : " cmt_show_hide_default";
 
                             $ret .= qq[ <span id="cmt${dtid}_hide" class="cmt_hide$hideclass" style="display:none;">(<a href='#' onClick="Expander.hideComments(this,'$dtid',true);return false;">];


### PR DESCRIPTION
- temporary opt-out still available just in case of last minute stuff
- reverse the text on the button if the beta feature key ends with "_optout"
