### PR TITLE
(Bug 5219) Make sure the DW cgi-bin is in @INC

### DIFF
--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -51,6 +51,7 @@ bail_on_fail;
 my $out = "$dir/out";
 my $err = "$dir/err";
 my $lib = File::Spec->catdir(dirname(dirname($0)), 'cgi-bin');
+unshift @INC, $lib;
 
 foreach my $file (@modules) {
     my $warnings = '';


### PR DESCRIPTION
In my testing, this fixes the issue Dre pointed out where the test
would fail if the DW cgi-bin was not already in @INC (e.g. by
setting PERL5LIB in the shell, which is what I had done).
