### PR TITLE
Fix "Oops" on journals with deleted themes

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2273,13 +2273,18 @@ sub Page
         my $theme;
 
         if ( $style && $style->{layer}->{theme} ) {
-            $theme = LJ::S2Theme->new(themeid => $style->{layer}->{theme}, user => $opts->{style_u} || $u );
+            $theme = LJ::S2Theme->new(
+                themeid => $style->{layer}->{theme},
+                user => $opts->{style_u} || $u,
+                undef_if_missing => 1 );
+        }
 
+        if ( $theme ) {
             $layoutname = $theme->layout_name;
             $themename = $theme->name;
             $layouturl = "$LJ::SITEROOT/customize/?layoutid=". $theme->layoutid if $theme->is_system_layout;
         } else {
-            $layoutname = S2::get_layer_info($style-> {layer}->{layout}, 'name');
+            $layoutname = S2::get_layer_info($style->{layer}->{layout}, 'name');
             $themename = LJ::Lang::ml("s2theme.themename.notheme");
         }
     }

--- a/cgi-bin/LJ/S2Theme.pm
+++ b/cgi-bin/LJ/S2Theme.pm
@@ -439,6 +439,7 @@ sub new {
             $layers = LJ::S2::get_layers_of_user($u);
             unless (ref $layers->{$themeid}) {
                 LJ::S2::load_layer_info(\%outhash, [ $themeid ]);
+                return undef if $opts{undef_if_missing} && ! exists $outhash{$themeid};
 
                 die "Given theme id does not correspond to a layer usable by the given user." unless $outhash{$themeid}->{is_public};
             }
@@ -449,6 +450,11 @@ sub new {
     }
 
     my $using_layer_info = scalar keys %outhash;
+
+    if ( $opts{undef_if_missing} ) {
+        return undef
+            unless $using_layer_info ? exists $outhash{$themeid} : exists $layers->{$themeid}->{type};
+    }
 
     die "Given theme id does not correspond to a theme."
         unless $using_layer_info ? $outhash{$themeid}->{type} eq "theme" : $layers->{$themeid}->{type} eq "theme";


### PR DESCRIPTION
Adding 'undef_if_missing' to avoid possibly
breaking other uses of this module.
