### PR TITLE
(Bug 5221) Fix uninitialized value warning in DW::SiteScheme

### DIFF
--- a/cgi-bin/DW/SiteScheme.pm
+++ b/cgi-bin/DW/SiteScheme.pm
@@ -196,7 +196,8 @@ sub current {
             $r->cookie( 'BMLschemepref' );
     }
 
-    return defined $sitescheme_data{$rv} ? $rv : $_[0]->default;
+    return $rv if defined $rv and defined $sitescheme_data{$rv};
+    return $_[0]->default;
 }
 
 =head2 C<< DW::SiteScheme->default >>


### PR DESCRIPTION
Use of uninitialized value $rv in hash element
 at /dreamhack/home/8398-kareila/dw/cgi-bin/DW/SiteScheme.pm line 199.
