### PR TITLE
(Bug 2165) Revamp community posting options

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2655,13 +2655,17 @@ setting.communitypostlevel.error.invalid=Invalid community post level setting op
 
 setting.communitypostlevel.label=Posting Access
 
-setting.communitypostlevel.option=Entries can be posted to this community by [[option]]
+setting.communitypostlevel.option=[[option]] can post
 
-setting.communitypostlevel.option.select.anybody=anybody, including non-members
+setting.communitypostlevel.option.select.anybody=Anyone, even non-members
 
-setting.communitypostlevel.option.select.members=community members
+setting.communitypostlevel.option.select.members=All members
 
-setting.communitypostlevel.option.select.select=select members, with moderator approval
+setting.communitypostlevel.option.select.select=Select members
+
+setting.communitypostlevelnew.label=New Member Posting
+
+setting.communitypostlevelnew.option=New members are automatically given posting access upon joining
 
 setting.communitypromo.label=Community Promo
 

--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -94,6 +94,14 @@ userproplist.optout_community_promo:
   multihomed: 0
   prettyname: Account creation community promo
 
+userproplist.comm_postlevel_new:
+  cldversion: 4
+  datatype: bool
+  des: Whether new members can post to the community or not
+  indexed: 0
+  multihomed: 0
+  prettyname: Post Level for New Members
+
 userproplist.comm_promo_blurb:
   cldversion: 4
   datatype: char

--- a/cgi-bin/DW/Controller/Community.pm
+++ b/cgi-bin/DW/Controller/Community.pm
@@ -720,7 +720,9 @@ sub members_edit_handler {
     $_->{ljuser} = LJ::ljuser( $_->{name} ) foreach @users;
 
     # figure out what member roles are relevant
-    my @available_roles = ( 'member', 'poster' );
+    my @available_roles = ( 'member' );
+    push @available_roles, 'poster'
+        if $cu->post_level eq 'select';
     my $has_moderated_posting = $cu->has_moderated_posting;
     push @available_roles, 'unmoderated'
         if $has_moderated_posting || $role_count->{N};

--- a/cgi-bin/DW/Setting/CommunityPostLevel.pm
+++ b/cgi-bin/DW/Setting/CommunityPostLevel.pm
@@ -47,6 +47,9 @@ sub option {
         name => "${key}communitypostlevel",
         id => "${key}communitypostlevel",
         selected => $communitypostlevel,
+        class => "js-related-setting",
+        "data-related-setting-id" => DW::Setting::CommunityPostLevelNew->pkgkey,
+        "data-related-setting-on" => "select",
     }, @options );
 
     my $ret;
@@ -90,6 +93,9 @@ sub save {
     $u->set_comm_settings( $remote, { membership => $current_comm_membership, postlevel => $val });
     $u->set_prop({ nonmember_posting => $nonmember_posting });
 
+    # unconditionally give posting access to all members
+    my $cid = $u->userid;
+    LJ::set_rel_multi( (map { [$cid, $_, 'P'] } $u->member_userids ) );
     return 1;
 }
 

--- a/cgi-bin/DW/Setting/CommunityPostLevelNew.pm
+++ b/cgi-bin/DW/Setting/CommunityPostLevelNew.pm
@@ -1,0 +1,36 @@
+#!/usr/bin/perl
+#
+# DW::Setting::CommunityPostLevelNew
+#
+# DW::Setting module for whether new members should be able to post to the community or not when they join
+#
+# Authors:
+#      Afuna <coder.dw@afunamatata.com>
+#
+# Copyright (c) 2014 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::Setting::CommunityPostLevelNew;
+use base 'LJ::Setting::BoolSetting';
+use strict;
+
+sub should_render { return $_[1]->is_community }
+
+sub label { $_[0]->ml( 'setting.communitypostlevelnew.label' ) }
+sub des { $_[0]->ml( 'setting.communitypostlevelnew.option' ) }
+
+sub prop_name { "comm_postlevel_new" }
+sub checked_value { 1 }
+sub unchecked_value { 0 }
+
+sub option {
+    my ( $class, $u, $errs, $args ) = @_;
+    return $class->as_html( $u, $errs, $args );
+}
+
+sub is_conditional_setting { 1 }
+1;

--- a/cgi-bin/LJ/Community.pm
+++ b/cgi-bin/LJ/Community.pm
@@ -309,7 +309,7 @@ sub join_community {
             $addpostacc = $canpost ? 1 : 0;
         } else {
             my $crow = $cu->get_community_row;
-            $addpostacc = $crow->{postlevel} eq 'members' ? 1 : 0
+            $addpostacc = $crow->{postlevel} eq 'members' || $cu->prop( 'comm_postlevel_new' ) ? 1 : 0
                 if defined $crow->{postlevel};
         }
     }

--- a/cgi-bin/LJ/Setting.pm
+++ b/cgi-bin/LJ/Setting.pm
@@ -24,6 +24,7 @@ LJ::ModuleLoader->require_subclasses( "DW::Setting" );
 # ----------------------------------------------------------------------------
 
 sub should_render { 1 }
+sub is_conditional_setting { 0 }
 sub disabled { 0 }
 sub selected { 0 }
 sub label { "" }

--- a/htdocs/js/jquery.settings.js
+++ b/htdocs/js/jquery.settings.js
@@ -1,0 +1,23 @@
+(function($) {
+    $.fn.relatedSetting = function() {
+        this.bind('setting_change', function(e) {
+            var $this = $(this);
+
+            var toggleOn = $this.data("related-setting-on");
+            var selected = ($this.val() === toggleOn);
+            var $related = $("#"+$this.data("related-setting-id"))
+
+            $related.toggle(selected);
+        });
+
+        this
+            .change(function(e) { $(this).trigger('setting_change')} )
+            .trigger('setting_change');
+
+        return this;
+    };
+})(jQuery);
+
+jQuery(function($) {
+    $('.js-related-setting').relatedSetting();
+});

--- a/htdocs/manage/settings/index.bml
+++ b/htdocs/manage/settings/index.bml
@@ -24,6 +24,11 @@ body<=
     LJ::need_res("stc/tabs.css", "stc/settings.css", "js/settings.js");
     LJ::set_active_crumb('manage');
 
+    LJ::need_res({ group => 'jquery' },
+        "js/jquery.settings.js"
+    );
+    LJ::set_active_resource_group( "jquery" );
+
     my $remote = LJ::get_remote();
     my $authas;
     my $u;
@@ -177,6 +182,7 @@ body<=
             settings => [qw(
                 DW::Setting::CommunityMembership
                 DW::Setting::CommunityPostLevel
+                DW::Setting::CommunityPostLevelNew
                 DW::Setting::CommunityEntryModeration
                 DW::Setting::CommunityJoinLinks
                 DW::Setting::CommunityGuidelinesLocation
@@ -440,8 +446,10 @@ body<=
     $ret .= "</p></div>";
 
     if ($cats_with_settings{$given_cat}->{form}) {
-        my $confirm_msg = LJ::ejs($ML{'.form.confirm1'});
-        $ret .= "<script>Settings.confirm_msg = \"$confirm_msg\";</script>";
+        if ( $LJ::ACTIVE_RES_GROUP ne "jquery"  ) {
+            my $confirm_msg = LJ::ejs($ML{'.form.confirm1'});
+            $ret .= "<script>Settings.confirm_msg = \"$confirm_msg\";</script>";
+        }
         $ret .= "<form class='table-form' id='settings_form' action='$LJ::SITEROOT/manage/settings/$getextra${getsep}cat=$given_cat' method='post'>";
         $ret .= LJ::form_auth();
     }
@@ -590,9 +598,11 @@ body<=
         ) . "<br />";
 
     } else {
-        my $setting_ct = 1;
+        my $setting_ct = 0;
         $ret .= "<table summary=''>";
         foreach my $setting (@settings) {
+            $setting_ct++ unless $setting->is_conditional_setting;
+
             my $errors = $setting->errors_from_save($save_rv);
             my $args = $setting->args_from_save($save_rv);
 
@@ -603,14 +613,13 @@ body<=
             my $last_class = $setting_ct == scalar @settings ? " last" : "";
 
             my $row_class = $setting_ct % 2 == 0 ? "even" : "odd";
-            $ret .= "<tr class='$row_class'>";
+            my $setting_id = $setting->pkgkey;
+            $ret .= "<tr class='$row_class' id='$setting_id'>";
             $ret .= "<th class='${given_cat}_label$last_class'>$label</th>" if $label;
             $ret .= "<td class='${given_cat}_option$last_class'>" . ($option ? $option : "&nbsp;") . "</td>";
             $ret .= "<td class='${given_cat}_actionlink$last_class'>" . ($actionlink ? $actionlink : "&nbsp;") . "</td>";
             $ret .= "<td class='help$last_class'>" . ($helpicon ? $helpicon : "&nbsp;") . "</td>";
             $ret .= "</tr>";
-
-            $setting_ct++;
         }
         $ret .= "</table>";
 

--- a/htdocs/stc/settings.css
+++ b/htdocs/stc/settings.css
@@ -1,5 +1,4 @@
 /*Common */
-
 #settings_page img {
     border: 0;
 }
@@ -19,20 +18,20 @@
 }
 
 /* Shared Content */
-.account table, .display table, .mobile table, .privacy table, .history table, .othersites table {
+.account table, .display table, .mobile table, .privacy table, .history table, .othersites table, .community table {
     width: 100%;
 }
-.account td, .display td, .mobile td, .privacy td, .history td, .othersites td {
+.account td, .display td, .mobile td, .privacy td, .history td, .othersites td, .community td {
     padding: 10px 10px 10px 5px;
 }
-.account td.last, .display td.last, .mobile td.last, .privacy td.last, .history td.last, .othersites td.last {
+.account td.last, .display td.last, .mobile td.last, .privacy td.last, .history td.last, .othersites td.last, .community td.last {
     border-bottom: none;
 }
-.account td.help, .display td.help, .mobile td.help, .privacy td.help, .history td.help, .othersites td.help {
+.account td.help, .display td.help, .mobile td.help, .privacy td.help, .history td.help, .othersites td.help, .community td.help {
     width: 14px;
     text-align: right;
 }
-.account_label, .display_label, .mobile_label, .privacy_label, .history_label, .othersites_label {
+.account_label, .display_label, .mobile_label, .privacy_label, .history_label, .othersites_label, .community_label {
     font-weight: bold;
 }
 


### PR DESCRIPTION
- "All members" now grants posting access to _all_ members, instead of
  still allowing you to selectively grant/take away access. This applies
  retroactively (so everyone, including those who didn't explicitly have
  posting access before, can now post to the community)
- "Select members" acts as described: you can choose which of your
  members has posting access
- New option: "new members can/cannot post" which is only visible when
  "select members" is selected. "New members can post" is like the old
  "all members" option. "New members cannot post" is like the old
  "select members" option. Default is for new members to be unable to
  post unless; they have to be given posting access
