### PR TITLE
(bug 5280) Workaround for bug in IO::Socket::SSL+LWPx::ParanoidAgent

### DIFF
--- a/bin/checkconfig.pl
+++ b/bin/checkconfig.pl
@@ -264,6 +264,9 @@ my %modules = (
                "Image::ExifTool" => {
                    deb => 'libimage-exiftool-perl',
                },
+# Workaround for IO::Socket::SSL + LPWx::ParanoidAgent
+#  ( see bug 5280 ) - 2013-10-25
+               "Crypt::SSLeay" => {}
               );
 
 

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -99,6 +99,13 @@ use DW::Mood;
 use LJ::Global::Img;  # defines LJ::Img
 use DW::Media;
 
+# Workaround for IO::Socket::SSL + LPWx::ParanoidAgent
+#  ( see bug 5280 ) - 2013-10-25
+BEGIN {
+    use Net::SSL;
+    $Net::HTTPS::SSL_SOCKET_CLASS = "Net::SSL";
+}
+
 # make Unicode::MapUTF8 autoload:
 sub Unicode::MapUTF8::AUTOLOAD {
     die "Unknown subroutine $Unicode::MapUTF8::AUTOLOAD"


### PR DESCRIPTION
Some combination of those two modules causes https://
to fail on "large" files ( >= 20k, in my tests )
