### PR TITLE
Bug 668: changed widget.location.fn.state.inline to "state/province/territory"

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -5195,7 +5195,7 @@ widget.location.fn.province=or non-US State/province/territory
 
 widget.location.fn.state=State
 
-widget.location.fn.state.inline=state
+widget.location.fn.state.inline2=state/province/territory
 
 widget.location.fn.timezone=Timezone
 

--- a/cgi-bin/LJ/Widget/Location.pm
+++ b/cgi-bin/LJ/Widget/Location.pm
@@ -59,7 +59,7 @@ sub render_body {
     my $state_options = $regions_cfg ? $class->region_options($regions_cfg) : undef;
 
 
-    my $state_inline_desc = $class->ml('widget.location.fn.state.inline');
+    my $state_inline_desc = $class->ml('widget.location.fn.state.inline2');
     my $city_inline_desc = $class->ml('widget.location.fn.city.inline');
 
     my $ret;
@@ -198,7 +198,7 @@ sub handle_post {
     my %countries;
     LJ::load_codes({ "country" => \%countries});
 
-    my $state_inline_desc = $class->ml('widget.location.fn.state.inline');
+    my $state_inline_desc = $class->ml('widget.location.fn.state.inline2');
     my $state_from_dropdown = $class->ml('states.head.defined');
     my $city_inline_desc = $class->ml('widget.location.fn.city.inline');
 


### PR DESCRIPTION
Changed widget.location.fn.state.inline from "state" to "state/province/territory".

Testing: 
http://www.quartzpebble.hack.dreamwidth.net/manage/profile/ (logged in as test_free) now shows "state/region/territory" as the inline text for the "state" box in the Identity/Location/country-state-city textboxes. 
