### PR TITLE
[#722] Only include the meta viewport tag conditionally:

### DIFF
--- a/styles/bannering/layout.s2
+++ b/styles/bannering/layout.s2
@@ -139,7 +139,7 @@ function print_module_navlinks() {
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/bases/layout.s2
+++ b/styles/bases/layout.s2
@@ -281,7 +281,7 @@ function print_module_navlinks() {
 function Page::print()
 {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/basicboxes/layout.s2
+++ b/styles/basicboxes/layout.s2
@@ -48,7 +48,7 @@ set module_navlinks_section = "header";
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/blanket/layout.s2
+++ b/styles/blanket/layout.s2
@@ -982,3 +982,6 @@ $userpic_css
 
 """;
 }
+
+function Page::print_meta_viewport_tag() {
+}

--- a/styles/boxesandborders/layout.s2
+++ b/styles/boxesandborders/layout.s2
@@ -64,7 +64,7 @@ set module_navlinks_section = "header";
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/brittle/layout.s2
+++ b/styles/brittle/layout.s2
@@ -1162,3 +1162,5 @@ $entryicon_css
 """;
 
 }
+
+function Page::print_meta_viewport_tag() {}

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -639,6 +639,9 @@ class Page
     function print_module_jump_link()
     "Print a link to jump to modules below the entries";
 
+    function print_meta_viewport_tag()
+    "Print the meta name=viewport tag for mobile devices";
+
     function print_wrapper_start() "Start the body wrapper for this page; includes default classes";
     function print_wrapper_start(string{} opts) "Start the body wrapper for this page; includes default classes and takes a hash using the key 'class'";
     function print_wrapper_end() "End the body wrapper for this entry or comment.";
@@ -3737,6 +3740,14 @@ function generate_font_css(string font_base, string font_fallback, string font_s
     return generate_font_css("", $font_base, $font_fallback, $font_size, $font_unit);
 }
 
+function Page::print_meta_viewport_tag() {
+    # they're using their own stylesheets which probably won't work with the initial scale
+    # (things will just look smooshed together)
+    if ($*include_default_stylesheet) {
+        print """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    }
+}
+
 function Page::print_header()
 {
     $this->print_global_title();
@@ -4779,7 +4790,7 @@ function Page::print()
 "The meat of each new layout. Describes how each page will look. In nearly all cases, the logic and decision-making processes should come from pre-existing functions in core2, and should not get written here. If you limit the structure of the page to HTML, function calls, and attached CSS, then you will be able to pick up all of the enhancements  and accessibility requirements managed by core2."
 {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/crossroads/layout.s2
+++ b/styles/crossroads/layout.s2
@@ -66,7 +66,7 @@ set module_navlinks_section = "header";
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/database/layout.s2
+++ b/styles/database/layout.s2
@@ -1102,7 +1102,7 @@ function Page::title() [notags] : string {
 function Page::print() {
 """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-"""<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/drifting/layout.s2
+++ b/styles/drifting/layout.s2
@@ -1084,7 +1084,7 @@ function Page::print()
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
     <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
     <head>""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+        $this->print_meta_viewport_tag();
         $this->print_head();
         $this->print_stylesheets();
         $this->print_head_title();
@@ -1356,3 +1356,5 @@ var MonthDay[] days = $*reverse_sortorder_month ? reverse $.days : $.days;
 
     $this->print_navigation();
 }
+
+function Page::print_meta_viewport_tag() {}

--- a/styles/dustyfoot/layout.s2
+++ b/styles/dustyfoot/layout.s2
@@ -152,7 +152,7 @@ function print_module_calendar() {
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/easyread/layout.s2
+++ b/styles/easyread/layout.s2
@@ -252,7 +252,7 @@ set module_calendar_order = 18;
 function Page::print()
 {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();
@@ -824,3 +824,5 @@ $userpic_css
 function Page::print_module_jump_link() {
     print """<div id="module-jump-link"><a href="#tertiary" title="Jump to modules below the entries">Modules</a></div>""";
 }
+
+function Page::print_meta_viewport_tag() {}

--- a/styles/fantaisie/layout.s2
+++ b/styles/fantaisie/layout.s2
@@ -309,7 +309,7 @@ function Page::print_entry(Entry e) {
 
 function Page::print() {
 """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-"""<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/fiveam/layout.s2
+++ b/styles/fiveam/layout.s2
@@ -117,7 +117,7 @@ set module_navlinks_section = "header";
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/fluidmeasure/layout.s2
+++ b/styles/fluidmeasure/layout.s2
@@ -54,7 +54,7 @@ function Page::print()
 "The meat of each new layout. Describes how each page will look. In nearly all cases, the logic and decision-making processes should come from pre-existing functions in core2, and should not get written here. If you limit the structure of the page to HTML, function calls, and attached CSS, then you will be able to pick up all of the enhancements  and accessibility requirements managed by core2."
 {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/headsup/layout.s2
+++ b/styles/headsup/layout.s2
@@ -116,7 +116,7 @@ function Page::print() {
 var string image_foreground_url = generate_image_url($*image_foreground_header_url);
 
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/hibiscus/layout.s2
+++ b/styles/hibiscus/layout.s2
@@ -79,7 +79,7 @@ function print_module_navlinks() {
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/lefty/layout.s2
+++ b/styles/lefty/layout.s2
@@ -90,7 +90,7 @@ function print_module_navlinks() {
 # Add section for navlinks module
 function Page::print() {
  """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
- """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+ $this->print_meta_viewport_tag();
  $this->print_head();
  $this->print_stylesheets();
  $this->print_head_title();

--- a/styles/librariansdream/layout.s2
+++ b/styles/librariansdream/layout.s2
@@ -106,7 +106,7 @@ function print_module_navlinks( bool apply_class_to_link ) {
 # Add section for navlinks module
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/marginless/layout.s2
+++ b/styles/marginless/layout.s2
@@ -75,7 +75,7 @@ function print_module_navlinks() {
 # Add section for navlinks module
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/modular/layout.s2
+++ b/styles/modular/layout.s2
@@ -69,7 +69,7 @@ function print_module_navlinks() {
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/motion/layout.s2
+++ b/styles/motion/layout.s2
@@ -185,7 +185,7 @@ set module_navlinks_section = "one";
 # Add section for navlinks module
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/negatives/layout.s2
+++ b/styles/negatives/layout.s2
@@ -1017,7 +1017,7 @@ function Page::print()
     println """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
     <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
     <head>""";
-        """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+        $this->print_meta_viewport_tag();
         $this->print_head();
         $this->print_stylesheets();
         $this->print_head_title();
@@ -1067,3 +1067,5 @@ function Page::print()
     $this->print_wrapper_end();
     println "</html>";
 }
+
+function Page::print_meta_viewport_tag() {}

--- a/styles/nouveauoleanders/layout.s2
+++ b/styles/nouveauoleanders/layout.s2
@@ -232,7 +232,7 @@ set text_unwatch_comments = "Untrack";
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/paletteable/layout.s2
+++ b/styles/paletteable/layout.s2
@@ -61,7 +61,7 @@ function print_module_navlinks() {
 # Add section for navlinks module
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/patsy/layout.s2
+++ b/styles/patsy/layout.s2
@@ -61,7 +61,7 @@ function print_module_navlinks() {
 # Add section for navlinks module, reorder header and footer
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/planetcaravan/layout.s2
+++ b/styles/planetcaravan/layout.s2
@@ -88,7 +88,7 @@ function print_module_navlinks() {
 # Add section for navlinks module
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/practicality/layout.s2
+++ b/styles/practicality/layout.s2
@@ -60,7 +60,7 @@ set module_navlinks_section = "one";
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/skittlishdreams/layout.s2
+++ b/styles/skittlishdreams/layout.s2
@@ -362,7 +362,7 @@ function Page::print()
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+        $this->print_meta_viewport_tag();
         $this->print_head();
         $this->print_stylesheets();
         $this->print_head_title();
@@ -1189,3 +1189,5 @@ $entryicon_css
 
     """;
 }
+
+function Page::print_meta_viewport_tag() {}

--- a/styles/strata/layout.s2
+++ b/styles/strata/layout.s2
@@ -684,7 +684,7 @@ function print_module_navlinks() {
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/summertime/layout.s2
+++ b/styles/summertime/layout.s2
@@ -339,7 +339,7 @@ var bool modules_in_two = (
 
 """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n
     <head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+        $this->print_meta_viewport_tag();
         $this->print_head();
         $this->print_stylesheets();
         $this->print_head_title();

--- a/styles/tectonic/layout.s2
+++ b/styles/tectonic/layout.s2
@@ -125,7 +125,7 @@ function print_module_navlinks() {
 
 function Page::print() {
     """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-    """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/trifecta/layout.s2
+++ b/styles/trifecta/layout.s2
@@ -334,7 +334,7 @@ function print_module_navlinks( bool apply_class_to_link ) {
 
 function Page::print() {
 """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-"""<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();

--- a/styles/wideopen/layout.s2
+++ b/styles/wideopen/layout.s2
@@ -357,7 +357,7 @@ function print_module_credit() {
 
 function Page::print() {
 """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n<head profile="http://www.w3.org/2006/03/hcard http://purl.org/uF/hAtom/0.1/ http://gmpg.org/xfn/11">\n""";
-"""<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
+    $this->print_meta_viewport_tag();
     $this->print_head();
     $this->print_stylesheets();
     $this->print_head_title();


### PR DESCRIPTION
- only if we're using the default stylesheet
- disabled in unconverted layout

The viewport tag with width=device-width, initial-scale=1 is only
suitable for converted layouts. Custom layouts probably don't fit the
bill, and unconverted layouts definitely don't. (they look smooshed)
