### PR TITLE
Allow long subjects in emailed entries

### DIFF
--- a/cgi-bin/DW/EmailPost/Entry.pm
+++ b/cgi-bin/DW/EmailPost/Entry.pm
@@ -123,7 +123,7 @@ sub _process {
 
     # post!
     my $post_error;
-    LJ::Protocol::do_request( "postevent", $req, \$post_error, { noauth => 1 } );
+    LJ::Protocol::do_request( "postevent", $req, \$post_error, { noauth => 1, allow_truncated_subject => 1 } );
     return $self->send_error( LJ::Protocol::error_message( $post_error ) ) if $post_error;
 
     $self->dblog( s => $self->{subject} );

--- a/t/data/emailpost/long-subject.txt
+++ b/t/data/emailpost/long-subject.txt
@@ -1,0 +1,12 @@
+Return-Path: <${FROM_EMAIL}>
+Delivered-To: bradfitz@danga.com
+To: LJ LJ <${TEMPUSER}+${EMAILPIN}@${POSTDOMAIN}>
+Mime-Version: 1.0 (Apple Message framework v752.2)
+Message-Id: <0DA4840B-93E7-4B3C-A278-4D4D10A3EA1A@tangent.org>
+Content-Transfer-Encoding: 7bit
+From: ${FROM_EMAIL}
+Date: Mon, 1 Jan 2007 12:28:00 -0800
+X-Mailer: Apple Mail (2.752.2)
+Subject: Here's an entry emailed-in with a long subject (>100 characters) which will end up being truncated silently and let through instead of being rejected
+
+This entry has a long subject, which we should allow through not reject.


### PR DESCRIPTION
Don't fail; instead just truncate. (we don't send back an error message, or they could be emailing in things from, e.g., instagram so treat this more like the bulk entry methods instead of the interactive ones where someone could be reasonably expected to edit and repost)

from @lebaer's comment in #277 
