### PR TITLE
(Bug 5256) : Changed favicon.

### DIFF
--- a/cgi-bin/DW/External/Site/DeviantArt.pm
+++ b/cgi-bin/DW/External/Site/DeviantArt.pm
@@ -68,7 +68,7 @@ sub badge_image {
 
     # for lack of anything better, let's use the favicon
     return {
-        url     => "http://deviantart.com/favicon.ico",
+        url     => "http://i.deviantart.net/favicon.png",
         width   => 16,
         height  => 16,
     }


### PR DESCRIPTION
I think this new icon is coming from the iPhone-specific version of their site - but the same URL without the i. returns a 404. I don't think there's a problem with us using that, so long as they keep it there...
