### PR TITLE
(Bug 4868) Display the name even for external site tags

### DIFF
--- a/cgi-bin/LJ/TextUtil.pm
+++ b/cgi-bin/LJ/TextUtil.pm
@@ -280,7 +280,7 @@ sub strip_html {
     my $str = $_[0];
     return '' unless defined $str;
 
-    $str =~ s/\<(lj user|user name)\=['"]?([\w-]+)['"]?\>/$2/g;   # "
+    $str =~ s/\<(?:lj(?: site=[^\s]+)? user|user(?: site=[^\s]+)? name)\=['"]?([\w-]+)['"]?[^>]*\>/$1/g;
     $str =~ s/\<([^\<])+\>//g;
     return $str;
 }

--- a/t/textutil.t
+++ b/t/textutil.t
@@ -6,7 +6,7 @@ use Test::More;
 use lib "$ENV{LJHOME}/cgi-bin";
 use LJ::TextUtil;
 
-plan tests => 16;
+plan tests => 22;
 
 note("html breaks");
 ok(   LJ::has_too_many( "abcdn<br />" x 1, linebreaks => 0 ), "0 max, 1 break" );
@@ -42,3 +42,13 @@ ok(   LJ::has_too_many( "abcdn\n", chars => 0, linebreaks => 5 ),
                                 "0 chars, 6 chars; 5 linebreaks, 1 break" );
 ok( ! LJ::has_too_many( "abcdn\n", chars => 9, linebreaks => 5 ),
                                 "9 chars, 6 chars; 5 linebreaks, 1 break" );
+
+note( "striphtml user tags");
+is( LJ::strip_html( qq{<lj user="test">} ), "test", qq{ strip_html <lj user="test"> } );
+is( LJ::strip_html( qq{<user name="test">} ), "test", qq{ strip_html <user name="test"> } );
+
+is( LJ::strip_html( qq{<lj user="test" site="dreamwidth.org">} ), "test", qq{ <lj user="test" site="dreamwidth.org"> } );
+is( LJ::strip_html( qq{<user name="test" site="dreamwidth.org">} ), "test", qq{ <user name="test" site="dreamwidth.org"> } );
+
+is( LJ::strip_html( qq{<lj site="dreamwidth.org" user="test">} ), "test", qq{ <lj site="dreamwidth.org" user="test"> } );
+is( LJ::strip_html( qq{<user site="dreamwidth.org" name="test">} ), "test", qq{ <user site="dreamwidth.org" name="test"> } );


### PR DESCRIPTION
We strip_html in some places where we don't want random HTML tags showing up,
but in these cases, we still want user names to be displayed as text.

That worked okay as long as there was no "site=..." in there; this change
makes us able to handle site=... (basically we ignore it, but then pick out
the user name to display as text)
