### PR TITLE
(Bug 5041) add comment search to search module

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2950,8 +2950,21 @@ sub viewer_can_search {
     return $ju->allow_search_by( $remote );
 }
 
+# Returns true if the viewer can search comments
+sub viewer_can_search_comments {
+    my $remote = LJ::get_remote();
+    return 0 unless $remote;
+    return 0 unless defined $LJ::S2::CURR_PAGE;
+
+    my $ju = $LJ::S2::CURR_PAGE->{_u};
+
+    return $ju->allow_comment_search ( $remote );
+}
+ 
 # Returns a search form for this journal
 sub print_search_form {
+    my $remote = LJ::get_remote();
+    return 0 unless $remote; 
     return "" unless defined($LJ::S2::CURR_PAGE);
 
     my $ju = $LJ::S2::CURR_PAGE->{_u};
@@ -2960,6 +2973,10 @@ sub print_search_form {
     $search_form .= '<form method="post" action="'. $LJ::SITEROOT. '/search?user=' . $ju->user . '">';
     $search_form .= LJ::form_auth();
     $search_form .= '<input class="search-box" type="text" name="query" maxlength="255">';
+    if ( $ju->allow_comment_search ( $remote )) {
+        $search_form .= '<br/><input class="comment_search_checkbox" type="checkbox">';
+        $search_form .= '<label for="with_comments">Include comments in search results</label>';
+    } 
     $search_form .= '<input class="search-button" type="submit" value="' . $_[1] . '" />';
     $search_form .= '</form></div>';
 

--- a/cgi-bin/LJ/User.pm
+++ b/cgi-bin/LJ/User.pm
@@ -1895,7 +1895,7 @@ sub add_to_class {
 }
 
 
-# 1/0 whether the argument is allowed to search this journal
+# 1/0 whether the argument is allowed to search this journal or not
 sub allow_search_by {
     my ( $u, $by ) = @_;
     return 0 unless LJ::isu( $u ) && LJ::isu( $by );
@@ -1919,6 +1919,20 @@ sub allow_search_by {
     return 0;
 }
 
+# 1/0 whether the argument is allowed to search comments
+sub allow_comment_search {
+    my ( $u, $by )= @_;
+
+    # if the person is not allowed to search at all, they also can't search comments
+    my $maysearch = $by->allow_search_by ( $by );
+    return 0 unless $maysearch = 1;
+
+    # only paid accounts may search comments, even on paid journals
+    return 1 if $by->is_paid;
+
+    # if the above two criteria aren't satisfied, no comment search
+    return 0;
+}
 
 sub caps {
     my $u = shift;


### PR DESCRIPTION
Method for testing whether person viewing journal can search comments
Search form prints out comment search checkbox if applicable

Currently checks based on paid status and search permissions only.
