### PR TITLE
Enables editing unused styles in the wizard.

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -4833,6 +4833,8 @@ widget.customizetheme.btn.reset=Reset to Default
 
 widget.customizetheme.btn.save=Save Changes
 
+widget.customizetheme.customstyle=You are currently editing your saved style <a [[aopts]]>#[[id]]: [[name]]</a>. <ul><li><a href='/customize/options'>Go back to editing your current style.</a></li><li><a href='/customize/advanced/styles'>Customize other styles.</a></li></ul>
+
 widget.customizetheme.nav.display=Display
 
 widget.customizetheme.nav.display.moodthemes=Mood Themes

--- a/htdocs/customize/advanced/styles.bml
+++ b/htdocs/customize/advanced/styles.bml
@@ -38,12 +38,12 @@ _c?>
         $body = '';
         $authasform->() if $remote;
         $body .= "<?p $_[0] p?>";
-        return;        
+        return;
     };
 
     # authenticate user
     $remote = LJ::get_remote();
-    return $err->($ML{'.error.notloggedin'}) 
+    return $err->($ML{'.error.notloggedin'})
         unless $remote;
 
     my $authas = $GET{'authas'} || $remote->{'user'};
@@ -121,6 +121,16 @@ _c?>
             return BML::redirect("styles$getextra");
         }
 
+        if ($POST{'action:customize'} && !$noactions) {
+            return "<b>$ML{'Error'}</b> $ML{'error.invalidform'}" unless LJ::check_form_auth();
+
+            my $opts;
+            $opts->{args}->{s2id} = $id;
+            $opts->{args}->{authas} = $GET{'authas'} if $GET{'authas'};
+
+            return BML::redirect( LJ::create_url( "/customize/options", %$opts ) );
+        }
+
         # get public layers
         $pub = LJ::S2::get_public_layers();
 
@@ -144,7 +154,7 @@ _c?>
         $POST{core} ||= $POST{core_hidden};
         $core = defined $POST{core} ? $POST{core} : $style->{layer}->{core};
         my $highest_core;
-        map { $highest_core = $_ if $pub->{$_}->{type} eq 'core' && /^\d+$/ && 
+        map { $highest_core = $_ if $pub->{$_}->{type} eq 'core' && /^\d+$/ &&
                 $pub->{$_}->{majorversion} > $pub->{$highest_core}->{majorversion} } keys %$pub;
         unless ( $core ) {
             $core = $highest_core;
@@ -152,7 +162,7 @@ _c?>
             # update in POST to keep things in sync
             $POST{core} = $highest_core;
         }
-        $style->{layer}->{core} = $highest_core unless $style->{layer}->{core}; 
+        $style->{layer}->{core} = $highest_core unless $style->{layer}->{core};
 
         # layout lid
         $layout = $POST{'action:change'} ? $eff_layer{'layout'} : $style->{'layer'}->{'layout'};
@@ -314,10 +324,11 @@ _c?>
                 $body .= $b[1];
                 $body .= "</td><td>";
                 $body .= LJ::html_submit('action:edit', $ML{'.btn.edit'}) . " ";
+                $body .= LJ::html_submit('action:customize', $ML{'.btn.customize'}) . " ";
 
                 my $confirm_msg = LJ::ejs(BML::ml('.delete.confirm', {'id' => $styleid}));
 
-                $body .= LJ::html_submit('action:delete', $ML{'.btn.delete'}, 
+                $body .= LJ::html_submit('action:delete', $ML{'.btn.delete'},
                                          { 'onclick' => "return confirm('$confirm_msg')", disabled => $noactions }) . " ";
                 $body .= LJ::html_submit('action:usestyle', $ML{'.btn.use'}, { 'disabled' => $styleid == $u->{'s2_style'} || $noactions }),
                 $body .= "</form></td></tr>\n";
@@ -439,8 +450,8 @@ _c?>
     my $coresel = $layerselect->('core', 0);
     $body .= $coresel->[0];
     $body .= LJ::html_hidden('core_hidden', $core);
-    my $dis = $coresel->[1]->{'disabled'} || $noactions ? { 'disabled' => 'disabled' } : undef;
-    $body .= " " . LJ::html_submit('action:change', $ML{'.btn.change'}, $dis) . "</td></tr>\n";
+    my $coredis = $coresel->[1]->{'disabled'} || $noactions ? { 'disabled' => 'disabled' } : undef;
+    $body .= " " . LJ::html_submit('action:change', $ML{'.btn.change'}, $coredis) . "</td></tr>\n";
     $body .= "</table>\n";
 
     ### i18nc / layout
@@ -458,8 +469,8 @@ _c?>
     my $layoutsel = $layerselect->('layout', $core);
     $body .= $layoutsel->[0];
     $body .= $layerother->('layout');
-    my $dis = $layoutsel->[1]->{'disabled'} || $noactions ? { 'disabled' => 'disabled' } : undef;
-    $body .= " " . LJ::html_submit("action:change", $ML{'.btn.change'}, $dis) . " </td></tr>\n";
+    my $laydis = $layoutsel->[1]->{'disabled'} || $noactions ? { 'disabled' => 'disabled' } : undef;
+    $body .= " " . LJ::html_submit("action:change", $ML{'.btn.change'}, $laydis) . " </td></tr>\n";
     $body .= "</table>\n";
 
     # do we need to show the rest of the form?

--- a/htdocs/customize/advanced/styles.bml.text
+++ b/htdocs/customize/advanced/styles.bml.text
@@ -7,6 +7,8 @@
 
 .btn.create=Create
 
+.btn.customize=Customize
+
 .btn.delete=Delete
 
 .btn.edit=Edit

--- a/htdocs/customize/options.bml
+++ b/htdocs/customize/options.bml
@@ -30,9 +30,6 @@ body<=
 
     $title = $u->is_community ? $ML{'.title.comm'} : $ML{'.title'};
 
-    # extra arguments for get requests
-    my $getextra = $authas ne $remote->user ? "?authas=$authas" : "";
-
     # if using s1, switch them to s2
     unless ($u->prop('stylesys') == 2) {
         $u->set_prop( stylesys => 2 );
@@ -40,17 +37,30 @@ body<=
 
     my $group = $GET{group} ? $GET{group} : "presentation";
 
+    # only accept valid s2id arguments, or use the s2_style userprop
+    my $s2id = undef;
+    $s2id = $GET{s2id} if $GET{s2id};   # need to be able to accept GET or
+    $s2id = $POST{s2id} if $POST{s2id}; # POST style requests
+    my $styleid = $s2id =~ /[0-9]+/ ? $s2id : $u->prop( 's2_style' );
+
     # make sure there's a style set and load it
-    my $style = LJ::Customize->verify_and_load_style($u);
+    my $style = LJ::Customize->verify_and_load_style( $u, $styleid );
 
     # lazy migration of style name
-    LJ::Customize->migrate_current_style($u);
+    LJ::Customize->migrate_current_style( $u, $styleid );
 
     my $ret;
 
     if (LJ::did_post()) {
-        my @errors = LJ::Widget->handle_post(\%POST, qw(CustomizeTheme CustomTextModule JournalTitles MoodThemeChooser NavStripChooser S2PropGroup LinksList LayoutChooser));
-        $ret .= LJ::bad_input(@errors) if @errors;
+        my @errors = LJ::Widget->handle_post( \%POST,
+            "CustomizeTheme",
+            "JournalTitles",
+            "MoodThemeChooser",
+            "NavStripChooser",
+            "S2PropGroup", { "styleid" => $styleid },
+            "LinksList",
+            "LayoutChooser", { "styleid" => $styleid } );
+        $ret .= LJ::bad_input( @errors ) if @errors;
     }
 
     $ret .= "<form action='$LJ::SITEROOT/customize/options' method='get' class='theme-switcher'>";
@@ -77,6 +87,7 @@ body<=
         group => $group,
         headextra => \$headextra,
         post => \%POST,
+        styleid => $styleid,
     );
     $ret .= "</div><!-- end .customize-wrapper -->";
 
@@ -87,6 +98,7 @@ body<=
     $ret .= $layout_chooser->render(
         headextra => \$headextra,
         no_theme_chooser => 1,
+        styleid => $styleid,
     );
     $ret .= "</div><!-- end .layout-selector-wrapper' -->";
 


### PR DESCRIPTION
- Adds a styleid variable to the wizard widgets, so it is not always
  assuming the current style.
- Gives an indication that the style being editing in the wizard is not the
  current style

Fixes Issue #759.
