### PR TITLE
http://bugs.dwscoalition.org/show_bug.cgi?id=5088

### DIFF
--- a/htdocs/js/jquery.iconselector.js
+++ b/htdocs/js/jquery.iconselector.js
@@ -263,7 +263,7 @@
                             });
                         }
 
-                        var $comment = ( icon.comment != "" ) ? $("<div class='comment'></div>").text( icon.comment ) : "";
+                        var $comment = ( icon.comment != "" ) ? $("<div class='icon-comment'></div>").text( icon.comment ) : "";
 
                         var $meta = $("<div class='meta_wrapper'></div>").append($keywords).append($comment);
                         var $item = $("<div class='iconselector_item'></div>").append($img).append($meta);

--- a/htdocs/stc/jquery.iconselector.css
+++ b/htdocs/stc/jquery.iconselector.css
@@ -98,7 +98,7 @@
 }
 
 
-.comment {
+.icon-comment {
   margin-top:.5em;
 }
 


### PR DESCRIPTION
Changed the class for icon comments in the icon selector from "comment"
to "icon-comment" in both the jQuery and CSS. This fixes a display
issue with the icon selector on site-schemed entry pages.
