### PR TITLE
(Bug 4882, 4878) Allow truncated subjects for imports/feeds

### DIFF
--- a/cgi-bin/DW/Worker/ContentImporter/Local/Entries.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/Local/Entries.pm
@@ -164,6 +164,7 @@ sub post_event {
             u => $posteru || $u,
             u_owner => $u,
             importer_bypass => 1,
+            allow_truncated_subject => 1,
         }
     );
 

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1043,7 +1043,7 @@ sub common_event_validation
 
     $did_trim = 0;
     $req->{'subject'} = LJ::text_trim( $req->{'subject'}, LJ::BMAX_SUBJECT, LJ::CMAX_SUBJECT, \$did_trim );
-    return fail( $err, 411 ) if $did_trim;
+    return fail( $err, 411 ) if $did_trim && ! $flags->{allow_truncated_subject};
 
     foreach (keys %{$req->{'props'}}) {
         # do not trim this property, as it's magical and handled later

--- a/cgi-bin/LJ/SynSuck.pm
+++ b/cgi-bin/LJ/SynSuck.pm
@@ -420,6 +420,7 @@ sub process_content {
 
         my $flags = {
             'nopassword' => 1,
+            'allow_truncated_subject' => 1,
         };
 
         # if the post contains html linebreaks, assume it's preformatted.


### PR DESCRIPTION
We recently switched from silent truncation of subjects when posting, to
preventing the entry from posting,  to give the user the chance to correct it.
But that doesn't make sense when we're pulling in entries in bulk, so let's
let this through (old behavior)
