### PR TITLE
(Bug 5254) Fallback to ext_123.livejournal.com

### DIFF
--- a/t/importer-remap-username.t
+++ b/t/importer-remap-username.t
@@ -1,0 +1,25 @@
+use strict;
+use Test::More tests => 3;
+use lib "$ENV{LJHOME}/cgi-bin";
+BEGIN { require 'ljlib.pl'; }
+use LJ::Test qw( temp_user);
+
+use DW::Worker::ContentImporter::LiveJournal;
+
+note( "check a username we know exists on livejournal.com" );
+{
+    my $uid = DW::Worker::ContentImporter::LiveJournal->remap_username_friend( {
+                 hostname => "livejournal.com",
+                }, "system" );
+    ok( $uid, "Got back a userid ($uid) for system\@livejournal.com" );
+}
+
+note( "check an openid username on the remote site (that is, they're not local to the site we're importing from)" );
+{
+    my $uid = DW::Worker::ContentImporter::LiveJournal->remap_username_friend( {
+                 hostname => "livejournal.com",
+                }, "ext_1662783" );
+
+    ok( $uid, "Got back a userid ($uid) for ext_1662783\@livejournal.com" );
+    is( LJ::load_userid( $uid )->openid_identity, "http://ext-1662783.livejournal.com/", "Local user's openid URL is of format ext-1234.imported-from-site.com" );
+}


### PR DESCRIPTION
For non-openid-based identity users on LJ, we won't be able to find a suitable
identity URL. So just use ext-1234.livejournal.com to identify them.

(Note: ughhhh I can't test as a whole system, because I don't have an
account to import that has the problem. But I have tested the function
that remaps the remote user to a local user)
