### PR TITLE
(bug 4907) Teach S2 to serve up icons for iOS

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2358,7 +2358,8 @@ sub Page
 
     # other useful link rels
     $p->{head_content} .= qq{<link rel="help" href="$LJ::SITEROOT/support/faq" />\n};
-
+    $p->{head_content} .= qq{<link rel="apple-touch-icon" href="$LJ::APPLE_TOUCH_ICON" />\n} 
+         if $LJ::APPLE_TOUCH_ICON;
     # Identity (type I) accounts only have read views
     $p->{views_order} = [ 'read', 'userinfo' ] if $u->is_identity;
     # feed accounts only have recent entries views

--- a/doc/config-local.pl.txt
+++ b/doc/config-local.pl.txt
@@ -138,6 +138,14 @@
     $COMMENT_IMPORT_MAX = undef;
     $COMMENT_IMPORT_ERROR = "Importing more than 10,000 comments is currently disabled.";
 
+    # Set the URI for iOS to find the icon it uses for home-screen
+    # bookmarks on user subdomains (or anything else rendered through 
+    # S2). This file is not part of the dw-free installation, and is 
+    # therefore disabled by default. 
+    #$APPLE_TOUCH_ICON = "$LJ::SITEROOT/apple-touch-icon.png";
+
+
+
 }
 
 1;


### PR DESCRIPTION
Add explicit reference to iOS home-screen 'Swirly d' icon in
(I think) any page served through S2. Let's hear it for 1-line
fixes.
