### PR TITLE
(Bug 5295) Respect the opt_noemail setting

### DIFF
--- a/cgi-bin/DW/Controller/EventOutput.pm
+++ b/cgi-bin/DW/Controller/EventOutput.pm
@@ -24,6 +24,7 @@ use DW::Template;
 use DW::Controller::Admin;
 
 use LJ::Event;
+use LJ::Subscription;
 
 DW::Routing->register_string( '/admin/eventoutput', \&event_output, app => 1 );
 DW::Controller::Admin->register_admin_page( '/',
@@ -76,8 +77,20 @@ sub handle_post {
 
     my $u = LJ::load_user( $post{subscr_user} );
 
+    my $subscription_arg1 = int $post{sarg1};
+    my $subscription_arg2 = int $post{sarg2};
+
     my $html_body = $event->as_email_html( $u );
     $html_body = LJ::html_newlines( $html_body ) unless $html_body =~ m!<br!i;
+
+    my $fake_subscr = LJ::Subscription->new_from_row( {
+                            userid  => $u->id,
+                            ntypeid => LJ::NotificationMethod::Email->ntypeid,
+                            etypeid => $eventtype,
+                            arg1    => $subscription_arg1,
+                            arg2    => $subscription_arg2,
+                        });
+
     my $vars = {
         event => {
             email   => {
@@ -87,6 +100,8 @@ sub handle_post {
                 subject     => $event->as_email_subject( $u ),
                 body_html   => $html_body,
                 body_text   => $event->as_email_string( $u ),
+
+                send        => $event->matches_filter( $fake_subscr ),
             },
 
             inbox   => {

--- a/cgi-bin/LJ/Event/JournalNewComment/Reply.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment/Reply.pm
@@ -148,8 +148,10 @@ sub matches_filter {
     my $comment = $self->comment;
 
     # Do not send on own comments
-
     return 0 unless $comment->visible_to( $watcher );
+
+    # Do not send if opt_noemail applies
+    return 0 if $self->apply_noemail( $watcher, $comment, $subscr->method );
 
     my $parent = $comment->parent;
 
@@ -157,7 +159,7 @@ sub matches_filter {
         # Someone replies to my comment
         return 0 unless $parent;
         return 0 unless $parent->posterid == $watcher->id;
-        
+
         # Make sure we didn't post the comment
         return 1 unless $comment->posterid == $watcher->id;
     } elsif ( $arg2 == 1 ) {

--- a/views/admin/eventoutput-select.tt
+++ b/views/admin/eventoutput-select.tt
@@ -62,6 +62,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
         <label for="arg[%loop.count%]">[% arg %]:</label> <input type="text" name="arg[%loop.count%]" id="arg[%loop.count%]" />[% note %]
     </li>
     [%- END -%]
+
+    [%- FOREACH arg_num = [ 1, 2 ] -%]
+    <li>
+        <label for="sarg[% arg_num %]">[% ".form.label.sarg" | ml ( arg = arg_num ) %]:</label> <input type="text" name="sarg[%arg_num%]" id="sarg[%arg_num%]" />
+    </li>
+    [%- END -%]
     </ul>
     </fieldset>
 

--- a/views/admin/eventoutput-select.tt.text
+++ b/views/admin/eventoutput-select.tt.text
@@ -7,6 +7,8 @@
 
 .form.label.eventuser=Event Journal
 
+.form.label.sarg=Subscription Argument [[arg]]
+
 .form.label.subscr_user=Subscriber
 
 .subtitle.details=Event Details

--- a/views/admin/eventoutput.tt
+++ b/views/admin/eventoutput.tt
@@ -27,10 +27,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <label>Summary:</label><div class='field'>[% event.inbox.summary %]</div>
 
 <h2>Email</h2>
+[% IF ! event.email.send %]<p>Note: this is only a preview; the subscription is such that it won't actually be sent.</p>
+<div class="disabled">[%- END -%]
 <label>From:</label><div class='field'>[% event.email.from | html %]</div>
 <label>To:</label><div class='field'>[% event.email.to | html %]</div>
 <label>Headers:</label><div class='field'>[% event.email.headers | html %]</div>
 <label>Subject:</label><div class='field'>[% event.email.subject | html %]</div>
 <label>Body (HTML):</label><div class='field'>[% event.email.body_html %]</div>
 <label>Body (Plain text):</label><div class='field'><textarea rows="20" cols="50">[% event.email.body_text %]</textarea></div>
-
+[% IF ! event.email.send %]</div>[%- END -%]


### PR DESCRIPTION
Logic was already in LJ::Event::JournalNewComment, so refactor that out, and
reuse.

(So many hours on so few lines of code! i feel like I've been chasing
ghosts in and out of the machine)
