### PR TITLE
(bug 4759) all-comments notification fires for non-paid comms

### DIFF
--- a/cgi-bin/LJ/Event.pm
+++ b/cgi-bin/LJ/Event.pm
@@ -366,6 +366,8 @@ sub zero_journalid_subs_means { "" }
 # INSTANCE METHOD: SHOULD OVERRIDE if the subscriptions support filtering
 sub matches_filter {
     my ($self, $subsc) = @_;
+
+    return 0 unless $subsc->available_for_user;
     return 1;
 }
 

--- a/cgi-bin/LJ/Event/Birthday.pm
+++ b/cgi-bin/LJ/Event/Birthday.pm
@@ -48,6 +48,8 @@ sub bday {
 sub matches_filter {
     my ($self, $subscr) = @_;
 
+    return 0 unless $subscr->available_for_user;
+
     return $self->bdayuser->can_notify_bday(to => $subscr->owner) ? 1 : 0;
 }
 

--- a/cgi-bin/LJ/Event/JournalNewComment/TopLevel.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment/TopLevel.pm
@@ -23,6 +23,8 @@ sub subscription_as_html {
 sub matches_filter {
     my ($self, $subscr) = @_;
 
+    return 0 unless $subscr->available_for_user;
+
     my $sjid = $subscr->journalid;
     my $ejid = $self->event_journal->{userid};
 

--- a/cgi-bin/LJ/Event/JournalNewEntry.pm
+++ b/cgi-bin/LJ/Event/JournalNewEntry.pm
@@ -42,6 +42,8 @@ sub entry {
 sub matches_filter {
     my ($self, $subscr) = @_;
 
+    return 0 unless $subscr->available_for_user;
+
     my $ditemid = $self->arg1;
     my $evtju = $self->event_journal;
     return 0 unless $evtju && $ditemid; # TODO: throw error?

--- a/cgi-bin/LJ/Event/PollVote.pm
+++ b/cgi-bin/LJ/Event/PollVote.pm
@@ -35,7 +35,9 @@ sub arg_list {
 }
 
 sub matches_filter {
-    my $self = shift;
+    my ($self,$subscr) = @_;
+
+    return 0 unless $subscr->available_for_user;
 
     # don't notify voters of their own answers
     return $self->voter->equals($self->event_journal) ? 0 : 1;


### PR DESCRIPTION
- Do not fire events that are not available

This also gets other instances of something firing that's not available for the user, I am assuming this is okay.
We still need a way to show to users things tracked that are not currently available.
