### PR TITLE
Bug 4935 - remove OBSOLETE setting warning

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1527,3 +1527,5 @@ general talk.comments.disabled_maintainer
 general /manage/circle/add.bml.groups.reading.feed1
 
 general /manage/invites.bml.fromline
+
+general settings.usermessaging.obsolete

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3165,8 +3165,6 @@ settings.state=State
 
 settings.state.us=US States
 
-settings.usermessaging.obsolete=OBSOLETE: this option has been moved to Account Settings.
-
 settings.yearofbirth=Year of Birth
 
 shop.email.accounttype=[[type]] for [[nummonths]] [[?nummonths|month|months]]

--- a/bin/upgrading/s2layers/core1.s2
+++ b/bin/upgrading/s2layers/core1.s2
@@ -1680,10 +1680,12 @@ property bool use_shared_pic {
 }
 set use_shared_pic = false;
 
+ # No longer displayed as obsolete in UI
 property bool view_entry_disabled {
     des = "Disable customized comment pages for your journal";
     note = "OBSOLETE: This option has been moved to Account Settings";
     obsolete = 1;
+    noui = 1; # No longer displayed in UI
 }
 set view_entry_disabled = false;
 

--- a/bin/upgrading/s2layers/core2.s2
+++ b/bin/upgrading/s2layers/core2.s2
@@ -1199,6 +1199,7 @@ property bool use_journalstyle_entry_page {
     des = "Show entry pages in my journal style rather than the site skin";
     note = "OBSOLETE: This option has been moved to Account Settings";
     obsolete = 1;
+    noui = 1; # No longer displayed in UI
 }
 
 property bool use_journalstyle_icons_page { des = "Show icons page in my journal style rather than the site skin"; }

--- a/htdocs/manage/profile/index.bml
+++ b/htdocs/manage/profile/index.bml
@@ -434,16 +434,6 @@ body<=
                 $ret .= "</td></tr>\n";
             }
 
-            # opt_usermsg
-            if ( LJ::is_enabled( 'user_messaging' ) ) {
-                $ret .= "<tr class='field_block" . $zebra_row->() . "'><td class='field_name'>";
-                $ret .= BML::ml( 'setting.usermessaging.label', { siteabbrev => $LJ::SITENAMEABBREV } );
-                $ret .= "</td><td><span class='helper'>";
-                $ret .= BML::ml( 'settings.usermessaging.obsolete' );
-                $ret .= "</span></td>\n<td class='selectvis'>";
-                $ret .= "</td></tr>\n";
-            }
-
         } # end is_person check
 
         if ( $u->can_use_textmessaging ) {


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4935
-- Remove obsolete section from manage/profile
-- Remove obsolete string and move to deadphrases
-- Hide obsolete option from customize
