### PR TITLE
Add MIME::Base64::URLSafe to checkconfig.pl

### DIFF
--- a/bin/checkconfig.pl
+++ b/bin/checkconfig.pl
@@ -268,6 +268,9 @@ my %modules = (
                    deb => 'libimage-exiftool-perl',
                },
                "Net::SSL" => { ver => "2.85" },
+               "MIME::Base64::URLSafe" => {
+                   deb => 'libmime-base64-urlsafe-perl',
+               },
               );
 
 


### PR DESCRIPTION
The dependency on MIME::Base64::URLSafe was committed in issue #506, but
hadn't been added to checkconfig.pl.
