### PR TITLE
(Bug 5286) Darken Light Gray Text on Foundation Pages

### DIFF
--- a/htdocs/scss/skins/celerity.scss
+++ b/htdocs/scss/skins/celerity.scss
@@ -18,7 +18,8 @@ $_light-olive-green: #ddddaa;
 
 $_white:             #fff;
 $_light-gray:        #f7f7f7;
-$_dark-gray:         #e9e9e9;
+$_mid-gray:          #e9e9e9;
+$_dark-gray:         #636363;
 $_low-contrast-gray: #ddd;
 $_off-black:         #222211;
 
@@ -27,9 +28,11 @@ $background-color:   $_white;
 $text-color:         $_off-black;
 $link-color:         $_dark-olive-green;
 
+$inactive-color:     $_dark-gray;
+
 $primary-color:      $_very-dark-olive;
 $primary-text-color: $_white;
-$secondary-color:    $_dark-gray;
+$secondary-color:    $_mid-gray;
 $strong-accent-color:$_very-dark-olive;
 $soft-accent-color:  $_light-olive-green;
 $border-color:       $_low-contrast-gray;
@@ -83,6 +86,13 @@ $input-prefix-border-color:             $input-border-color;
 
 // panel
 $panel-bg:                              darken( $body-bg, 5% );
+
+// sub-nav
+$sub-nav-font-color:	$inactive-color;
+
+// pagination
+$pagination-link-font-color:	$inactive-color;
+$pagination-link-unavailable-font-color:	$inactive-color;
 
 // tables
 $table-bg:              $form-bg-color;

--- a/htdocs/scss/skins/lynx.scss
+++ b/htdocs/scss/skins/lynx.scss
@@ -1,10 +1,12 @@
 // color names. Only use these variables in the color assignment section
-$_black: #000;
-$_white: #FFF;
+$_black:     #000;
+$_white:     #FFF;
+$_dark-gray: #636363;
 
 // color assignment
 $text-color: $_black;
 $primary-text-color: $_white;
+$inactive-color: $_dark-gray;
 
 @import "skins/alert-colors";
 
@@ -14,6 +16,13 @@ $body-font-color:   $text-color;
 $code-color:                            tint( $body-font-color, 20% );
 $blockquote-font-color:                 tint( $body-font-color, 20% );
 $small-font-color:                      $body-font-color;
+
+// sub-nav
+$sub-nav-font-color:	$inactive-color;
+
+// pagination
+$pagination-link-font-color:	 $inactive-color;
+$pagination-link-unavailable-font-color:	$inactive-color;
 
 $include-html-classes: true;
 @import "foundation/foundation";


### PR DESCRIPTION
Lynx:

Set $_dark-gray to #636363, name this $secondary-color, then define
$sub-nav-font-color and $pagination-link-font-color and
$pagination-unavailable-link-font-color to be this color.

Note: The white on blue for active Pagination and Sub Nav links
fails AAA for Normal Text. Not fixed as part of this bug.

Celerity:
Changes $_dark-gray to $_mid-gray and defines $_dark-gray as
color to $sub-nav-font-color and $pagination-link-font-color and
$pagination-unavailable-link-font-color using intermediate variables
$sub-nav-color and $pagination-font-color.

Gradation:
No changes made.

Note: $sub-nav-active-bg (set to $primary-color) fails contrast
check for white text. Not fixed as part of this bug.
