### PR TITLE
Add metadata to interestdata

### DIFF
--- a/htdocs/misc/interestdata.bml
+++ b/htdocs/misc/interestdata.bml
@@ -35,6 +35,8 @@ _c?>
         return "! invalid user, or no interests\n" unless $ret;
         $ret = "# Note: Polite data miners cache on their end.  Impolite ones get banned.\n" .
             "# <intid> <intcount> <interest ...>\n" .
+            "# metadata:id=" . $u->id . "\n" .
+            "# metadata:journaltype=" . $u->journaltype . "\n" .
             $ret;
         return $ret;
     }


### PR DESCRIPTION
Having basic user metadata (id and journaltype) in the output of interestdata makes it a lot easier to program scripts that use this data without having to take the same data from elsewhere. This pull request adds the metadata in comments for compatibility with existing clients that use this data.

(I will probably work on a user-side /data/interests that would output this data in JSON, too, but I wanted to make the quicker change first. This would be useful for a project I'm working on.)
