### PR TITLE
(Bug1867) Add editing of module title in wizard

### DIFF
--- a/bin/upgrading/s2layers/abstractia/layout.s2
+++ b/bin/upgrading/s2layers/abstractia/layout.s2
@@ -371,6 +371,7 @@ propgroup text {
     property use text_module_credit;
     property use text_module_search;
     property use text_module_cuttagcontrols;
+    property use text_module_subscriptionfilters;
 
 ##===============================
 ## Text - main navigation

--- a/bin/upgrading/s2layers/bases/layout.s2
+++ b/bin/upgrading/s2layers/bases/layout.s2
@@ -210,6 +210,7 @@ propgroup text {
     property use text_module_credit;
     property use text_module_search;
     property use text_module_cuttagcontrols;
+    property use text_module_subscriptionfilters;
 
     property use text_view_recent;
     property use text_view_archive;

--- a/bin/upgrading/s2layers/blanket/layout.s2
+++ b/bin/upgrading/s2layers/blanket/layout.s2
@@ -191,6 +191,7 @@ propgroup text {
     property use text_module_credit;
     property use text_module_search;
     property use text_module_cuttagcontrols;
+    property use text_module_subscriptionfilters;
 
     property use text_view_recent;
     property use text_view_archive;

--- a/bin/upgrading/s2layers/brittle/layout.s2
+++ b/bin/upgrading/s2layers/brittle/layout.s2
@@ -259,6 +259,7 @@ propgroup text {
     property use text_module_credit;
     property use text_module_search;
     property use text_module_cuttagcontrols;
+    property use text_module_subscriptionfilters;
 
     property use text_view_recent;
     property use text_view_archive;

--- a/bin/upgrading/s2layers/core2base/layout.s2
+++ b/bin/upgrading/s2layers/core2base/layout.s2
@@ -189,6 +189,7 @@ propgroup text {
     property use text_module_credit;
     property use text_module_search;
     property use text_module_cuttagcontrols;
+    property use text_module_subscriptionfilters;
 
     property use text_view_recent;
     property use text_view_archive;

--- a/bin/upgrading/s2layers/drifting/layout.s2
+++ b/bin/upgrading/s2layers/drifting/layout.s2
@@ -215,6 +215,7 @@ propgroup text
     property use text_module_credit;
     property use text_module_search;
     property use text_module_cuttagcontrols;
+    property use text_module_subscriptionfilters;
 
     property use text_view_recent;
     property use text_view_friends;

--- a/bin/upgrading/s2layers/easyread/layout.s2
+++ b/bin/upgrading/s2layers/easyread/layout.s2
@@ -161,6 +161,7 @@ propgroup text {
     property use text_module_credit;
     property use text_module_search;
     property use text_module_cuttagcontrols;
+    property use text_module_subscriptionfilters;
 
 ##===============================
 ## Text - main navigation

--- a/bin/upgrading/s2layers/negatives/layout.s2
+++ b/bin/upgrading/s2layers/negatives/layout.s2
@@ -192,6 +192,7 @@ propgroup text {
     property use text_module_credit;
     property use text_module_search;
     property use text_module_cuttagcontrols;
+    property use text_module_subscriptionfilters;
 
     property use text_view_recent;
     property use text_view_archive;

--- a/bin/upgrading/s2layers/skittlishdreams/layout.s2
+++ b/bin/upgrading/s2layers/skittlishdreams/layout.s2
@@ -280,6 +280,7 @@ propgroup text {
     property use text_module_customtext;
     property use text_module_customtext_url;
     property use text_module_customtext_content;
+    property use text_module_subscriptionfilters;
 
     property use text_view_recent;
     property use text_view_archive;

--- a/cgi-bin/LJ/S2Theme.pm
+++ b/cgi-bin/LJ/S2Theme.pm
@@ -955,6 +955,7 @@ sub module_props {
         text_module_credit
         text_module_search
         text_module_cuttagcontrols
+        text_module_subscriptionfilters
     )
 }
 


### PR DESCRIPTION
@ninetyd noted on the last pull on this bug that
text_module_subscriptionfilters was missing in the wizard as an
option; this commit adds in that ability across all the layouts
that have defined text_module_\* properties.
