### PR TITLE
(Bug 4909) Make sure to load _config-local.bml

### DIFF
--- a/cgi-bin/Apache/BML.pm
+++ b/cgi-bin/Apache/BML.pm
@@ -584,7 +584,7 @@ sub load_conffile
             foreach my $k (qw(ExtraConfig)) {
                 next unless exists $sconf->{$k};
                 $sconf->{$k} =~ s/\$(\w+)/$1 eq "HTTP_HOST" ? clean_http_host() : $ENV{$1}/eg;
-                $sconf->{$k} = [ map { dir_rel2abs($dirs, $_) } grep { $_ }
+                $sconf->{$k} = [ map { LJ::resolve_file( $_ ) } grep { $_ }
                                  split(/\s*,\s*/, $sconf->{$k}) ];
             }
 

--- a/htdocs/_config.bml
+++ b/htdocs/_config.bml
@@ -4,7 +4,7 @@ DefaultScheme blueshift
 IncludePath inc/
 
 AllowOldSyntax 0
-ExtraConfig _config-local.bml, $LJHOME/cgi-bin/LJ/Global/BMLInit.pm
+ExtraConfig htdocs/_config-local.bml, cgi-bin/LJ/Global/BMLInit.pm
 AllowCode 1
 AllowTemplateCode 1
 MildXSSProtection 1


### PR DESCRIPTION
Slightly weird behavior in terms of strings, including FAQs, because we had a
default language of en instead of en_DW (latter includes everything that's
live on the site, instead of just the repo). Reason behind _that_ is that we
weren't loading the site-specific
_config-local.bml

So load it.
