### PR TITLE
(Bug 2642) Add action links to OfficialPost notif

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -1463,6 +1463,8 @@ esn.reply_at_webpage=[[openlink]]Reply[[closelink]] at the webpage
 
 esn.reply_to_email2=You can reply to this comment by replying to this email. Your comment needs to be the very first thing in the reply email and appear before all other text.  Do not change the reply-to address, as it uses a secret address to post your reply. You should [[openlink]]reset the secret address[[closelink]] if you've accidentally shared it with anyone else.
 
+esn.reply_to_entry=[[openlink]]Leave a reply to this entry[[closelink]]
+
 esn.reply_to_message=[[openlink]]Reply to this message[[closelink]]
 
 esn.screened=This comment was screened.

--- a/cgi-bin/LJ/Event/JournalNewEntry.pm
+++ b/cgi-bin/LJ/Event/JournalNewEntry.pm
@@ -207,6 +207,7 @@ my @_ml_strings_en = (
     'esn.you_can',                                  # 'You can:',
     'esn.view_entry.nosubject',                     # '[[openlink]]View entry [[ditemid]][[closelink]]'
     'esn.view_entry.subject',                       # '[[openlink]]View entry titled [[subject]][[closelink]]',
+    'esn.reply_to_entry',                           # '[[openlink]]Leave a reply to this entry[[closelink]]',
     'esn.read_recent_entries',                      # '[[openlink]]Read the recent entries in [[journal]][[closelink]]',
     'esn.join_community',                           # '[[openlink]]Join [[journal]] to read Members-only entries[[closelink]]',
     'esn.read_user_entries',                        # '[[openlink]]Read [[poster]]\'s recent entries[[closelink]]',
@@ -294,13 +295,14 @@ sub _as_email {
         $self->format_options($is_html, $lang, $vars,
             {
                 "esn.view_entry.$has_subject" => [ 1, $entry_url ],
-                'esn.read_recent_entries'   => [ $self->entry->journal->is_comm ? 2 : 0,
+                'esn.reply_to_entry'        => [ 2, "$entry_url?mode=reply" ],
+                'esn.read_recent_entries'   => [ $self->entry->journal->is_comm ? 3 : 0,
                                                     $journal_url ],
-                'esn.join_community'        => [ ($self->entry->journal->is_comm && !$u->member_of( $self->entry->journal )) ? 3 : 0,
+                'esn.join_community'        => [ ($self->entry->journal->is_comm && !$u->member_of( $self->entry->journal )) ? 4 : 0,
                                                     "$LJ::SITEROOT/community/join?comm=$journal_user" ],
-                'esn.read_user_entries'     => [ ($self->entry->journal->is_comm) ? 0 : 4,
+                'esn.read_user_entries'     => [ ($self->entry->journal->is_comm) ? 0 : 5,
                                                     $journal_url ],
-                'esn.add_watch'             => [ $u->watches( $self->entry->journal ) ? 0 : 5,
+                'esn.add_watch'             => [ $u->watches( $self->entry->journal ) ? 0 : 6,
                                                     "$LJ::SITEROOT/manage/circle/add?user=$journal_user&action=subscribe" ],
             });
 
@@ -326,7 +328,7 @@ sub subscription_applicable {
 
     return 1 unless $subscr->arg1;
 
-    # subscription is for entries with tsgs.
+    # subscription is for entries with tags.
     # not applicable if user has no tags
     my $journal = $subscr->journal;
 


### PR DESCRIPTION
Refactors LJ::Event::OfficialPost to use LJ::Event::JournalNewEntry.
Adds "Reply | Link" to DW inbox notifs of official posts.
Adds "Leave a reply to this entry" to all e-mail notifs of news posts.
