### PR TITLE
(Bug 4904) Cast to int before we use it

### DIFF
--- a/htdocs/tools/endpoints/poll.bml
+++ b/htdocs/tools/endpoints/poll.bml
@@ -31,12 +31,12 @@ _c?>
     BML::finish();
     BML::noparse();
 
-    my $pollid   = $POST{pollid}  or return $err->("No pollid");
-    my $pollqid  = $POST{pollqid} || 0;
-    my $userid   = $POST{userid} || 0;
+    my $pollid   = ( ( $POST{pollid} || 0 ) + 0 )  or return $err->("No pollid");
+    my $pollqid  = ( $POST{pollqid} || 0 ) + 0;
+    my $userid   = ( $POST{userid} || 0 ) + 0;
     my $action   = $POST{action};
-    my $page     = $POST{page};
-    my $pagesize = $POST{pagesize} || 2000;
+    my $page     = ( $POST{page} || 0 ) + 0;
+    my $pagesize = ( $POST{pagesize} || 2000 ) + 0;
 
     my $poll = LJ::Poll->new($pollid) or return $err->("Error loading poll $pollid");
 


### PR DESCRIPTION
This ensures that it's recognized as a number by the JSON library and gets
sent over that way.
