### PR TITLE
Bug 4247 - Clarify invite notification and options on /manage/invites

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1522,4 +1522,6 @@ general esn.security_attribute_changed.account_renamed.email_text
 general /manage/circle/edit.bml.circle.maintainer
 general /community/leave.bml.label.lastmaintainer.deletedcomm
 general entryform.comment.settings.nocomments.maintainer
-genereal talk.comments.disabled_maintainer
+general talk.comments.disabled_maintainer
+
+general /manage/invites.bml.fromline

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -1277,7 +1277,7 @@ esn.mail_comments.subject.reply_to_your_entry=Reply to your entry.
 
 esn.manage_community=[[openlink]]Manage your communities[[closelink]]
 
-esn.manage_invitations=[[openlink]]Manage your invitations[[closelink]]
+esn.manage_invitations2=[[openlink]]Accept or decline the invitation[[closelink]]
 
 esn.manage_membership_reqs=[[openlink]]Manage [[communityname]]'s membership requests[[closelink]]
 

--- a/cgi-bin/LJ/Event/CommunityInvite.pm
+++ b/cgi-bin/LJ/Event/CommunityInvite.pm
@@ -39,7 +39,7 @@ my @_ml_strings = (
                                     # [[maintainer]] has invited you to join the community [[community]]!
                                     #
                                     # You can:'
-    'esn.manage_invitations',       # '[[openlink]]Manage your invitations[[closelink]]'
+    'esn.manage_invitations2',       # '[[openlink]]Accept or decline the invitation[[closelink]]'
     'esn.read_last_comm_entries',   # '[[openlink]]Read the latest entries in [[journal]][[closelink]]'
     'esn.view_profile',             # '[[openlink]]View [[postername]]'s profile[[closelink]]',
     'esn.add_watch',                # '[[openlink]]Subscribe to [[journal]][[closelink]]',
@@ -83,7 +83,7 @@ sub _as_email {
     return LJ::Lang::get_text($lang, 'esn.comm_invite.email', undef, $vars) .
         $self->format_options($is_html, $lang, $vars,
         {
-            'esn.manage_invitations'        => [ 1, "$LJ::SITEROOT/manage/invites" ],
+            'esn.manage_invitations2'       => [ 1, "$LJ::SITEROOT/manage/invites" ],
             'esn.read_last_comm_entries'    => [ 2, $community_url ],
             'esn.view_profile'              => [ 3, $community_profile ],
             'esn.add_watch'                 => [ $u->watches( $self->comm ) ? 0 : 4,
@@ -126,7 +126,7 @@ sub as_html_actions {
 
     my $ret .= "<div class='actions'>";
     $ret .= " <a href='" . $self->comm->profile_url . "'>View Profile</a>";
-    $ret .= " | <a href='$LJ::SITEROOT/manage/invites'>Join Community</a>"
+    $ret .= " | <a href='$LJ::SITEROOT/manage/invites'>Accept or Decline</a>"
         unless $self->u->member_of( $self->comm );
     $ret .= "</div>";
 

--- a/htdocs/community/manage.bml
+++ b/htdocs/community/manage.bml
@@ -196,8 +196,8 @@ body<=
     $ret .= "<?h1 $ML{'.create.header'} h1?>";
     $ret .= "<?p " . BML::ml('.create.text2', {'aopts' => "href='$LJ::SITEROOT/community/create'"}) . " p?>";
 
-    $ret .= "<?h1 $ML{'/manage/invites.bml.title'} h1?>";
-    $ret .= "<?p <a href=\"/manage/invites\"><?_ml /manage/invites.bml.title _ml?></a> p?>";
+    $ret .= "<?h1 $ML{'/manage/invites.bml.title2'} h1?>";
+    $ret .= "<?p " . BML::ml('.invite.text', {'aopts' => "href='$LJ::SITEROOT/manage/invites'"}) . " p?>";
     $ret .= "</div><!-- end .columns-2-right -->";
     $ret .= "</div><!-- end .columns-2 -->";
     return $ret;

--- a/htdocs/community/manage.bml.text
+++ b/htdocs/community/manage.bml.text
@@ -48,6 +48,8 @@
 
 .error.badaccounttype=You must be logged in to a personal account to access this page.
 
+.invite.text=You can <a [[aopts]]>view any pending invitations</a> you've received to join communities.
+
 .joinmail.body2=For communities with moderated membership, you can <a [[aopts]]>be notified</a> when anyone requests membership.
 
 .joinmail.email.all=Email me every time someone requests to join.

--- a/htdocs/manage/index.bml
+++ b/htdocs/manage/index.bml
@@ -266,7 +266,7 @@ about=><?_ml .communities        _ml?>
 list<=
 <li><a href="/community/create" title="<?_ml .communities.create.about _ml?>"><?_ml /community/create.bml.title _ml?></a></li>
 <li><a href="/community/manage" title="<?_ml .communities.manage.about _ml?>"><?_ml /community/manage.bml.title2 _ml?></a></li>
-<li><a href="/manage/invites" title="<?_ml .communities.invites.about _ml?>"><?_ml /manage/invites.bml.title _ml?></a></li>
+<li><a href="/manage/invites" title="<?_ml .communities.invites.about _ml?>"><?_ml /manage/invites.bml.title2 _ml?></a></li>
 <=list
 block?>
           );

--- a/htdocs/manage/invites.bml
+++ b/htdocs/manage/invites.bml
@@ -13,7 +13,7 @@
 # part of this distribution.
 _c?>
 <?page
-title=><?_ml .title _ml?>
+title=><?_ml .title2 _ml?>
 body<=
 <?_code
 {
@@ -42,7 +42,7 @@ body<=
     my $pending = $u->get_pending_invites || [];
 
     # short out?
-    return "<?h1 $ML{'.none.title'} h1?><?p $ML{'.none.body'} p?>"
+    return "<?p $ML{'.none.body'} p?>"
         unless @$pending;
 
     # load communities and maintainers
@@ -55,7 +55,7 @@ body<=
 
     # see if they posted and if we should take actions
     if (LJ::did_post()) {
-        return "<?h1 $ML{'Error'} h1?><?p $ML{'error.invalidform'} p?>"
+        return "<?h2 $ML{'Error'} h2?><?p $ML{'error.invalidform'} p?>"
             unless LJ::check_form_auth();
 
         my (@accepted, @rejected, @undecided);
@@ -75,43 +75,52 @@ body<=
                 push @undecided, $commid;
             }
         }
-
+        $ret .= "<?h1 $ML{'.success.head'} h1?>";
         # communities they've joined
         if (@accepted) {
-            $ret .= "<?h1 $ML{'.accepted.title'} h1?><?p $ML{'.accepted.body'} p?><ul>";
+            $ret .= "<?h2 $ML{'.accepted.title'} h2?><?p $ML{'.accepted.body2'} p?><dl>";
             foreach my $row (@accepted) {
-                $ret .= "<li>" . LJ::ljuser($us->{$row->[0]}, { type => 'C' }) . ": ";
+                $ret .= "<dd>" . LJ::ljuser($us->{$row->[0]}, { type => 'C' }) . ": ";
                 foreach my $attrib (@allattribs) {
                     $ret .= "$ML{\".label.$attrib\"}, " if $row->[1]{$attrib};
                 }
                 chop $ret; chop $ret;
-                $ret .= "</li>\n";
+                $ret .= "</dd>\n";
             }
-            $ret .= "</ul>";
+            $ret .= "</dl><br />";
         }
 
         # communities they rejected
         if (@rejected) {
-            $ret .= "<?h1 $ML{'.rejected.title'} h1?><?p $ML{'.rejected.body'} p?><ul>";
-            $ret .= "<li>" . LJ::ljuser($us->{$_}, { type => 'C' }) . "</li>\n" foreach @rejected;
-            $ret .= "</ul>";
+            $ret .= "<?h2 $ML{'.rejected.title'} h2?><?p $ML{'.rejected.body2'} p?><dl>";
+            $ret .= "<dd>" . LJ::ljuser($us->{$_}, { type => 'C' }) . "</dd>\n" foreach @rejected;
+            $ret .= "</dl><br />";
         }
 
         # now print out undecided results
         if (@undecided) {
-            $ret .= "<?h1 $ML{'.undecided.title'} h1?><?p $ML{'.undecided.body'} p?><ul>";
-            $ret .= "<li>" . LJ::ljuser($us->{$_}, { type => 'C' }) . "</li>\n" foreach @undecided;
-            $ret .= "</ul>";
+            $ret .= "<?h2 $ML{'.undecided.title'} h2?><?p $ML{'.undecided.body2'} p?><dl>";
+            $ret .= "<dd>" . LJ::ljuser($us->{$_}, { type => 'C' }) . "</dd>\n" foreach @undecided;
+            $ret .= "</dl><br />";
         }
-
+        $ret .= "<?p $ML{'.success.fromhere'} p?>";
+        $ret .= "<ul>";
+            if (@undecided) {
+                $ret .= "<li><a href='$LJ::SITEROOT/manage/invites'>$ML{'.success.manageinvites'}</a></li>";
+            }
+        $ret .= "<li><a href='" . $u->journal_base . "/read'>$ML{'.success.readingpage'}</a></li>";
+        $ret .= "<li><a href='$LJ::SITEROOT/manage/circle/edit'>$ML{'.success.managecircle'}</a></li>";
+        $ret .= "<li><a href='$LJ::SITEROOT/community/manage'>$ML{'.success.managecomm'}</a></li>";
+        $ret .= "</ul>";
         return $ret;
     }
 
     # prepare table
+    $ret .= "<?p $ML{'.pending.body'} p?><br />";
     $ret .= "<form method='post'>\n<div align='center'><table id='invites-list' cellspacing='0' cellpadding='0'>";
     $ret .= LJ::form_auth();
-    $ret .= "<thead><tr><th>$ML{'.community.title'}</th><th>$ML{'.abilities.title'}</th>";
-    $ret .= "<th colspan='2'>$ML{'.actions.title'}</th>";
+    $ret .= "<thead><tr><th>$ML{'.community.title'}</th><th>$ML{'.abilities.title2'}</th>";
+    $ret .= "<th colspan='2'>$ML{'.answer.title'}</th>";
     $ret .= "</tr></thead>";
 
     # now list memberships
@@ -131,8 +140,11 @@ body<=
         my $date = LJ::mysql_time($invite->[2]);
 
         # now generate HTML
-        $ret .= "<tr class='$rstyle'><td class='invite-info'>" . LJ::ljuser($cu, { type => 'C' }) . " <br />$ename<br /><span class='invite-from'>";
-        $ret .= BML::ml('.fromline', { user => LJ::ljuser($us->{$invite->[1]}, { type => 'P' }), date => $date });
+        $ret .= "<tr class='$rstyle'><td class='invite-info'>" . LJ::ljuser($cu, { type => 'C' });
+        $ret .= "<br />$ename</br />";
+        $ret .= "<span class='invite-from'>";
+        $ret .= BML::ml('.from', { user => LJ::ljuser($us->{$invite->[1]}, { type => 'P' }) });
+        $ret .= "<br />" . BML::ml('.date', { date => $date });
         $ret .= "</span></td>";
         $ret .= "<td>" . join(', ', @tags) . "</td>";
         $ret .= "<td class='invite-accept'>" . LJ::html_check({ type => 'radio', name => $key, id => "yes$key", value => 'yes' });
@@ -144,7 +156,7 @@ body<=
 
     # all done
     $ret .= "</table><br />";
-    $ret .= "<div class='action-box'><ul class='nostyle inner'><li>" . LJ::html_submit('submit', $ML{'.submit'}) . "</li></ul></div><div class='clear-floats'></div>";
+    $ret .= "<div class='action-box'><ul class='nostyle inner'><li>" . LJ::html_submit('submit', $ML{'.submit2'}) . "</li></ul></div><div class='clear-floats'></div>";
     $ret .= "</div></form>";
 
     return $ret;

--- a/htdocs/manage/invites.bml.text
+++ b/htdocs/manage/invites.bml.text
@@ -1,27 +1,29 @@
 ;; -*- coding: utf-8 -*-
-.abilities.title=Abilities
+.abilities.title2=Relationships and Abilities
 
 .accept=Accept
 
-.accepted.body=You've joined the following communities, with the listed capabilities:
+.accepted.body2=You've joined the following communities, with the listed relationships and abilities:
 
 .accepted.title=Invitations Accepted
 
-.actions.title=Actions
+.answer.title=Answer
 
 .back=Manage invites
 
 .community.title=Community
 
+.date=([[date]])
+
 .decline=Decline
 
-.fromline=From [[user]] ([[date]])
+.from=from [[user]]
 
 .label.admin=Administrator
 
-.label.member=Member
+.label.member=Subscriber, Member
 
-.label.moderate=Administrator
+.label.moderate=Moderator
 
 .label.post=Can Post
 
@@ -33,15 +35,29 @@
 
 .none.title=Nothing Pending
 
-.rejected.body=You've rejected the following community invitations:
+.pending.body=You've been invited to join the following communities. You can either accept or decline each invitation. To leave an invitation pending don't select any answer.
+
+.rejected.body2=You've rejected invitations to the following communities:
 
 .rejected.title=Invitations Rejected
 
-.submit=Submit Selections
+.submit2=Submit Answers
 
-.title=Manage Community Invitations
+.success.fromhere=From here, you can:
 
-.undecided.body=You haven't decided on actions for the following invitations:
+.success.head=Success
+
+.success.manageinvites=Answer your community invitations
+
+.success.managecircle=Manage your Circle
+
+.success.managecomm=Manage your communities
+
+.success.readingpage=View your Reading Page
+
+.title2=Answer Community Invitations
+
+.undecided.body2=You haven't answered invitations to the following communities:
 
 .undecided.title=Invitations Still Pending
 


### PR DESCRIPTION
-- Rephrase link to /manage/invites in notifications
-- Rephrase Manage Invites title in several locations
-- Add explanatory text on /manage/invites and /community/manage
-- Rephrase various string on /manage/invites
-- Add text and list of links on success page
-- Add line-breaks
-- Downgrade subheaders to H2
-- Change UL to DL for community lists
-- Move dead string to deadphrases
