### PR TITLE
(Bug 4866) Allow collapsing of all profile sections to stick

### DIFF
--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -1056,7 +1056,7 @@ userproplist.posting_guidelines_location:
 
 userproplist.profile_collapsed_headers:
   cldversion: 4
-  datatype: char
+  datatype: blobchar
   des: Comma-separated list of header ids that should start out collapsed when the user is viewing any profile.
   indexed: 0
   multihomed: 0


### PR DESCRIPTION
This changes profile_collapsed_headers in userproplist from
a char to a blobchar - char is limited to 255 characteters, and
with the number of sections we have, not all would fit and the
last property would get truncated, which means existing data
is potentially corrupt.

As such, this change does not migrate old data, and users will
have to reset the collapsed sections after it goes live.
