### PR TITLE
(bug5114) Load 20 journals so we can be reasonably assured of getting 10...

### DIFF
--- a/htdocs/stats.bml
+++ b/htdocs/stats.bml
@@ -104,24 +104,27 @@ body<=
      $ret .= "<h1>$ML{'.recent.header'}</h1>";
      # Personal accounts
      $ret .= "<p>$ML{'.recent.desc.personal'}</p><ul>";
-     $sth = $dbr->prepare( "SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate > DATE_SUB(NOW(), INTERVAL 30 DAY) AND u.journaltype = 'P' ORDER BY uu.timeupdate DESC LIMIT 10" );
+     $sth = $dbr->prepare( "SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate > DATE_SUB(NOW(), INTERVAL 30 DAY) AND u.journaltype = 'P' ORDER BY uu.timeupdate DESC LIMIT 20" );
      $sth->execute;
      my $accounts = $sth->fetchall_arrayref({});
 
      if ( @$accounts ) {
          my $userobj_for = LJ::load_userids(map { $_->{userid} } @$accounts);
+         my $i = 0;
 
          ACCOUNT:
          foreach my $account (@$accounts) {
              my $u = $userobj_for->{$account->{userid}};
 
              next ACCOUNT unless $u && $u->is_visible;
+             last if $i > 9;
 
              $ret .= sprintf("<li>%s - %s, %s</li>\n",
                  $u->ljuser_display,
                  $u->name_html,
                  $account->{timeupdate}
              );
+             $i++;
          }
      }
      else {
@@ -131,24 +134,27 @@ body<=
      $ret .= "</ul>\n";
      # Community accounts
      $ret .= "<p>$ML{'.recent.desc.community'}</p><ul>";
-     $sth = $dbr->prepare( "SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate > DATE_SUB(NOW(), INTERVAL 30 DAY) AND u.journaltype = 'C' ORDER BY uu.timeupdate DESC LIMIT 10" );
+     $sth = $dbr->prepare( "SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate > DATE_SUB(NOW(), INTERVAL 30 DAY) AND u.journaltype = 'C' ORDER BY uu.timeupdate DESC LIMIT 20" );
      $sth->execute;
      my $accounts = $sth->fetchall_arrayref({});
 
      if ( @$accounts ) {
          my $userobj_for = LJ::load_userids(map { $_->{userid} } @$accounts);
+         my $i = 0;
 
          ACCOUNT:
          foreach my $account (@$accounts) {
              my $u = $userobj_for->{$account->{userid}};
 
              next ACCOUNT unless $u && $u->is_visible;
+             last if $i > 9;
 
              $ret .= sprintf("<li>%s - %s, %s</li>\n",
                  $u->ljuser_display,
                  $u->name_html,
                  $account->{timeupdate}
              );
+             $i++;
          }
      }
      else {
@@ -158,23 +164,27 @@ body<=
      $ret .= "</ul>\n";
      # Feeds
      $ret .= "<p>$ML{'.recent.desc.feeds'}</p><ul>";
-     $sth = $dbr->prepare( "SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate > DATE_SUB(NOW(), INTERVAL 30 DAY) AND u.journaltype = 'Y' ORDER BY uu.timeupdate DESC LIMIT 10" );
+     $sth = $dbr->prepare( "SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate > DATE_SUB(NOW(), INTERVAL 30 DAY) AND u.journaltype = 'Y' ORDER BY uu.timeupdate DESC LIMIT 20" );
      $sth->execute;
      my $accounts = $sth->fetchall_arrayref({});
 
      if ( @$accounts ) {
          my $userobj_for = LJ::load_userids(map { $_->{userid} } @$accounts);
+         my $i = 0;
+
          ACCOUNT:
          foreach my $account (@$accounts) {
              my $u = $userobj_for->{$account->{userid}};
 
              next ACCOUNT unless $u && $u->is_visible;
+             last if $i > 9;
 
              $ret .= sprintf("<li>%s - %s, %s</li>\n",
                  $u->ljuser_display,
                  $u->name_html,
                  $account->{timeupdate}
              );
+             $i++;
          }
      }
      else {
@@ -189,24 +199,27 @@ body<=
      $ret .= "<h1>$ML{'.new.header'}</h1>";
      # Personal accounts
      $ret .= "<p>$ML{'.new.desc.personal'}</p><ul>";
-     $sth = $dbr->prepare("SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate IS NOT NULL AND u.journaltype = 'P' ORDER BY uu.timecreate DESC LIMIT 10");
+     $sth = $dbr->prepare("SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate IS NOT NULL AND u.journaltype = 'P' ORDER BY uu.timecreate DESC LIMIT 20");
      $sth->execute;
      my $accounts = $sth->fetchall_arrayref({});
 
      if ( @$accounts ) {
          my $userobj_for = LJ::load_userids(map { $_->{userid} } @$accounts);
+         my $i = 0;
 
          ACCOUNT:
          foreach my $account (@$accounts) {
              my $u = $userobj_for->{$account->{userid}};
 
              next ACCOUNT unless $u && $u->is_visible;
+             last if $i > 9;
 
              $ret .= sprintf("<li>%s - %s, %s</li>\n",
                  $u->ljuser_display,
                  $u->name_html,
                  $account->{timeupdate}
              );
+             $i++;
          }
      }
      else {
@@ -216,24 +229,27 @@ body<=
      $ret .= "</ul>\n";
      # Community accounts
      $ret .= "<p>$ML{'.new.desc.community'}</p><ul>";
-     $sth = $dbr->prepare("SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate IS NOT NULL AND u.journaltype = 'C' ORDER BY uu.timecreate DESC LIMIT 10");
+     $sth = $dbr->prepare("SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate IS NOT NULL AND u.journaltype = 'C' ORDER BY uu.timecreate DESC LIMIT 20");
      $sth->execute;
      my $accounts = $sth->fetchall_arrayref({});
 
      if ( @$accounts ) {
          my $userobj_for = LJ::load_userids(map { $_->{userid} } @$accounts);
+         my $i = 0;
 
          ACCOUNT:
          foreach my $account (@$accounts) {
              my $u = $userobj_for->{$account->{userid}};
 
              next ACCOUNT unless $u && $u->is_visible;
+             last if $i > 9;
 
              $ret .= sprintf("<li>%s - %s, %s</li>\n",
                  $u->ljuser_display,
                  $u->name_html,
                  $account->{timeupdate}
              );
+             $i++;
          }
      }
      else {
@@ -243,24 +259,27 @@ body<=
      $ret .= "</ul>\n";
      # Feeds
      $ret .= "<p>$ML{'.new.desc.feeds'}</p><ul>";
-     $sth = $dbr->prepare("SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate IS NOT NULL AND u.journaltype = 'Y' ORDER BY uu.timecreate DESC LIMIT 10");
+     $sth = $dbr->prepare("SELECT u.userid, uu.timeupdate FROM user u, userusage uu WHERE u.userid=uu.userid AND uu.timeupdate IS NOT NULL AND u.journaltype = 'Y' ORDER BY uu.timecreate DESC LIMIT 20");
      $sth->execute;
      my $accounts = $sth->fetchall_arrayref({});
 
      if ( @$accounts ) {
          my $userobj_for = LJ::load_userids(map { $_->{userid} } @$accounts);
+         my $i = 0;
 
          ACCOUNT:
          foreach my $account (@$accounts) {
              my $u = $userobj_for->{$account->{userid}};
 
              next ACCOUNT unless $u && $u->is_visible;
+             last if $i > 9;
 
              $ret .= sprintf("<li>%s - %s, %s</li>\n",
                  $u->ljuser_display,
                  $u->name_html,
                  $account->{timeupdate}
              );
+            $i++;
          }
      }
      else {


### PR DESCRIPTION
... good ones, then add

an index to the loop that will bail once we've hit the count of 10. (Less refactoring doing
it this way, even though it's a tidge kludgy.) Still has potential to have an empty list if
there's a massive spam wave and we suspend dozens at a time, but less so, and any other way
of fixing it would probably a) be overkill and b) be a performance issue.
