### PR TITLE
(Bug 5027) Pass up the error message to the caller

### DIFF
--- a/t/comment-create.t
+++ b/t/comment-create.t
@@ -1,0 +1,50 @@
+use strict;
+use Test::More tests => 6;
+use lib "$ENV{LJHOME}/cgi-bin";
+BEGIN { require 'ljlib.pl'; }
+use LJ::Test qw( temp_user );
+use LJ::Comment;
+
+my $ju = temp_user();
+my $pu = temp_user();
+
+{
+    my $err_ref;
+    my $c = LJ::Comment->create(
+        err_ref => \$err_ref,
+
+        journal => undef,
+        poster => undef,
+    );
+
+    ok( ! $c, "No comment created: invalid journal" );
+    is( $err_ref->{code}, "bad_journal" );
+}
+
+{
+    my $err_ref;
+    my $c = LJ::Comment->create(
+        err_ref => \$err_ref,
+
+        journal => $ju,
+        poster => undef,
+    );
+
+    ok( ! $c, "No comment created: invalid poster" );
+    is( $err_ref->{code}, "bad_poster" );
+}
+
+{
+    my $err_ref;
+    my $c = LJ::Comment->create(
+        err_ref => \$err_ref,
+
+        journal => $ju,
+        poster => $pu,
+
+        extra_args => undef
+    );
+
+    ok( ! $c, "No comment created: invalid args" );
+    is( $err_ref->{code}, "bad_args" );
+}


### PR DESCRIPTION
This lets us recover from the error state and fire off error messages 
properly. It also means we get to choose whether to retry or not
(instead of catastrophic failure all the time)
