### PR TITLE
(Bug 5238) Return an empty hashref instead of undef

### DIFF
--- a/cgi-bin/DW/Request/Base.pm
+++ b/cgi-bin/DW/Request/Base.pm
@@ -154,7 +154,7 @@ sub post_args {
 
     # Requires a POST with the proper content type for us to parse it, else just
     # bail and return empty.
-    return {}
+    return Hash::MultiValue->new
         unless $self->method eq 'POST' &&
                $self->header_in( 'Content-Type' ) =~ m!^application/x-www-form-urlencoded(?:;.+)?$!;
 


### PR DESCRIPTION
This makes it so callers don't have to care whether the POST was valid or not,
when looking up whether something might be in $r->post_args
