### PR TITLE
(Bug 4934) Abort the ajax request if user moves away from the trigger

### DIFF
--- a/htdocs/js/jquery.ajaxtip.js
+++ b/htdocs/js/jquery.ajaxtip.js
@@ -55,6 +55,15 @@ $.widget("dw.ajaxtip", $.ui.tooltip, {
         // this is only a confirmation message. We can fade away quickly
         window.setTimeout( function() { self.close(); }, 1500 );
     },
+    abort: function () {
+        var self = this;
+        if ( self.requests.length ) {
+            $.each( self.requests, function (i, req) {
+                req.abort();
+            });
+            self.requests = [];
+        }
+    },
     load: function(args) {
         /* opts is an object (or array of objects) containing overrides:
          *
@@ -75,12 +84,7 @@ $.widget("dw.ajaxtip", $.ui.tooltip, {
         var self = this;
 
         // abort and remove any old requests
-        if ( self.requests.length ) {
-            $.each( self.requests, function (i, req) {
-                req.abort();
-            });
-            self.requests = [];
-        }
+        self.abort();
 
         if ( self.options.loadingContent ) {
             self.option("content", self.options.loadingContent);

--- a/htdocs/js/jquery.contextualhover.js
+++ b/htdocs/js/jquery.contextualhover.js
@@ -59,6 +59,7 @@ function _initIcons(context) {
         - if you move the mouse from the trigger to the contextual popup
         - as long as the mouse is over the tooltip
         - NOT if you move the mouse away from the trigger before the popup is fully visible
+        - NOT if you move the mouse away from the trigger before the ajax request is done
 
     disappears:
         - when you move the mouse over then out of the contextual popup
@@ -178,6 +179,7 @@ _create: function() {
         out: function(e) {
             var persist = trigger.data("popup-persist");
             if ( ! persist ) {
+                trigger.ajaxtip( "abort" );
                 trigger.ajaxtip( "close" );
             }
             trigger.removeData("popup-persist");


### PR DESCRIPTION
If the user moves away from the trigger while we're still loading, the loading
symbol disappears, but then a few moments later the popup with content shows
up. In this case, we should assume that they're no longer interested, or
triggered it by accident, and prevent the request from going through.
