### PR TITLE
bug 5225: adding vanishing skip link to free site scheme. looks unfortun...

### DIFF
--- a/htdocs/stc/lj_base-app.css
+++ b/htdocs/stc/lj_base-app.css
@@ -217,5 +217,28 @@ div.columns-2-r300 .columns-2-right {
     margin-bottom: 1em;
 }
 
+/* allow hidden skip links */
+#skip a, #skip a:hover, #skip a:visited
+{
+    position:absolute;
+    left:0px;
+    top:-500px;
+    width:1px;
+    height:1px;
+    overflow:hidden;
+}
+
+#skip a:active, #skip a:focus
+{
+    position:fixed;
+    top:.25em;
+    left:.25em;
+    width:auto;
+    height:auto;
+    background: #ffffff;
+    z-index: 500;
+    font-weight: bold;
+} 
+
 /* clearing element at the foot of Support index */
 .clear-floats { clear: both; }

--- a/schemes/celerity.tt
+++ b/schemes/celerity.tt
@@ -40,6 +40,10 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <body [% sections.bodyopts %]>
         <div id="canvas">
             <div id="page">
+                [%# Visible only with screenreader or keyboard, per css %]
+                <div id="skip">
+                    <a href="#content" tabindex="1">Skip to Main Content</a>
+                </div>
                 [%# Not using the HTML 5 <header> element for now
                 because of incompatibilities with JAWS and
                 Firefox %]
@@ -48,25 +52,25 @@ the same terms as Perl itself.  For a copy of the license, please reference
                 </div><!-- end masthead-->
 
                 <div id="content" role="main" [% sections.contentopts %]>
-                <h1>[% sections.title %]</h1>
-                [% content %]
+                    <h1>[% sections.title %]</h1>
+                    [% content %]
                 </div><!--end content-->
                 <div id="page-decoration"></div>
-                </div><!-- end page-->
-                <div id="account-links" role="navigation">
-                    [% PROCESS block.accountlinks %]
-                </div><!-- end account links-->
-                <nav role="navigation">
-                    [% PROCESS block.userpic %]
-                    [% PROCESS block.menunav %]
-                </nav>
-                <div id="header-divider"> <div id="header-divider-insert"></div></div>
-                <div id="header-search" role="search">
-                    [% dw_scheme.search_render %]
-                </div><!-- end header-search-->
-                <footer role="contentinfo">
-                    [% PROCESS block.footer %]
-                </footer>
+            </div><!-- end page-->
+            <div id="account-links" role="navigation">
+                [% PROCESS block.accountlinks %]
+            </div><!-- end account links-->
+            <nav role="navigation">
+                [% PROCESS block.userpic %]
+                [% PROCESS block.menunav %]
+            </nav>
+            <div id="header-divider"> <div id="header-divider-insert"></div></div>
+            <div id="header-search" role="search">
+                [% dw_scheme.search_render %]
+            </div><!-- end header-search-->
+            <footer role="contentinfo">
+                [% PROCESS block.footer %]
+            </footer>
         </div> <!-- end canvas-->
         [% dw_scheme.final_body_html %]
     </body>

--- a/schemes/common.tt
+++ b/schemes/common.tt
@@ -131,6 +131,10 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- BLOCK block.pagediv -%]
 <div id="page">
+    [%# Visible only with screenreader or keyboard, per css %]
+    <div id="skip">
+         <a href="#content" tabindex="1">Skip to Main Content</a>
+    </div>
     [%# Not using the HTML 5 <header> element for now
     because of incompatibilities with JAWS and
     Firefox %]


### PR DESCRIPTION
...ate in IE 7 (unsupported) due to ie 7 completely flaking out when an empty, unstyled div (or a contenty, styled div) is placed above the logo. And a little fixing of indentation for easier reading.
