### PR TITLE
(Bug 4257) Show number of unread flagged items in inbox

### DIFF
--- a/cgi-bin/LJ/NotificationInbox.pm
+++ b/cgi-bin/LJ/NotificationInbox.pm
@@ -573,6 +573,13 @@ sub can_add_bookmark {
     return 1;
 }
 
+# return count of unread bookmarks
+sub bookmark_count {
+    my ( $self, $count ) = @_;
+    my $unread_bookmark_count = scalar grep { $_->unread } $self->bookmark_items;
+    return $unread_bookmark_count;
+}
+
 sub delete_all {
     my ( $self, $view, %args ) = @_;
     my @items;

--- a/cgi-bin/LJ/Widget/InboxFolderNav.pm
+++ b/cgi-bin/LJ/Widget/InboxFolderNav.pm
@@ -51,8 +51,8 @@ sub render_body {
 
         my $link = qq{<a href=".?view=$link_view" class="$class" id="esn_folder_$link_view">};
         $link .= BML::ml( $link_label );
-        $link .= " $img" if $img;
         $link .= $unread if $unread;
+        $link .= " $img" if $img;
         $link .= qq{</a>\n};
         return $link;
     };
@@ -97,7 +97,7 @@ sub render_body {
     $body .= $subfolder_link->( "usermsg_sent", "inbox.menu.sent", "subs", 
         $unread_html->( $inbox->usermsg_sent_event_count ) ) if LJ::is_enabled( 'user_messaging' );
     $body .= qq{<span class="subs">&nbsp;</span>\n};
-    $body .= $subfolder_link->( "bookmark", "inbox.menu.bookmarks", "subs", "", LJ::img( 'flag', '' ) );
+    $body .= $subfolder_link->( "bookmark", "inbox.menu.bookmarks", "subs", $unread_html->( $inbox->bookmark_count ), LJ::img( 'flag', '' ) );
     $body .= $subfolder_link->( "archived", "inbox.menu.archive", "subs" ) if LJ::is_enabled( 'esn_archive' );
     $body .= qq{
             </p></div>&nbsp;<br />


### PR DESCRIPTION
Adds a count of the number of unread flagged items in the inbox, in line
with the count given for the other subfolders, which is also just of the
unread items.
