### PR TITLE
Better error message when cleaning out purged members

### DIFF
--- a/cgi-bin/DW/Controller/Community.pm
+++ b/cgi-bin/DW/Controller/Community.pm
@@ -678,14 +678,18 @@ sub members_edit_handler {
             my $u = $us{$uid};
             next unless $u;
 
-            my ( $changed_roles_msg, @added_roles, @removed_roles );
-            push @added_roles, $role_strings{$_}
-                foreach grep { $_ ne "member"           # reinvited members need to confirm, so we don't want a success message
-                                || $uid == $remote_uid  # but if you're adding yourself as a member, that's fine
-                            } keys %{$add_user_to_role{$uid} || {}};
-            push @removed_roles , $role_strings{$_}
-                foreach keys %{$delete_user_to_role{$uid} || {}};
-            push @roles_changed, { user => $u->ljuser_display, added => \@added_roles, removed => \@removed_roles } if @added_roles || @removed_roles;
+            if ( $post->{"action:purge"} ) {
+                push @roles_changed, { user => $u->ljuser_display, purged => 1 };
+            } else {
+                my ( $changed_roles_msg, @added_roles, @removed_roles );
+                push @added_roles, $role_strings{$_}
+                    foreach grep { $_ ne "member"           # reinvited members need to confirm, so we don't want a success message
+                                    || $uid == $remote_uid  # but if you're adding yourself as a member, that's fine
+                                } keys %{$add_user_to_role{$uid} || {}};
+                push @removed_roles , $role_strings{$_}
+                    foreach keys %{$delete_user_to_role{$uid} || {}};
+                push @roles_changed, { user => $u->ljuser_display, added => \@added_roles, removed => \@removed_roles } if @added_roles || @removed_roles;
+            }
         }
 
     }

--- a/views/communities/members/edit.tt
+++ b/views/communities/members/edit.tt
@@ -34,12 +34,15 @@ the same terms as Perl itself.  For a copy of the license, please reference
   [%- END -%]
   [%- FOREACH role = roles_changed -%]
     <div class="alert-box success">[%-  role.user -%] - 
-      [%- IF role.added.size > 0 -%]
+      [%- IF role.added and role.added.size > 0 -%]
         [%- '.success.added' | ml( list = role.added.join( ", " ) ) -%]
       [%- END -%]
-      [%- IF role.added.size > 0 and role.removed.size > 0 -%]; [% END -%]
-      [%- IF role.removed.size > 0 -%]
+      [%- IF role.added and role.added.size > 0 and role.removed and role.removed.size > 0 -%]; [% END -%]
+      [%- IF role.removed and role.removed.size > 0 -%]
         [%- '.success.removed' | ml( list = role.removed.join( ", ") ) -%]
+      [%- END -%]
+      [%- IF role.purged -%]
+        [%- '.success.purged' | ml -%]
       [%- END -%]
     </div>
   [%- END -%]

--- a/views/communities/members/edit.tt.text
+++ b/views/communities/members/edit.tt.text
@@ -50,6 +50,8 @@ To manage your communities please visit [your community management page]([[commu
 
 .success.added=added: [[list]]
 
+.success.purged=removed from community
+
 .success.removed=removed: [[list]]
 
 .title=Edit Community Members

--- a/views/communities/members/purge.tt
+++ b/views/communities/members/purge.tt
@@ -32,7 +32,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- END -%]
     [%- END -%]
 
-    [%- form.submit( value = dw.ml( '.confirm.button' ) ) -%]
+    [%- form.submit( value = dw.ml( '.confirm.button' ), name = "action:purge" ) -%]
 
     <a href="[% members_url %]" class="secondary button">[% '.back' | ml %]</a>
 </form>


### PR DESCRIPTION
Instead of saying "removed: (list of all roles)" which may or may not be true,
just say that they were removed from the community
