### PR TITLE
Bug 4566 - change notification email when OpenID account grants access t...

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -1008,6 +1008,14 @@ Hi [[user]],
 You can:
 .
 
+esn.addedtocircle.trusted.openid.email_text<<
+Hi [[user]],
+
+[[poster]] has granted you access; you'll now be able to view [[poster]]'s protected information.
+
+You can:
+.
+
 esn.addedtocircle.trusted.subject=[[who]] granted you access.
 
 esn.addedtocircle.watched.email_text<<

--- a/cgi-bin/LJ/Event/AddedToCircle.pm
+++ b/cgi-bin/LJ/Event/AddedToCircle.pm
@@ -89,7 +89,7 @@ sub _as_email {
 
     if ( $self->trusted ) {
         if ( $self->fromuser->is_identity ) {
-            return LJ::Lang::get_text( $lang, 'esn.addedtocircle.trusted.email_text', undef, $vars ) .
+            return LJ::Lang::get_text( $lang, 'esn.addedtocircle.trusted.openid.email_text', undef, $vars ) .
                 $self->format_options( $is_html, $lang, $vars,
                 {
                     'esn.add_trust'       => [ $u->trusts( $self->fromuser ) ? 0 : 1, "$LJ::SITEROOT/manage/circle/add?user=$postername&action=access" ],


### PR DESCRIPTION
...o someone

http://bugs.dwscoalition.org/show_bug.cgi?id=4566
-- Use different email text when an OpenID user grants you access to prevent confusion
