### PR TITLE
(Bug 5265) Check if $u is defined first

### DIFF
--- a/htdocs/manage/settings/index.bml
+++ b/htdocs/manage/settings/index.bml
@@ -170,7 +170,7 @@ body<=
         },
         community => {
             name => $ML{'.cat.community'},
-            visible => $u->is_community ? 1 : 0,
+            visible => $u && $u->is_community ? 1 : 0,
             disabled => 0,
             form => 1,
             desc => $ML{'.cat.community.desc'},


### PR DESCRIPTION
Because logged out users can view the account settings page, which means
$u may be undefined here.
