### PR TITLE
Issue #658 patch: updating landing page for screened comments

### DIFF
--- a/htdocs/talkpost_do.bml
+++ b/htdocs/talkpost_do.bml
@@ -244,7 +244,7 @@ body<=
             if ( $POST{'usertype'} eq 'anonymous' ) {
                 $mlcode = 'success.screened.comm.anon2';
             } elsif ( $commentu && $commentu->can_manage( $journalu ) ) {
-                $mlcode = '.success.screened.comm.owncomm2';
+                $mlcode = '.success.screened.comm.owncomm3';
             } else {
                 $mlcode = '.success.screened.comm2';
             }
@@ -252,7 +252,7 @@ body<=
             if ( $POST{'usertype'} eq 'anonymous' ) {
                 $mlcode = '.success.screened.user.anon2';
             } elsif ( $commentu && $commentu->equals( $journalu ) ) {
-                $mlcode = '.success.screened.user.ownjournal';
+                $mlcode = '.success.screened.user.ownjournal2';
             } else {
                 $mlcode = '.success.screened.user2';
             }

--- a/htdocs/talkpost_do.bml.text
+++ b/htdocs/talkpost_do.bml.text
@@ -92,13 +92,13 @@
 
 .success.screened.comm.anon2=Your anonymous comment has been added and marked as screened; it will be visible only to the community administrators until they choose to unscreen it. <a [[aopts]]>Go back to the comment thread</a>.
 
-.success.screened.comm.owncomm2=Your comment has been added. According to this community or entry's settings, it was marked as screened, and will be visible only to you and any other community admins until one of you chooses to unscreen it. You can view your comment <a [[aopts]]>here</a>.
+.success.screened.comm.owncomm3=Your comment has been added. According to this community or entry's settings, it was marked as screened, and will be visible only to you and any other community admins until one of you chooses to unscreen it. <a [[aopts]]>View your comment</a>.
 
 .success.screened.comm2=Your comment has been added and marked as screened; it will be visible only to you and the community administrators until they choose to unscreen it. <a [[aopts]]>View your comment</a>.
 
 .success.screened.user.anon2=Your anonymous comment has been added. According to this account's settings, it was marked as screened and will be visible only to the account owner until the owner chooses to unscreen it. <a [[aopts]]>Go back to the comment thread</a>.
 
-.success.screened.user.ownjournal=Your comment has been added. According to this journal's settings, it was marked as screened, and will be visible only to you until you choose to unscreen it. You can view your comment <a [[aopts]]>here</a>.
+.success.screened.user.ownjournal2=Your comment has been added. According to this journal's settings, it was marked as screened, and will be visible only to you until you choose to unscreen it. <a [[aopts]]>View your comment</a>.
 
 .success.screened.user2=Your comment has been added. According to this account's settings, it was marked as screened and will be visible only to you and the journal's owner until the owner chooses to unscreen it. <a [[aopts]]>View your comment</a>.
 


### PR DESCRIPTION
Tested on my dreamhack: 

Replied to the journal owner's own screened comment: http://test-free.quartzpebble.hack.dreamwidth.net/1202.html?view=1458#cmt1458
Result:
Your comment has been added. According to this journal's settings, it was marked as screened, and will be visible only to you until you choose to unscreen it. View your comment.

Commented here, replying to another journal's screened comment: http://test-free.quartzpebble.hack.dreamwidth.net/1202.html?thread=1202#cmt1202
Result:
Your comment has been added. According to this journal's settings, it was marked as screened, and will be visible only to you until you choose to unscreen it. View your comment.

Replying to own screened comment on own post in community. http://test-comm-free.quartzpebble.hack.dreamwidth.net/443.html?view=699#cmt699
Result:
Your comment has been added. According to this community or entry's settings, it was marked as screened, and will be visible only to you and any other community admins until one of you chooses to unscreen it. View your comment.

Community administrator replies to non-member's screened comment. http://test-comm-free.quartzpebble.hack.dreamwidth.net/443.html?view=1211#cmt1211
Result:
Your comment has been added. According to this community or entry's settings, it was marked as screened, and will be visible only to you and any other community admins until one of you chooses to unscreen it. View your comment.
