### PR TITLE
[#830] Fix success page for communities admin

### DIFF
--- a/cgi-bin/DW/Controller.pm
+++ b/cgi-bin/DW/Controller.pm
@@ -62,9 +62,9 @@ sub success_ml {
 sub render_success {
     return DW::Template->render_template(
         'success-page.tt', {
-            scope => "/" . $_[0],
-            message_arguments => $_[1],
-            links => $_[2],
+            scope => "/" . $_[1],
+            message_arguments => $_[2],
+            links => $_[3],
     });
 }
 


### PR DESCRIPTION
We changed the way we call render_success from just `success_ml` to
`DW::Controller->render_success`, so update the expected arguments.

Fixes #830
