### PR TITLE
(Bug 5154) Only print the multiform start if we have comments

### DIFF
--- a/bin/upgrading/s2layers/siteviews/layout.s2
+++ b/bin/upgrading/s2layers/siteviews/layout.s2
@@ -292,8 +292,11 @@ function EntryPage::print_comment_section(Entry e) {
         """<div class='comments-message'>$*text_comments_disabled_maintainer</div>""";
    }
    $.comment_nav->print({ "class" => "comment-pages toppages" });
-    $this->print_reply_container({ "target" => "topcomment" });
-   $this->print_multiform_start();
+   $this->print_reply_container({ "target" => "topcomment" });
+
+   if ($.comment_pages.total_subitems > 0) {
+      $this->print_multiform_start();
+   }
 
    $this->print_comments($.comments);
    if ($.comment_pages.total_subitems > 0) {


### PR DESCRIPTION
Fixes a non-matching form tags issue
