### PR TITLE
(Issue #661) Allow People with Siteadmin Priv to PM Uncomfirmed Accounts

### DIFF
--- a/htdocs/inbox/compose.bml
+++ b/htdocs/inbox/compose.bml
@@ -121,7 +121,7 @@ body<=
                 }
 
                 # Can't send to unvalidated users
-                unless ($tou->is_validated) {
+                unless ( $tou->is_validated || $remote->has_priv( "siteadmin", "*" ) ) {
                     push @errors, BML::ml( 'error.message.unvalidated',
                       { ljuser => $tou->ljuser_display } );
                     next;


### PR DESCRIPTION
Allows somebody to PM an unvalidated account (unconfirmed email address) if they have the siteadmin:\* priv. Fixes #661.
