### PR TITLE
(Bug 5133) Master check-box for email notifs not working on settings/notifications

### DIFF
--- a/htdocs/manage/settings/index.bml
+++ b/htdocs/manage/settings/index.bml
@@ -434,7 +434,9 @@ body<=
     if ($given_cat eq "notifications") {
 
         LJ::set_active_resource_group( 'jquery' );
-        LJ::need_res( { group => 'jquery' }, 'js/notifications.js' );
+        LJ::need_res( { group => 'jquery' }, 'js/notifications.js',
+            'js/6alib/core.js', 'js/6alib/dom.js', 
+            'js/livejournal.js', 'js/esn.js', 'js/6alib/checkallbutton.js' );
 
         $ret .= "<div id='settings_save' class='action-bar'>";
         $ret .= $cats_with_settings{$given_cat}->{form} ? LJ::html_submit($ML{'.btn.save'}) : "&nbsp;";


### PR DESCRIPTION
Adds previously used JavaScript calls into htdocs/manage/settings/index.bml.
