### PR TITLE
(Bug 4895) Include jquery.ui.core.js in more places

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -1809,11 +1809,14 @@ sub use_journalstyle_entry_page {
 sub tracking_popup_js {
     return LJ::is_enabled( 'esn_ajax' ) ? (
         { group => 'jquery' }, qw(
+        js/jquery/jquery.ui.core.js
         js/jquery/jquery.ui.widget.js
 
         js/jquery/jquery.ui.tooltip.js
         js/jquery.ajaxtip.js
         js/jquery/jquery.ui.position.js
+
+        stc/jquery/jquery.ui.core.css
         stc/jquery/jquery.ui.tooltip.css
 
         js/jquery.esn.js

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -98,6 +98,8 @@ sub EntryPage
                     ));
 
     LJ::need_res( { group => "jquery" }, qw(
+            js/jquery/jquery.ui.core.js
+            stc/jquery/jquery.ui.core.css
             js/jquery/jquery.ui.widget.js
             js/jquery.quickreply.js
             js/jquery.threadexpander.js
@@ -410,12 +412,14 @@ sub EntryPage
 
     LJ::need_res( "js/commentmanage.js" );
     LJ::need_res( { group => "jquery" }, qw(
+            js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.tooltip.js
             js/jquery.ajaxtip.js
             js/jquery/jquery.ui.button.js
             js/jquery/jquery.ui.dialog.js
             js/jquery.commentmanage.js
             js/jquery/jquery.ui.position.js
+            stc/jquery/jquery.ui.core.css
             stc/jquery/jquery.ui.tooltip.css
             stc/jquery/jquery.ui.button.css
             stc/jquery/jquery.ui.dialog.css

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -993,11 +993,13 @@ sub start_request
 
             LJ::need_res( { priority => $LJ::LIB_RES_PRIORITY, group=> 'jquery' },
                 qw(
+                    js/jquery/jquery.ui.core.js
                     js/jquery/jquery.ui.widget.js
 
                     js/jquery/jquery.ui.tooltip.js
                     js/jquery.ajaxtip.js
                     js/jquery/jquery.ui.position.js
+                    stc/jquery/jquery.ui.core.css
                     stc/jquery/jquery.ui.tooltip.css
                     stc/jquery/jquery.ui.theme.smoothness.css
 

--- a/htdocs/talkread.bml
+++ b/htdocs/talkread.bml
@@ -844,12 +844,14 @@ body<=
             if ($do_commentmanage_js) {
                 LJ::need_res('js/commentmanage.js');
                 LJ::need_res( { group => "jquery" }, qw(
+                            js/jquery/jquery.ui.core.js
                             js/jquery/jquery.ui.tooltip.js
                             js/jquery.ajaxtip.js
                             js/jquery/jquery.ui.button.js
                             js/jquery/jquery.ui.dialog.js
                             js/jquery.commentmanage.js
                             js/jquery/jquery.ui.position.js
+                            stc/jquery/jquery.ui.core.css
                             stc/jquery/jquery.ui.tooltip.css
                             stc/jquery/jquery.ui.button.css
                             stc/jquery/jquery.ui.dialog.css


### PR DESCRIPTION
Dependency of the other jquery.ui.\* components, we were including it some of
the time but not all of the time, which made things break in very specific
cases.
