### PR TITLE
Bug 2977: Stop #tertiary modules from breaking out

### DIFF
--- a/styles/brittle/layout.s2
+++ b/styles/brittle/layout.s2
@@ -1031,6 +1031,8 @@ ul.userlite-interaction-links.icon-links li {
     padding: 0 0.2em;
     }
 
+.module-powered, .module-tags_cloud, .module-time { width: 90%; }
+
 #tertiary .module-powered,
 #tertiary .module-tags_cloud,
 #tertiary .module-time {


### PR DESCRIPTION
- Brittle:
  - Stop some `#tertiary` modules from breaking out of their container.
  - Modules concerned: `.module-powered`, `.module-tags_cloud`, `.module-time`.
