### PR TITLE
Bug 4950 - add "extra large" setting for image placeholders

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2867,6 +2867,8 @@ setting.imageplaceholders.option.select.large=large images (over [[width]]x[[hei
 
 setting.imageplaceholders.option.select.medium=medium images (over [[width]]x[[height]])
 
+setting.imageplaceholders.option.select.xlarge=extra large images (over [[width]]x[[height]])
+
 setting.imageplaceholders.option.select.none=nothing (display all images)
 
 setting.imageplaceholders.option.undef2=Replace images of unknown size with a placeholder

--- a/cgi-bin/LJ/Setting/ImagePlaceholders.pm
+++ b/cgi-bin/LJ/Setting/ImagePlaceholders.pm
@@ -48,6 +48,7 @@ sub option {
     my $is_stock = {
         "320|240" => 1,
         "640|480" => 1,
+        "800|600" => 1,
         "0|0" => 1,
         "" => 1,
     }->{$imgplaceholders};
@@ -60,6 +61,7 @@ sub option {
         "0|0" => $class->ml('setting.imageplaceholders.option.select.all'),
         "320|240" => $class->ml('setting.imageplaceholders.option.select.medium', { width => 320, height => 240 }),
         "640|480" => $class->ml('setting.imageplaceholders.option.select.large', { width => 640, height => 480 }),
+        "800|600" => $class->ml('setting.imageplaceholders.option.select.xlarge', { width => 800, height => 600 }),
         $extra ? ("$maxwidth|$maxheight" => $extra) : ()
     );
 


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4950
-- Add setting for images over 800x600
