### PR TITLE
(bug 5224) Update feed token generator for twitter feeds going away

### DIFF
--- a/cgi-bin/DW/Controller/Admin/Feeds.pm
+++ b/cgi-bin/DW/Controller/Admin/Feeds.pm
@@ -56,8 +56,21 @@ sub duplicate_controller {
 
 sub _score_url {
     my $url = $_[0];
-    return 10 if $url =~ m/atom/i;
-    return 5 if $url =~ m/rss/i;
+    my $score = 0;
+
+    # Twitter feeds are gone for good
+    return -1000
+        if $url =~ m/twitter\.com/i;
+
+    # If they are using feedburner
+    #   this is likely the correct url
+    $score += 20
+        if $url =~ m/feedburner\.com/i;
+
+    return $score + 10
+        if $url =~ m/atom/i;
+    return $score + 5
+        if $url =~ m/rss/i;
     return 0;
 }
 

--- a/cgi-bin/DW/FeedCanonicalizer.pm
+++ b/cgi-bin/DW/FeedCanonicalizer.pm
@@ -186,13 +186,7 @@ sub canonicalize {
             return "wordpress://$username/$datepart/$article";
         }
 
-        when ( m!^https?://(?:www\.)?twitter\.com/+([a-z][a-z0-9\-_]*)/?$!i && $src eq 'link' ) {
-            my $username = lc($1);
-            $username =~ s/-/_/g;
-
-            return "twitter://$username";
-        }
-        
+        # Unfortunately, these two twitter ones cannot go away (yet)
         when ( m!^https?://(?:www\.)?twitter\.com/+statuses/user_timeline/([a-z][a-z0-9\-_]*)\.rss$!i ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
@@ -214,20 +208,14 @@ sub canonicalize {
             return "twitter://$username";
         }
 
-        when ( m!^https?://(?:www\.)?twitter\.com/+([a-z][a-z0-9\-_]*)/favorites/?$!i && $src eq 'link' ) {
+        # twfeed.com replacement feed service
+        when ( m!^https?://(?:www\.)twfeed\.com/+(?:rss|atom)/([a-z][a-z0-9\-_]*)$!i ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
 
-            return "twitter://$username/favorites";
+            return "twitter://$username";
         }
 
-        when ( m!^https?://(?:www\.)?twitter\.com/+favorites/([a-z][a-z0-9\-_]*)\.rss$!i ) {
-            my $username = lc($1);
-            $username =~ s/-/_/g;
-
-            return "twitter://$username/favorites";
-        }
-        
         when ( m!^https?://blog\.myspace\.com/+([a-z][a-z0-9\-_]*)/?!i && $src eq 'link' ) {
             my $username = lc($1);
             $username =~ s/-/_/g;


### PR DESCRIPTION
twfeed.com provides a replacement service, let's treat them as "twitter://"
