### PR TITLE
(Bug 5220) Don't warn about MogileFS tables in development environments.

### DIFF
--- a/bin/upgrading/update-db.pl
+++ b/bin/upgrading/update-db.pl
@@ -168,17 +168,20 @@ CLUSTER: foreach my $cluster (@clusters) {
         delete $table_unknown{$t};
     }
 
-    foreach my $t (keys %table_unknown)
     {
-        # dreamhacks use the same database for website and mogilefs
+        # dreamhacks use the same database for website, schwartz, and mogilefs
         my @mogile_tables = qw( domain class file tempfile file_to_delete
                                 unreachable_fids file_on file_on_corrupt
                                 host device server_settings file_to_replicate
                                 file_to_delete_later fsck_log file_to_queue
-                                file_to_delete2 checksum note error job
-                                funcmap exitstatus );
-        print "# Warning: unknown live table: $t\n"
-            unless $LJ::IGNORE_MOGILE_TABLES && $t ~~ @mogile_tables;
+                                file_to_delete2 checksum );
+        my @schwartz_tables = qw( note error job funcmap exitstatus );
+        my %skip_tables = map { $_ => 1 } ( @mogile_tables, @schwartz_tables );
+
+        foreach my $t ( keys %table_unknown ) {
+            print "# Warning: unknown live table: $t\n"
+                unless $LJ::IGNORE_MOGILE_SCHWARTZ_TABLES && $skip_tables{$t};
+        }
     }
 
     my $run_alter = $table_exists{dbnotes};


### PR DESCRIPTION
This keeps a hardcoded list of tables created by MogileFS and checks against it if IS_DEV_SERVER==1 when deciding whether to print a warning about unknown live tables.

(Excited to find a use for the nifty ~~ operator I just learned about!)
