### PR TITLE
(bug 5149) allow network-rel URLs in YT embeds

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -81,6 +81,11 @@ LJ::Hooks::register_hook( 'allow_iframe_embeds', sub {
 
     return 0 unless $embed_url;
 
+    # the URI module hates network-relative URIs, eg '//youtube.com'
+    if ( substr($embed_url, 0,2) eq '//' ) {
+        $embed_url = 'http:' . $embed_url;
+    }
+
     my $parsed_uri = URI->new( $embed_url );
 
     my $uri_scheme = $parsed_uri->scheme;

--- a/cgi-bin/LJ/EmbedModule.pm
+++ b/cgi-bin/LJ/EmbedModule.pm
@@ -285,7 +285,15 @@ sub extract_src_info {
     my ($contents, $cmptext, $journal, $id, $preview, $vid_id, $host, $linktext, $url)
        = map { delete $args->{$_} } qw( contents cmptext journal id preview vid_id host linktext url );
 
-    if ( $contents =~ /src="http:\/\/.*youtube\.com/ ) {
+    my $youtube_uri = qr{    # match...
+        src=["']             # src=" or src='
+        (?:                  # ...then, as a (non-capturing) group:
+            https?:          #     either http: or https:
+        )?                   # ...but matching the group is optional
+        //.*youtube\.com     # //youtube.com, //www.youtube.com, etc
+    }xi ;
+
+    if ( $contents =~ /$youtube_uri/ ) {
         # YouTube
 
         my $host = "https://www.youtube.com/";

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 34;
+use Test::More tests => 37;
 
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { require 'ljlib.pl'; }
@@ -60,6 +60,11 @@ note( "youtube" );
 
     test_bad_url( "http://www.youtube.com/notreallyembed/x1xx2xxxxxX", "wrong path");
     test_bad_url( "http://www.youtube.com/embed/x1xx2xxxxxX/butnotreally", "wrong path");
+
+    # network-relative URLs
+    test_good_url( "//www.youtube.com/embed/uzmR-Ru_P8Y", "network-relative url (//)" );
+    test_bad_url( "/www.youtube.com/embed/uzmR-Ru_P8Y", "mis-pasted local-relative url" );
+    test_bad_url( "ttp://www.youtube.com/embed/uzmR-Ru_P8Y", "mis-pasted url /w bad scheme" );
 }
 
 note( "misc" );


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=5149

Youtube has started using network-relative URLs in its embed codes, eg src="//www.youtube.com/...".  This is a legit but uncommon syntax -- it means "fetch this location, using the same protocol as you used for this page" -- eg http for http, https for https.  

This patch updates the allow_iframe_embeds hook to permit URLs of this form.  Unfortunately, the URI module can't cope with them, so we have to lie to it about the URL scheme to get the rest of its parsing to work.  We don't modify the URL that's actually used to do the embedding, though -- just what's used for checks inside the hook.

We also tune up the regex used to provide accessibility links for Youtube videos in cgi-bin/LJ/EmbedModule.pm so that that feature continues to work with network-relative URLs.

Feedback appreciated, in particular with how I wrote out the Youtube URL matching regex in EmbedModule.pm.  Is it clearer using extended format?  Is it overbroad?
