### PR TITLE
Bug 4240 - Profile module: match text links with icon links

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -4102,7 +4102,7 @@ userlinkbar.joincomm.title.loggedout=You must be logged in to join this communit
 
 userlinkbar.joincomm.title.open=Join this community
 
-userlinkbar.leavecomm=Leave
+userlinkbar.leavecomm2=Leave Community
 
 userlinkbar.leavecomm.title=Leave this community
 
@@ -4148,7 +4148,7 @@ userlinkbar.sendmessage.title.loggedout=You must be logged in to send a private 
 
 userlinkbar.sendmessage.title.self=Send a private message to yourself
 
-userlinkbar.tellafriend=Tell someone about this
+userlinkbar.tellafriend2=Tell Someone
 
 userlinkbar.tellafriend.title.other=Tell someone about this journal
 

--- a/bin/upgrading/s2layers/core2.s2
+++ b/bin/upgrading/s2layers/core2.s2
@@ -2254,53 +2254,6 @@ set text_module_search_btn = "Search";
 
 ##=======================================
 ## Display properties - Text
-## Module user linkbar
-##=======================================
-
-property string text_user_manage_membership {
-    des = "Link text to manage your membership to a community journal";
-    example = "Membership";
-}
-property string text_user_trust {
-    des = "Link text to manage your access settings for this journal";
-    example = "Manage Access";
-}
-property string text_user_watch {
-    des = "Link text to manage your subscription settings for this journal";
-    example = "Manage Subscription";
-}
-property string text_user_post_entry {
-    des = "Link text to post an entry to this journal";
-    example = "Post Entry";
-}
-property string text_user_message {
-    des = "Link text to send a message to this user";
-    example = "Send Message";
-}
-property string text_user_track {
-    des = "Link text to track new entries made to this journal";
-    example = "Track Entries";
-}
-property string text_user_memories {
-    des = "Link text to memories saved by this journal";
-    example = "Memories";
-}
-property string text_user_tell_friend {
-    des = "Link text to send other people a link to this journal";
-    example = "Share Journal Link";
-}
-
-set text_user_manage_membership = "Membership";
-set text_user_trust = "Manage Access";
-set text_user_watch = "Manage Subscription";
-set text_user_post_entry = "Post";
-set text_user_message = "Send Message";
-set text_user_track = "Track Entries";
-set text_user_memories = "Memories";
-set text_user_tell_friend = "Share Journal Link";
-
-##=======================================
-## Display properties - Text
 ## Metadata
 ##=======================================
 

--- a/cgi-bin/DW/Logic/UserLinkBar.pm
+++ b/cgi-bin/DW/Logic/UserLinkBar.pm
@@ -143,7 +143,7 @@ sub manage_membership {
                 url      => "community/leave?comm=$user",
                 title_ml => 'userlinkbar.leavecomm.title',
                 image    => 'community_leave.png',
-                text_ml  => 'userlinkbar.leavecomm',
+                text_ml  => 'userlinkbar.leavecomm2',
                 class    => "leave",
             } );
 
@@ -419,7 +419,7 @@ sub tellafriend {
             image => "$LJ::IMGPREFIX/silk/profile/tellafriend.png",
             width => 16,
             height => 16,
-            text_ml => 'userlinkbar.tellafriend',
+            text_ml => 'userlinkbar.tellafriend2',
             class => 'tellafriend',
         };
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -3923,8 +3923,9 @@ sub UserLite__get_link
         return undef unless $link;
 
         my $caption = $ctx->[S2::PROPS]->{userlite_interaction_links} eq "text"
-            ? $ctx->[S2::PROPS]->{"text_user_$key"}
+            ? $link->{text}
             : $link->{title};
+
         return LJ::S2::Link( $link->{url}, $caption, LJ::S2::Image( $link->{image}, $link->{width} || 20, $link->{height} || 18 ) );
     };
 


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4240
-- Use text strings from en.dat instead of Core2 props
-- Rephrase some strings
-- Remove no obsolete props from Core2
-- All credit goes to @jeshyr
