### PR TITLE
Bug4988/search strings

### DIFF
--- a/htdocs/search.bml
+++ b/htdocs/search.bml
@@ -19,14 +19,16 @@ body<=
 <?_code
 {
     use strict;
-    use vars qw/ %POST %GET /;
+    use vars qw/ %POST %GET $title /;
     use Storable;
 
-    # FIXME: english strip and make the UI a lot better :)
+    # FIXME: make the UI a lot better :)
+
+    $title = LJ::Lang::ml( '.title' );
 
     # if no gearman, bail
     my $gc = LJ::gearman_client();
-    return "$ML{'.error.notconfigured'}\n"
+    return LJ::Lang::ml( '.error.notconfigured' ) . "\n"
         unless $gc && @LJ::SPHINX_SEARCHD;
 
     # for pages that require authentication
@@ -45,31 +47,33 @@ body<=
         my $ret = "<form method='post' action='$LJ::SITEROOT/search'>" . LJ::form_auth();
 
         $ret .= LJ::html_check( { type => 'radio', selected => $su ? 0 : 1, id => 'm-global', name => 'mode',
-                                  value => '', label => "$ML{'.label.sitesearch'}" } );
+                                  value => '', label => LJ::Lang::ml( '.label.sitesearch' ) } );
 
         my $tu = $su || $remote;
         if ( $tu->allow_search_by( $remote ) ) {
             $ret .= LJ::html_check( { type => 'radio', selected => $su ? 1 : 0, id => 'm-user', name => 'mode',
-                                      value => $tu->user, label => "$ML{'.label.journalsearch'}" . " <strong>" . $tu->user . "</strong>", noescape => 1 } );
+                                      value => $tu->user, label => LJ::Lang::ml( '.label.journalsearch' ) . " <strong>" . $tu->user . "</strong>", noescape => 1 } );
         }
 
         $ret .= '<br /><input type="text" name="query" maxlength="255" size="60" value="' . LJ::ehtml( $q ) . '">';
-        $ret .= " <input type='submit' value='$ML{'.button.search'}' /><br />";
-        $ret .= "$ML{'.sortby'} ";
+        $ret .= " <input type='submit' value='" . LJ::Lang::ml( '.button.search' ) . "' /><br />";
+        $ret .= LJ::Lang::ml( '.sortby' );
         $ret .= LJ::html_select(
             { selected => $sby, name => 'sort_by' },
-            new => BML::ml( '.sort.date.new' ),
-            old => BML::ml( '.sort.date.old' ),
-            rel => BML::ml( '.sort.relevance' ),
+            new => LJ::Lang::ml( '.sort.date.new' ),
+            old => LJ::Lang::ml( '.sort.date.old' ),
+            rel => LJ::Lang::ml( '.sort.relevance' ),
         );
         $ret .= '<br />';
         if ( !$tu || $tu->is_paid ) {
-            $ret .= LJ::html_check({ id => 'with_comments', name => 'with_comments',
-                    selected => $wc, label => "$ML{'.comments.include'}" });
+            $ret .= LJ::html_check( { id => 'with_comments', name => 'with_comments',
+                    selected => $wc, label => LJ::Lang::ml( '.comments.include' ) } );
+            $ret .= '<br />' . LJ::Lang::ml( '.comments.include.note' );
         } else {
-            $ret .= LJ::html_check({ id => 'with_comments', name => 'with_comments',
-                    label => "$ML{'.comments.disabled'}",
-                    disabled => 1 });
+            $ret .= LJ::html_check( { id => 'with_comments', name => 'with_comments',
+                    label => LJ::Lang::ml( '.comments.disabled' ),
+                    disabled => 1 } );
+            $ret .= '<br />' . LJ::Lang::ml( '.comments.disabled.note' );
         }
         $ret .= '</form>';
 
@@ -78,12 +82,12 @@ body<=
 
     # an error redisplays the form, with an error message
     my $error = sub {
-        return $search_form->() . "<br /><?p <strong>$ML{'.error'}</strong> $_[0] p?>";
+        return $search_form->() . "<br /><?p <strong>" . LJ::Lang::ml( '.error' ) . "</strong> $_[0] p?>";
     };
 
     # if no $su, then this is a public search, that's allowed.  but if it's a user,
     # ensure that it's an account that we CAN search
-    return $error->( "$ML{'.error.forbidden'}" )
+    return $error->( LJ::Lang::ml( '.error.forbidden' ) )
         if $su && ! $su->allow_search_by( $remote );
 
     ################################################################################
@@ -92,26 +96,26 @@ body<=
     # give them the form to do a search if they haven't actually posted to us yet
     unless ( LJ::did_post() ) {
         # give them a form to enter their search options
-        return "<?p " . BML::ml( '.blurb', { site => $LJ::SITENAME } ) ." p?>" .
+        return "<?p " . LJ::Lang::ml( '.blurb', { sitename => $LJ::SITENAME } ) ." p?>" .
                $search_form->() .
-               '</form><br /> <?p ' . BML::ml( '.security.setting', { aopts => "href='$LJ::SITEROOT/manage/settings/?cat=privacy'" } ) .' p?>';
+               '</form><br /> <?p ' . LJ::Lang::ml( '.security.setting', { aopts => "href='$LJ::SITEROOT/manage/settings/?cat=privacy'" } ) . ' p?>';
     }
 
     ################################################################################
     ################################################################################
 
     # at this point, they have done a POST, which means they want to search something
-    return $error->( "$ML{'.error.refresh'}" ) unless LJ::check_form_auth();
+    return $error->( LJ::Lang::ml( '.error.refresh' ) ) unless LJ::check_form_auth();
 
     # and make sure we got a query
-    return $error->( "$ML{'.error.longquery'}" )
+    return $error->( LJ::Lang::ml( '.error.longquery' ) )
         if length( $q ) > 255;
-    return $error->( "$ML{'.error.noquery'}" )
+    return $error->( LJ::Lang::ml( '.error.noquery' ) )
         unless $q;
 
     # if an offset, less than 1000 please
     my $offset = $GET{offset} + 0;
-    return $error->( "$ML{'.error.wrongoffset'}" )
+    return $error->( LJ::Lang::ml( '.error.wrongoffset' ) )
         if $offset < 0 || $offset > 1000;
 
     # we have to set a few flags on what to search.  default to public and no bits.
@@ -162,11 +166,11 @@ body<=
     $ts->wait( timeout => 20 );
 
     # if we didn't get a result...
-    return $error->( "$ML{'.error.timedout'}" )
+    return $error->( LJ::Lang::ml( '.error.timedout' ) )
         unless $result;
 
     # if we didn't get any matches...
-    return $error->( BML::ml( '.error.noresults', { query => $q, time => $result->{time} } ) )
+    return $error->( LJ::Lang::ml( '.error.noresults', { query => $q, time => $result->{time} } ) )
         if $result->{total} <= 0;
 
     # now we can process the results and do something fascinating!
@@ -187,26 +191,28 @@ body<=
             }->{$match->{security}};
 
         my $tags = join( ', ', map { "<strong>" . $match->{tags}->{$_} . "</strong>" } keys %{ $match->{tags} } );
-        $tags = "<br />$ML{'.tags'} $tags"
+        $tags = "<br />" . LJ::Lang::ml( '.tags' ) . $tags
             if $tags;
 
         my $attribution;
         if ( $match->{jtalkid} > 0 ) {
             if ( $match->{poster_id} > 0 ) {
-                $attribution = BML::ml( '.attribution.comment', { journal => $mu->ljuser_display,
+                $attribution = LJ::Lang::ml( '.attribution.comment', { journal => $mu->ljuser_display,
                         poster => $pu->ljuser_display } );
             } else {
-                $attribution = BML::ml( '.attribution.comment.anon', { journal => $mu->ljuser_display } );
+                $attribution = LJ::Lang::ml( '.attribution.comment.anon', { journal => $mu->ljuser_display } );
             }
         } else {
             $attribution = $mu->is_comm
-                            ? BML::ml( '.attribution.comm', { journal => $mu->ljuser_display, poster => $pu->ljuser_display } )
-                            : BML::ml( '.attribution', { journal => $mu->ljuser_display } );
+                            ? LJ::Lang::ml( '.attribution.comm', { journal => $mu->ljuser_display, poster => $pu->ljuser_display } )
+                            : LJ::Lang::ml( '.attribution', { journal => $mu->ljuser_display } );
         }
 
-        my $html = qq(<div class='searchres'>$attribution: $icon <a href="$match->{url}">$match->{subject}</a><br />
-                      <span class='exc'>$match->{excerpt}</span>$tags<br />$ML{'.date'} <strong>$match->{eventtime}</strong><br /><br />
-                      </div>);
+        my $html = "<div class='searchres'>" . $attribution . ": " . $icon .
+                    "<a href='" . $match->{url} . "'>" . $match->{subject} . "</a><br />" .
+                    "<span class='exc'>" . $match->{excerpt} . "</span>" . $tags . "<br />" .
+                    LJ::Lang::ml( '.date' ) . "<strong>" . $match->{eventtime} . "</strong><br /><br />" .
+                    "</div>";
         $matches .= $html;
     }
 
@@ -215,10 +221,10 @@ body<=
 
     # put some stats on the output
     my $matchct = scalar( @{ $result->{matches} } );
-    my $skip = $offset > 0 ? " " . BML::ml( '.results.skipped', { journal => $offset } ) : "";
+    my $skip = $offset > 0 ? " " . LJ::Lang::ml( '.results.skipped', { journal => $offset } ) : "";
     $ret .= "<span class='stats'>";
-    $ret .= BML::ml( '.results.displayed', { results => $matchct, total => $result->{total}, skipped => $skip, query => $q } );
-    $ret .= BML::ml( '.results.time', { time => $result->{time} } );
+    $ret .= LJ::Lang::ml( '.results.displayed', { results => $matchct, total => $result->{total}, skipped => $skip, query => $q } );
+    $ret .= " " . LJ::Lang::ml( '.results.time', { time => $result->{time} } );
     $ret .= "</span>";
 
     if ( $result->{total} > ( $offset + $matchct ) ) {
@@ -228,7 +234,7 @@ body<=
                 "<input type='hidden' name='mode' value='" . ( $su ? $su->user : '' ) . "'>" .
                 "<input type='hidden' name='sort_by' value='" . $sby . "'>" .
                 "<input type='hidden' name='with_comments' value='" . $wc . "'>" .
-                "<input type='submit' value='$ML{'.button.more'}' />" .
+                "<input type='submit' value='" . LJ::Lang::ml( '.button.more' ) . "' />" .
                 "</form>";
     }
 
@@ -236,7 +242,7 @@ body<=
 }
 _code?>
 <=body
-title=><?_ml .title _ml?>
+title=><?_code return $title; _code?>
 head<=
 <style type="text/css">
 .exc { padding-left: 1em; font-style: italic; font-size: smaller; }

--- a/htdocs/search.bml.text
+++ b/htdocs/search.bml.text
@@ -7,15 +7,19 @@
 
 .attribution.comment.anon=Comment in [[journal]] by an anonymous person
 
-.blurb=[[site]] content search. Please select where to search and enter your search terms.
+.blurb=[[sitename]] content search. Please select where to search and enter your search terms.
 
 .button.more=More Results...
 
 .button.search=Search
 
-.comments.disabled=Also search in comments made on paid journals (disabled; this account is not paid)
+.comments.disabled=Also search in comments
 
-.comments.include=Also search in comments made on paid journals
+.comments.disabled.note=Disabled: your account type or the account type of the journal you're searching doesn't permit you to use this feature.
+
+.comments.include=Also search in comments
+
+.comments.include.note=Note: only comments made in paid journals can be searched.
 
 .date=Posted:
 


### PR DESCRIPTION
-- fixed as per review
-- decided against doing something smarter with the comment box in this bug (i.e. displaying four different text strings depending on each situation) as I think it depends on bug 5185. I opted for comprehensive explanatory notes instead.
