### PR TITLE
(Bug 4750) Misleading error message when exceeding tag limit counts

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3990,7 +3990,7 @@ taglib.error.mergenoname=You did not provide a tag name you want to merge to.
 
 taglib.error.mergetoexisting=The tag name '[[tagname]]' is already in use, but you did not select it. Please select the tag or merge to a different tag name.
 
-taglib.error.toomany=Adding this tag would exceed your maximum of [[max]] tags.  You will not be able to add new tags until you delete [[excess]] existing [[?excess|tag|tags]].
+taglib.error.toomany3=Adding this tag would exceed your maximum of [[max]] tags.  You will not be able to add new tags until you delete [[excess]] existing [[?excess|tag|tags]].
 
 talk.agerestriction.18plus=18+
 

--- a/cgi-bin/LJ/Tags.pm
+++ b/cgi-bin/LJ/Tags.pm
@@ -837,7 +837,7 @@ sub update_logtags {
     if (@to_create && $max && $max > 0) {
         my $total = scalar(keys %$utags) + scalar(@to_create);
         if ( $total > $max ) {
-            return $err->(LJ::Lang::ml('taglib.error.toomany', { max => $max,
+            return $err->(LJ::Lang::ml('taglib.error.toomany3', { max => $max,
                                                                  excess => $total - $max }));
         }
     }
@@ -1110,7 +1110,7 @@ sub create_usertag {
         my $cur = scalar(keys %{ LJ::Tags::get_usertags($u) || {} });
         my $tagtotal = $cur + scalar(@$tags);
         if ($tagtotal > $max) {
-            return $err->(LJ::Lang::ml('taglib.error.toomany', { max => $max,
+            return $err->(LJ::Lang::ml('taglib.error.toomany3', { max => $max,
                                                                  excess => $tagtotal - $max }));
         }
     }


### PR DESCRIPTION
Changes error message when exceeding tag limit count to: "Adding this tag
would exceed your maximum of n tags. You will not be able to add new tags
until you delete n existing tags."
