### PR TITLE
(Bug 5025) Enables markdown parsing for replies-by-email

### DIFF
--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -1325,6 +1325,11 @@ talkproplist.deleted_poster:
   des: If the comment poster's account is deleted, this field gets added to all of their posts, so the UI can show something besides 'anonymous' when posterid gets set to 0
   prettyname: Username of deleted poster
 
+talkproplist.editor:
+  datatype: char
+  des: Type of editor used when making this content. Values: "markdown" or undefined (plain/raw html)
+  prettyname: Comment editor
+
 talkproplist.import_source:
   datatype: char
   des: Where this comment was imported from

--- a/cgi-bin/DW/EmailPost/Comment.pm
+++ b/cgi-bin/DW/EmailPost/Comment.pm
@@ -109,6 +109,7 @@ sub _process {
         prop_picture_keyword => $self->{props}->{picture_keyword},
 
         useragent => "emailpost",
+        editor    => "markdown",
     };
 
     # post!

--- a/cgi-bin/LJ/Comment.pm
+++ b/cgi-bin/LJ/Comment.pm
@@ -864,6 +864,7 @@ sub body_html {
     my $opts;
     $opts->{preformatted} = $self->prop("opt_preformatted");
     $opts->{anon_comment} = LJ::Talk::treat_as_anon( $self->poster, $self->journal );
+    $opts->{editor} = $self->prop( "editor" );
 
     my $body = $self->body_raw;
     LJ::CleanHTML::clean_comment(\$body, $opts) if $body;

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -262,7 +262,10 @@ sub addcomment
 
     return fail( $err, $err_code_mapping, $comment_err->{msg} ) if $comment_err;
 
-    $comment->set_prop( useragent => $req->{useragent} ) if $req->{useragent};
+    my %props = ();
+    $props{useragent} = $req->{useragent} if $req->{useragent};
+    $props{editor} = $req->{editor} if $req->{editor};
+    $comment->set_props( %props );
 
     # OK
     return {

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -161,6 +161,7 @@ sub EntryPage
 
             LJ::CleanHTML::clean_comment( \$text, { preformatted => $com->{props}->{opt_preformatted},
                                                     anon_comment => LJ::Talk::treat_as_anon( $pu, $u ),
+                                                    editor => $com->{props}->{editor}
                                                   } );
 
             # local time in mysql format to gmtime

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -203,6 +203,7 @@ sub ReplyPage
                                      {
                                          preformatted => $parpost->{props}->{opt_preformatted},
                                          anon_comment => LJ::Talk::treat_as_anon( $pu, $u ),
+                                         editor => $parpost->{props}->{editor},
                                      });
 
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -4043,7 +4043,9 @@ sub make_preview {
     my $u = LJ::load_user( $form->{journal} );
     my $cleanok = LJ::CleanHTML::clean_comment( \$event,
                   { anon_comment => LJ::Talk::treat_as_anon( $remote, $u ),
-                    preformatted => $form->{prop_opt_preformatted} } );
+                    preformatted => $form->{prop_opt_preformatted},
+                    editor       => $form->{editor}, # no form option yet
+                  } );
     if (defined($cleanok) && $LJ::SPELLER && $form->{'do_spellcheck'}) {
         my $s = new LJ::SpellCheck { 'spellcommand' => $LJ::SPELLER,
                                      'color' => '<?hotcolor?>', };

--- a/htdocs/talkread.bml
+++ b/htdocs/talkread.bml
@@ -628,6 +628,7 @@ body<=
                 $ret .= "</td></tr><tr><td class='commentbody usercontent'>";
 
                 LJ::CleanHTML::clean_comment( \$post->{body}, { preformatted => $post->{'props'}->{'opt_preformatted'},
+                                                                editor => $post->{props}->{editor},
                                                                 anon_comment => LJ::Talk::treat_as_anon( $pu, $u ),
                                                               } );
                 BML::ebml(\$post->{'body'});

--- a/htdocs/tools/recent_comments.bml
+++ b/htdocs/tools/recent_comments.bml
@@ -238,6 +238,7 @@ body<=
 
             my $comment = $comment_text->{$r->{jtalkid}}[1];
             LJ::CleanHTML::clean_comment( \$comment, { preformatted => $r->{props}->{opt_preformatted},
+                                                       editor => $r->{props}->{editor},
                                                        anon_comment => LJ::Talk::treat_as_anon( $pu, $u ),
                                                        nocss => 1,
                                                      } );


### PR DESCRIPTION
So. Gmail automatically hardwraps sent messages. We can strive to unwrap it,
with the attendant difficulties (what if the wrapping is in the middle of an
HTML tag? what about multiple line breaks vs single line breaks?), or we can
rely on a library which is meant to handle text like this.

So. Markdown -- HTML still works, along with the various formatting shortcuts
markdown offers.

For a certain subset of users who regularly use their mobile phones, this
should also be easier than switching keyboards to type angled brackets/quotes

We use regular markdown, with a variant of @username to refer to a specific
user.
