### PR TITLE
(Bug 4703) Fixes double-loading of stylesheets

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -2480,9 +2480,10 @@ sub res_includes {
     my ( %opts ) = @_;
 
     my $include_js = ! $opts{nojs};
-    my $include_links = ! $opts{nolinks};
     my $include_libs = ! $opts{nolib};
+    my $include_stylesheets = ! $opts{no_stylesheets};
     my $include_script_tags = $opts{script_tags};
+    my $include_links = $include_stylesheets || $include_script_tags;
 
     # TODO: automatic dependencies from external map and/or content of files,
     # currently it's limited to dependencies on the order you call LJ::need_res();
@@ -2669,8 +2670,10 @@ sub res_includes {
             }
         };
 
-        $tags->("stccss",  "<link rel=\"stylesheet\" type=\"text/css\" href=\"$statprefix/___\" />\n");
-        $tags->("wstccss", "<link rel=\"stylesheet\" type=\"text/css\" href=\"$wstatprefix/___\" />\n");
+        if ( $include_stylesheets ) {
+            $tags->("stccss",  "<link rel=\"stylesheet\" type=\"text/css\" href=\"$statprefix/___\" />\n");
+            $tags->("wstccss", "<link rel=\"stylesheet\" type=\"text/css\" href=\"$wstatprefix/___\" />\n");
+        }
 
         if ( $include_script_tags ) {
             $tags->("js",      "<script type=\"text/javascript\" src=\"$jsprefix/___\"></script>\n");
@@ -2683,7 +2686,7 @@ sub res_includes {
 }
 
 sub res_includes_body {
-    return LJ::res_includes( nojs => 1, script_tags => 1 );
+    return LJ::res_includes( nojs => 1, no_stylesheets => 1, script_tags => 1 );
 }
 
 # called to set the active resource group


### PR DESCRIPTION
We call need_res twice now: once at the top of the page (for JS variables and
stylesheets), once at the bottom of the page (for JS scripts).

There was a bug which caused the stylesheets to be printed twice. Oops...
