### PR TITLE
[#785] Only use the parent post's subject if we're not editing comment

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1910,7 +1910,7 @@ sub talkform {
     } # end edit check
 
     my $basesubject = $form->{subject} || "";
-    if ($opts->{replyto} && !$basesubject && $parpost->{'subject'}) {
+    if (!$editid && $opts->{replyto} && !$basesubject && $parpost->{'subject'}) {
         $basesubject = $parpost->{'subject'};
         $basesubject =~ s/^Re:\s*//i;
         $basesubject = "Re: $basesubject";


### PR DESCRIPTION
Fixes an edge case where you: reply to a comment with a subject, your
reply has no subject, and you then edit the reply

Fixes #785
