### PR TITLE
(bug 4842) make expired poll form auth more explicit

### DIFF
--- a/htdocs/tools/endpoints/pollvote.bml
+++ b/htdocs/tools/endpoints/pollvote.bml
@@ -67,7 +67,7 @@ _c?>
         }
 
         unless (LJ::check_form_auth()) {
-            return $err->("Form is invalid");
+            return $err->("Form is invalid; reload and try again");
         }
     
         my $error;


### PR DESCRIPTION
When people hit an expired form auth (because the tab's been open too
long), make it more obvious how they can recover.
