### PR TITLE
Don't print out too many closing divs

### DIFF
--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -6127,13 +6127,16 @@ function EntryPage::print_comments (Comment[] cs) {
         push $cs_stack, reverse $c.replies;
 
         # close some divs when not increasing depth
-        if ($c.depth < $MAX_NESTED_DEPTH  and $prev_depth >= 0) {
+        if ($c.depth < $MAX_NESTED_DEPTH and $prev_depth >= 0) {
             for (var int i = $prev_depth; $i >= $c.depth; $i--) {
                 "</div>\n";
             }
         }
 
-        $prev_depth = $c.depth;
+        if ($c.depth < $MAX_NESTED_DEPTH) {
+            $prev_depth = $c.depth;
+        }
+
         if ($first_depth < 0) {
             $first_depth = $c.depth;
         }
@@ -6159,7 +6162,7 @@ function EntryPage::print_comments (Comment[] cs) {
         }
     }
 
-    if ($c.depth < $MAX_NESTED_DEPTH) {
+    if ($c.depth <= $MAX_NESTED_DEPTH) {
         # close any remaining divs
         for (var int i = $prev_depth; $i >= $first_depth; $i--) {
             "</div>\n";


### PR DESCRIPTION
Make sure not to update the $prev_depth variable past MAX_NESTED_DEPTH
(because the div should be closed immediately).
