### PR TITLE
Bug 4941 - console command documentation wrong

### DIFF
--- a/cgi-bin/LJ/Console/Command/ResetPassword.pm
+++ b/cgi-bin/LJ/Console/Command/ResetPassword.pm
@@ -22,7 +22,7 @@ sub cmd { "reset_password" }
 sub desc { "Resets the password for a given account" }
 
 sub args_desc { [
-                 'user' => "The account to reset the email address for.",
+                 'user' => "The account to reset the password for.",
                  'reason' => "Reason for the password reset.",
                  ] }
 


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=4941
-- Fix doc for reset_password command
