### PR TITLE
(Bug 4899) Convert to JSON::true/false

### DIFF
--- a/cgi-bin/LJ/JSON.pm
+++ b/cgi-bin/LJ/JSON.pm
@@ -25,7 +25,12 @@ LJ::JSON - Wrapper for JSON which handles text encoding
 
   use LJ::JSON; # never use JSON! That could introduce subtle encoding issues
 
-  my $json_string = to_json( { a => "apple" } );
+  my $is_yummy = 1;
+  my $json_string = to_json( { a => "apple",
+                        yummy  => LJ::JSON->to_boolean( $is_yummy ) # true/false
+                        yummy2 => $is_yummy                         # 1/0
+                                                                    # both can work in JS, but prefer true/false
+                    } );
   my $object      = from_json( q!{ "a": "apple" }! );
 
 =cut

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2207,8 +2207,8 @@ sub js_iconbrowser_button {
     my $remote = LJ::get_remote();
     my $iconbrowser_opts = to_json({
         selectorButtons => "#lj_userpicselect",
-        metatext => $remote->iconbrowser_metatext ? "true" : "false",
-        smallicons => $remote->iconbrowser_smallicons ? "true" : "false"
+        metatext => LJ::JSON->to_boolean( $remote->iconbrowser_metatext ),
+        smallicons => LJ::JSON->to_boolean( $remote->iconbrowser_smallicons ),
     });
 
     return ! LJ::BetaFeatures->user_in_beta( LJ::get_remote() => "journaljquery_optout" )


### PR DESCRIPTION
Don't use string "true/false" which is what we had to do before. Instead, use 
the proper datatypes and let the JSON module handle it for us.
