### PR TITLE
Bug 5151: granting unknown privs via console fails

### DIFF
--- a/cgi-bin/LJ/User.pm
+++ b/cgi-bin/LJ/User.pm
@@ -5656,11 +5656,6 @@ sub grant_priv {
 
     return 1 if $u->has_priv( $priv, $arg );
 
-    if ( $arg && $arg ne '*' && $priv !~ /^support/ ) {
-        my $valid_args = LJ::list_valid_args( $priv );
-        return 0 if $valid_args and not $valid_args->{$arg};
-    }
-
     my $privid = $dbh->selectrow_array("SELECT prlid FROM priv_list".
                                        " WHERE privcode = ?", undef, $priv);
     return 0 unless $privid;


### PR DESCRIPTION
Per Denise, we should allow all arguments even if they do not match the
known list of valid arguments. This is in part to allow for broader
vanity privileges (besides the already functioning support vanity
privs), and in part to allow admins to pre-grant privs before a code
change which would otherwise cause a priv gap (such as the
aforementioned bug 5144).

![screen shot 2013-09-02 at 8 35 30 pm](https://f.cloud.github.com/assets/185758/1070268/f0cf5f2a-1449-11e3-9f3a-8896b9d0c11e.png)
