### PR TITLE
Fix "change email" function

### DIFF
--- a/cgi-bin/DW/Controller/ChangeEmail.pm
+++ b/cgi-bin/DW/Controller/ChangeEmail.pm
@@ -43,6 +43,7 @@ sub changeemail_handler {
     return error_ml( '/changeemail.tt.error.suspended' ) if $u->is_suspended;
     
     $vars->{getextra} = ( $u ne $remote) ? ( "?authas=" . $u->user ) : '';
+    $vars->{usessl} = $LJ::USE_SSL;
 
     my $is_identity_no_email = $u->is_identity && !$u->email_raw;
     $vars->{noemail} = 1 if $is_identity_no_email;
@@ -51,13 +52,13 @@ sub changeemail_handler {
     $vars->{is_community} = 1 if $u->is_community;
 
     # Warn if logged in and not validated
-    $vars->{notvalidated} = 1 if ( $u && !LJ::did_post() && $u->{'status'} ne 'A' && !$is_identity_no_email );
+    $vars->{notvalidated} = 1 if ( $u && !$r->did_post && $u->{'status'} ne 'A' && !$is_identity_no_email );
 
     $vars->{old_email} = $is_identity_no_email ? '' : $u->email_raw;
 
     $vars->{authas_html} = $rv->{authas_html};
-    
-    if ( ( $post->{mode} || "" ) eq 'submit' && ( $post->{email} || $post->{password} ) ) {
+
+    if ( $r->did_post && ( $post->{email} || $post->{password} ) ) {
         my $password;
         $password = $post->{password} unless $remote->is_identity;
         my $email = LJ::trim( $post->{email} );

--- a/views/changeemail.tt
+++ b/views/changeemail.tt
@@ -47,7 +47,7 @@ the same terms as Perl itself. For a copy of the license, please reference
         [% authas_html %]
     </form>
     
-    <form action='[% site.root %]/changeemail[% getextra %]' method='post'>
+    <form action='[% IF usessl %][% site.ssl.root %][% ELSE %][% site.root %][% END %]/changeemail[% getextra %]' method='post'>
         [% dw.form_auth() %]
     
         <br/><br/><div>[% '.label.username' | ml %]<br />[% u.ljuser_display %]</div><br/>


### PR DESCRIPTION
Steps to reproduce:
Go to change email page https://www.dreamwidth.org/changeemail
Fill out fields, then click "change email address" button
The email address does not change, no "your email has been changed" emails are sent, and no error messages are thrown. There are no errors in the inbox either.

This was first noticed after the 9 June code push. Reported by shatteredshards, confirmed by myself and Pau on varying browsers/OSes. Pau thinks it might have something to do with this: https://github.com/dreamwidth/dw-free/commit/9e6946417f8ce43ce6c8fa6bcdb8f1bd32806639
