### PR TITLE
Bug 4509 - Bug 4509 - Makes expand/collapse arrows scalable with font size, adds svg versions for higher res, adds logic for gif fallback

### DIFF
--- a/htdocs/img/collapse-end.svg
+++ b/htdocs/img/collapse-end.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="11"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="collapse-end.svg">
+  <defs
+     id="defs4">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5197">
+      <rect
+         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:1.69829202px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+         id="rect5199"
+         width="26.713154"
+         height="43.187649"
+         x="575.1087"
+         y="111.77785"
+         transform="matrix(0.69465839,0.71933978,-0.71933979,0.69465838,0,0)" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-176.09784"
+     inkscape:cy="-36.160897"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="853"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="vectors"
+     transform="translate(0,-1041.3622)" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1041.3622)">
+    <path
+       sodipodi:type="star"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3009"
+       sodipodi:sides="3"
+       sodipodi:cx="311"
+       sodipodi:cy="519.36218"
+       sodipodi:r1="8.2462111"
+       sodipodi:r2="4.1231055"
+       sodipodi:arg1="1.3258177"
+       sodipodi:arg2="2.3730153"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 313,527.36218 -4.9641,-5.13397 -4.9641,-5.13398 6.9282,-1.73205 6.9282,-1.73205 -1.9641,6.86603 z"
+       inkscape:transform-center-x="1.4364831"
+       inkscape:transform-center-y="-0.26142674"
+       transform="matrix(-0.26573477,-0.41487761,0.2566171,-0.42961833,-44.122403,1398.7478)"
+       clip-path="url(#clipPath5197)" />
+  </g>
+</svg>

--- a/htdocs/img/collapse.svg
+++ b/htdocs/img/collapse.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="11"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="collapse-end.svg">
+  <defs
+     id="defs4">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5197">
+      <rect
+         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:1.69829202px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+         id="rect5199"
+         width="26.713154"
+         height="43.187649"
+         x="575.1087"
+         y="111.77785"
+         transform="matrix(0.69465839,0.71933978,-0.71933979,0.69465838,0,0)" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-176.09784"
+     inkscape:cy="-36.160897"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="853"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="vectors"
+     transform="translate(0,-1041.3622)" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1041.3622)">
+    <path
+       sodipodi:type="star"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3009"
+       sodipodi:sides="3"
+       sodipodi:cx="311"
+       sodipodi:cy="519.36218"
+       sodipodi:r1="8.2462111"
+       sodipodi:r2="4.1231055"
+       sodipodi:arg1="1.3258177"
+       sodipodi:arg2="2.3730153"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 313,527.36218 -4.9641,-5.13397 -4.9641,-5.13398 6.9282,-1.73205 6.9282,-1.73205 -1.9641,6.86603 z"
+       inkscape:transform-center-x="-1.4364829"
+       inkscape:transform-center-y="0.26142893"
+       transform="matrix(0.26573477,0.41487761,-0.2566171,0.42961833,56.496503,694.95864)"
+       clip-path="url(#clipPath5197)" />
+  </g>
+</svg>

--- a/htdocs/img/collapseAll.svg
+++ b/htdocs/img/collapseAll.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="15"
+   height="11"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="collapseAll.svg">
+  <defs
+     id="defs4">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5197">
+      <rect
+         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:1.69829202px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+         id="rect5199"
+         width="26.713154"
+         height="43.187649"
+         x="575.1087"
+         y="111.77785"
+         transform="matrix(0.69465839,0.71933978,-0.71933979,0.69465838,0,0)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5197-1">
+      <rect
+         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:1.69829202px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+         id="rect5199-7"
+         width="26.713154"
+         height="43.187649"
+         x="575.1087"
+         y="111.77785"
+         transform="matrix(0.69465839,0.71933978,-0.71933979,0.69465838,0,0)" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="2.4466238"
+     inkscape:cy="5.2048501"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="853"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="vectors"
+     transform="translate(0,-1041.3622)" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1041.3622)">
+    <path
+       sodipodi:type="star"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3009"
+       sodipodi:sides="3"
+       sodipodi:cx="311"
+       sodipodi:cy="519.36218"
+       sodipodi:r1="8.2462111"
+       sodipodi:r2="4.1231055"
+       sodipodi:arg1="1.3258177"
+       sodipodi:arg2="2.3730153"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 313,527.36218 -4.9641,-5.13397 -4.9641,-5.13398 6.9282,-1.73205 6.9282,-1.73205 -1.9641,6.86603 z"
+       inkscape:transform-center-x="-1.4365089"
+       inkscape:transform-center-y="0.26142891"
+       transform="matrix(0.26573477,0.41487761,-0.2566171,0.42961833,52.496529,694.95864)"
+       clip-path="url(#clipPath5197)" />
+    <path
+       sodipodi:type="star"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3009-4"
+       sodipodi:sides="3"
+       sodipodi:cx="311"
+       sodipodi:cy="519.36218"
+       sodipodi:r1="8.2462111"
+       sodipodi:r2="4.1231055"
+       sodipodi:arg1="1.3258177"
+       sodipodi:arg2="2.3730153"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 313,527.36218 -4.9641,-5.13397 -4.9641,-5.13398 6.9282,-1.73205 6.9282,-1.73205 -1.9641,6.86603 z"
+       inkscape:transform-center-x="-1.4365089"
+       inkscape:transform-center-y="0.26142891"
+       transform="matrix(0.26573477,0.41487761,-0.2566171,0.42961833,57.496529,694.95864)"
+       clip-path="url(#clipPath5197-1)" />
+  </g>
+</svg>

--- a/htdocs/img/expand.svg
+++ b/htdocs/img/expand.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="11"
+   height="11"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="expand.svg">
+  <defs
+     id="defs4">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5197">
+      <rect
+         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:1.69829202px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+         id="rect5199"
+         width="26.713154"
+         height="43.187649"
+         x="575.1087"
+         y="111.77785"
+         transform="matrix(0.69465839,0.71933978,-0.71933979,0.69465838,0,0)" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-176.09784"
+     inkscape:cy="-36.160897"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="853"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="vectors"
+     transform="translate(0,-1041.3622)" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1041.3622)">
+    <path
+       sodipodi:type="star"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3009"
+       sodipodi:sides="3"
+       sodipodi:cx="311"
+       sodipodi:cy="519.36218"
+       sodipodi:r1="8.2462111"
+       sodipodi:r2="4.1231055"
+       sodipodi:arg1="1.3258177"
+       sodipodi:arg2="2.3730153"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 313,527.36218 -4.9641,-5.13397 -4.9641,-5.13398 6.9282,-1.73205 6.9282,-1.73205 -1.9641,6.86603 z"
+       inkscape:transform-center-x="0.26142791"
+       inkscape:transform-center-y="1.4365111"
+       transform="matrix(-0.41487761,0.26573477,-0.42961833,-0.2566171,357.08163,1098.1627)"
+       clip-path="url(#clipPath5197)" />
+  </g>
+</svg>

--- a/htdocs/img/expandAll.svg
+++ b/htdocs/img/expandAll.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="11"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="expandAll.svg">
+  <defs
+     id="defs4">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5197">
+      <rect
+         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:1.69829202px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+         id="rect5199"
+         width="26.713154"
+         height="43.187649"
+         x="575.1087"
+         y="111.77785"
+         transform="matrix(0.69465839,0.71933978,-0.71933979,0.69465838,0,0)" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5197-1">
+      <rect
+         style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:1.69829202px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0"
+         id="rect5199-7"
+         width="26.713154"
+         height="43.187649"
+         x="575.1087"
+         y="111.77785"
+         transform="matrix(0.69465839,0.71933978,-0.71933979,0.69465838,0,0)" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-176.09784"
+     inkscape:cy="-36.160897"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="853"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2997"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="vectors"
+     transform="translate(0,-1041.3622)" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1041.3622)">
+    <path
+       sodipodi:type="star"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3009"
+       sodipodi:sides="3"
+       sodipodi:cx="311"
+       sodipodi:cy="519.36218"
+       sodipodi:r1="8.2462111"
+       sodipodi:r2="4.1231055"
+       sodipodi:arg1="1.3258177"
+       sodipodi:arg2="2.3730153"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 313,527.36218 -4.9641,-5.13397 -4.9641,-5.13398 6.9282,-1.73205 6.9282,-1.73205 -1.9641,6.86603 z"
+       inkscape:transform-center-x="0.26142796"
+       inkscape:transform-center-y="1.4365111"
+       transform="matrix(-0.41487761,0.26573477,-0.42961833,-0.2566171,357.08163,1098.1627)"
+       clip-path="url(#clipPath5197)" />
+    <path
+       sodipodi:type="star"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.00061345;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3009-4"
+       sodipodi:sides="3"
+       sodipodi:cx="311"
+       sodipodi:cy="519.36218"
+       sodipodi:r1="8.2462111"
+       sodipodi:r2="4.1231055"
+       sodipodi:arg1="1.3258177"
+       sodipodi:arg2="2.3730153"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 313,527.36218 -4.9641,-5.13397 -4.9641,-5.13398 6.9282,-1.73205 6.9282,-1.73205 -1.9641,6.86603 z"
+       inkscape:transform-center-x="0.26142796"
+       inkscape:transform-center-y="1.4365111"
+       transform="matrix(-0.41487761,0.26573477,-0.42961833,-0.2566171,366.08163,1098.1627)"
+       clip-path="url(#clipPath5197-1)" />
+  </g>
+</svg>

--- a/htdocs/js/cuttag-ajax.js
+++ b/htdocs/js/cuttag-ajax.js
@@ -84,7 +84,7 @@ CutTagHandler = new Class(Object, {
 
         var closeEnd = document.createElement("span");
 
-        closeEnd.innerHTML = ' <a href="#span-'+this.identifier+'" onclick=" CutTagHandler.toggleCutTag(\''+this.data.journal+'\', \''+this.data.ditemid+'\', \''+this.data.cutid+'\');"><img style="border: 0;" src="' + Site.imgprefix + '/collapse-end.gif" aria-controls="div-cuttag_' + this.identifier + '" alt="' + expanded + '" title="' + expanded + '"/></a>';
+        closeEnd.innerHTML = ' <a href="#span-'+this.identifier+'" onclick=" CutTagHandler.toggleCutTag(\''+this.data.journal+'\', \''+this.data.ditemid+'\', \''+this.data.cutid+'\');"><img style="border: 0; max-width: 100%; width: 0.7em; padding: 0.2em;" src="' + Site.imgprefix + '/collapse-end.gif" aria-controls="div-cuttag_' + this.identifier + '" alt="' + expanded + '" title="' + expanded + '"/></a>';
         replaceDiv.appendChild(closeEnd);
 
         DOM.addClassName(replaceDiv, "cuttag-open");
@@ -123,7 +123,7 @@ CutTagHandler.toggleCutTag = function(journal, ditemid, cutid) {
 CutTagHandler.writeExpandTag = function(tag, journal, ditemid, cutid) {
   var identifier = journal + '_' + ditemid + '_' + cutid;
   tag.style.display = 'inline'
-  tag.innerHTML = '<a href="#" onclick="return CutTagHandler.toggleCutTag(\'' + journal + '\', \'' + ditemid + '\', \'' + cutid + '\');" id="cuttag_' + identifier +'" ><img style="border: 0;" id="img-cuttag_' + identifier + '" src="' + Site.imgprefix + '/collapse.gif" aria-controls="div-cuttag_' + identifier + '" alt="' + collapsed + '" title="' + collapsed + '"/></a>';
+  tag.innerHTML = '<a href="#" onclick="return CutTagHandler.toggleCutTag(\'' + journal + '\', \'' + ditemid + '\', \'' + cutid + '\');" id="cuttag_' + identifier +'" ><img style="border: 0; max-width: 100%; width: 0.7em; padding: 0.2em;" id="img-cuttag_' + identifier + '" src="' + Site.imgprefix + '/collapse.gif" aria-controls="div-cuttag_' + identifier + '" alt="' + collapsed + '" title="' + collapsed + '"/></a>';
 }
 
 

--- a/htdocs/js/jquery.cuttag-ajax.js
+++ b/htdocs/js/jquery.cuttag-ajax.js
@@ -4,6 +4,30 @@ var isExpandingAll = 0;
 
 var loadPending = 0;
 
+// Test for SVG support from
+// http://stackoverflow.com/questions/654112/how-do-you-detect-support-for-vml-or-svg-in-a-browser
+// If we expand SVG usage on the site this function should get
+// pulled out of this file.
+function supportsSVG() {
+            return !!document.createElementNS && !!document.createElementNS('http://www.w3.org/2000/svg', "svg").createSVGRect;
+}
+
+if ( supportsSVG() ) {
+        var collapse_img        = "/collapse.svg";
+        var expand_img          = "/expand.svg";
+        var collapseall_img     = "/collapseAll.svg";
+        var expandall_img       = "/expandAll.svg";
+        var ajaxloader_img      = "/ajax-loader.gif";
+        var collapseend_img     = "/collapse-end.svg";
+} else {
+        var collapse_img        = "/collapse.gif";
+        var expand_img          = "/expand.gif";
+        var collapseall_img     = "/collapseAll.gif";
+        var expandall_img       = "/expandAll.gif";
+        var ajaxloader_img      = "/ajax-loader.gif";
+        var collapseend_img     = "/collapse-end.gif";
+}
+
 $.widget("dw.cuttag", {
     options: {
         journal: undefined,
@@ -49,7 +73,7 @@ $.widget("dw.cuttag", {
             "div": theDiv
         };
 
-        self._setArrow("/collapse.gif", self.config.text.expand);
+        self._setArrow(collapse_img, self.config.text.expand);
 
         self.element.append(a);
 
@@ -80,7 +104,7 @@ $.widget("dw.cuttag", {
             return;
 
         loadPending++;
-        self._setArrow("/ajax-loader.gif", self.config.text.loading);
+        self._setArrow(ajaxloader_img, self.config.text.loading);
         $.ajax({
             "method": "GET",
             "url": self.ajaxUrl,
@@ -96,7 +120,7 @@ $.widget("dw.cuttag", {
         if ( ! this.isOpen() )
             return;
         this.tag.div.removeClass("cuttag-open");
-        this._setArrow("/collapse.gif", this.config.text.expand);
+        this._setArrow(collapse_img, this.config.text.expand);
 
         this.tag.div.empty();
         this.tag.div.css("display","none");
@@ -108,15 +132,16 @@ $.widget("dw.cuttag", {
         i.attr("src",Site.imgprefix + path);
         i.attr("alt",str);
         i.attr("title",str);
+        i.attr("style","max-width: 100%; width: 0.7em; padding: 0.2em;");
     },
     handleError: function(error) {
-        this._setArrow("/collapse.gif", this.config.text.expand);
+        this._setArrow(collapse_img, this.config.text.expand);
         alert(error);
     },
     replaceCutTag: function(resObj) {
         var self = this;
         if ( resObj.error ) {
-            self._setArrow("/collapse.gif", self.config.text.expand);
+            self._setArrow(collapse_img, self.config.text.expand);
         } else {
             var replaceDiv = self.tag.div;
             replaceDiv.html(resObj.text)
@@ -128,8 +153,8 @@ $.widget("dw.cuttag", {
                 "class": "cuttag-action cuttag-action-after"
             });
             var img = $("<img>",{
-                style: "border: 0;",
-                src: Site.imgprefix + "/collapse-end.gif",
+                style: "border: 0; max-width: 100%; width: 0.7em; padding: 0.2em;",
+                src: Site.imgprefix + collapseend_img,
                 "aria-controls": 'div-cuttag_' + self.identifier,
                 alt: self.config.text.collapse,
                 title: self.config.text.collapse
@@ -145,7 +170,7 @@ $.widget("dw.cuttag", {
                 self.toggle();
             });
 
-            self._setArrow("/expand.gif", self.config.text.collapse);
+            self._setArrow(expand_img, self.config.text.collapse);
 
             replaceDiv.trigger( "updatedcontent.entry" );
             $.dw.cuttag.initLinks(replaceDiv);
@@ -202,12 +227,12 @@ $.widget("dw.cuttag_controls", {
         var el_exp = $("<img>", {
             alt: self.config.text.expand,
             title: self.config.text.expand,
-            src: Site.imgprefix + "/collapseAll.gif",
+            src: Site.imgprefix + collapseall_img,
             style: aria_closed ? self.config.image_style.enabled : self.config.image_style.disabled
         });
 
         if ( isExpandingAll ) {
-            el_exp.attr("src",Site.imgprefix + "/ajax-loader.gif");
+            el_exp.attr("src",Site.imgprefix + ajaxloader_img);
             el_exp.attr("style",self.config.image_style.enabled);
             el_exp.attr("title",self.config.text.expanding);
             el_exp.attr("alt",self.config.text.expanding);
@@ -233,7 +258,7 @@ $.widget("dw.cuttag_controls", {
         var el_col = $("<img>", {
             alt: self.config.text.collapse,
             title: self.config.text.collapse,
-            src: Site.imgprefix + "/expandAll.gif",
+            src: Site.imgprefix + expandall_img,
             style: aria_open ? self.config.image_style.enabled : self.config.image_style.disabled
         });
         if ( aria_open ) {


### PR DESCRIPTION
It's possible the svg files will be considered to need some design work, but that had best be done by 
- someone with an eye for design, who
- has working hands

I did the best I could to emulate our very pixelated triangles as svgs, but a graphic designer I am not.
