### PR TITLE
Make success_ml use the same format as DW::Template->render_template

### DIFF
--- a/cgi-bin/DW/Controller.pm
+++ b/cgi-bin/DW/Controller.pm
@@ -51,7 +51,7 @@ sub error_ml {
 sub success_ml {
     return DW::Template->render_template(
         'success.tt', {
-            scope => $_[0],
+            scope => "/" . $_[0],
             message_arguments => $_[1],
             links => $_[2],
     });

--- a/cgi-bin/DW/Controller/Community.pm
+++ b/cgi-bin/DW/Controller/Community.pm
@@ -265,7 +265,7 @@ sub new_handler {
                     journal_adult_settings  => $post->{age_restriction},
                 ) unless $second_submit;
 
-            return success_ml( '/communities/new.tt', { user => $cu->ljuser_display },
+            return success_ml( 'communities/new.tt', { user => $cu->ljuser_display },
             [
                 {   text_ml => ".success.link.settings",
                     url => LJ::create_url( "/manage/settings", args => { authas => $cu->user, cat => "community" } ),
@@ -391,7 +391,7 @@ sub convert_handler {
             $cu->lazy_interests_cleanup;
             LJ::Hooks::run_hook("change_journal_type", $cu);
 
-            return success_ml( '/communities/convert.tt', { comm => $cu->ljuser_display },
+            return success_ml( 'communities/convert.tt', { comm => $cu->ljuser_display },
             [
                 {   text_ml => ".success.link.settings",
                     url => LJ::create_url( "/manage/settings", args => { authas => $cu->user, cat => "community" } ),


### PR DESCRIPTION
The page passed to success_ml used to need a leading slash, but that made it
inconsistent with what DW::Template->render_template expected
(the .tt file without a leading slash). So make them consistent: that will be
less painful later
