### PR TITLE
Changes all livejournal references to dreamwidth in jbackup

### DIFF
--- a/src/jbackup/jbackup.pl
+++ b/src/jbackup/jbackup.pl
@@ -103,7 +103,7 @@ if (-e "$ENV{HOME}/.jbackup") {
 }
 
 # setup some nice, sane defaults
-$opts{server} ||= 'www.livejournal.com';
+$opts{server} ||= 'www.dreamwidth.org';
 $opts{port} += 0;
 $opts{verbose} = $opts{quiet} ? 0 : 1;
 $opts{server} = "$opts{server}:$opts{port}"
@@ -128,7 +128,7 @@ jbackup.pl -- journal database generator and formatter
     --md5pass=X     Alternately, provide the MD5 digest of the password.
     --journal=X     Specify an alternate journal to use.
                     NOTE: You must be maintainer of the journal.
-    --server=X      Use a different server.  (Default: www.livejournal.com)
+    --server=X      Use a different server.  (Default: www.dreamwidth.org)
     --port=X        Use a non-default port.  (Default: 80)
 
   Data update options:
@@ -856,7 +856,7 @@ sub dump_xml {
 
     # dump xml formatted comments
     $ret .= "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
-    $ret .= "<livejournal>\n\t<events>\n";
+    $ret .= "<dreamwidth>\n\t<events>\n";
 
     # now start iterating
     my $tree = make_tree($comments);
@@ -895,7 +895,7 @@ sub dump_xml {
     d("100.00% ..."); # spit and polish
 
     # close out, we're done
-    $ret .= "\t</events>\n</livejournal>\n";
+    $ret .= "\t</events>\n</dreamwidth>\n";
     d("dump_xml: done.");
     return $ret;
 }


### PR DESCRIPTION
Just a quick little thing I had hanging around--noticed jbackup.pl still referring to LiveJournal as the default server and other sundries, and updated it to refer to Dreamwidth instead.
