### PR TITLE
Implement drafts and scheduled posts in the new update page

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -713,6 +713,8 @@ entryform.delete=Delete Entry
 
 entryform.delete.confirm=Are you sure you want to delete this entry?
 
+entryform.delete.draft.confirm=Are you sure you want to delete this draft?
+
 entryform.delete.xposts.confirm=This will also delete the selected crossposts.  Are you sure?
 
 entryform.deletespam=Delete and Mark as Spam

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -3228,6 +3228,30 @@ CREATE TABLE `logslugs` (
 )
 EOC
 
+register_tablecreate("draft", <<'EOC');
+CREATE TABLE `draft` (
+    `userid` INT(10) UNSIGNED NOT NULL,
+    `id` MEDIUMINT UNSIGNED NOT NULL,
+    `subject` VARCHAR(255) DEFAULT NULL,
+    `summary` VARCHAR(255) DEFAULT NULL,
+    `createtime` DATETIME NOT NULL,
+    `modtime` DATETIME DEFAULT NULL,
+    `recurring_period` VARCHAR(255) DEFAULT NULL,
+    `nextscheduletime` DATETIME DEFAULT NULL,
+    `status` char(1) NOT NULL DEFAULT 'D',
+    PRIMARY KEY  (`userid`, `id`)
+)
+EOC
+
+register_tablecreate("draftblob", <<'EOC');
+CREATE TABLE `draftblob` (
+    `userid` INT(10) UNSIGNED NOT NULL,
+    `id` MEDIUMINT UNSIGNED NOT NULL,
+    `req_stor` MEDIUMBLOB,
+    PRIMARY KEY (`userid`, `id`)
+)
+EOC
+
 # NOTE: new table declarations go ABOVE here ;)
 
 ### changes

--- a/bin/worker/scheduled-posts
+++ b/bin/worker/scheduled-posts
@@ -1,0 +1,52 @@
+#!/usr/bin/perl
+#
+# bin/worker/scheduled-posts
+#
+# Worker that handles scheduled posts
+#
+# Authors:
+#       Allen Petersen <allen@suberic.net>
+#
+# Copyright (c) 2013 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+package DW::Worker::ScheduledPosts;
+
+use strict;
+use lib "$ENV{LJHOME}/extlib/lib/perl5";
+use lib "$ENV{LJHOME}/cgi-bin";
+BEGIN {
+    require 'ljlib.pl';
+}
+
+use DW::Draft;
+
+sub work {
+    my $class = shift;
+    my @uids = @_;
+
+    # pick a cluster to work on, get a lock
+    my $lock;
+    foreach my $cid ( @LJ::CLUSTERS ) {
+        last if @uids;
+
+        next unless ($cid);
+
+        $lock = LJ::locker()->trylock("scheduled-post:" . $cid);
+        next unless $lock;
+
+        # got a lock; post all the scheduled posts from there
+        DW::Draft->post_by_cluster( $cid );
+
+        last;
+    }
+
+    # when we return 0 here, we'll be considered idle
+    return 0 unless @uids;
+    return 1;
+}
+work();
+1;

--- a/cgi-bin/DW/BaseDbObj.pm
+++ b/cgi-bin/DW/BaseDbObj.pm
@@ -1,0 +1,613 @@
+#!/usr/bin/perl
+#
+# Base class for DB objects
+#
+# Authors:
+#      Allen Petersen <allen@suberic.net>
+#
+# Copyright (c) 2012 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+## Derived classes must implement the following methods:
+## 
+## _obj_props { }
+## _tablename { }
+## _skeleton { } -- NOTE: the other methods here may be inherited, but 
+##                  _skeleton() must be implemented by each subclass
+##
+## _memcache_id                 { $_[0]->userid                 }
+## _memcache_key_prefix         { "user"                        }
+## _memcache_stored_props       { qw/$VERSION name age caps /   }
+## _memcache_hashref_to_object  { LJ::User->new_from_row($_[0]) }
+## _memcache_expires            { 24*3600                       }
+
+package DW::BaseDbObj;
+
+use strict;
+use warnings;
+
+use base 'LJ::MemCacheable';
+
+# Object key column.
+sub _key_column {
+    return "id";
+}
+
+# Editable properties for the object. Defaults to all; may be overridden.
+sub _editable_obj_props {
+    return $_[0]->_obj_props;
+}
+
+# returns the WHERE clause for searching by ID
+sub _where_by_id {
+    return "WHERE " . $_[0]->_key_column . " = ?";
+}
+
+# creates a WHERE clause for searching
+sub _create_where_clause {
+    my ( $class, $filter ) = @_;
+    
+    my $default_filter = $class->_default_filter;
+
+    my $return_value = $filter || "";
+    if ( ( $filter && $filter ne "" ) || ( $default_filter && $default_filter ne "" ) ) {
+        if ( $default_filter && $default_filter ne "" ) {
+            if ( $return_value && $return_value ne "" ) {
+                $return_value .= " AND ";
+            }
+            $return_value .= $default_filter;
+        }
+        $return_value = " WHERE " . $return_value;
+    }
+    return $return_value;
+}
+
+sub _default_filter {
+    return "";
+}
+
+
+# returns the full object key for this object
+sub _key {
+    my $self = $_[0];
+    return $self->{$self->_key_column};
+}
+
+sub _default_order_by {
+    return "";
+}
+
+# DB utils
+sub get_db_writer {
+    return LJ::get_db_writer();
+}
+sub get_db_reader {
+    return LJ::get_db_reader();
+}
+
+
+# create a new instance
+sub instance {
+    my ( $class, $id ) = @_;
+    
+    my $obj = $class->_skeleton( $id );
+    return $obj;
+}
+*new = \&instance;
+
+# instance methods
+sub _absorb_row {
+    my ($self, $row) = @_;
+
+    # set the key
+    $self->{$self->_key_column} = $row->{$self->_key_column};
+    # and set all the properties
+    for my $f ( $self->_obj_props ) {
+        $self->{$f} = $row->{$f};
+    }
+    return $self;
+}
+
+# creates an new DbObj from a DB row
+sub _new_from_row {
+    my ($class, $row) = @_;
+    die unless $row && $row->{$class->_key_column};
+    my $self = $class->new( $row->{$class->_key_column} );
+    $self->_absorb_row($row);
+    return $self;
+}
+
+# creates a new instance
+sub _create {
+    my ( $class, $opts ) = @_;
+
+    # validate the inputs first
+    $class->validate( $opts );
+
+    my $dbh = $class->get_db_writer();
+    # new objectid
+    #my $objid = $class->_get_next_id();
+
+    # create and run the SQL
+    my $entrystring =  join ( ',' , $class->_obj_props );
+    my $qs = join( ', ', map { '?' } $class->_obj_props );
+    my @values = map { $opts->{$_} }  $class->_obj_props;
+    my $sql = "INSERT INTO " . $class->_tablename . " ( $entrystring ) values ( $qs )";
+    #warn("running $sql, values=" . join( ",", @values));
+    $dbh->do( $sql, undef, @values );
+    
+    LJ::throw($dbh->errstr) if $dbh->err;
+
+    my $objid = $dbh->selectrow_array( "SELECT LAST_INSERT_ID()" );
+
+    # now return the created object.
+    my $obj = $class->_get_obj( $objid ) or LJ::throw("Error instantiating object");
+
+    # clear the appropriate caches for this object
+    $obj->_clear_associated_caches();
+
+    return $obj;
+}
+
+# updates an existing instance
+sub _update {
+    my ( $self ) = @_;
+
+    # validate the inputs first
+    $self->validate( $self );
+
+    my $dbh = $self->get_db_writer();
+
+    # create and run the SQL
+    my $qs = join( ', ', map { $_ . "=?" } $self->_obj_props );
+    my @values = map { $self->{$_} }  $self->_obj_props;
+    my $sql = "UPDATE " . $self->_tablename . " set $qs WHERE " . $self->_key_column . "=?";
+    #warn ("updating: running $sql ; values = " . join (',', @values ));
+    $dbh->do( $sql, undef, @values, $self->id );
+    
+    LJ::throw($dbh->errstr) if $dbh->err;
+
+    # return the updated object.
+    my $obj = $self->by_id( $self->id ) or LJ::throw("Error instantiating object");
+
+    # clear the cache.
+    $obj->_clear_cache();
+    $obj->_clear_associated_caches();
+
+    return $obj;
+}
+
+# retrieves a single object by id, either from database or memcache
+sub _get_obj {
+    my ( $class, $objid ) = @_;
+
+    my @keyarray = ( $objid );
+    my @objarray = $class->_load_objs_from_keys( \@keyarray );
+    if ( @objarray && scalar@objarray  ) {
+        return $objarray[0];
+    } else {
+        return undef;
+    }
+}
+
+# retrieves a set of objects by ids, either from database or memcache
+# as appropriate
+sub _load_objs_from_keys {
+    my ( $class, $keys ) = @_;
+
+    # return an empty array for an empty request
+    if ( ! defined $keys || ! scalar @$keys ) {
+        return ();
+    }
+    #warn("loading objs from keys ( " . join(",", @$keys ) . " ) ");
+
+    # try from memcache first.  if we get all the results from memcache,
+    # just return those.  otherwise, keep the misses and an id map for the
+    # hits.
+    my %memcache_objmap = ();
+    my %db_objmap = ();
+    my @memcache_misses = @$keys;
+    if ( $class->memcache_enabled ) {
+        my $cached_value = $class->_load_batch_from_memcache( $keys );
+        @memcache_misses = @{$cached_value->{misses}};
+        %memcache_objmap = %{$cached_value->{objmap}};
+    }
+
+    if ( @memcache_misses ) {
+        # if we got to here, then we need to query the db for at least a 
+        # subset of the objects
+        my $dbr = $class->get_db_reader();
+
+        my $qs = join( ', ', map { '?' } @memcache_misses );
+        my $sql = "SELECT " . join ( ',' , ( $class->_key_column, $class->_obj_props ) ) . " FROM " . $class->_tablename . " WHERE ".  $class->_key_column . " IN ( $qs )";
+        #warn("running $sql, values = " . join (',', @memcache_misses ));
+        my $sth = $dbr->prepare( $sql );
+        $sth->execute( @memcache_misses );
+        LJ::throw( $dbr->err ) if ( $dbr->err );
+        
+        # ok, now we create the objects from the db query
+        my $obj;
+        my @db_objs = ();
+        while ( my $row = $sth->fetchrow_hashref ) {
+            $obj = $class->_new_from_row( $row );
+            push @db_objs, $obj;
+            $db_objmap{$obj->_key} = $obj;
+        }
+
+        # if we're using memcache, save the newly loaded objects to it.
+        if ( $class->memcache_enabled ) {
+            $class->_store_batch_to_memcache( \@db_objs );
+        }
+    }
+
+    # stitch together the memcache results and the db results in the
+    # original id order
+    my @returnvalue = ();
+    foreach my $key ( @$keys ) {
+        push @returnvalue, $db_objmap{$key} || $memcache_objmap{$key};
+    }
+    return @returnvalue;
+}
+
+# updates this object's values from the provided object (or hash)
+sub _copy_from_object {
+    my ( $self, $source ) = @_;
+
+    # go through each property available and, if it's set, copy it to
+    # this object.
+    foreach my $prop ( $self->_editable_obj_props ) {
+        if ( exists $source->{$prop} ) {
+            $self->{$prop} = $source->{$prop};
+        }
+    }
+}
+
+# updates this object's values from the provided object (or hash).
+sub copy_from_object {
+    my ( $self, @args ) = @_;
+    $self->_copy_from_object( @args );
+}
+
+# deletes this object.  may be overridden by subclasses.
+sub delete {
+    return $_[0]->_delete();
+}
+
+# deletes this object
+sub _delete {
+    my ( $self ) = @_;
+    
+    my $dbh = $self->get_db_writer();
+    #warn("deleting " . $self->_key);
+    $dbh->do("DELETE FROM " . $self->_tablename . " " . $self->_where_by_id, 
+           undef, $self->_key );
+
+    # clear the cache.
+    $self->_clear_cache();
+    $self->_clear_associated_caches();
+
+    return 1;
+}
+
+
+# clears the cache for the given item
+sub _clear_cache {
+    my ( $self ) = @_;
+
+    $self->_remove_obj_from_memcache( $self );
+}
+
+# clears the cache for the given item
+sub _clear_associated_caches {
+    my ( $self ) = @_;
+    
+    #my $data = $class->_load_from_memcache( "q:$field:$value" );
+    #LJ::MemCache::delete( $class->_memcache_key( "q:userid:" . $self->{userid} ) );
+    # a no-op by default; subclasses should override
+}
+
+# does the DB query for the appropriate values. 
+sub _search_ids {
+    my ( $class, $where_clause, @values ) = @_;
+
+    my $dbr = $class->get_db_reader();
+
+    my $sql = "SELECT " . $class->_key_column . " FROM " . $class->_tablename . " " . $class->_create_where_clause( $where_clause ) . " " . $class->_default_order_by;
+    #warn("running $sql, values - " . join (",", @values ) );
+    my $ids = $dbr->selectcol_arrayref( $sql, undef, @values );
+    LJ::throw( $dbr->errstr ) if $dbr->err;
+    
+    #warn("for search_ids, got $ids - scalar " . scalar @$ids . "; values " . join(",", @$ids ) );
+    return $ids;
+}
+
+# returns all of the objects for the requested value
+# NOTE:  $field should _never_ be user provided, since we're
+# putting it directly in the query.
+sub _all_items_by_value {
+    my ( $class, $field, $value ) = @_;
+   
+    my @ids = $class->_keys_by_value( $field, $value );
+    my @items = $class->_load_objs_from_keys( \@ids );
+
+    return @items;
+}
+
+# returns all of the ids for the requested value
+# NOTE:  $field should _never_ be user provided, since we're
+# putting it directly in the query.
+sub _keys_by_value {
+    my ( $class, $field, $value ) = @_;
+
+    my $ids;
+    my @objs;
+    # see if we can get it from memcache
+    if ( $class->memcache_query_enabled ) {
+        $ids = $class->_load_keys( { $field => $value } );
+        if ( $ids && ref $ids eq 'ARRAY' && scalar @$ids > 1 ) {
+            return wantarray ? @$ids : $ids;
+        }
+    }
+
+    # if we didn't get anything from memcache, try the database
+    my $where_clause =  " $field = ?";
+    $ids = $class->_search_ids( $where_clause, $value );
+
+    if ( $class->memcache_query_enabled ) {
+        $class->_store_keys( { $field => $value }, $ids );
+    }
+    return wantarray ? @$ids : $ids;
+}
+
+# returns all of the ids that match the given search
+sub _keys_by_search {
+    my ( $class, $search ) = @_;
+
+    #warn("running _keys_by_search");
+    my $ids;
+    # see if we can get it from memcache
+    my @objs;
+    # see if we can get it from memcache
+    # FIXME figure out how to make a proper key for search, as well as
+    # how to clear those (dynammic) searches on update
+    #if ( $class->memcache_query_enabled ) {
+        #warn("running _keys_by_value for memcache.");
+        #$ids = $class->_load_keys( { $field => $value } );
+        #warn("got $ids");
+        #if ( $ids && ref $ids eq 'ARRAY' && scalar @$ids > 1 ) {
+            #warn("(not) returning ids - " . join(",", @$ids ) );
+        #    return wantarray ? @$ids : $;
+        #}
+    #}
+    
+    # if we didn't get anything from memcache, try the database
+    
+    #warn("checking db");
+    my $where_clause = "";
+    my @values = ();
+    foreach my $searchterm ( @$search ) {
+        #warn("adding searchterm");
+        if ( $searchterm->{conjunction} ) {
+            $where_clause .= $searchterm->{conjunction} . " ";
+        }
+        $where_clause .= $searchterm->{whereclause} . " ";
+        if ( $searchterm->{values} ) {
+            push @values, @$searchterm->{values};
+        } elsif ( $searchterm->{value} ) {
+            push @values, $searchterm->{value};
+        }
+        #warn("whereclause = " . $where_clause);
+    }
+    $ids = $class->_search_ids( $where_clause, @values );
+    #warn("searched ids; got $ids - " . join(",", @$ids ));
+    
+    #if ( $class->memcache_query_enabled ) {
+    #    $class->_store_keys( { $field => $value }, $ids );
+    #}
+    return wantarray ? @$ids : $ids;
+}
+
+# creates a search hash for a given key and value set. this version just
+# does simple column comparisons; subclasses sould provide more complex
+# examples
+sub create_searchterm {
+    my ( $class, $key, $comparator, @values ) = @_;
+    # only allow registered columns
+    if ( grep {$_ eq $key} $class->_obj_props ) {
+        my $whereclause = " $key $comparator ";
+        #warn ("using values @values");
+        if ( scalar @values > 1 ) {
+            $whereclause .= "(" . join( ', ', map { '?' } @values ) . ") ";
+        } else {
+            $whereclause .= "? ";
+        }
+        my $term = {
+            column => $key,
+            comparator => $comparator,
+            whereclause => $whereclause,
+        };
+        if ( scalar @values > 1 ) {
+            $term->{values} = \@values,
+        } else {
+            $term->{value} = $values[0];
+        }
+        return $term;
+    }
+
+    return 0;
+}
+
+
+# creates the appropriate key for the given set of key/value pairs
+sub _create_memc_fvmap_key {
+    my ( $class, $field_value_map ) = @_;
+
+    my $returnvalue = 'q:' . join( ':', map { "$_" . ":" . $field_value_map->{$_} } sort keys %$field_value_map );
+}
+
+# loads a list of keys from memcache
+sub _load_keys {
+    my ( $class, $field_value_map ) = @_;
+
+    my $id = $class->_create_memc_fvmap_key( $field_value_map );
+    my $memc_key = $class->_memcache_key( $id );
+    my $data = LJ::MemCache::get( $memc_key );
+    return unless $data && ref $data eq 'ARRAY';
+
+    return $data;
+}
+
+# saves a list of keys to memcache
+sub _store_keys {
+    my ( $class, $field_value_map, $keys ) = @_;
+
+    my $id = $class->_create_memc_fvmap_key( $field_value_map );
+    my $memc_key = $class->_memcache_key( $id );
+    LJ::MemCache::set( $memc_key, $keys, $class->_memcache_expires);
+}
+
+# saves a list of keys to memcache
+sub _clear_keys {
+    my ( $class, $field_value_map ) = @_;
+
+    my $id = $class->_create_memc_fvmap_key( $field_value_map );
+    my $memc_key = $class->_memcache_key( $id );
+    LJ::MemCache::delete( $memc_key );
+}
+
+
+# returns the next available id
+sub _get_next_id {
+    my ( $class, $dbh ) = @_;
+    
+    return LJ::alloc_global_counter( $class->_globalcounter_id );
+}
+
+#validates the new object.  should be overridden by subclasses
+sub validate {
+    my ( $class, $opts ) = @_;
+
+    return 1;
+}
+
+# returns the id of this object.
+sub id {
+    return $_[0]->{_obj_id};
+}
+
+# returns the object with the given id
+sub by_id {
+    my ( $class, $id ) = @_;
+
+    return $class->_get_obj( $id );
+}
+
+#updates
+sub update {
+    my ( $self ) = @_;
+
+    $self->_update();
+}
+
+# default memcache implementations
+
+# use memcache for object storage
+sub memcache_enabled { 1 }
+# use memcache for search queries
+sub memcache_query_enabled { 0 }
+
+sub _memcache_id {
+    return $_[0]->id;
+}
+
+# returns the properties stored in memcache for this object.
+# default implementation:  returns the keys and properties of the object
+sub _memcache_stored_props {
+    my $class = $_[0];
+
+    # first element of props is a VERSION
+    # next - allowed object properties
+    return (  $class->_memcache_version, $class->_key_column, $class->_obj_props );
+}
+
+# create a new object from a memcache row
+sub _memcache_hashref_to_object {
+    my ($class, $row) = @_;
+    return $class->_new_from_row( $row );
+}
+
+# default expiration
+sub _memcache_expires  { 24*3600 }
+
+# loads an entire batch of ids from memcache.
+sub _load_batch_from_memcache {
+    my $class = shift;
+    my $ids = shift;
+
+    my @memcache_keys = ();
+    my $keymap = {};
+    # get the memcache keys for each of the provided object ids
+    for my $id ( @$ids ) {
+        my $memcache_key = $class->_memcache_key( $id );
+        push @memcache_keys, $memcache_key->[1];
+        $keymap->{$memcache_key->[1]} = $id;
+    }
+    my $mem = LJ::MemCache::get_multi( @memcache_keys );
+
+    my ($version, @props) = $class->_memcache_stored_props;
+    my @hits = ();
+    my %misses = %$keymap;
+    my @objects = ();
+    my %objmap = ();
+    # go through each returned value, map it by id, and then remove it from
+    # the misses list
+    while (my ($k, $v) = each %$mem) {
+        if ( defined $v && ref $v eq 'ARRAY' ) {
+            push @hits, $keymap->{$k};
+            if ( $v->[0] == $version ) {
+                my %hash;
+                foreach my $i (0..$#props) {
+                    $hash{ $props[$i] } = $v->[$i+1];
+                }
+                my $obj = $class->_memcache_hashref_to_object(\%hash);
+                push @objects, $obj;
+                $objmap{$keymap->{$k}}=$obj;
+                delete $misses{$k};
+            }
+        }
+    }
+    my @misses = values %misses;
+    #warn("returning; hits=@hits, misses=@misses objects=@objects, objmap=" . %objmap );
+    return {
+        hits => \@hits,
+        misses => \@misses,
+        objects => \@objects,
+        objmap => \%objmap,
+    };
+}
+
+# save an entire batch of ids to memcache.
+sub _store_batch_to_memcache {
+    my $class = shift;
+    my $objs = shift;
+
+    # from what i can tell this is as efficient as trying to do it in batch
+    for my $obj ( @$objs ) {
+        $obj->_store_to_memcache();
+    }
+}
+
+## warning: instance or class method.
+## $id may be absent when calling on instance.
+sub _remove_obj_from_memcache {
+    my $class = shift;
+    my $object = shift;
+
+    LJ::MemCache::delete($object->_memcache_key );
+}
+
+1;
+

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -22,6 +22,10 @@ use DW::Controller;
 use DW::Routing;
 use DW::Template;
 
+use DW::Draft;
+use DW::FlashScope;
+
+use DateTime::Format::Strptime;
 use Hash::MultiValue;
 use HTTP::Status qw( :constants );
 use LJ::JSON;
@@ -42,7 +46,7 @@ my @modules = qw(
     slug tags currents displaydate
     access journal comments
     age_restriction icons crosspost
-    flags
+    flags scheduled draft
 );
 
 
@@ -58,6 +62,12 @@ Handlers for creating and editing entries
 
 DW::Routing->register_string( '/entry/new', \&new_handler, app => 1 );
 DW::Routing->register_regex( '^/entry/([^/]+)/new$', \&new_handler, app => 1 );
+
+DW::Routing->register_string( '/draft/new', \&draft_handler, app => 1 );
+DW::Routing->register_regex( '^/draft/([^/]+)/([0-9]+)(/.*)?$', \&draft_handler, app => 1 );
+
+DW::Routing->register_string( '/scheduled/new', \&scheduled_handler, app => 1 );
+#DW::Routing->register_regex( '^/scheduled/([^/]+)/([0-9]+)(/.*)?$', \&scheduled_handler, app => 1 );
 
 DW::Routing->register_string( '/entry/preview', \&preview_handler, app => 1, methods => { POST => 1 } );
 
@@ -117,6 +127,8 @@ sub new_handler {
 
         my $mode_preview    = $post->{"action:preview"} ? 1 : 0;
         my $mode_spellcheck = $post->{"action:spellcheck"} ? 1 : 0;
+        my $mode_schedule   = $post->{"action:schedule"} ? 1 : 0;
+        my $mode_draft      = $post->{"action:draft"} ? 1 : 0;
 
         push @error_list, LJ::Lang::ml( 'bml.badinput.body' )
             unless LJ::text_in( $post );
@@ -182,11 +194,96 @@ sub new_handler {
 
             # if we didn't have any errors with decoding the form, proceed to post
             unless ( @error_list ) {
-                my %post_res = _do_post( $form_req, $flags, \%auth, warnings => \@warnings );
-                return $post_res{render} if $post_res{status} eq "ok";
+                if ( $mode_draft ) {
+                    # save as draft
+                    # see if this is an edit or a new draft
+                    # FIXME there probably needs to be some error checking in
+                    # here for the case where the remote user has changed;
+                    # we don't want to have someone accidentally overwrite a
+                    # draft in one account if they started editing it and then
+                    # logged into a different account in another tab
+                    my $draftid =  $post->{draftid};
+                    my $draft;
+                    if ( $draftid ) {
+                        if ( $draft = DW::Draft->by_id( $remote, $draftid ) ) {
+                            $draft->{status} = 'D';
+                            $draft->set_req( $form_req );
+                            $draft->update();
+                        } else {
+                            $draftid = 0;
+                        }
+                    }
+                    if ( ! $draftid ) {
+                        $draft = DW::Draft->create_draft( $remote, $form_req );
+                        $draftid = $draft->id;
+                    }
+                    # FIXME handle errors
+                    my $successmsg = LJ::Lang::ml( "/entry/success.tt.draft.success" );
+                    my $poststatus = qq{<div class="message-box info-box"><p>$successmsg</p></div>};
 
-                # oops errors when posting: show error, fall through to show form
-                push @error_list, $post_res{errors} if $post_res{errors};
+                    my $vars = {
+                        poststatus => $poststatus, 
+                        links => [
+                            { url => $draft->edit_url,
+                              ml_string => "/entry/success.tt.draft.success.edit" ,
+                            },
+                            { url => LJ::create_url( "/entry/new", host => $LJ::DOMAIN_WEB ),
+                              ml_string => "/entry/success.tt.draft.success.entry.new" ,
+                            },
+                            ],
+                            links_header => "/entry/success.tt.draft.success.linkheader",
+                    };
+                    return DW::FlashScope->flash_redirect( $r, "/draft/" . $remote->user . "/" . $draftid . "/success", $vars );
+                } elsif ( $mode_schedule ) {
+                    # save as scheduled post
+                    # see if this is an edit or a new draft
+                    # FIXME there probably needs to be some error checking in
+                    # here for the case where the remote user has changed;
+                    # we don't want to have someone accidentally overwrite a
+                    # draft in one account if they started editing it and then
+                    # logged into a different account in another tab
+                    my $draftid =  $post->{draftid};
+                    my $draft;
+                    if ( $draftid ) {
+                        if ( $draft = DW::Draft->by_id( $remote, $draftid ) ) {
+                            $draft->{nextscheduletime} = LJ::mysql_time( $post->{parsedtime} );
+                            $draft->{recurring_period} =  $post->{recurring_period};
+                            $draft->{status} = 'S';
+                            $draft->set_req( $form_req );
+                            $draft->update();
+                        } else {
+                            $draftid = 0;
+                        }
+                    }
+                    if ( ! $draftid ) {
+                        $draft = DW::Draft->create_scheduled_draft( $remote, $form_req, { nextscheduletime => LJ::mysql_time( $post->{parsedtime} ), recurring_period => $post->{recurring_period} } );
+                        $draftid = $draft->id;
+                    }
+                    # FIXME handle errors
+                    my $successmsg = LJ::Lang::ml( "/entry/success.tt.scheduled.success", { date => $draft->nextscheduletime_dt->strftime( '%Y-%m-%d %H:%M' ) } );
+                    my $poststatus = qq{<div class="message-box info-box"><p>$successmsg</p></div>};
+
+                    my $vars = {
+                        poststatus => $poststatus, 
+                        links => [
+                            { url => $draft->edit_url,
+                              ml_string => "/entry/success.tt.schedule.success.edit" ,
+                            },
+                            { url => LJ::create_url( "/entry/new", host => $LJ::DOMAIN_WEB ),
+                              ml_string => "/entry/success.tt.draft.success.entry.new" ,
+                            },
+                            ],
+                            links_header => "/entry/success.tt.draft.success.linkheader",
+                    };
+                    return DW::FlashScope->flash_redirect( $r, "/draft/" . $remote->user . "/" . $draftid . "/success", $vars );
+                } else {
+                    # normal post
+                    my %post_res = _do_post( $form_req, $flags, \%auth, warnings => \@warnings );
+                    return $post_res{render} if $post_res{status} eq "ok";
+
+                    # oops errors when posting: show error, fall through to show form
+                    push @error_list, $post_res{errors} if $post_res{errors};
+                }
             }
         }
     }
@@ -259,11 +356,260 @@ sub new_handler {
 
     $vars->{action} = {
         url  => LJ::create_url( undef, keep_args => 1 ),
+        post_url => LJ::create_url( undef, keep_args => 1 ),
+        draft_url => LJ::create_url( "/draft/new", keep_args => 1 ),
+        schedule_url => LJ::create_url( "/scheduled/new", keep_args => 1 ),
     };
+
+    my $drafts = DW::Draft->all_for_user( $remote );
+
+    $vars->{drafts} = $drafts;
 
     return DW::Template->render_template( 'entry/form.tt', $vars );
 }
 
+
+=head2 C<< DW::Controller::Entry::draft_handler( ) >>
+
+Handles editing a draft
+
+=cut
+sub draft_handler {
+    my ( $opts, $username, $draftid, $action ) = @_;
+    
+    my ( $ok, $rv ) = controller();
+    return $rv unless $ok;
+    
+    my $remote = $rv->{remote};
+
+    my $journal = defined $username ? LJ::load_user( $username ) : $remote;
+
+    return error_ml( 'error.invalidauth' ) unless $journal;
+
+    my $r = DW::Request->get;
+
+    if ( $action && ( $action eq '/success' || $action eq '/deleted' ) ) {
+        my $flash_vars = DW::FlashScope->flash_vars( $r );
+        return DW::Template->render_template( 'entry/success.tt', $flash_vars );
+    }
+    
+    if ( $r->did_post ) {
+        # submitting.  either an edit, a post, or a delete.
+        my $post = $r->post_args;
+        if ( $username && $draftid ) {
+            my $draft = DW::Draft->by_id( $journal, $draftid );
+            if ( ! $draft ) {
+                return error_ml( "/entry/form.tt.error.nofind" );
+            }
+            if ( ( $action && $action eq '/delete' ) || $post->{'action:delete'} ) {
+                # deleting the draft
+                $draft->delete();
+                my $successmsg = LJ::Lang::ml( "/entry/success.tt.draft.delete.success" );
+                my $poststatus = qq{<div class="message-box info-box"><p>$successmsg</p></div>};
+
+                my $vars = {
+                    poststatus => $poststatus, 
+                    links_header => "/entry/success.tt.draft.delete.success.linkheader",
+                    links => [
+                        { url => LJ::create_url( "/entry/new", host => $LJ::DOMAIN_WEB ),
+                          ml_string => "/entry/success.tt.draft.success.entry.new" ,
+                        },],
+                };
+
+                return DW::FlashScope->flash_redirect( $r, "/draft/" . $journal->user . "/$draftid/deleted", $vars );
+            } else {
+                # we're updating a draft
+                my $form_req = {};
+                my %status = _form_to_backend( $form_req, $post );
+                $draft->set_req( $form_req );
+                $draft->update();
+                my $successmsg = LJ::Lang::ml( "/entry/success.tt.draft.update.success" );
+                my $poststatus = qq{<div class="message-box info-box"><p>$successmsg</p></div>};
+                
+                my $vars = {
+                    poststatus => $poststatus, 
+                    links => [
+                        { url => $draft->edit_url,
+                          ml_string => "/entry/success.tt.draft.success.edit" ,
+                        },
+                        { url => LJ::create_url( "/entry/new", host => $LJ::DOMAIN_WEB ),
+                          ml_string => "/entry/success.tt.draft.success.entry.new" ,
+                        },
+                        ],
+                        links_header => "/entry/success.tt.draft.success.linkheader",
+                };
+                return DW::FlashScope->flash_redirect( $r, "/draft/" . $journal->user . "/$draftid/success", $vars );
+            }
+        } else {
+            # handle it as a new draft
+            $post->{"action:draft"} = 1;
+            return new_handler();
+        }
+    } # end if did_post
+
+    if ( ! $journal || ! $draftid ) {
+        return DW::Request->get->redirect( LJ::create_url( "/entry/new", host => $LJ::DOMAIN_WEB ) );
+    }
+
+    my $draft = DW::Draft->by_id( $journal, $draftid );
+    if ( ! $draft ) {
+        # draft doesn't exist
+        
+        my $error = LJ::Lang::ml( "/entry/form.tt.error.draft.nofind", { user => $journal, id => $draftid } );
+        # FIXME we don't display the error right now.  which is ok, but 
+        # could be better.
+        return DW::FlashScope->flash_redirect( DW::Request->get, "/entry/new", { errors => [ $error ]} );
+    }
+    
+    my @error_list;
+    my @warnings;
+    my %spellcheck;    
+    
+    # this is a draft; use the current datetime.
+    my $now = DateTime->now;
+    
+    # if user has timezone, use it!
+    if ( $remote && $remote->prop( "timezone" ) ) {
+        my $tz = $remote->prop( "timezone" );
+        $tz = $tz ? eval { DateTime::TimeZone->new( name => $tz ); } : undef;
+        $now = eval { DateTime->from_epoch( epoch => time(), time_zone => $tz ); }
+        if $tz;
+    }
+    
+    my $datetime = $now->strftime( "%F %R" ),
+    my $trust_datetime_value = 0;  # may want to override with client-side JS
+    
+    my $vars = _init( { usejournal  => $journal->username,
+                        remote      => $remote,
+                        
+                        datetime => $datetime,
+                        trust_datetime_value => $trust_datetime_value,
+                        
+#                        crosspost => \%crosspost,
+                      }, @_ );
+
+    # now look for errors that we still want to recover from
+    my $get = $r->get_args;
+    push @error_list, LJ::Lang::ml( "/update.bml.error.invalidusejournal" )
+        if defined $get->{usejournal} && ! $vars->{usejournal};
+    
+    # this is an error in the user-submitted data, so regenerate the form with the error message and previous values
+    $vars->{error_list} = \@error_list if @error_list;
+    $vars->{warnings} = \@warnings;
+    
+    $vars->{spellcheck} = \%spellcheck;
+    
+    $vars->{formdata} = _draft_to_form( $draft );
+
+    my %editable = map { $_ => 1 } @modules;
+    $vars->{editable} = \%editable;
+    
+    # this can't be edited after posting
+    delete $editable{journal};
+
+    $vars->{action} = {
+        edit => 0,
+        url  => LJ::create_url( undef, keep_args => 1 ),
+        post_url => LJ::create_url( "/entry/new", keep_args => 1 ),
+        schedule_url => LJ::create_url( "/scheduled/new", keep_args => 1 ),
+    };
+    if ( $draft->status eq 'D' ) {
+        $vars->{action}->{editdraft} = 1; 
+        $vars->{action}->{draft_url} = LJ::create_url( undef, keep_args => 1 );
+    } else {
+        $vars->{action}->{editscheduled} = 1; 
+    }
+
+    $vars->{draftid} = $draftid;
+
+    return DW::Template->render_template( 'entry/form.tt', $vars );
+}
+
+=head2 C<< DW::Controller::Entry::scheduled_handler( ) >>
+
+Handles creating/editing a scheduled post
+
+=cut
+sub scheduled_handler {
+    my ( $opts, $username, $draftid, $action ) = @_;
+    
+    my ( $ok, $rv ) = controller();
+    return $rv unless $ok;
+    
+    my $remote = $rv->{remote};
+
+    my $journal = defined $username ? LJ::load_user( $username ) : $remote;
+
+    return error_ml( 'error.invalidauth' ) unless $journal;
+
+    my $r = DW::Request->get;
+
+    if ( $action && ( $action eq '/success' || $action eq '/deleted' ) ) {
+        my $flash_vars = DW::FlashScope->flash_vars( $r );
+        return DW::Template->render_template( 'entry/success.tt', $flash_vars );
+    }
+    
+    if ( $r->did_post ) {
+        # submitting.  either an edit, a post, or a delete.
+        my $post = $r->post_args;
+        # FIXME no error checking, no timezone checking
+        my $parser = DateTime::Format::Strptime->new( pattern => '%Y-%m-%d %H:%M:%S' );
+
+        my $publishingtime = $parser->parse_datetime( $post->{publishingtime_date} . ' ' . $post->{publishingtime_hr} . ':' . $post->{publishingtime_min} . ':00' );
+
+        if ( $username && $draftid ) {
+            my $draft = DW::Draft->by_id( $journal, $draftid );
+            if ( ! $draft ) {
+                return error_ml( "/entry/form.tt.error.nofind" );
+            }
+            if ( ( $action && $action eq '/delete' ) || $post->{'action:delete'} ) {
+                # deleting the draft
+                $draft->delete();
+                my $successmsg = LJ::Lang::ml( "/entry/success.tt.scheduled.delete.success" );
+                my $poststatus = qq{<div class="message-box info-box"><p>$successmsg</p></div>};
+
+                my $vars = {
+                    poststatus => $poststatus, 
+                    links_header => "/entry/success.tt.draft.delete.success.linkheader",
+                    links => [
+                        { url => LJ::create_url( "/entry/new", host => $LJ::DOMAIN_WEB ),
+                          ml_string => "/entry/success.tt.draft.success.entry.new" ,
+                        },],
+                };
+
+                return DW::FlashScope->flash_redirect( $r, "/draft/" . $journal->user . "/$draftid/deleted", $vars );
+            } else {
+                # we're updating a scheduled post
+                my $form_req = {};
+                my %status = _form_to_backend( $form_req, $post );
+                $draft->set_req( $form_req );
+                $draft->{schedule} = $publishingtime->epoch();
+                $draft->update();
+                my $successmsg = LJ::Lang::ml( "/entry/success.tt.draft.update.success" );
+                my $poststatus = qq{<div class="message-box info-box"><p>$successmsg</p></div>};
+                
+                my $vars = {
+                    poststatus => $poststatus, 
+                    links => [
+                        { url => $draft->edit_url,
+                          ml_string => "/entry/success.tt.draft.success.edit" ,
+                        },
+                        { url => LJ::create_url( "/entry/new", host => $LJ::DOMAIN_WEB ),
+                          ml_string => "/entry/success.tt.draft.success.entry.new" ,
+                        },
+                        ],
+                        links_header => "/entry/success.tt.draft.success.linkheader",
+                };
+                return DW::FlashScope->flash_redirect( $r, "/draft/" . $journal->user . "/$draftid/success", $vars );
+            }
+        } else {
+            # handle it as a new scheduled post
+            $post->{"action:schedule"} = 1;
+            $post->{parsedtime} = $publishingtime->epoch();
+            return new_handler();
+        }
+    } # end if did_post
+}
 
 # Initializes entry form values.
 # Can be used when posting a new entry or editing an old entry. .
@@ -603,6 +949,7 @@ sub _edit {
     $vars->{action} = {
         edit => 1,
         url  => LJ::create_url( undef, keep_args => 1 ),
+        post_url => LJ::create_url( undef, keep_args => 1 ),
     };
 
     return DW::Template->render_template( 'entry/form.tt', $vars );
@@ -678,6 +1025,9 @@ sub _form_to_backend {
     # handle event subject and body
     $req->{subject} = $post->{subject};
     $req->{event} = $post->{event} || "";
+    if ( $post->{draftid} ) {
+        $req->{draftid} = $post->{draftid};
+    }
 
     push @errors, LJ::Lang::ml( "/update.bml.error.noentry" )
         if $req->{event} eq "" && ! $opts{allow_empty};
@@ -754,8 +1104,7 @@ sub _form_to_backend {
     $req->{security} = $sec;
     $req->{allowmask} = $amask;
 
-
-    # date/time
+    # date/times
     my ( $year, $month, $day ) = split( /\D/, $post->{entrytime} || "" );
     my ( $hour, $min ) = ( $post->{entrytime_hr}, $post->{entrytime_min} );
 
@@ -857,6 +1206,118 @@ sub _backend_to_form {
         %formprops,
         %otherprops,
     };
+}
+
+# given a DW::Draft object, returns a hashref populated with data suitable for 
+# use in generating the form
+sub _draft_to_form {
+    my ( $draft ) = @_;
+    my $req = $draft->req;
+
+    my $form = {};
+
+    # handle event subject and body
+    $form->{subject} = $req->{subject};
+    $form->{event} = $req->{event} || "";
+
+    # initialize props hash
+    $req->{props} ||= {};
+    my $props = $req->{props};
+
+    while ( my ( $formname, $propname ) = each %form_to_props ) {
+        $form->{$formname} = $props->{$propname}
+            if defined $props->{$propname};
+    }
+    $form->{taglist} = $props->{taglist} if defined $props->{taglist};
+    $form->{icon} = $props->{picture_keyword} if defined $props->{picture_keyword};
+    $form->{entrytime_outoforder} = $props->{opt_backdated}? 1 : 0;
+
+    # old implementation of comments
+    # FIXME: remove this before taking the page out of beta
+    $form->{opt_screening}  = $props->{opt_screening};
+
+    $form->{comment_settings} = $props->{opt_nocomments} ? "nocomments" : $props->{opt_noemail} ? "noemail" : "default";
+
+    # nuke taglists that are just blank
+    $form->{taglist} = $props->{taglist};
+
+    if ( LJ::is_enabled( 'adult_content' ) ) {
+        $form->{age_restriction} = {
+            ''              => '',
+            'none'          => 'none',
+            'concepts'      => 'discretion',
+            'explicit'      => 'restricted',
+        }->{$props->{adult_content}} || "";
+        
+        $form->{age_restriction_reason} = $props->{adult_content_reason} || "";
+    }
+    
+    # Set entry slug if it's been specified
+    $form->{entry_slug} = $req->{slug};
+
+    # entry security
+    my $security = $req->{security} || "";
+    my @custom_groups;
+    if ( $security eq "usemask" ) {
+        my $amask = $req->{allowmask};
+
+        if ( $amask == 1 ) {
+            $security = "access";
+        } else {
+            $security = "custom";
+            @custom_groups = grep { $amask & ( 1 << $_ ) } 1..60;
+        }
+    }
+    $form->{security} = $security;
+    $form->{custom_bit}  = \@custom_groups;
+
+    # date/time
+    #my ( $year, $month, $day ) = split( /\D/, $post->{entrytime} || "" );
+    #my ( $hour, $min ) = ( $post->{entrytime_hr}, $post->{entrytime_min} );
+
+    # if we trust_datetime, it's because we either are in a mode where we've saved the datetime before (e.g., edit)
+    # or we have run the JS that syncs the datetime with the user's current time
+    # we also have to trust the datetime when the user has JS disabled, because otherwise we won't have any fallback value
+    #if ( $post->{trust_datetime} || $post->{nojs} ) {
+    #    delete $req->{tz};
+    #    $req->{year}    = $year;
+    #    $req->{mon}     = $month;
+    #    $req->{day}     = $day;
+    #    $req->{hour}    = $hour;
+    #    $req->{min}     = $min;
+    #}
+
+    # crosspost
+    #$req->{crosspost_entry} = $post->{crosspost_entry} ? 1 : 0;
+    #if ( $req->{crosspost_entry} ) {
+    #    foreach my $acctid ( $post->get_all( "crosspost" ) ) {
+    #        $req->{crosspost}->{$acctid} = {
+    #            id          => $acctid,
+    #            password    => $post->{"crosspost_password_$acctid"},
+    #            chal        => $post->{"crosspost_chal_$acctid"},
+    #            resp        => $post->{"crosspost_resp_$acctid"},
+    #        };
+    #    }
+    #}
+
+    if ( $draft->{status} eq 'S' ) {
+        my $nextscheduletime = $draft->nextscheduletime_dt;
+        #my $date_formatter = DateTime::Format::Strptime->new( pattern => '%Y-%m-%d %H:%M:%S' );
+        my $date_formatter = DateTime::Format::Strptime->new( pattern => '%Y-%m-%d' );
+        my $date = $date_formatter->format_datetime( $nextscheduletime );
+        my $hour_formatter = DateTime::Format::Strptime->new( pattern => '%H' );
+        my $hour = $hour_formatter->format_datetime( $nextscheduletime );
+        my $minute_formatter = DateTime::Format::Strptime->new( pattern => '%M' );
+        my $min = $minute_formatter->format_datetime( $nextscheduletime );
+        $form->{publishingtime_date} = $date;
+        $form->{publishingtime_hr} = $hour;
+        $form->{publishingtime_min} = $min;
+
+        $form->{recurring_period} = $draft->recurring_period;
+    }
+
+    $form->{edit} = 1;
+    return $form;
 }
 
 sub _queue_crosspost {

--- a/cgi-bin/DW/Draft.pm
+++ b/cgi-bin/DW/Draft.pm
@@ -1,0 +1,369 @@
+#!/usr/bin/perl
+#
+# DW::Draft
+#
+# Draft/scheduled posts.
+#
+# Authors:
+#      Allen Petersen <allen@suberic.net>
+#
+# Copyright (c) 2013 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+package DW::Draft;
+use strict;
+use warnings;
+
+use Storable;
+use DateTime::Format::Strptime;
+
+use base 'DW::UserDbObj';
+
+sub _tablename { "draft" }
+
+sub _obj_props {
+    # be sure to add to _editable_obj_props below if a new property is 
+    # editable.
+    return qw( subject summary createtime modtime status recurring_period nextscheduletime );
+}
+
+# Editable properties for the object. 
+sub _editable_obj_props {
+    return qw( subject summary modtime status recurring_period nextscheduletime );
+}
+
+sub _default_order_by {
+    return " ORDER BY nextscheduletime, createtime ";
+}
+
+sub _usercounter_id { "2" }
+
+sub _memcache_key_prefix            { "draft" }
+sub _memcache_version { "1" }
+
+sub memcache_enabled { 1 }
+sub memcache_query_enabled { 1 }
+
+# populates the basic keys for a Draft post; everything else is
+# loaded from absorb_row
+sub _skeleton {
+    my ( $class, $u, $id ) = @_;
+    return bless {
+        id => $id,
+        _obj_id => $id,
+        userid => $u->id,
+        _userid => $u->id,
+    };
+}
+
+# does a full create.  should probably not be called directly; instead
+# use create_draft or create_scheduled
+sub create {
+    my ( $class, $u, $req, $opts ) = @_;
+
+    $opts ||= {};
+
+    $opts->{createtime} = LJ::mysql_time( time );
+    $opts->{modtime} = LJ::mysql_time( time );
+    $opts->{subject} = $req->{subject};
+    $opts->{summary} = $class->_create_summary( $req->{event} );
+
+    my $draft = $class->_create( $u, $opts );
+
+    $draft->set_req( $req );
+    $draft->_save_req();
+
+    $draft->_clear_associated_caches();
+
+    return $draft;
+}
+
+# creates a draft
+sub create_draft {
+    my ( $class, $u, $req, $opts ) = @_;
+
+    $opts ||= {};
+    $opts->{status} = 'D';
+ 
+    return $class->create( $u, $req, $opts );
+}
+
+# creates a scheduled post
+sub create_scheduled_draft {
+    my ( $class, $u, $req, $opts ) = @_;
+
+    $opts ||= {};
+    $opts->{status} = 'S';
+
+    return $class->create( $u, $req, $opts );
+}
+
+# updates an existing instance.  overrides UserDbObj->update().
+sub update {
+    my ( $self ) = @_;
+
+    # need to update modtime and then do a save_req in addition to 
+    # modifying the base table.
+    $self->{modtime} = LJ::mysql_time( time );
+    $self->SUPER::update();
+    $self->_save_req();
+}
+
+# saves the request to the draftblob table.
+sub _save_req {
+    my ( $self ) = @_;
+
+    # only update if we've set the request already
+    my $req = $self->{req};
+    if ( $req ) {
+        my $u = $self->user;
+
+        # delete the old req
+        $u->do( "DELETE FROM draftblob WHERE userid = ? AND id = ?", undef, $u->{userid}, $self->{id} );
+        LJ::throw($u->errstr) if $u->err;
+        
+        my $frozen_req = Storable::nfreeze( $req );
+
+        # and save the new one
+        $u->do( "INSERT INTO draftblob (userid, id, req_stor) VALUES (?, ?, ?)", undef, $u->{userid}, $self->{id}, $frozen_req );
+        LJ::throw($u->errstr) if $u->err;
+    }
+}
+
+# loads the req from the draftblob table
+sub _load_req {
+    my ( $self ) = @_;
+    
+    if ( defined $self->{req} ) {
+        return;
+    }
+    my $u = $self->user;
+
+    my $sth = $u->prepare( "SELECT req_stor FROM draftblob WHERE userid = ? AND id = ?" );
+    $sth->execute( $u->{userid}, $self->{id});
+    LJ::throw( $u->errstr ) if $u->err;
+    
+    my $blob = $sth->fetchrow_hashref->{req_stor};
+    $self->{req} = Storable::thaw( $blob );
+}
+
+# deletes this object
+sub delete {
+    my ($self) = @_;
+    my $u = $self->user;
+
+    $u->do("DELETE FROM draftblob " . $self->_where_by_id, 
+           undef, $self->_key );
+
+    $u->do("DELETE FROM " . $self->_tablename . " " . $self->_where_by_id, 
+           undef, $self->_key );
+
+    # clear the cache.
+    $self->_clear_cache();
+    $self->_clear_associated_caches();
+
+    return 1;
+}
+
+# copies from an existing object
+sub copy_from_object {
+    my ( $self, $source ) = @_;
+    
+    $self->_copy_from_object( $source );
+    if ( exists $source->{req} ) {
+        $self->set_req( $source->{req} );
+    } 
+}
+
+# all drafts (not scheduled) for user
+sub all_drafts_for_user {
+    my ( $class, $u ) = @_;
+
+    # we require a user here.
+    $u = LJ::want_user($u) or LJ::throw("no user");
+
+    return DW::UserDbObjAccessor->new( $class, $u )->_fv_query_by_user( { status => 'D' } );
+}
+
+# all scheduled drafts for user
+sub all_scheduled_posts_for_user {
+    my ( $class, $u ) = @_;
+
+    # we require a user here.
+    $u = LJ::want_user($u) or LJ::throw("no user");
+
+    return DW::UserDbObjAccessor->new( $class, $u )->_fv_query_by_user( { status => 'S' } );
+}
+
+# sets the req for this Draft, plus updates the associated fields (subject, 
+# summary)
+sub set_req {
+    my ( $self, $req ) = @_;
+
+    $self->{subject} = $req->{subject};
+    $self->{summary} = $self->_create_summary( $req->{event} );
+
+    $self->{req} = $req;
+}
+
+# returns the req for this draft
+sub req {
+    my ( $self ) = @_;
+
+    if ( ! defined $self->{req} ) {
+        $self->_load_req();
+    }
+    return $self->{req};
+}
+
+# field accessors
+sub subject { return $_[0]->{subject}; }
+sub summary { return $_[0]->{summary}; }
+sub createtime { return $_[0]->{createtime}; }
+sub modtime { return $_[0]->{modtime}; }
+sub status { return $_[0]->{status}; }
+sub recurring_period { return $_[0]->{recurring_period}; }
+
+# returns the nextscheduletime as a DateTime object
+sub nextscheduletime_dt {
+    my ( $self ) = @_;
+
+    # only return if we're scheduled to post
+    if ( $self->status eq 'S' ) {
+        if ( ! defined $self->{nextschedule_dt} ) {
+            my $parser = DateTime::Format::Strptime->new( pattern => '%Y-%m-%d %H:%M:%S' );
+            my $nextschedule_dt = $parser->parse_datetime( $self->{nextscheduletime} );
+            $self->{nextschedule_dt} = $nextschedule_dt;
+        }
+        return $self->{nextschedule_dt};
+    }
+
+    return undef;
+}
+
+# creates the summary. separated out because we need to make sure that 
+# the trimmed value is small enough to fit in the db field
+sub _create_summary {
+    my ( $class, $event ) = @_;
+
+    my $summary = LJ::html_trim( $event, 128 );
+    # give it two tries and then give up
+    if ( $summary && length( $summary ) > 255 ) {
+        $summary =  LJ::html_trim( $event, 64 );
+        if ( $summary && length( $summary ) > 255 ) {
+            $summary = "";
+        }
+    }
+    return $summary;
+}
+
+# returns the edit url for this draft
+sub edit_url {
+    my ( $self ) = @_;
+  
+    return LJ::create_url( "/draft/" . $self->user->user . "/" . $self->id . "/edit", host => $LJ::DOMAIN_WEB ),
+}
+
+# finds and posts scheduled drafts for a cluster
+sub post_by_cluster {
+    my ( $class, $cid ) = @_;
+
+    my $dbcr = LJ::get_cluster_def_reader($cid)
+        or die "Unable to load reader for cluster: $cid";
+    my $sql = "SELECT userid, id FROM " . $class->_tablename . " WHERE nextscheduletime <= now()";
+    my $sth = $dbcr->prepare( $sql );
+    $sth->execute();
+    LJ::throw( $dbcr->errstr ) if $dbcr->err;
+
+    while ( my $row = $sth->fetchrow_hashref ) {
+        my $uid = $row->{userid};
+        my $id = $row->{id};
+        my $u = LJ::want_user( $uid );
+        my $scheduled_draft = DW::Draft->by_id( $u, $id );
+        my $result = $scheduled_draft->post();
+        # FIXME should probably send out a notification for these
+        if ( $result->{success} ) {
+            warn("success!");
+        } else {
+            warn("error: " . $result->{errors});
+        }
+    }
+}
+
+# posts a scheduled draft
+sub post {
+    my ( $self ) = @_;
+
+    my $req = $self->req;
+    $req->{ver} = $LJ::PROTOCOL_VER;
+    $req->{draftid} = $self->{id};
+    $req->{username} = $self->user->user;
+
+    # set the date to now
+    my $now = DateTime->now;
+    # if user has timezone, use it!
+    if ( $self->user && $self->user->prop( "timezone" ) ) {
+        my $tz = $self->user->prop( "timezone" );
+        $tz = $tz ? eval { DateTime::TimeZone->new( name => $tz ); } : undef;
+        $now = eval { DateTime->from_epoch( epoch => time(), time_zone => $tz ); } if $tz;
+    }
+
+    $req->{year}    = $now->year;
+    $req->{mon}     = $now->month;
+    $req->{day}     = $now->day;
+    $req->{hour}    = $now->hour;
+    $req->{min}     = $now->min;
+    
+    my $err = 0;
+    my $res = LJ::Protocol::do_request( "postevent", $req, \$err, { noauth => 1 } );
+
+    return { errors => LJ::Protocol::error_message( $err ) } unless $res;
+    return { success => 1 };
+}
+
+# handles a draft having been posted
+sub handle_posted {
+    my ( $self ) = @_;
+
+    if ( $self->status eq 'D' ) {
+        # if it's a draft, just delete it
+        $self->delete();
+    } elsif  ( $self->status eq 'S' ) {
+        if ( $self->recurring_period eq 'never' ) {
+            $self->delete();
+        } else {
+            # if this was scheduled to be posted in the past, then we need
+            # to schedule the next post
+            if ( $self->nextscheduletime_dt->epoch() < time ) {
+                if ( $self->recurring_period eq 'day' ) {
+                    $self->{nextscheduletime} =  LJ::mysql_time( time + ( 60 * 60 * 24 ) );
+                    $self->update();
+                } elsif ( $self->recurring_period eq 'week' ) {
+                    $self->{nextscheduletime} =  LJ::mysql_time( time + ( 60 * 60 * 24 * 7 ) );
+                    $self->update();
+                } elsif ( $self->recurring_period eq 'month' ) {
+                    # FIXME this isn't really monthly
+                    $self->{nextscheduletime} =  LJ::mysql_time( time + ( 60 * 60 * 24 * 30 ) );
+                    $self->update();
+                } else {
+                    # no match means treat as never
+                    $self->delete();
+                }
+            } 
+        }
+    }
+}
+
+# clears associated cache for add/delete
+sub _clear_associated_caches() {
+    my ($self) = @_;
+
+    $self->_clear_keys( { userid => $self->user->id } );
+    $self->_clear_keys( { userid => $self->user->id, status => $self->{status} } );
+}
+
+
+1;

--- a/cgi-bin/DW/FlashScope.pm
+++ b/cgi-bin/DW/FlashScope.pm
@@ -1,0 +1,89 @@
+#!/usr/bin/perl
+#
+# DW::FlashScope
+#
+# Controls storing parameters temporarily in memcache for redirects.
+#
+# Authors:
+#      Allen Petersen <allen@suberic.net>
+#
+# Copyright (c) 2013 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+package DW::FlashScope;
+use strict;
+use warnings;
+
+use Storable;
+
+my $fs_id_arg = "dw_fs";
+
+# redirects the request if flash scope is available.  if not, returns
+# an internal redirect to the given page.
+sub flash_redirect {
+    my ( $class, $request, $uri, $vars ) = @_;
+
+    # freeze the frozen vars
+    my $frozen = Storable::nfreeze( $vars );
+    my $remote = LJ::get_remote();
+    # we can only do a flash scope redirect if we have a user.  in theory
+    # we could do it without a remote, but then we'd need a better guid
+    # algorithm for the key
+    if ( $remote ) {
+        my $flashkey = $class->create_flashkey();
+        my $memkey = $class->create_memkey( $flashkey );
+        my $set_value = $remote->memc_set( $memkey => $frozen, 300 );
+        if ( $set_value ) {
+            # if we successfully set the value in memcache, then redirect
+            # with the flash key
+            my $redir_url =  LJ::create_url( $uri, host => $LJ::DOMAIN_WEB, args => { $fs_id_arg, $flashkey } );
+            return $request->redirect( $redir_url );
+        }
+    }
+
+    # memcache isn't available, so just do an internal redirect instead
+    LJ::start_request();
+    $request->note( 'internal_redir', $uri );
+    $request->pnote( 'flash_vars', $frozen );
+    my $redir_handler = DW::Routing->call( uri => $uri, role => 'app', format => 'html' );
+    return $request->DECLINED;
+}
+
+# returns flash-scoped variables for the request. gets the values either from
+# the request (if an internal redirect was done) or memcache (if a proper
+# redirect was done)
+sub flash_vars {
+    my ( $class, $request ) = @_;
+    my $frozen;
+    # the pnote should only be set if an internal redirect was done
+    if ( $request->pnote( 'flash_vars' ) ) {
+        $frozen = $request->pnote( 'flash_vars' );
+    } else {
+        # try getting the value from memcache
+        my $remote = LJ::get_remote();
+        if ( $remote ) {
+            my $flashkey = $request->get_args->{$fs_id_arg};
+            my $memkey = $class->create_memkey( $flashkey );
+            $frozen = $remote->memc_get( $memkey );
+            $remote->memc_delete( $memkey );
+        }
+    }
+    return Storable::thaw( $frozen );
+}
+
+# creates a key we can use to save and recover the flash scope
+sub create_flashkey {
+    # FIXME we can do better than this.  need a real unique id
+    return time();
+}
+
+# makes the actual key we use in memcache
+sub create_memkey {
+    my ( $class, $flashkey ) = @_;
+    return "flash:" . $flashkey;
+}
+1;
+

--- a/cgi-bin/DW/Request/Apache2.pm
+++ b/cgi-bin/DW/Request/Apache2.pm
@@ -292,6 +292,10 @@ sub FORBIDDEN {
     return Apache2::Const::FORBIDDEN;
 }
 
+sub DECLINED {
+    return Apache2::Const::DECLINED;
+}
+
 # spawn a process for an external program
 sub spawn {
     my DW::Request::Apache2 $self = shift;

--- a/cgi-bin/DW/UserDbObj.pm
+++ b/cgi-bin/DW/UserDbObj.pm
@@ -1,0 +1,247 @@
+#!/usr/bin/perl
+#
+# DW::UserDbObj
+#
+# Base class for DB objects that belong to a user
+#
+# Authors:
+#      Allen Petersen <allen@suberic.net>
+#
+# Copyright (c) 2012 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+
+
+## Derived classes must implement the following methods:
+## 
+## _obj_props { }
+## _usercounter_id { } ## see LJ::alloc_user_counter in LJ/DB.pm
+## _skeleton { }
+## _tablename { }
+##
+## _memcache_id                 { $_[0]->userid                 }
+## _memcache_key_prefix         { "myobjname"                        }
+## _memcache_stored_props       { qw/$VERSION name age caps /   }
+## _memcache_hashref_to_object  { LJ::User->new_from_row($_[0]) }
+## _memcache_expires            { 24*3600                       }
+
+package DW::UserDbObj;
+use strict;
+use warnings;
+use DW::UserDbObjAccessor;
+#use Carp qw(cluck);
+
+use base 'DW::BaseDbObj';
+
+# returns the WHERE clause for searching by ID
+sub _where_by_id {
+    return "WHERE " . join ( ' AND ', map { $_ . "=?" } $_[0]->_key_column );
+}
+
+# returns the full object key(userid and objectid) for this object
+sub _key {
+    return map { $_[0]->{$_} }  $_[0]->_key_column;
+}
+
+# returns the full object key(userid and objectid) for this object
+sub _key_column {
+    return qw ( userid id );
+}
+
+# default memcache implementations
+sub _memcache_id {
+    return $_[0]->{_userid} . ":" . $_[0]->{_obj_id};
+}
+sub _memcache_stored_props          {
+    my $class = $_[0];
+
+    # first element of props is a VERSION
+    # next - allowed object properties
+    return ( $class->_memcache_version, $class->_key_column, $class->_obj_props );
+}
+sub _memcache_hashref_to_object {
+    my ($class, $row) = @_;
+    my $u = LJ::load_userid($row->{userid});
+    return $class->_new_from_row($u, $row);
+}
+
+sub _memcache_expires  { 24*3600 }
+
+#sub _memcache_key_prefix            { "keyprefix" }
+
+# note: remember to change the _memcache_version every time the _key_column or
+# _obj_props changes.
+#sub _memcache_version { "1" }
+
+# creates a new instance of a UserDbObj.
+sub instance {
+    my ( $class, $u, $id ) = @_;
+
+    my $obj = $class->_skeleton( $u, $id );
+    return $obj;
+}
+*new = \&instance;
+
+# creates an new UserDbObj from a DB row.  Overrides BaseDbObj _new_from_row.
+sub _new_from_row {
+    my ($class, $u, $row) = @_;
+    die unless $row && $row->{userid} && $row->{id};
+    my $self = $class->new($u, $row->{id});
+    $self->_absorb_row($row);
+    return $self;
+}
+
+# creates a new instance
+sub create {
+    my ( $class, $u, $opts ) = @_;
+    $class->_create( $u, $opts );
+}
+
+# creates a new instance
+sub _create {
+    my ( $class, $u, $opts ) = @_;
+
+    # validate the inputs first
+    $class->validate( $u, $opts );
+
+    # new objectid
+    my $objid = LJ::alloc_user_counter($u, $class->_usercounter_id );
+
+    # create and run the SQL
+    my $entrystring =  join ( ',' , $class->_obj_props );
+    my $qs = join( ', ', map { '?' } $class->_obj_props );
+    my @values = map { $opts->{$_} }  $class->_obj_props;
+
+    my $sql = "INSERT INTO " . $class->_tablename . " ( " . join(",", $class->_key_column) . ",$entrystring ) values ( ?, ?, $qs )";
+    #warn("running '$sql', values " . $u->{userid} . ", " .  $objid . ", " . join(", ", @values ) );
+    $u->do( $sql, undef, $u->{userid}, $objid, @values );
+    LJ::throw($u->errstr) if $u->err;
+
+    # now return the created object.
+    my $obj = $class->_get_obj( $u, $objid ) or LJ::throw("Error instantiating object");
+
+    # clear the cache.
+    $obj->_clear_associated_caches();
+
+    return $obj;
+}
+
+# updates an existing instance
+sub update {
+    my ( $self ) = @_;
+
+    my $u = $self->user;
+
+    # validate the inputs first
+    $self->validate( $self->user, $self );
+
+    # create and run the SQL
+    my $qs = join( ', ', map { $_ . "=?" } $self->_obj_props );
+    my $key_query = join( ', ', map { $_ . "=?" } $self->_key_column );
+    my @values = map { $self->{$_} }  $self->_obj_props;
+    $u->do( "UPDATE " . $self->_tablename . " set $qs ". $self->_where_by_id , undef, @values, $self->_key );
+    
+    LJ::throw($u->errstr) if $u->err;
+
+    # now return the created object.
+    my $obj = $self->_get_obj( $u, $self->{_obj_id} ) or LJ::throw("Error instantiating object");
+
+    # clear the cache.
+    $self->_clear_cache();
+    $self->_clear_associated_caches();
+
+    return $obj;
+}
+
+# retrieves a single object by id, either from database or memcache
+sub _get_obj {
+    my ( $class, $u, $objid ) = @_;
+
+    # try from memcache first.
+    my $cached_value = $class->_load_from_memcache( $u->userid . ":$objid" );
+    if ($cached_value) {
+        return $cached_value;
+    }
+
+    # if that didn't work, run the select
+    my $sth = $u->prepare( "SELECT " . join ( ',' , ( $class->_key_column, $class->_obj_props ) ) . " FROM " . $class->_tablename . " " .$class->_where_by_id );
+    $sth->execute( $u->userid, $objid );
+    LJ::throw( $u->err ) if ( $u->err );
+
+    my $obj;
+    if ( my $row = $sth->fetchrow_hashref ) {
+        $obj = $class->_new_from_row($u, $row);
+    }
+    $obj->_store_to_memcache if $obj;
+
+    return $obj;
+}
+
+# returns all of the objects for the requested user
+sub all_for_user {
+    my ( $class, $u ) = @_;
+    
+    # we require a user here.
+    $u = LJ::want_user($u) or LJ::throw("no user");
+
+    return DW::UserDbObjAccessor->new( $class, $u )->_all_for_user();
+}
+
+
+# deletes this object
+sub delete {
+    my ($self) = @_;
+    my $u = $self->user;
+
+    $u->do("DELETE FROM " . $self->_tablename . " " . $self->_where_by_id, 
+           undef, $self->_key );
+
+    # clear the cache.
+    $self->_clear_cache();
+    $self->_clear_associated_caches();
+
+    return 1;
+}
+
+# clears associated cache for add/delete
+sub _clear_associated_caches() {
+    my ($self) = @_;
+
+    #cluck("MMM clearing associated cache for " . $self . ", userid=" .  $self->user->id);
+    $self->_clear_keys( { "userid" => $self->user->id } );
+}
+
+# available for all UserDbObjs
+sub user {
+    my $self = $_[0];
+
+    if ( ! $self->{user} ) {
+        my $user = LJ::load_userid( $self->{_userid} );
+        $self->{user} = $user;
+    }
+    return $self->{user};
+}
+
+# validates the new object.  should be overridden by subclasses
+sub validate {
+    my ( $class, $u, $opts ) = @_;
+    
+    # we require a user here.
+
+    $u = LJ::want_user($u) or LJ::throw("no user");
+
+    return 1;
+}
+
+# gets a UserDbObj by id and user. may be overridden by subclasses if they
+# require more than the default functionality
+sub by_id {
+    my ( $class, $u, $id ) = @_;
+
+    return $class->_get_obj( $u, $id );
+}
+
+1;

--- a/cgi-bin/DW/UserDbObjAccessor.pm
+++ b/cgi-bin/DW/UserDbObjAccessor.pm
@@ -1,0 +1,262 @@
+#!/usr/bin/perl
+#
+# DW::UserDbObjAccessor
+#
+# An accessor object for UserDbObjs.
+#
+# Authors:
+#      Allen Petersen <allen@suberic.net>
+#
+# Copyright (c) 2013 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+
+package DW::UserDbObjAccessor;
+use strict;
+use warnings;
+
+# create a new instance
+sub instance {
+    my ( $class, $target_class, $u ) = @_;
+    
+    $u = LJ::want_user($u) or LJ::throw("no user");
+    return bless {
+        u => $u,
+        target_class => $target_class,
+        single_key_column => 'id',
+    };
+}
+*new = \&instance;
+
+sub target_class {
+    return $_[0]->{target_class};
+}
+
+sub user {
+    return $_[0]->{u};
+}
+
+sub single_key_column {
+    return $_[0]->{single_key_column};
+}
+
+sub get_db_reader {
+    my $u = $_[0]->user;
+    my $dbcm = $u->{'_dbcm'} ||= LJ::get_cluster_master($u);
+    return $dbcm;
+}
+sub get_db_writer {
+    my $u = $_[0]->user;
+    my $dbcm = $u->{'_dbcm'} ||= LJ::get_cluster_master($u);
+    return $dbcm;
+}
+
+# returns all of the objects for the requested user
+sub _all_for_user {
+    my ( $self ) = @_;
+
+    my $all_for_user = $self->_all_items_by_value( "userid", $self->user->id );
+    return $all_for_user;
+}
+
+# returns all matches for this use where the field-value pairs match
+sub _fv_query_by_user {
+    my ( $self, $field_value_map ) = @_;
+
+    my %local_fv_map = %$field_value_map;
+    $local_fv_map{userid} = $self->user->id;
+
+    return $self->_all_items_by_values( \%local_fv_map );
+}
+
+# returns all of the objects for the requested value
+# NOTE:  $field should _never_ be user provided, since we're
+# putting it directly in the query.
+sub _all_items_by_value {
+    my ( $self, $field, $value ) = @_;
+   
+    return $self->_all_items_by_values( { $field => $value } );
+}
+
+# returns all of the objects for the requested value
+# NOTE:  the keys in the field_value_map  should _never_ be user provided,
+# since we're putting them directly in the query.
+sub _all_items_by_values {
+    my ( $self, $field_value_map ) = @_;
+   
+    my @ids = $self->_keys_by_values( $field_value_map );
+    my $items = $self->_load_objs_from_keys( \@ids );
+
+    return $items;
+}
+
+# returns all of the ids for the requested field/value pairs
+# NOTE:  the keys in the field_value_map  should _never_ be user provided,
+# since we're putting them directly in the query.
+sub _keys_by_values {
+    my ( $self, $field_value_map ) = @_;
+    
+    my $ids;
+    my @objs;
+    # see if we can get it from memcache
+    if ( $self->target_class->memcache_query_enabled ) {
+        $ids = $self->target_class->_load_keys( $field_value_map );
+        if ( $ids && ref $ids eq 'ARRAY' && scalar @$ids > 1 ) {
+            return wantarray ? @$ids : $ids;
+        }
+    }
+
+    # if we didn't get anything from memcache, try the database
+
+    # need a consistent order for fields to use for values
+    my @fields =  sort keys %$field_value_map;
+    my $where_clause = " " . join( ' AND ', map { "`$_`" . " = ?" } @fields ) . " ";
+    my @values = map { $field_value_map->{$_} } @fields ;
+    $ids = $self->_search_ids( $where_clause, \@values );
+    
+    if ( $self->target_class->memcache_query_enabled ) {
+        $self->target_class->_store_keys( $field_value_map, $ids );
+    }
+    return wantarray ? @$ids : $ids;
+}
+
+# does the DB query for the appropriate values.
+sub _search_ids {
+    my ( $self, $where_clause, $values ) = @_;
+
+    my $dbr = $self->get_db_reader();
+
+    my $sql = "SELECT " . $self->single_key_column . " FROM " . $self->target_class->_tablename . " " .$self->target_class->_create_where_clause( $where_clause ) . " " . $self->target_class->_default_order_by;
+    #warn("search_ids: running sql '$sql'");
+    my $ids = $dbr->selectcol_arrayref( $sql, undef, @$values );
+    LJ::throw( $dbr->errstr ) if $dbr->err;
+    
+    return $ids;
+}
+
+# retrieves a set of objects by ids for a user, either from database or 
+# memcache as appropriate
+sub _load_objs_from_keys {
+    my ( $self, $keys ) = @_;
+
+    # return an empty array for an empty request
+    if ( ! defined $keys || ! scalar @$keys ) {
+        return [];
+    }
+
+    # try from memcache first.  if we get all the results from memcache,
+    # just return that.  otherwise, keep the misses and an id map for the
+    # hits.
+    my %memcache_objmap = ();
+    my %db_objmap = ();
+    my @memcache_misses = @$keys;
+    if ( $self->target_class->memcache_enabled ) {
+        my $cached_value = $self->_load_batch_from_memcache( $keys );
+        @memcache_misses = @{$cached_value->{misses}};
+        %memcache_objmap = %{$cached_value->{objmap}};
+    }
+
+    if ( @memcache_misses ) {
+        # if we got to here, then we need to query the db for at least a 
+        # subset of the objects
+        my $dbr = $self->get_db_reader();
+
+        my $qs = join( ', ', map { '?' } @memcache_misses );
+        
+        my $sql = "SELECT " . join ( ',' , ( 'userid', $self->single_key_column, $self->target_class->_obj_props ) ) . " FROM " . $self->target_class->_tablename . " WHERE userid = ? AND id IN ( $qs )";
+        #warn ("running $sql");
+        my $sth = $dbr->prepare( $sql );
+        $sth->execute( $self->user->id, @memcache_misses );
+        LJ::throw( $dbr->err ) if ( $dbr->err );
+        
+        # ok, now we create the objects from the db query
+        my $obj;
+        my @db_objs = ();
+        while ( my $row = $sth->fetchrow_hashref ) {
+            $obj = $self->target_class->_new_from_row( $self->user, $row );
+
+            push @db_objs, $obj;
+            $db_objmap{$obj->{$self->single_key_column}} = $obj;
+        }
+
+        # if we're using memcache, save the newly loaded objects to it.
+        if ( $self->target_class->memcache_enabled ) {
+            $self->target_class->_store_batch_to_memcache( \@db_objs );
+        }
+    }
+
+    # stitch together the memcache results and the db results in the
+    # original id order
+    my @returnvalue = ();
+    foreach my $key ( @$keys ) {
+        if ( defined $db_objmap{$key} ) {
+            push @returnvalue, $db_objmap{$key};
+        } elsif ( defined $memcache_objmap{$key} ) {
+            push @returnvalue,  $memcache_objmap{$key};
+        }
+    }
+    
+    return \@returnvalue;
+}
+
+# loads an entire batch of ids from memcache.
+sub _load_batch_from_memcache {
+    my $self = shift;
+    my $ids = shift;
+    my $u = $self->user;
+
+    my @memcache_keys = ();
+    my $keymap = {};
+    for my $id ( @$ids ) {
+        my $memcache_key = $self->target_class->_memcache_key( $u->id . ":" . $id );
+        push @memcache_keys, $memcache_key->[1];
+        $keymap->{$memcache_key->[1]} = $id;
+    }
+    my $mem = LJ::MemCache::get_multi( @memcache_keys );
+
+    my ($version, @props) = $self->target_class->_memcache_stored_props;
+    my @hits = ();
+    my %misses = %$keymap;
+    my @objects = ();
+    my %objmap = ();
+    while (my ($k, $v) = each %$mem) {
+        if ( defined $v && ref $v eq 'ARRAY' ) {
+            push @hits, $keymap->{$k};
+            if ( $v->[0]==$version ) {
+                my %hash;
+                foreach my $i (0..$#props) {
+                    $hash{ $props[$i] } = $v->[$i+1];
+                }
+                my $obj = $self->target_class->_memcache_hashref_to_object(\%hash);
+                push @objects, $obj;
+                $objmap{$keymap->{$k}}=$obj;
+                delete $misses{$k};
+            }
+        }
+    }
+    my @misses = values %misses;
+    return {
+        hits => \@hits,
+        misses => \@misses,
+        objects => \@objects,
+        objmap => \%objmap,
+    };
+}
+
+# save an entire batch of ids to memcache.
+sub _store_batch_to_memcache {
+    my $self = shift;
+    my $objs = shift;
+
+    for my $obj ( @$objs ) {
+        $obj->_store_to_memcache();
+    }
+}
+
+
+
+1;
+

--- a/cgi-bin/LJ/DB.pm
+++ b/cgi-bin/LJ/DB.pm
@@ -63,7 +63,7 @@ $LJ::DBIRole = new DBI::Role {
                     "logprop_history", "import_status", "externalaccount",
                     "content_filters", "content_filter_data", "userpicmap3",
                     "media", "collections", "collection_items", "logslugs",
-                    "media_versions", "media_props",
+                    "media_versions", "media_props", "draft", "draftblob",
                     );
 
 # keep track of what db locks we have out
@@ -735,7 +735,7 @@ sub alloc_global_counter
 #       'Z' == import status item, 'X' == eXternal account
 #       'F' == filter id, 'Y' = pic/keYword mapping id
 #       'A' == mediA item id, 'O' == cOllection id,
-#       'N' == collectioN item id
+#       'N' == collectioN item id, '2' Draft (because why not?)
 #
 sub alloc_user_counter
 {
@@ -744,7 +744,7 @@ sub alloc_user_counter
 
     ##################################################################
     # IF YOU UPDATE THIS MAKE SURE YOU ADD INITIALIZATION CODE BELOW #
-    return undef unless $dom =~ /^[LTMPSRKCOVEQGDIZXFYA]$/;          #
+    return undef unless $dom =~ /^[LTMPSRKCOVEQGDIZXFYA2]$/;          #
     ##################################################################
 
     my $dbh = LJ::get_db_writer();
@@ -870,6 +870,9 @@ sub alloc_user_counter
                                       undef, $uid);
     } elsif ($dom eq "N") {
         $newmax = $u->selectrow_array("SELECT MAX(colitemid) FROM collection_items WHERE userid = ?",
+                                      undef, $uid);
+    } elsif ($dom eq "2") {
+        $newmax = $u->selectrow_array("SELECT MAX(id) FROM draft WHERE userid = ?",
                                       undef, $uid);
     } else {
         die "No user counter initializer defined for area '$dom'.\n";

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1790,6 +1790,14 @@ sub postevent
         # TODO: error on failure?  depends on the job I suppose?  property of the job?
     }
 
+    # if this was a draft, respond to having been posted
+    if ( $req->{draftid} ) {
+        my $draft = DW::Draft->by_id( $u, $req->{draftid} );
+        if ( $draft ) {
+            $draft->handle_posted();
+        }
+    }
+
     return $res;
 }
 

--- a/cgi-bin/LJ/User.pm
+++ b/cgi-bin/LJ/User.pm
@@ -4902,8 +4902,7 @@ sub entryform_panels {
                    # FIXME: should be [ "status"  "journal" "comments" "age_restriction" ] %]
                    [ "access", "journal", "currents", "comments", "age_restriction" ],
 
-                   # FIXME: should be [ "icons" "crosspost" "scheduled" ]
-                   [ "icons", "crosspost", "flags" ],
+                   [ "icons", "crosspost", "flags", "scheduled", "draft" ],
                 ],
         show => {
             "tags"          => 1,
@@ -4917,7 +4916,8 @@ sub entryform_panels {
             "icons"         => 1,
             "crosspost"     => 0,
             "flags"     => 1,
-            #"scheduled"     => 0,
+            "draft"         => 0,
+            "scheduled"     => 0,
             #"status"        => 1,
         },
         collapsed => {

--- a/htdocs/js/jquery.postform.js
+++ b/htdocs/js/jquery.postform.js
@@ -281,7 +281,6 @@ init: function(formData) {
             var postas = $.trim($("#post_username").val());
             journal = $.trim($("#postas_usejournal").val()) || postas;
             iscomm = journal !== postas;
-            console.log(journal, postas)
             $(this).trigger( "journalselect", {"name":journal, "iscomm":iscomm, isremote: false});
         });
         $("#post_as_other").click(function() {
@@ -458,6 +457,14 @@ init: function(formData) {
             $(this.form).data("skipchecks", "spellcheck");
         });
 
+        // note if we're doing a draft or schedule
+        $("input[type='submit'].submit_draft").click(function(e) { 
+            $(this.form).data("skipchecks", "draft");
+        });
+        $("input[type='submit'].submit_schedule").click(function(e) { 
+            $(this.form).data("skipchecks", "schedule");
+        });
+
         $("#delete_entry").click(function(e) {
             $(this.form).data("skipchecks", "delete");
             var do_delete = confirm(formData.strings.delete_confirm);
@@ -467,8 +474,13 @@ init: function(formData) {
 
             if ( ! do_delete ) {
                 e.preventDefault();
+                return false;
+            } else {
+                // we've already confirmed, so do a post instead of a get
+                $(this).attr("formmethod", "post");
             }
         });
+
 
 
         $("#post_options").click(function(e){

--- a/htdocs/stc/postform.css
+++ b/htdocs/stc/postform.css
@@ -371,6 +371,15 @@ ul.icon-functions li {
 }
 
 
+/* Drafts */
+
+.dw-draft-details {
+  display: none;
+}
+li.dw-draft a:hover + .dw-draft-details, li.dw-draft a:focus + .dw-draft-details {
+  display: block;
+} 
+
 /* Scheduled Posts */
 
 /* Footer Buttons */

--- a/t/draft.t
+++ b/t/draft.t
@@ -1,0 +1,182 @@
+# -*-perl-*-
+use strict;
+
+use Test::More;
+use lib "$ENV{LJHOME}/cgi-bin";
+BEGIN {
+    require 'ljlib.pl'; 
+}
+use LJ::Test qw ( temp_user temp_comm );
+
+use DW::Draft;
+use LJ::Protocol;
+
+plan tests => 20;
+
+# set up user
+
+my $u = temp_user();
+
+# checking.
+my $all_drafts = DW::Draft->all_drafts_for_user( $u );
+is ( scalar @$all_drafts, 0, "all_drafts_for_user() returning correct value (0)" );
+
+
+my $req =  {
+    posterid => $u->id,
+    anum => 1,
+    subject => "Test Subject",
+    hour => '13',
+    min => '53',
+    subject => 'test draft',
+    allowmask => '1',
+    event => "this is a test of draft\n\nText after newlines.\n",
+    props => { 
+        current_mood => 'moody',
+        current_location => 'test world',
+        opt_nocomments => 0,
+        taglist => 'tagone',
+        current_moodid => '68',
+        current_music => 'keystrokes',
+        opt_preformatted => '0',
+        adult_content_reason => 'none',
+        picture_keyword => 'test keyword',
+        opt_backdated => '0',
+        opt_screening => 'R',
+        adult_content => 'none',
+        opt_noemail => '0',
+    },
+    day => '19',
+    slug => 'slug slug slug slug slug',
+    security => 'usemask',
+    mon => '06',
+    year => '2013',
+};
+
+# basic CRUD
+my $draft = DW::Draft->create_draft( $u, $req );
+
+my $firstid = $draft->id;
+
+$draft = DW::Draft->create_draft( $u, $req );
+
+ok ( $draft->id > 0 );
+
+$all_drafts = DW::Draft->all_drafts_for_user( $u );
+
+is ( scalar @$all_drafts, 2, "all_drafts_for_user() returning correct value." );
+
+my $all_scheduled = DW::Draft->all_scheduled_posts_for_user( $u );
+is ( scalar @$all_scheduled, 0, "all_scheduled_posts_for_user() still returning 0 after 2 drafts created." );
+
+my $id =  $draft->id;
+$draft = DW::Draft->by_id( $u, $id );
+
+ok ( $draft->{modtime} > 0, "modtime set" );
+ok ( $draft->{createtime} > 0, "createtime set" );
+is ( $req->{subject}, $draft->{subject}, "subject set" );
+# event is short enough that it should match summary
+is ( $req->{event}, $draft->{summary}, "summary" );
+
+$draft->delete();
+warn("deleted");
+$all_drafts = DW::Draft->all_drafts_for_user( $u );
+warn("loaded drafts");
+
+is ( scalar @$all_drafts, 1, "delete() removed draft." );
+
+$draft = DW::Draft->by_id( $u, $firstid);
+$draft->delete();
+
+$all_drafts = DW::Draft->all_drafts_for_user( $u );
+is ( scalar @$all_drafts, 0, "second delete() removed last draft." );
+
+# test create/load round trip
+
+$draft = DW::Draft->create_draft( $u, $req );
+
+ok ( $draft->id > 0 );
+
+$id =  $draft->id;
+
+$draft = DW::Draft->by_id( $u, $id );
+$req->{subject} = "new subject";
+$req->{props}->{current_mood} = 'updated';
+
+$draft->set_req( $req );
+$draft->update();
+
+$draft = $draft->by_id( $u, $id );
+is ( $draft->{subject}, "new subject", "subject updated" );
+is ( $draft->req->{subject}, "new subject", "subject updated on req" );
+is ( $draft->req->{props}->{current_mood}, 'updated', 'req props updated' );
+
+# test scheduled posts
+
+my $scheduled_req = {
+    posterid => $u->id,
+    anum => 1,
+    subject => "Test Scheduled",
+    hour => '13',
+    min => '53',
+    subject => 'test scheduled',
+    allowmask => '1',
+    event => "this is a test of draft\n\nText after newlines.\n",
+    props => { 
+        current_mood => 'moody',
+        current_location => 'test world',
+        opt_nocomments => 0,
+        taglist => 'tagone',
+        current_moodid => '68',
+        current_music => 'keystrokes',
+        opt_preformatted => '0',
+        adult_content_reason => 'none',
+        picture_keyword => 'test keyword',
+        opt_backdated => '0',
+        opt_screening => 'R',
+        adult_content => 'none',
+        opt_noemail => '0',
+    },
+    day => '19',
+    slug => 'slug slug slug slug slug',
+    security => 'usemask',
+    mon => '06',
+    year => '2013',
+};
+
+my $scheduled_opts = {
+    nextscheduletime => LJ::mysql_time( time ),
+};
+
+my $scheduled_once = DW::Draft->create_scheduled_draft( $u, $scheduled_req, { nextscheduletime => LJ::mysql_time( time )} );
+
+$all_scheduled = DW::Draft->all_scheduled_posts_for_user( $u );
+is ( scalar @$all_scheduled, 1, "all_scheduled_posts_for_user() for scheduled posts returning correct value after creating a scheduled post." );
+
+my $scheduled_multi = DW::Draft->create_scheduled_draft( $u, $scheduled_req, { nextscheduletime => LJ::mysql_time( time ), recurring_period => 'day' } );
+
+is ( 'day', $scheduled_multi->recurring_period, "recurring period saved correctly." );
+
+# check that the sizes are correct
+
+$all_drafts = DW::Draft->all_drafts_for_user( $u );
+
+# testing both to make sure caching works
+is ( scalar @$all_drafts, 1, "all_drafts_for_user() returning correct value after creating two scheduled posts." );
+
+$all_scheduled = DW::Draft->all_scheduled_posts_for_user( $u );
+is ( scalar @$all_scheduled, 2, "all_scheduled_posts_for_user() returning correct value after creating a scheduled post." );
+
+$scheduled_multi->delete();
+$scheduled_once->delete();
+$draft->delete();
+
+$all_drafts = DW::Draft->all_drafts_for_user( $u );
+
+# testing both to make sure caching works
+is ( scalar @$all_drafts, 0, "all_drafts_for_user() returning correct value after deleting all drafts" );
+
+$all_scheduled = DW::Draft->all_scheduled_posts_for_user( $u );
+is ( scalar @$all_scheduled, 0, "all_scheduled_posts_for_user() returning correct value after delting all scheduled posts." );
+
+

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -68,7 +68,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     );
 END -%]
 
-[% sections.title = action.edit ? dw.ml( '.title.edit' ) : dw.ml( '.title' ) %]
+[% sections.title = action.edit ? dw.ml( '.title.edit' ) : action.editdraft ? dw.ml( '.title.draft.edit') : action.editscheduled ? dw.ml( '.title.scheduled.edit' ) : dw.ml( '.title' ) %]
 [% sections.contentopts = '' %]
 
 [% sections.head = BLOCK %]
@@ -97,7 +97,7 @@ END -%]
 
 <script type="text/javascript">
 var postFormInitData = new Object();
-postFormInitData.edit = [% action.edit ? "true" : "false" %];
+postFormInitData.edit = [% ( action.edit || action.editdraft || action.editscheduled ) ? "true" : "false" %];
 postFormInitData.icons = [
     [%- FOREACH icon = icons %]
         { 'src': '[% icon.userpic.url %]', 'alt': [% icon.userpic.description | js %] }
@@ -124,7 +124,11 @@ postFormInitData.panels = {
 postFormInitData.minAnimation = [% min_animation ? "true" : "false" %];
 
 postFormInitData.strings = {
+    [% IF draftid %]
+  "delete_confirm" : [%- "entryform.delete.draft.confirm" | ml | js -%],
+    [% ELSE %]
   "delete_confirm" : [%- "entryform.delete.confirm" | ml | js -%],
+    [% END %]
   "delete_xposts_confirm": [%- "entryform.delete.xposts.confirm" | ml | js  -%]
 };
 
@@ -183,6 +187,9 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
 
     [%- dw.form_auth -%]
 
+    [% IF draftid %]
+        <input type="hidden" id="draftid" name="draftid" value="[%- draftid -%]" />
+    [% END %]
     <div id="primary"><!-- Start main column sub & entry -->
         <div id="current_entry">
             <fieldset>
@@ -251,6 +258,24 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
                 </div>
             </fieldset>
             <fieldset class='submit'>
+                [%- IF ! action.edit -%]
+                [%- IF ! action.editscheduled -%]
+                [%- draft_label = '.button.save.draft' | ml;
+                    form.submit( value = draft_label
+                                 name = "action:draft"
+                                 class = "submit_draft"
+                                 formaction = action.draft_url )
+                -%]
+                [% END %]
+                [%- schedule_label = '.button.schedule' | ml;
+                    form.submit( value = schedule_label
+                                 name = "action:schedule"
+                                 class = "submit_schedule"
+                                 formaction = action.schedule_url )
+
+               -%]
+                [% END %]
+
                 [%- preview_label = 'talk.btn.preview' | ml;
                     form.submit( value = preview_label
                                  name = "action:preview"
@@ -267,7 +292,8 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
                 [%- post_label = action.edit ? '.button.edit' : '.button.post' | ml;
                     form.submit( value = post_label
                                  name = "action:post"
-                                 id = "submit_entry" )
+                                 id = "submit_entry"
+                                 formaction = action.post_url )
                 -%]
             </fieldset>
         </div>
@@ -301,15 +327,35 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
         <span id="actions">
             [%- form.submit( value = post_label
                              name = "action:post"
-                             id = "submit_entry_large" )
+                             id = "submit_entry_large"
+                             formaction = action.post_url )
             -%]
+                [%- IF ! action.edit -%]
+                [%- schedule_label = '.button.schedule' | ml;
+                    form.submit( value = schedule_label
+                                 name = "action:schedule"
+                                 class = "submit_schedule",
+                                 formaction = action.schedule_url )
+
+                -%]
+                [%- IF ! action.editscheduled -%]
+                [%- draft_label = '.button.save.draft' | ml;
+                    form.submit( value = draft_label
+                                 name = "action:draft"
+                                 class = "submit_draft",
+                                 formaction = action.draft_url )
+                -%]
+                [% END %]
+                [% END %]
         </span>
 
-        [% IF action.edit %]
+        [% IF action.edit || action.editdraft || action.editscheduled %]
         <span class="destructive">
             [%- form.submit( value = dw.ml( '.button.delete' )
                              name  = "action:delete"
-                             id    = "delete_entry" )
+                             id    = "delete_entry",
+                             formaction = action.delete_url,
+                             formmethod = "get" )
             -%]
         </span>
         [% END %]

--- a/views/entry/form.tt.text
+++ b/views/entry/form.tt.text
@@ -9,6 +9,12 @@
 
 .button.post=Post Entry
 
+.button.save.draft=Save Draft
+
+.button.schedule=Schedule
+
+.error.draft.nofind=Could not find draft id [[id]] for user [[user]].
+
 .error.header=Error
 
 .error.nofind=Could not find selected journal entry.
@@ -23,4 +29,8 @@
 
 .title=Create Entries
 
+.title.draft.edit=Edit Draft
+
 .title.edit=Edit Entry
+
+.title.scheduled.edit=Edit Scheduled Post

--- a/views/entry/module-draft.tt
+++ b/views/entry/module-draft.tt
@@ -1,0 +1,39 @@
+[%# views/entry/module-scheduled.tt
+
+Module for accessing drafts
+
+Authors:
+    Allen <allen@suberic.net>
+
+Copyright (c) 2013 by Dreamwidth Studios, LLC.
+
+This program is free software; you may redistribute it and/or modify it under
+the same terms as Perl itself.  For a copy of the license, please reference
+'perldoc perlartistic' or 'perldoc perlgpl'.
+%]
+
+[% USE date %]
+
+<fieldset>
+  <h3 class='ui-corner-top'>[% '.drafts' | ml %]</h3>
+    <div class="inner">
+    <div id="drafts_container">
+      [% IF drafts %]
+      <table>
+        <tr>
+          <th>[% '.th.subject' | ml %]</th>
+          <th>[% '.th.postdate' | ml %]</th>
+          <th>[% '.th.lastedited' | ml %]</th>
+        </tr>
+        [% FOREACH draft IN drafts %]
+        <tr>
+          <td><a href = "/draft/[% draft.user.user %]/[% draft.id %]/edit">[% IF draft.subject %][% draft.subject | html %][% ELSE %][% '.nosubject' | ml %][% END %]</a></td>
+          <td>[% IF draft.status == 'S' %][% date.format( draft.nextscheduletime, '%d-%b-%Y %H:%M') %] [% ELSE %][% '.unscheduled' | ml %][% END %]</td>
+          <td>[% date.format( draft.modtime, '%d-%b-%Y %H:%M:%S') %]</td>
+        </tr>
+        [% END %]
+      </table>
+      [% END %]
+    </div>
+  </div>
+</fieldset>

--- a/views/entry/module-draft.tt.text
+++ b/views/entry/module-draft.tt.text
@@ -1,0 +1,13 @@
+.title=Drafts
+
+.header=Drafts
+
+.drafts=Drafts
+
+.nosubject=(no subject)
+
+.th.subject=Subject
+.th.postdate=Post Date
+.th.lastedited=Last Modified
+
+.unscheduled=Draft

--- a/views/entry/module-scheduled.tt
+++ b/views/entry/module-scheduled.tt
@@ -12,23 +12,56 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
 
+[% USE date %]
+
 <fieldset>
-  <h3 class='ui-corner-top'>Scheduled Publishing</h3>
+  <h3 class='ui-corner-top'>[%- '.header' | ml %]</h3>
     <div class="inner">
+
     <div class='time_container' id="publishingtime_container">
-      <input type="text" name="publishingtime" id="publishingtime" value="2010-04-10" maxlength="10" size="10" />
-      <input type="text" name="publishingtime_hr" id="publishingtime_hr" value="03" maxlength="2" size="2" class='time_hr' />:<input type="text" name="publishingtime_min" id="publishingtime_min" value="15" maxlength="2" size="2" class='time_min' />
+        [% label = ".date" | ml;
+           form.textbox( label = label
+                name = "publishingtime_date"
+                id = "publishingtime_date"
+                size = "10"
+                maxlength = "10"
+                placeholder = "2010-04-10"
+        );
+           form.textbox(
+                name = "publishingtime_hr"
+                id = "publishintime_hr"
+                size = "2"
+                maxlength = "2"
+                placeholder = "03"
+        );
+           form.textbox(
+                name = "publishingtime_min"
+                id = "publishingdate_min"
+                size = "2"
+                maxlength = "2"
+                placeholder = "15"
+        );
+
+         %]
       <div class="dateformat">(e.g. 2010-01-30 23:45)</div>
     </div>
 
     <div class="recurring_container">
-      <label for="recurring_period">Recurring:</label>
-      <select name="recurring_period" class="select" id="recurring_period">
-        <option value="never">never</option>
-        <option value="day">every day</option>
-        <option value="week">every week</option>
-        <option value="month">every month</option>
-      </select>
+     [%- label = ".recurring" | ml;
+         rec_never = '.recurring.never' | ml;
+         rec_day = '.recurring.day' | ml;
+         rec_week = '.recurring.week' | ml;
+         rec_month = '.recurring.month' | ml;
+        form.select( label = label
+            name = "recurring_period"
+            id = "recurring_period"
+            items = [
+            "never"    rec_never
+            "day"      rec_day
+            "week"     rec_week
+            "month"    rec_month
+            ]
+        ) -%]
     </div>
   </div>
 </fieldset>

--- a/views/entry/module-scheduled.tt.text
+++ b/views/entry/module-scheduled.tt.text
@@ -1,0 +1,12 @@
+.date=Scheduled Date:
+
+.header=Scheduled Publishing
+
+.recurring=Recurring:
+.recurring.never=Never
+.recurring.day=Every Day
+.recurring.week=Every Week
+.recurring.month=Every Month
+
+.scheduled=Scheduled Posts
+

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -14,7 +14,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- sections.title = 'success' | ml -%]
 
-[%- IF warnings.size > 0 -%]
+[%- IF warnings && warnings.size > 0 -%]
     [%- FOREACH warning IN warnings -%]
         <div class="message-box [% warning.type %]-box">[%- warning.message -%]</div>
     [%- END -%]
@@ -22,7 +22,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 <p>[% poststatus %]</p>
 
-[%- IF crossposts.size > 0 -%]
+[%- IF crossposts && crossposts.size > 0 -%]
 <div class='message-box'>
 <ul>
     [%- FOREACH crosspost IN crossposts -%]

--- a/views/entry/success.tt.text
+++ b/views/entry/success.tt.text
@@ -1,0 +1,15 @@
+.draft.delete.success=Draft deleted.
+.draft.delete.success.linkheader=Now you can:
+
+.draft.success=Draft saved successfully.
+.draft.success.linkheader=Now that you have saved this draft, you can:
+.draft.success.edit=Post or continue editing this draft
+.draft.success.entry.new=Start a new entry or draft
+
+.draft.update.success=Draft updated successfully.
+
+.scheduled.delete.success=Scheduled post deleted.
+.scheduled.success=New entry scheduled to be posted on [[date]].
+.scheduled.update.success=Scheduled post updated successfully.
+
+.schedule.success.edit=Edit or reschedule this entry.


### PR DESCRIPTION
Fu, you wanted bugs 29 (draft posts) and 51 (scheduled posts) back, right?

This has drafts more or less working (probably needs some more testing without javascript, especially on
older browsers, plus some better error handling).  Scheduled posts also work, but only in the simplest way;
we don't even check for the dates being in the future, there's no notification for successful or unsuccessful
posts.  That probably needs the most work.
