### PR TITLE
(Issue #691) Hide 'track thread' icon from free users

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -3443,7 +3443,7 @@ sub _Comment__get_link
 
     if ($key eq "watch_thread" || $key eq "unwatch_thread" || $key eq "watching_parent") {
         return $null_link unless LJ::is_enabled('esn');
-        return $null_link unless $remote && $remote->can_use_esn;
+        return $null_link unless $remote && $remote->can_use_esn && $remote->can_track_thread;
 
         if ($key eq "unwatch_thread") {
             return $null_link unless $remote->has_subscription(journal => $u, event => "JournalNewComment", arg2 => $comment->jtalkid);


### PR DESCRIPTION
Checks whether a user can track threads before displaying tracking icon. Fixes #691.
