### PR TITLE
(Bug 5073) Use $background-color instead of $body-bg

### DIFF
--- a/htdocs/scss/skins/_community-menu.scss
+++ b/htdocs/scss/skins/_community-menu.scss
@@ -1,5 +1,5 @@
 .community-menu {
-  @include panel( darken( $body-bg, 8% ) );
+  @include panel( darken( $background-color, 8% ) );
   font-size: .8rem;
 
   label {

--- a/htdocs/scss/skins/lynx.scss
+++ b/htdocs/scss/skins/lynx.scss
@@ -7,9 +7,11 @@ $_dark-gray: #636363;
 $text-color: $_black;
 $primary-text-color: $_white;
 $inactive-color: $_dark-gray;
+$background-color: $_white;
 
 @import "skins/alert-colors";
 
+$body-bg:           $background-color;
 $body-font-color:   $text-color;
 $form-font-color:   rgba(0,0,0,0.75);
 $form-bg-color:     #f7f7f7;


### PR DESCRIPTION
$body-bg can contain images, etc, so we can't use darken with this. So just
use $background-color which only contains a color.

Also add this variable to Lynx, which doesn't currently have it (was using the
default before)
