### PR TITLE
Bug 4151 - Entry metadata not currently reorder-able/reposition-able

### DIFF
--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -5087,7 +5087,8 @@ function Entry::print_metadata() {
     if (size $.metadata) {
         var string position = ($*entry_metadata_position == "top") ? " top-metadata" : " bottom-metadata";
         """<div class="metadata$position">\n<ul>\n""";
-        foreach var string m ( keys_alpha( $.metadata )  ) {
+        foreach var string m ( [ "mood", "location", "music", "groups", "xpost" ] ) {
+                if ($.metadata{$m}) {
                 var string metadata_name = lang_metadata_title($m);
                 """<li id="metadata-$m"><span class="metadata-label metadata-label-$m">$metadata_name</span> """;
                 if ($m == "mood") {
@@ -5095,6 +5096,7 @@ function Entry::print_metadata() {
                 }
                 """<span class="metadata-item metadata-item-$m">$.metadata{$m}</span></li>\n""";
             }
+         }
         "</ul>\n</div>\n";
     }
 }


### PR DESCRIPTION
Link for bug : http://bugs.dwscoalition.org/show_bug.cgi?id=4151
Made chnges in function Entry::print_metadata() at core2.s2 end. As mentioned in the bug description I have added li id="metadata-$m in code. And also an "If" block is removed just after foreach loop.
