### PR TITLE
(Bug 2596) Paginate the notifications page

### DIFF
--- a/htdocs/manage/settings/index.bml
+++ b/htdocs/manage/settings/index.bml
@@ -543,6 +543,8 @@ body<=
             categories    => \@categories,
             showtracking  => 1,
             settings_page => 1,
+            num_per_page  => 250,
+            page          => int( $GET{page} || 0 ),
         ) . "<br />";
 
     } else {


### PR DESCRIPTION
Pagination happens at 250 items per page; the non-custom tracking items are
always displayed
