### PR TITLE
(bug 5145) Fix problem with S2.pm's get_policy looking for the styles

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -1663,7 +1663,7 @@ sub get_policy
     local $_;
 
     foreach my $infix ("", "-local") {
-        my $file = "$LJ::HOME/bin/upgrading/s2layers/policy${infix}.dat";
+        my $file = "$LJ::HOME/styles/policy${infix}.dat";
         my $layer = undef;
         open (P, $file) or next;
         while (<P>) {


### PR DESCRIPTION
policies in the wrong location. This is the quick & dirty fix; long-term
this should probably go into a config variable so if we move things
in the future it doesn't break. I also checked for other instances
of referring to the old location and didn't find any, so this should
be the last of the problems.
