### PR TITLE
Let DW::FormErrors be called from a test

### DIFF
--- a/cgi-bin/DW/FormErrors.pm
+++ b/cgi-bin/DW/FormErrors.pm
@@ -13,7 +13,7 @@ package DW::FormErrors;
 
 use strict;
 
-
+use DW::Request;
 use Hash::MultiValue;
 
 =head1 NAME


### PR DESCRIPTION
Make sure we include DW::Request explicitly instead of relying on the 
environment to load it for us.
