### PR TITLE
Bug 5175: Add missing Title + Subtitle to 3 styles

### DIFF
--- a/styles/brittle/layout.s2
+++ b/styles/brittle/layout.s2
@@ -57,6 +57,7 @@ set custom_background_element = "userpic_background";
 propgroup colors {
     property use color_page_background;
     property use color_page_text;
+    property use color_page_title;
     property use color_page_link;
     property use color_page_link_hover;
     property use color_page_link_visited;
@@ -93,6 +94,12 @@ propgroup fonts {
     property use font_fallback;
     property use font_base_size;
     property use font_base_units;
+    property use font_journal_title;
+    property use font_journal_title_size;
+    property use font_journal_title_units;
+    property use font_journal_subtitle;
+    property use font_journal_subtitle_size;
+    property use font_journal_subtitle_units;
     property use font_module_heading;
     property use font_module_heading_size;
     property use font_module_heading_units;
@@ -329,6 +336,8 @@ function Page::print_default_stylesheet() {
     var string entry_background = generate_background_css ($*image_background_entry_url, $*image_background_entry_repeat, $*image_background_entry_position, $*color_entry_background);
 
     var string page_font = generate_font_css("", $*font_base, $*font_fallback, $*font_base_size, $*font_base_units);
+    var string journal_title_font = generate_font_css($*font_journal_title, $*font_base, $*font_fallback, $*font_journal_title_size, $*font_journal_title_units);
+    var string journal_subtitle_font = generate_font_css($*font_journal_subtitle, $*font_base, $*font_fallback, $*font_journal_subtitle_size, $*font_journal_subtitle_units);
     var string entry_font = generate_font_css($*font_entry_text, $*font_base, $*font_fallback, $*font_entry_text_size, $*font_entry_text_units);
     var string entry_title_font = generate_font_css($*font_entry_title, $*font_base, $*font_fallback, $*font_entry_title_size, $*font_entry_title_units);
     var string comment_title_font = generate_font_css($*font_comment_title, $*font_base, $*font_fallback, $*font_comment_title_size, $*font_comment_title_units);
@@ -452,9 +461,26 @@ q { font-style: italic; }
 #tertiary .separator-after { clear: both; }
 
 
-/*--- header + footer ---*/
+/*--- header---*/
+#header {
+    margin-$sidebar_position: auto;
+    text-transform: lowercase;
+    width: 45%;
+}
+.two-columns-left #header {
+    text-align: right;
+}
+#header {
+  color: $*color_page_title;
+}
+#header h1 {
+  $journal_title_font
+}
+#header h2 {
+  $journal_subtitle_font
+}
 
-#header { display: none; }
+/*--- footer ---*/
 #footer {
     background: $*color_footer_background;
     width: 45%;

--- a/styles/negatives/layout.s2
+++ b/styles/negatives/layout.s2
@@ -53,6 +53,7 @@ set custom_colors_template = "%%new%% div.footer, %%new%% div.footer ul, %%new%%
 propgroup colors {
     property use color_page_background;
     property use color_page_text;
+    property use color_page_title;
     property use color_page_link;
     property use color_page_link_active;
     property use color_page_link_hover;
@@ -108,6 +109,12 @@ propgroup fonts {
     property use font_fallback;
     property use font_base_size;
     property use font_base_units;
+    property use font_journal_title;
+    property use font_journal_title_size;
+    property use font_journal_title_units;
+    property use font_journal_subtitle;
+    property use font_journal_subtitle_size;
+    property use font_journal_subtitle_units;
     property use font_module_heading;
     property use font_module_heading_units;
     property use font_module_heading_size;
@@ -270,6 +277,8 @@ function Page::print_default_stylesheet()
         $header_background = $header_background + "\n        height: " + $*image_background_header_height + "px;";
     }
     var string page_font = generate_font_css("", $*font_base, $*font_fallback, $*font_base_size, $*font_base_units);
+    var string journal_title_font = generate_font_css($*font_journal_title, $*font_base, $*font_fallback, $*font_journal_title_size, $*font_journal_title_units);
+    var string journal_subtitle_font = generate_font_css($*font_journal_subtitle, $*font_base, $*font_fallback, $*font_journal_subtitle_size, $*font_journal_subtitle_units);
     var string entry_title_font = generate_font_css($*font_entry_title, $*font_base, $*font_fallback, $*font_entry_title_size, $*font_entry_title_units);
     var string comment_title_font = generate_font_css($*font_comment_title, $*font_base, $*font_fallback, $*font_comment_title_size, $*font_comment_title_units);
     var string module_font = generate_font_css($*font_module_text, $*font_base, $*font_fallback, $*font_module_text_size, $*font_module_text_units);
@@ -333,7 +342,16 @@ function Page::print_default_stylesheet()
     #header {
         border-top: 0!important;
         border-bottom: 5px double $*color_module_border;
+        color: $*color_page_title;
         $header_background
+    }
+    #header h1 {
+        $journal_title_font
+        padding: 0 1.25em;
+    }
+    #header h2 {
+        $journal_subtitle_font
+        padding: 0 1.7em;
     }
     #header a {
         color: $*color_header_link;
@@ -995,7 +1013,10 @@ function Page::print()
         $this->print_wrapper_start();
         $this->print_control_strip();
         println "<div id=\"header\">";
-        $this->print_module_section("two");
+            println "<a name=\"top\"></a>";
+            $this->print_global_title();
+            $this->print_global_subtitle();
+            $this->print_module_section("two");
         println "</div>";
         if ($*layout_type == "one-column-split") {
             println "<div id=\"secondary\">";

--- a/styles/skittlishdreams/layout.s2
+++ b/styles/skittlishdreams/layout.s2
@@ -121,6 +121,9 @@ propgroup fonts {
     property use font_journal_title;
     property use font_journal_title_size;
     property use font_journal_title_units;
+    property use font_journal_subtitle;
+    property use font_journal_subtitle_size;
+    property use font_journal_subtitle_units;
     property use font_entry_title;
     property use font_entry_title_size;
     property use font_entry_title_units;
@@ -368,6 +371,7 @@ function Page::print()
                 <a name="top">
     """;
     $this->print_global_title();
+    $this->print_global_subtitle();
     """
                 </a>
             </div>
@@ -502,6 +506,7 @@ function Page::print_default_stylesheet () {
 
     var string page_font = generate_font_css("", $*font_base, $*font_fallback, $*font_base_size, $*font_base_units );
     var string journal_title_font = generate_font_css($*font_journal_title, $*font_base, $*font_fallback, $*font_journal_title_size, $*font_journal_title_units);
+    var string journal_subtitle_font = generate_font_css($*font_journal_subtitle, $*font_base, $*font_fallback, $*font_journal_subtitle_size, $*font_journal_subtitle_units);
     var string entry_title_font = generate_font_css($*font_entry_title, $*font_base, $*font_fallback, $*font_entry_title_size, $*font_entry_title_units);
     var string comment_title_font = generate_font_css($*font_comment_title, $*font_base, $*font_fallback, $*font_comment_title_size, $*font_comment_title_units);
     var string module_title_font = generate_font_css($*font_module_heading, $*font_base, $*font_fallback, $*font_module_heading_size, $*font_module_heading_units);
@@ -669,7 +674,7 @@ html body {
 .two-columns-left #container { $container_background_redux }
 .two-columns-right #container, .two-columns-left #container { $container_colors margin: 0 4%; }
 
-#header { $header_background $header_footer_colors  padding: 0; }
+#header { $header_background $header_footer_colors padding: 0; }
 .two-columns-right #header { margin: 0 5px 0 0; }
 .two-columns-left #header { margin: 0 0 0 5px; text-align: right; }
 #footer {margin: 0 4%; padding: 0; background:transparent;}
@@ -678,8 +683,8 @@ html body {
 #header a, #footer a { $header_footer_colors text-decoration: none; }
 
 h1, h2, h3, h4 {font-weight: 700; font-variant: normal; letter-spacing: 0.08em; }
-#header h1 {margin: 0; padding: 20px  20px  0  2em; $journal_title_font font-weight: lighter; font-variant: normal; text-transform: lowercase; letter-spacing: 0.2em; }
-#header h2 {padding: 0 2em; $page_title_colors }
+#header h1 {margin: 0; padding: 20px  20px  0  2em; $page_title_colors $journal_title_font font-weight: lighter; font-variant: normal; text-transform: lowercase; letter-spacing: 0.2em; }
+#header h2 {padding: 0 20px 0 2.7em; $page_title_colors $journal_subtitle_font}
 
 #wrap { $page_text_colors }
 .two-columns-right #wrap {padding-right: $*sidebar_width; padding-top: 20px; padding-left:  20px;}


### PR DESCRIPTION
- Britle:
  - Supplement propgroups and CSS to display and customize Title,
    Subtitle, Pagetitle.
- Negatives:
  - Supplement Page::print to add call to print_global_title() and
    print_global_subtitle().
  - Supplement propgroups and CSS to display and customize Title
    and Subtitle.
- Skittlish Dreams:
  - Supplement Page::print to add call to print_global_subtitle().
  - Supplement propgroups and CSS to display and customize Title
    and Subtitle.
