### PR TITLE
(Bug 5221) More S2-related uninitialized value warnings.

### DIFF
--- a/cgi-bin/LJ/S2/IconsPage.pm
+++ b/cgi-bin/LJ/S2/IconsPage.pm
@@ -66,7 +66,7 @@ sub IconsPage {
     my $page_size = S2::get_property_value($opts->{'ctx'}, "num_items_icons")+0 || $LJ::MAX_ICONS_PER_PAGE || 0;
 
     $page_size = $LJ::MAX_ICONS_PER_PAGE if ( $LJ::MAX_ICONS_PER_PAGE && $page_size > $LJ::MAX_ICONS_PER_PAGE );
-    $page_size = 0 if $get->{view} eq 'all';
+    $page_size = 0 if $get->{view} && $get->{view} eq 'all';
 
     $p->{pages} = ItemRange_fromopts({
         items => \@pics,

--- a/cgi-bin/LJ/Widget/S2PropGroup.pm
+++ b/cgi-bin/LJ/Widget/S2PropGroup.pm
@@ -124,7 +124,8 @@ sub render_body {
 
             # module_*_section_override overrides module_*_section;
             # for use in child layouts since they cannot redefine an existing property
-            my $prop_name_section_override = $props->{$overriding_prop_name}->{values};
+            my $prop_name_section_override = defined $overriding_prop_name
+                ? $props->{$overriding_prop_name}->{values} : undef;
 
             # put this property under the proper subheader (this is the original; may be overriden)
             my %prop_values = LJ::Customize->get_s2_prop_values( $prop_name_section, $u, $style );
@@ -180,7 +181,7 @@ sub render_body {
                 next if $class->skip_prop( $props->{$prop_name}, $prop_name, theme => $theme, user => $u, style => $style );
 
                 unless ($header_printed) {
-                    my $prop_list_class;
+                    my $prop_list_class = '';
                     $prop_list_class = " first" if $subheader_counter == 1;
 
                     $ret .= "<div class='subheader subheader-modules collapsible expanded' id='subheader__modules__${subheader}'><div class='collapse-button'>"


### PR DESCRIPTION
Use of uninitialized value in string eq at
/dreamhack/home/8103-alierak/dw/cgi-bin/LJ/S2/IconsPage.pm line 69.

Use of uninitialized value $overriding_prop_name in hash element at
/dreamhack/home/8103-alierak/dw/cgi-bin/LJ/Widget/S2PropGroup.pm line 127.

Use of uninitialized value $prop_list_class in concatenation (.) or string at
/dreamhack/home/8103-alierak/dw/cgi-bin/LJ/Widget/S2PropGroup.pm line 189.
