### PR TITLE
Remove past-dating checks on posting, allow any time 

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -685,7 +685,7 @@ entryform.backdated=Entry is Backdated:
 
 entryform.backdated2=Backdate &amp; exclude from all Friends Pages
 
-entryform.backdated3=Don't show on Reading Pages (allows dating out of order)
+entryform.backdated4=Don't show on Reading Pages
 
 entryform.comment.disable=Disable comments?
 

--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -1522,7 +1522,7 @@ logproplist.interface:
 logproplist.opt_backdated:
   datatype: bool
   des: Set to true if this item shouldn't show up on people's friends lists (because it occurred in the past)
-  prettyname: Back-dated
+  prettyname: Don't Show on Reading Pages
   sortorder: 35
   ownership: user
 

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1319,14 +1319,6 @@ sub postevent
         $uowner->preload_props( @owner_props );
     }
 
-    # are they trying to post back in time?
-    if ($posterid == $ownerid && !$u->is_syndicated &&
-        !$time_was_faked && $u->{'newesteventtime'} &&
-        $eventtime lt $u->{'newesteventtime'} &&
-        !$req->{'props'}->{'opt_backdated'}) {
-        return fail($err, 153, "You have an entry which was posted at $u->{'newesteventtime'}, but you're trying to post an entry before this. Please check the date and time of both entries. If the other entry is set in the future on purpose, edit that entry to use the \"Don't show on Reading Pages\" option. Otherwise, use the \"Don't show on Reading Pages\" option for this entry instead.");
-    }
-
     my $qallowmask = $req->{'allowmask'}+0;
     my $security = "public";
     my $uselogsec = 0;

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -1416,7 +1416,7 @@ sub entry_form {
                     'name' => "prop_opt_backdated", "value" => 1,
                     'selected' => $opts->{'prop_opt_backdated'},
                     'tabindex' => $tabindex->() });
-            $out .= "<label for='prop_opt_backdated' class='right'>" . BML::ml('entryform.backdated3') . "</label>\n";
+            $out .= "<label for='prop_opt_backdated' class='right'>" . BML::ml('entryform.backdated4') . "</label>\n";
             $out .= LJ::help_icon_html("backdate", "", "") . "\n";
             $out .= "</span><!-- end #modifydate -->\n";
             $out .= "</p>\n";

--- a/views/entry/module-displaydate.tt
+++ b/views/entry/module-displaydate.tt
@@ -88,7 +88,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         ) -%]
         </p>
         <p>
-        [%- dateoutoforder_label = ".label.dateoutoforder" | ml;
+        [%- dateoutoforder_label = ".label.dateoutoforder2" | ml;
         form.checkbox( label = dateoutoforder_label
             name ="entrytime_outoforder"
             id = "entrytime_outoforder"

--- a/views/entry/module-displaydate.tt.text
+++ b/views/entry/module-displaydate.tt.text
@@ -3,7 +3,7 @@
 
 .label.autoupdate=Use the time when entry is posted
 
-.label.dateoutoforder=Don't show on Reading Pages (allows dating out of order)
+.label.dateoutoforder2=Don't show on Reading Pages
 
 .label.sticky=Make sticky (future option?)
 


### PR DESCRIPTION
See http://dw-dev.dreamwidth.org/154479.html for discussion and rationale.
- Remove the "are you posting in the past" check on posting to a personal journal and no longer prevent people from posting an entry dated out of order.
- Rename the "date out of order" checkbox "Don't show on reading pages"
- Keep the distinction between entries in personal journals and entries in communities: the Recent Entries view in personal journals should still sort by user-provided date, not server posting time. 
