### PR TITLE
Skip importing the "uniq" and "poster_ip" logprops

### DIFF
--- a/cgi-bin/DW/Worker/ContentImporter/Local/Entries.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/Local/Entries.pm
@@ -131,6 +131,8 @@ sub post_event {
         personifi_tags => 1,
         give_features => 1,
         spam_counter => 1,
+        poster_ip => 1,
+        uniq => 1,
     );
     foreach my $prop ( keys %$props ) {
         next if $bad_props{$prop};


### PR DESCRIPTION
Causes the importer to stutter.

Was running into this when doing importer testing. Not sure what's going
on here though: if it was causing all imports to fail, we'd be getting a
lot more import failures than we actually do...
