### PR TITLE
(Bug #5068) Add layout credit to Lefty

### DIFF
--- a/bin/upgrading/s2layers/lefty/layout.s2
+++ b/bin/upgrading/s2layers/lefty/layout.s2
@@ -4,6 +4,8 @@ layerinfo redist_uniq = "lefty/layout";
 layerinfo author_name = "sarken";
 layerinfo lang = "en";
 
+set layout_authors = [ { "name" => "sarken", "type" => "user" } ];
+
 set layout_type = "two-columns-left";
 set entry_management_links = "text";
 set margins_size = "4";


### PR DESCRIPTION
Makes the credit module work correctly in Lefty, fixing http://bugs.dwscoalition.org/show_bug.cgi?id=5058

Single line fix, needs layout_authors as well as author_name. I have tested this in various combinations and it seems to work as expected.
