### PR TITLE
bug 5093 Firefox 3.6.8 supports SVG but not in line. Without modernizr b...

### DIFF
--- a/htdocs/js/jquery.cuttag-ajax.js
+++ b/htdocs/js/jquery.cuttag-ajax.js
@@ -9,7 +9,15 @@ var loadPending = 0;
 // If we expand SVG usage on the site this function should get
 // pulled out of this file.
 function supportsSVG() {
-            return !!document.createElementNS && !!document.createElementNS('http://www.w3.org/2000/svg', "svg").createSVGRect;
+            return !!document.createElementNS 
+         && !!document.createElementNS('http://www.w3.org/2000/svg', "svg").createSVGRect
+         // FF 3.6.8 supports SVG but not inline
+         && !isOldFirefox();
+}
+
+function isOldFirefox () {
+           // check for 3.6.8 or older (hardware limitations cap some users here)
+           return !!(jQuery.browser.mozilla && jQuery.browser.version < '1.9.3')
 }
 
 if ( supportsSVG() ) {


### PR DESCRIPTION
...rowser detection is the easiest way to deal with this

When we get modernizr we should redo this.

For the record, Firefox 3.6.8 is the newest version that can be used by people on PowerPC chips.
