### PR TITLE
(Bug 4624) Add Edit Profile link to Manage Icons

### DIFF
--- a/htdocs/editicons.bml
+++ b/htdocs/editicons.bml
@@ -334,6 +334,9 @@ use strict;
     $body .= LJ::make_authas_select($remote, { 'authas' => $GET{'authas'} }) . "\n";
     $body .= "</form>\n\n";
 
+    # link back to edit profile
+    $body .= BML::ml( '.profile.edit', { aopts => "href='$LJ::SITEROOT/manage/profile$getextra'" } ) . "</p>";
+
     # if we're disabling media, say so
     $body .= "<?warningbar $ML{'error.mediauploadsdisabled'} warningbar?>"
         if $LJ::DISABLE_MEDIA_UPLOADS;

--- a/htdocs/editicons.bml.text
+++ b/htdocs/editicons.bml.text
@@ -117,6 +117,8 @@
 
 .piclimitstatus=Currently uploaded: [[current]] out of [[max]]. 
 
+.profile.edit=<a [[aopts]]>Edit your profile.</a>
+
 .restriction.fileformat=File format must be either PNG, GIF, or JPG
 
 .restriction.filesize=File size must be less than 40k


### PR DESCRIPTION
Issues I would like to discuss:

(1) Where should the "Edit your profile." text go? Its current positioning is kind of ugly but I would like to have other input before I fiddle w/ fine-tuning.
(2) Depends on (1) -- what exactly should the text be?
