### PR TITLE
[#834] Background color to comments in some layouts

### DIFF
--- a/styles/basicboxes/layout.s2
+++ b/styles/basicboxes/layout.s2
@@ -134,6 +134,7 @@ function print_stylesheet () {
 
     var string entry_colors = generate_color_css( new Color, $*color_entry_title_background, $*color_entry_border );
     var string entry_title_colors = generate_color_css( $*color_entry_title, new Color, new Color );
+    var string comment_colors = generate_color_css( $*color_entry_text, $*color_entry_background, new Color );
     var string comment_header_colors = generate_color_css( $*color_page_title, $*color_header_background, $*color_entry_border );
     var string comment_title_colors = generate_color_css( $*color_page_title, new Color, new Color );
 
@@ -314,9 +315,12 @@ ul.entry-interaction-links { text-align: right;
     min-height: 17px; } /* prevent entry-management icons from shoving quickreply aside */
 
 /* comments */
-.comment { margin-bottom: 1em; }
+.page-entry #primary > .inner:first-child { padding: 1em 0; }
+.page-entry .entry-wrapper { padding: 0 1em; }
+.partial .comment { margin-bottom: 0; padding: 0 .5em; }
+.comment > .inner:first-child { padding: 1em; }
 
-.partial .comment { margin-bottom: 0;} 
+.comment { margin-bottom: 1em; $comment_colors }
 
 .comment .header { $comment_header_colors
     padding: 2px 5px;

--- a/styles/ciel/layout.s2
+++ b/styles/ciel/layout.s2
@@ -241,7 +241,7 @@ $userpic_css
 
 /* Comments */
 
-.comment { min-height: 138px; }
+.comment { min-height: 138px; $entry_colors }
 
 .comment-pages { text-align:center;}
 

--- a/styles/colorside/layout.s2
+++ b/styles/colorside/layout.s2
@@ -148,7 +148,11 @@ width: 96% !important; }
 /* main column */
 
 .any-column #primary > .inner:first-child {
-    padding: 0 1em !important;
+    padding: 0 1em;
+}
+
+.page-entry.any-column #primary > .inner:first-child {
+    padding: 0;
 }
 
 @media $*desktop_media_query {
@@ -172,7 +176,7 @@ width: 96% !important; }
     margin: 1em 10%; }
 
 .entry { margin: 0 0 50px 0;
-    padding: 10px 0 0 0; /* gap/margin fix */
+    padding: 10px 1em 0 1em; /* gap/margin fix */
     position: relative; }
 
 .entry .header { $entry_header_colors
@@ -247,11 +251,12 @@ ul.entry-interaction-links { text-align: right;
 
 /* comments */
 .comment { margin: 0 0 20px 0;
-    padding: 15px 0 0 0; 
-    position: relative; }
+    padding: 15px 1em 0 1em;
+    position: relative;
+    $entry_elements_colors }
 
 .partial .comment { margin: 0 0 0 0; 
-    padding: 1px 0 0 0;} 
+    padding: 1px .5em 0 .5em;}
 
 .comment .header { $entry_header_colors
     padding: 5px;

--- a/styles/dustyfoot/layout.s2
+++ b/styles/dustyfoot/layout.s2
@@ -613,6 +613,7 @@ h2#pagetitle {
     margin-bottom: 20px;
     margin-right: 10px;
     padding: 10px;
+    background-color: $*color_entry_background;
     }
 
 #content .comment-wrapper .comment-title,

--- a/styles/headsup/layout.s2
+++ b/styles/headsup/layout.s2
@@ -488,6 +488,10 @@ ul.entry-interaction-links, .comment-interaction-links {
     color: $*color_entry_interaction_links;
     }
 
+.comment-wrapper {
+    background-color: $*color_entry_background;
+    }
+
 .comment-wrapper .header {
     border-bottom: 5px solid $*color_comment_title_border;
     padding: .25em .5em;
@@ -502,7 +506,16 @@ ul.entry-interaction-links, .comment-interaction-links {
     margin-bottom: .25em;
     }
 
-.partial .comment {
+.page-entry #primary > .inner:first-child {
+    padding: 1em 0;
+}
+.page-entry .entry-wrapper {
+    padding: 0 1em;
+}
+.comment > .inner:first-child {
+    padding: 1em;
+}
+.partial .comment > .inner.first-child {
     padding: .25em .5em;
     }
 

--- a/styles/lefty/layout.s2
+++ b/styles/lefty/layout.s2
@@ -491,8 +491,12 @@ display: none;
 margin-bottom: 3.5em;
 position: relative;
 color: $*color_entry_text;
+background-color: $*color_entry_background;
 }
 
+.page-entry #primary > .inner:first-child { padding: 1em 0; }
+.page-entry .entry-wrapper { padding: 0 1em; }
+.comment > .inner:first-child { padding: 0 1em; }
 
 .no-userpic .entry .header, .no-userpic .comment .header {
 margin-right: 0;

--- a/styles/marginless/layout.s2
+++ b/styles/marginless/layout.s2
@@ -359,6 +359,10 @@ ul.entry-interaction-links, ul.comment-interaction-links {
     margin-top: .5em;
     }
 
+.comment-wrapper {
+    background-color: $*color_entry_background;
+    }
+
 .comment-wrapper .header {
     padding: .25em .5em;
     }

--- a/styles/paletteable/layout.s2
+++ b/styles/paletteable/layout.s2
@@ -307,6 +307,10 @@ ul.entry-interaction-links, .comment-interaction-links {
     margin-top: .5em;
     }
 
+.comment-wrapper {
+    background-color: $*color_entry_background;
+    }
+
 .comment-wrapper .header {
     padding: .25em .5em;
     }
@@ -343,7 +347,16 @@ ul.entry-interaction-links, .comment-interaction-links {
     display: block;
     }
 
-.partial .comment {
+.page-entry #primary > .inner:first-child {
+    padding: 1em 0;
+    }
+.page-entry .entry-wrapper {
+    padding: 0 1em;
+    }
+.comment > .inner:first-child {
+    padding: 1em;
+    }
+.partial .comment  > .inner:first-child {
     padding: .25em .5em;
     }
 

--- a/styles/tranquilityiii/layout.s2
+++ b/styles/tranquilityiii/layout.s2
@@ -282,7 +282,7 @@ ul.entry-interaction-links li.entry-readlink { font-weight: bold; }
 /* Comments
 ******************************/
 
-.comment { padding: .5em }
+.comment { padding: .5em; background-color: $*color_entry_background; }
 
 #comments .separator-after {
     border-top: 1px solid;


### PR DESCRIPTION
This makes sure that the comment text is readable once they extend over
to the right, and away from the page background

In some cases, add a little padding around the comments so that they
have some space to breathe when they're over the page background

Removes padding from #primary .inner, but adds it back via other
elements, so that there's not doubled padding around comments that are
still over #primary
