### PR TITLE
Members not getting posting access in communities when they accept invite

### DIFF
--- a/cgi-bin/DW/Controller/Community.pm
+++ b/cgi-bin/DW/Controller/Community.pm
@@ -19,6 +19,7 @@ use DW::Template;
 use DW::FormErrors;
 
 use POSIX;
+use List::MoreUtils qw/ uniq /;
 use DW::Entry::Moderated;
 
 =head1 NAME
@@ -466,9 +467,14 @@ sub _invite_new_member {
             if $adult_content eq "explicit";
         }
 
+        # turn on posting access according to community settings
+        my $post_level = $cu->post_level;
+        push @roles_for_user, "poster"
+            if $post_level eq 'members';
+
         # all good, let's extend an invite to this person
         # these map the form field POSTed to the form expected in send_comm_invite
-        my @attribs = map { $form_to_invite_attrib->{$_}} @roles_for_user;
+        my @attribs = map { $form_to_invite_attrib->{$_}} uniq @roles_for_user;
         if ( $invited_u->send_comm_invite( $cu, $remote, \@attribs ) ) {
             # succeeded, clear from the form so they don't display again
             $post->remove( $user_field );

--- a/cgi-bin/LJ/Community.pm
+++ b/cgi-bin/LJ/Community.pm
@@ -309,8 +309,8 @@ sub join_community {
             $addpostacc = $canpost ? 1 : 0;
         } else {
             my $crow = $cu->get_community_row;
-            $addpostacc = $crow->{postlevel} eq 'members' || $cu->prop( 'comm_postlevel_new' ) ? 1 : 0
-                if defined $crow->{postlevel};
+            $addpostacc = $crow->{postlevel} eq 'members'
+                    || ( $crow->{postlevel} eq "select" && $cu->prop( 'comm_postlevel_new' ) );
         }
     }
 


### PR DESCRIPTION
Steps to reproduce:
Set community to give posting access to all members.
Invite user to community.
User does not get posting access. (There's no box to check on the invite page which is good because they should automatically get it anyway).
You have to give posting access manually to all invited members.

Request: http://www.dreamwidth.org/support/see_request?id=29073
