### PR TITLE
Core1: move userpic_listing_url to parent class for broader use

### DIFF
--- a/bin/upgrading/s2layers/core1.s2
+++ b/bin/upgrading/s2layers/core1.s2
@@ -261,6 +261,7 @@ class UserLite
     var readonly string username "Canonical Username, ex: johnqpub.  Note that if journal_type is an external identity, there will be no username, so this field will be a display version of their URL, longer than 15 characters, and with characters other than a-z, 0-9 and underscore.";
     var readonly string name "User's formatted name, ex: John Q. Public";
     var readonly string journal_type "Type of account: P (personal), C (community), Y (syndicated), S (shared), I (external identity) etc";
+    var readonly string userpic_listing_url "URL of a page listing this user's userpics";
 
     var Link{} data_link "Links to various machine-readable data sources relating to this user";
     var string[] data_links_order "An array of data views which can be used to order the data_link hash";
@@ -433,7 +434,6 @@ class User extends UserLite
 "A more information-rich userinfo structure"
 {
     var Image default_pic "Information about default userpic";
-    var readonly string userpic_listing_url "URL of a page listing this user's userpics";
     var readonly string website_url "URL pointer to user's website";
     var readonly string website_name "'pretty' name of user's website";
 }


### PR DESCRIPTION
Bug 4881 - Core1: move userpic_listing_url from User to UserLite
http://bugs.dwscoalition.org/show_bug.cgi?id=4881
