### PR TITLE
(Bug 5026) Don't hardcode the "---Original Message---" text

### DIFF
--- a/cgi-bin/DW/CleanEmail.pm
+++ b/cgi-bin/DW/CleanEmail.pm
@@ -36,7 +36,11 @@ sub nonquoted_text {
     # remove all quoted lines, nice and easy
     foreach ( @lines ) {
         last if m/^\s*>/;
-        last if m/^\s*-*Original Message-*/;
+
+        # e.g., --- Original Message ---
+        # but this can be in various languages, so  not hardcoding the text
+        last if m/^\s*-{3,}[^-]+-{3,}\s*$/;
+
         $num_lines++;
     }
 

--- a/t/cleanemail.t
+++ b/t/cleanemail.t
@@ -1,7 +1,7 @@
 # -*-perl-*-
 
 use strict;
-use Test::More tests => 12;
+use Test::More tests => 13;
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { require 'ljlib.pl'; }
 use DW::CleanEmail;
@@ -114,6 +114,7 @@ tuv
 wxyz}, "'On wrote...' separator too many lines back - don't count as end of the message" );
 }
 
+# blackberry, etc
 {
     my $nonquoted = DW::CleanEmail->nonquoted_text(q{
 foo
@@ -123,9 +124,20 @@ Reply-To: etc
 some original text here
 });
 
-    # blackberry
     is( $nonquoted, q{
 foo}, "---Original Message--- separator")
+}
+
+{
+    my $nonquoted = DW::CleanEmail->nonquoted_text(q{
+foo
+------Message d'origine------
+De: etc
+some original text here
+});
+
+    is( $nonquoted, q{
+foo}, "------Message d'origine------ separator")
 }
 
 {


### PR DESCRIPTION
This seems a reasonable enough pattern to match against. Switching to a
pattern so that it doesn't matter what language it is.
