### PR TITLE
Display poster column only when relevant

### DIFF
--- a/cgi-bin/DW/Controller/Community.pm
+++ b/cgi-bin/DW/Controller/Community.pm
@@ -416,7 +416,9 @@ sub members_new_handler {
     }
 
     # figure out what member roles are relevant
-    my @available_roles = ( 'member', 'poster' );
+    my @available_roles = ( 'member' );
+    push @available_roles, 'poster'
+        if $cu->post_level eq 'select';
     push @available_roles, qw( unmoderated moderator )
         if $cu->has_moderated_posting;
     push @available_roles, 'admin';
@@ -722,7 +724,7 @@ sub members_edit_handler {
     # figure out what member roles are relevant
     my @available_roles = ( 'member' );
     push @available_roles, 'poster'
-        if $cu->post_level eq 'select';
+        if $cu->post_level eq 'select' || $role_count->{P};
     my $has_moderated_posting = $cu->has_moderated_posting;
     push @available_roles, 'unmoderated'
         if $has_moderated_posting || $role_count->{N};


### PR DESCRIPTION
- in members/new, only show the poster column if the community post
  level is "select", instead of always showing (that was left over from
  when you could always revoke poster access, even if the post level was
  "all")
- in members/edit, always show the poster column if anyone has "posting
  access" set on them (this makes it act the same as
  unmoderated/moderator columns). This is a bit of an edge case, caused
  when someone switches community settings, but their community members
  used to have posting access explicitly -- this meant that the members
  would still show up on the "edit community members" page, because they
  still had an edge connected to the community, but there might not be a
  checkbox to uncheck
