### PR TITLE
(bug 5149) recognize network-relative URIs from YT

### DIFF
--- a/cgi-bin/LJ/EmbedModule.pm
+++ b/cgi-bin/LJ/EmbedModule.pm
@@ -285,7 +285,15 @@ sub extract_src_info {
     my ($contents, $cmptext, $journal, $id, $preview, $vid_id, $host, $linktext, $url)
        = map { delete $args->{$_} } qw( contents cmptext journal id preview vid_id host linktext url );
 
-    if ( $contents =~ /src="http:\/\/.*youtube\.com/ ) {
+    my $youtube_uri = qr{    # match...
+        src=["']             # src=" or src='
+        (?:                  # ...then, as a (non-capturing) group:
+            https?:          #     either http: or https:
+        )?                   # ...but matching the group is optional
+        //.*youtube\.com     # //youtube.com, //www.youtube.com, etc
+    }x ;
+
+    if ( $contents =~ /$youtube_uri/ ) {
         # YouTube
 
         my $host = "https://www.youtube.com/";


### PR DESCRIPTION
http://bugs.dwscoalition.org/show_bug.cgi?id=5149

Tweak the URI-matching regex to recognize either a scheme of http, of https, or a schemeless network-relative URI (starts with //) when it is coming from Youtube, so that the "Watch on Youtube" accessibility link can be added.
