### PR TITLE
Bug 5216 - add instagram as comment-embed source

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -74,6 +74,8 @@ my %host_path_match = (
     "player.vimeo.com"      => qr!^/video/\d+$!,
 
     "www.plurk.com"         => qr!^/getWidget$!,
+
+    "instagram.com"         => qr!^/p/.*/embed/$!,
 );
 
 LJ::Hooks::register_hook( 'allow_iframe_embeds', sub {

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 37;
+use Test::More tests => 42;
 
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { require 'ljlib.pl'; }
@@ -78,6 +78,8 @@ note( "misc" );
     test_good_url( "http://www.dailymotion.com/embed/video/x1xx11x" );
 
     test_good_url( "http://dotsub.com/media/9db493c6-6168-44b0-89ea-e33a31db48db/e/m" );
+
+    test_good_url( "//instagram.com/p/cA1pRXKGBT/embed/" );
 
     test_good_url( "http://www.goodreads.com/widgets/user_update_widget?height=400&num_updates=3&user=12345&width=250" );
 


### PR DESCRIPTION
Added instagram to the whitelist and added a URL to the test suite.

![screen shot 2013-09-02 at 4 04 15 pm](https://f.cloud.github.com/assets/185758/1069604/5965c9a0-1424-11e3-8933-afc5c5e5e9ad.png)
