### PR TITLE
Bug5115

### DIFF
--- a/cgi-bin/LJ/Userpic.pm
+++ b/cgi-bin/LJ/Userpic.pm
@@ -1077,7 +1077,7 @@ sub set_keywords {
     $sth->execute( $u->userid, $self->id );
 
     my %exist_kwids;
-    while (my ($kwid) = $sth->fetchrow_array) {
+    while ( my ($kwid) = $sth->fetchrow_array ) {
 
         # This is an edge case to catch keyword changes where the existing keyword
         # is in the pic#  format.  In this case kwid is NULL and we want to 
@@ -1132,9 +1132,9 @@ sub set_keywords {
 
     foreach my $kwid (keys %exist_kwids) {
         if ( $have_mapid ) {
-            $u->do("UPDATE userpicmap3 SET picid=NULL WHERE userid=? AND picid=? AND kwid=?", undef, $u->id, $self->id, $kwid);
+            $u->do( "UPDATE userpicmap3 SET picid=NULL WHERE userid=? AND picid=? AND kwid=?", undef, $u->id, $self->id, $kwid );
         } else {
-            $u->do("DELETE FROM userpicmap2 WHERE userid=? AND picid=? AND kwid=?", undef, $u->id, $self->id, $kwid);
+            $u->do( "DELETE FROM userpicmap2 WHERE userid=? AND picid=? AND kwid=?", undef, $u->id, $self->id, $kwid );
         }
     }
 
@@ -1258,12 +1258,9 @@ sub set_and_rename_keywords {
                             undef, $u->get_keyword_id( $newkw ), $u->get_keyword_id( $origkw ), $u->id );
                     die $u->errstr if $u->err;
                 } else {
-#                    my $new_mapid = LJ::alloc_user_counter( $u, 'Y' );
-#                    $u->do( "INSERT INTO userpicmap3 SET mapid = ?, kwid = ?, userid = ?, picid = ?",
-#                            undef, $new_mapid, $u->get_keyword_id( $newkw ), $u->id, $self->picid );
-                    my $picid = $1;
-                    $u->do( "UPDATE userpicmap3 SET kwid = ? WHERE kwid is NULL and userid = ? AND picid = ?",
-			    undef, $u->get_keyword_id( $newkw ), $u->id, $picid );
+                    my $new_mapid = LJ::alloc_user_counter( $u, 'Y' );
+                    $u->do( "INSERT INTO userpicmap3 SET mapid = ?, kwid = ?, userid = ?, picid = ?",
+                            undef, $new_mapid, $u->get_keyword_id( $newkw ), $u->id, $self->picid );
                     die $u->errstr if $u->err;
                 }
             }


### PR DESCRIPTION
Bug 5115 resulted in people only being able to rename one icon which previously had a pic#xxx keyword.  A little investigation revealed this only occurred when the icon was unused and had never previously had keywords attached.  It turned out to be caused because the icon was not assigned a proper mapid when it was renamed and so the relevant database row was over-written the next time a pic#xxx icon was renamed.
