### PR TITLE
Bug4764/s2 pagination

### DIFF
--- a/bin/upgrading/s2layers/siteviews/layout.s2
+++ b/bin/upgrading/s2layers/siteviews/layout.s2
@@ -56,27 +56,31 @@ function ItemRange::print(string{} opts) {
     """<div class="$class">""";
     print """<p style="font-weight: bolder; margin: 0 0 .5em 0;">""" + lang_page_of_pages($.current, $.total) + "</p>";
     var string url_prev = $this->url_of($.current - 1);
+    """<span class="page-prev">""";
     if ($.current != 1) {
         print " <b><a href='$url_prev$anchor'>$*comment_page_prev</a></b> ";
     } else {
         print " <b>$*comment_page_prev</b> ";
     }
-    """<span style="text-align: center">""";
+    """</span>
+    <span style="text-align: center" class="page-links">""";
     foreach var int i (1..$.total) {
         if ($i == $.current) { "<b>[$i]</b> "; }
         else {
             var string url_of = $this->url_of($i);
             "<a href='$url_of$anchor'><b>[$i]</b></a> ";
         }
-    }
+        if ($i % 10 == 0){ """<br />"""; }
+        }
     """</span>""";
     var string url_next = $this->url_of($.current + 1);
+    """<span class="page-next">""";
     if ($.current != $.total) {
          print " <b><a href='$url_next$anchor'>$*comment_page_next</a></b> ";
     } else {
          print " <b>$*comment_page_next</b> ";
     }
-
+    """</span>""";
     if ( $.url_all != "" ) {
         """<p><a href="$.url_all">View All</a></p>""";
     }
@@ -275,8 +279,10 @@ if ($p isa ReplyPage) {
 
 }
 function EntryPage::print_entry_footer(Entry e) {
-    """<hr class="above-entry-interaction-links" />""";
+    """<hr class="above-entry-interaction-links" />
+    <div class="comment-pages-wrapper">""";
     $.comment_pages->print({ "anchor" => "comments", "class" => "comment-pages toppages comment-page-list" });
+    """</div>""";
     $e->print_interaction_links("topcomment");
 }
 
@@ -302,8 +308,9 @@ function EntryPage::print_comment_section(Entry e) {
         $this->print_multiform_actionline();
         $this->print_multiform_end();
    }
+    """<div class="commment-pages-wrapper">""";
    $.comment_pages->print({ "anchor" => "comments", "class" => "comment-pages bottompages comment-page-list" });
-    "</div></div>";
+    "</div></div></div>";
 }
 
 function EntryPage::print_comments (Comment[] cs) {

--- a/htdocs/stc/entrypage.css
+++ b/htdocs/stc/entrypage.css
@@ -41,8 +41,10 @@ hr.above-entry-interaction-links, hr.below-entry-interaction-links {margin: 1em 
 .entry-interaction-links, .comment-pages {text-align: center; font-weight:bold; float:none;}
 .entry-interaction-links li {display:inline;}
 ul.entry-interaction-links {list-style: none outside none; display: inline; text-align: center; padding: 0.5em 0; margin:0;}
-.comment-page-list {max-width: 28em; margin: 1em auto; padding: .5em;}
-
+.comment-page-list { margin: 1em auto; padding: .5em;display:inline-block;}
+.page-prev, .page-next, .page-links {display: table-cell;}
+.page-prev, .page-next { vertical-align: middle; padding:0 .5em;}
+.commment-pages-wrapper {text-align: center;}
 /* give talkread styling to management links without S2 overrides*/
 .entry-interaction-links li:before, .comment-interaction-links li:before, .view-flat:before, .view-threaded:before, .view-top-only:before, .expand_all:before {content:"(";}
 .entry-interaction-links li:after, .comment-interaction-links li:after, .view-flat:after, .view-threaded:after, .view-top-only:after, .expand_all:after {content:")";}


### PR DESCRIPTION
Updated to D's specs! Tested in FF18 on Linux by me (extensively, haha), and IE8 by Drew, both are functional. CSS compatibility means Chrome/Opera/Safari all should be good to go, though it's maybe worth a look. In IE7 it fails back to look like the current talkread pagination, and IE6 does the same though with bonus full-width background box because IE6.
