### PR TITLE
(Bug 4903) Check whether we have a .full element properly

### DIFF
--- a/htdocs/js/jquery.threadexpander.js
+++ b/htdocs/js/jquery.threadexpander.js
@@ -145,7 +145,7 @@
                   LJ[cmtId].full = true;
                 }
               } else {
-                if (newComment.find(".full")) {
+                if (newComment.find(".full").length > 0) {
                   LJ[cmtId].full = true;
                   setFull(cmtElement, true);
                 }


### PR DESCRIPTION
find(".full") returns an empty array [] when there's no full elements. Which
means that we falsely assume that this comment has been expanded and mark it
as such. Which then breaks nested expansion. Tsk.
