### PR TITLE
(Bug 5073) Adjust the error color orange

### DIFF
--- a/htdocs/scss/skins/_alert-colors.scss
+++ b/htdocs/scss/skins/_alert-colors.scss
@@ -1,6 +1,6 @@
 // shared colors for elements between themes
 $_gray:             #e9e9e9;
-$_orange:           #ffbc88;
+$_orange:           #e3741e;
 $_light-orange:     #fff0e4;
 $_light-green:      #e1eed7;
 $_light-yellow:     #fbf9dd;


### PR DESCRIPTION
This adjusts the error color orange to a darker, less bright shade.
