### PR TITLE
(bug 5191) can make entries with slug URLs sticky

### DIFF
--- a/cgi-bin/LJ/User.pm
+++ b/cgi-bin/LJ/User.pm
@@ -3257,8 +3257,8 @@ sub sticky_entry {
         }
 
         # takes slug from URL
-        $slug = $3
-            if $input =~ m!^(.+)/(\d\d\d\d/\d\d/\d\d)/([a-z0-9_-]+)\.html$!;
+        $slug = $1
+            if $input =~ m!^(?:.+)/(?:\d\d\d\d/\d\d/\d\d)/([a-z0-9_-]+)\.html$!;
 
         #checks that one of $slug and $ditemid exists
         return 0 unless $ditemid || $slug;


### PR DESCRIPTION
Previously, you could only use a ditemid or a URL with ditemid to set
a sticky entry; putting in a URL with a slug would lead to an error
message.

I modified sub sticky_entry in cgi-bin/LJ/User.pm so that it would accept
ditemids, URLs with ditemids, and URLs with slugs. sticky_entry still
validates the entry and uses its ditemid to set the sticky property.

Testing:
Used the free individual account test_free on my 'hack

Strings that set the corresponding entry as sticky:
- "http://test-free.quartzpebble.hack.dreamwidth.net/1202.html"
- "http://test-free.quartzpebble.hack.dreamwidth.net/2014/03/25/slugbug.html" (public entry)
- "http://test-free.quartzpebble.hack.dreamwidth.net/2014/03/24/friendly-slug.html" (access-locked entry)
- "http://test-free.quartzpebble.hack.dreamwidth.net/2014/03/25/private-slug.html" (private entry)
- "test-free.quartzpebble.hack.dreamwidth.net/2014/03/25/private-slug.html"
- "test-free.quartzpebble.hack.dreamwidth.net/2014/03/21/private-slug.html" <-- note date doesn't matter
- setting "" or " " still removes the current sticky entry

Strings that resulted in an error message ("Invalid Dreamwidth entry ID or URL entered."):
- "slugbug"
- "private-slug"
- ";ouasenouth"
- '!@$%(*#&%#"@'
- "http://test-free.quartzpebble.hack.dreamwidth.net/2014/03/25/private slug.html"
- "http://test-free.quartzpebble.hack.dreamwidth.net/2014/03/25/private-slug"
