### PR TITLE
Fix nested comments not showing up sometimes

### DIFF
--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -4233,7 +4233,11 @@ function print_module_poweredby() {
 function print_module_pagesummary_comment_count(Comment comment) : int {
     var int count = 0;
     var Comment c;
-    var Comment[] replies_stack = $comment.replies;
+
+    # copy over to avoid munging the existing array for other callers
+    var Comment[] replies_stack = [];
+    push $replies_stack, $comment.replies;
+
     while (size $replies_stack) {
       $c = pop $replies_stack;
       push $replies_stack, $c.replies;


### PR DESCRIPTION
We were popping from the original comments array... so in one-column-split,
after processing the page summary module, there were no more comment replies
to be printed. Oops. Fixed by working on a copy of the original array.
