### PR TITLE
Bug3081 Allow renaming pic#xxx keywords 

### DIFF
--- a/cgi-bin/LJ/Userpic.pm
+++ b/cgi-bin/LJ/Userpic.pm
@@ -1083,7 +1083,7 @@ sub set_keywords {
         # is in the pic#  format.  In this case kwid is NULL and we want to 
         # delete any records from userpicmap3 that involve it.
         unless ( $kwid ) {
-           $u->do( "DELETE FROM userpicmap3 WHERE userid=? AND picid=?", undef, $u->id, $self->id, " AND keyword IS NULL" );
+           $u->do( "DELETE FROM userpicmap3 WHERE userid=? AND picid=? AND kwid IS NULL", undef, $u->id, $self->id );
         }
 
         $exist_kwids{$kwid} = 1;


### PR DESCRIPTION
Allows pic#xxx keywords to be renamed.  

The patch also fixes the behaviour of keyword changes from a pic#xxx keyword to some other where rename is not selected.  This behaviour now returns the icon attached to any posts using the pic#xxx keyword to default.

allen advised.
