### PR TITLE
(Bug 4176) Fix errors in notif username display

### DIFF
--- a/cgi-bin/LJ/Support.pm
+++ b/cgi-bin/LJ/Support.pm
@@ -1092,10 +1092,10 @@ sub work {
         my $show_name;
         if ( $posterid ) {
             my $u = LJ::load_userid ( $posterid );
-            $show_name = $u->display_name if $show_name;
+            $show_name = $u->display_name if $u;
         }
 
-           $show_name ||= $sp->{reqname};
+        $show_name ||= $sp->{reqname};
 
         # build body
         $body = LJ::Lang::ml( "support.email.notif.update.body2", {


### PR DESCRIPTION
Previous commit displayed original requester's display name
in all notifs relating to a support request. It should display
username not user-set display name, and should display u/name
of person who triggered notif, instead of name of OP.
