### PR TITLE
Bug #725 - Zero count spamreports lose breadcrumbs

### DIFF
--- a/htdocs/admin/spamreports.bml
+++ b/htdocs/admin/spamreports.bml
@@ -260,8 +260,8 @@ _c?>
         }
 
         unless (@$res) {
-            $body .= "<?_ml .view.noreports _ml?>";
             $body .= "<?p [ <a href=\"spamreports\">&lt;&lt; <?_ml .nav.frontpage _ml?></a> ] p?>";
+            $body .= "<?_ml .view.noreports _ml?>";
             return undef;
         }
         $body .= '<table summary="">';


### PR DESCRIPTION
Add breadcrumbs back in for when there are no reports.
