### PR TITLE
(bug 5109) keep closed requests around longer.

### DIFF
--- a/htdocs/support/help.bml
+++ b/htdocs/support/help.bml
@@ -111,7 +111,7 @@ body<=
          $sth = $dbr->prepare("SELECT s.*, SUBSTRING(sl.message, 1, 200) AS 'message' " .
                               "FROM support s, supportlog sl " .
                               "WHERE s.state='closed' AND s.spid = sl.spid AND sl.type = 'req' " .
-                              "AND s.timeclosed > (UNIX_TIMESTAMP() - (3600*24)) " .
+                              "AND s.timeclosed > (UNIX_TIMESTAMP() - (3600*168)) " .
                               "AND s.spcatid = ?");
      } else { # triggers on green, open
          $sth = $dbr->prepare("SELECT s.*, SUBSTRING(sl.message, 1, 200) AS 'message' " .


### PR DESCRIPTION
Change the length of time that closed support requests are visible on
the "closed" view of help.bml  from 24h to 168h (1 week).

I tried to test this, but for some reason closing support requests
on my hack isn't working. So this is untested!
