### PR TITLE
(Bug 5329) clarify that only registered users can vote in polls

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1551,3 +1551,13 @@ general setting.commentemailnotify.label
 general setting.commentemailnotify.option
 general setting.selfcommentemail.label
 general setting.selfcommentemail.option
+
+general poll.security
+general poll.security.all
+general poll.security.friends
+general poll.security.none
+general poll.security.none_others|notes
+general poll.security.none_others2
+general poll.security.none_remote|notes
+general poll.security.none_remote
+general poll.security.trusted

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2293,23 +2293,29 @@ poll.respondents.user=[[user]] answered:
 
 poll.scaleanswers=<strong>Mean:</strong> [[mean]] <strong>Median:</strong> [[median]] <strong>Std. Dev</strong> [[stddev]]
 
-poll.security=Open to <strong>[[whovote]]</strong>. Results viewable to <strong>[[whoview]]</strong>
-
-poll.security.all=All
-
-poll.security.friends=Friends
-
-poll.security.none=None
-
-poll.security.none_others|notes=Shown to everyone who can see the poll except the poster
-poll.security.none_others2=Just the Poll Creator
-
-poll.security.none_remote|notes=Shown only to the poster of the poll
-poll.security.none_remote=Just Me
-
-poll.security.trusted=Access List
-
 poll.security2=Open to: <strong>[[whovote]]</strong>, detailed results viewable to: <strong>[[whoview]]</strong>
+
+poll.security.whoview.all=All
+
+poll.security.whoview.friends=Friends
+
+poll.security.whoview.none=None
+
+poll.security.whoview.none_others|notes=Shown to everyone who can see the poll except the poster
+poll.security.whoview.none_others2=Just the Poll Creator
+
+poll.security.whoview.none_remote|notes=Shown only to the poster of the poll
+poll.security.whoview.none_remote=Just Me
+
+poll.security.whoview.trusted=Access List
+
+poll.security.whovote.all=Registered Users
+
+poll.security.whovote.friends=Friends
+
+poll.security.whovote.none=None
+
+poll.security.whovote.trusted=Access List
 
 poll.seeresults=Display Results
 

--- a/cgi-bin/LJ/Poll.pm
+++ b/cgi-bin/LJ/Poll.pm
@@ -816,7 +816,7 @@ sub preview {
         if ($self->isanon eq "yes");
 
     my $whoview = $self->whoview eq "none" ? "none_remote" : $self->whoview;
-    $ret .= LJ::Lang::ml('poll.security2', { 'whovote' => LJ::Lang::ml('poll.security.'.$self->whovote), 'whoview' => LJ::Lang::ml('poll.security.'.$whoview), });
+    $ret .= LJ::Lang::ml('poll.security2', { 'whovote' => LJ::Lang::ml('poll.security.whovote.'.$self->whovote), 'whoview' => LJ::Lang::ml('poll.security.whoview.'.$whoview), });
 
     # iterate through all questions
     foreach my $q ($self->questions) {
@@ -968,8 +968,8 @@ sub render {
     if ($whoview eq "none") {
         $whoview = $remote && $remote->id == $self->posterid ? "none_remote" : "none_others2";
     }
-    $ret .= LJ::Lang::ml('poll.security2', { 'whovote' => LJ::Lang::ml('poll.security.'.$self->whovote),
-                                       'whoview' => LJ::Lang::ml('poll.security.'.$whoview) });
+    $ret .= LJ::Lang::ml('poll.security2', { 'whovote' => LJ::Lang::ml('poll.security.whovote.'.$self->whovote),
+                                       'whoview' => LJ::Lang::ml('poll.security.whoview.'.$whoview) });
 
     $ret .= LJ::Lang::ml('poll.participants', { 'total' => $self->num_participants });
     $ret .= "</div>";

--- a/htdocs/poll/create.bml
+++ b/htdocs/poll/create.bml
@@ -465,9 +465,9 @@ _c?>
             $ret .= "<option value='$sec'";
             $ret .= " selected='selected'" if $poll->{'whoview'} eq $sec;
             if ($sec eq "none") {
-                $ret .= ">" . $ML{'poll.security.none_remote'} . "</option>\n";
+                $ret .= ">" . $ML{'poll.security.whoview.none_remote'} . "</option>\n";
             } else {
-                $ret .= ">" . $ML{'poll.security.' . $sec} . "</option>\n";
+                $ret .= ">" . $ML{'poll.security.whoview.' . $sec} . "</option>\n";
             }
         }
         $ret .= "</select></p>\n";
@@ -476,7 +476,7 @@ _c?>
         foreach my $sec ( qw(all trusted) ) {
             $ret .= "<option value='$sec'";
             $ret .= " selected='selected'" if $poll->{'whovote'} eq $sec;
-            $ret .= ">" . $ML{'poll.security.'.$sec} . "\n";
+            $ret .= ">" . $ML{'poll.security.whovote.'.$sec} . "\n";
         }
         $ret .= "</select></p>\n";
 


### PR DESCRIPTION
-- separate whoview and whovote security strings in en.dat
-- use new strings in poll.pm and /poll/create
-- move old strings to deadphrases.dat
-- also move old poll.security to deadphrases
