### PR TITLE
[#794] Easyread: print out the meta viewport tag

### DIFF
--- a/styles/easyread/layout.s2
+++ b/styles/easyread/layout.s2
@@ -824,5 +824,3 @@ $userpic_css
 function Page::print_module_jump_link() {
     print """<div id="module-jump-link"><a href="#tertiary" title="Jump to modules below the entries">Modules</a></div>""";
 }
-
-function Page::print_meta_viewport_tag() {}


### PR DESCRIPTION
(was disabled pending conversion to work on mobile; no changes were
needed)

Fixes #794
