### PR TITLE
Bug 5106 - allow embeds from kickstarter fundraising widget

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -59,7 +59,7 @@ my %host_path_match = (
     "maps.google.com"       => qr!^/maps!,
     "www.google.com"        => qr!^/calendar/!,
 
-    "www.kickstarter.com"   => qr!/widget/video.html$!,
+    "www.kickstarter.com"   => qr!/widget/[a-zA-Z]+\.html$!,
 
     "ext.nicovideo.jp"      => qr!^/thumb/!,
 

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 37;
+use Test::More tests => 38;
 
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { require 'ljlib.pl'; }
@@ -85,6 +85,7 @@ note( "misc" );
     test_good_url( "https://www.google.com/calendar/b/0/embed?showPrint=0&showTabs=0&showCalendars=0&showTz=0&height=600&wkst=1&bgcolor=%23FFFFFF&src=foo%40group.calendar.google.com" );
 
     test_good_url( "http://www.kickstarter.com/projects/25352323/arrival-a-short-film-by-alex-myung/widget/video.html" );
+    test_good_url( "http://www.kickstarter.com/projects/25352323/arrival-a-short-film-by-alex-myung/widget/card.html" );
 
     test_good_url( "http://ext.nicovideo.jp/thumb/sm123123123" );
     test_good_url( "http://ext.nicovideo.jp/thumb/nm123123123" );


### PR DESCRIPTION
Kickstarter has multiple widgets which we want to allow embedding for. Bug 4852 allowed www.kickstarter.com/*/widget/video.html, but we also want to enable card.html, and other widgets that Kickstarter may create in the future.

Also add a new test URL based on a modification of the URL added in bug 4852.
