### PR TITLE
(Issue #821) Respect edge blacklist, lower limit

### DIFF
--- a/cgi-bin/DW/Controller/Edges.pm
+++ b/cgi-bin/DW/Controller/Edges.pm
@@ -9,6 +9,7 @@
 #      foxfirefey <skittisheclipse@gmail.com>
 #      Mark Smith <mark@dreamwidth.org>
 #      Andrea Nall <anall@andreanall.com>
+#      Sophie Hamilton <sophie-dw@theblob.org>
 #
 # Copyright (c) 2009 by Dreamwidth Studios, LLC.
 #
@@ -47,14 +48,17 @@ sub edges_handler {
     };
 
     # Load the account or error
-    return $error_out->(404, 'Need account name as user parameter') unless $opts->username;
+    return $error_out->( $r->NOT_FOUND, 'Need account name as user parameter' ) unless $opts->username;
     my $u = LJ::load_user_or_identity( $opts->username )
-        or return $error_out->( 404, "invalid account");
+        or return $error_out->( $r->NOT_FOUND, "invalid account" );
 
     # Check for other conditions
-    return $error_out->( 410, 'expunged' ) if $u->is_expunged;
-    return $error_out->( 403, 'suspended' ) if $u->is_suspended;
-    return $error_out->( 404, 'deleted' ) if $u->is_deleted;
+    return $error_out->( $r->HTTP_GONE, 'expunged' ) if $u->is_expunged;
+    return $error_out->( $r->FORBIDDEN, 'suspended' ) if $u->is_suspended;
+    return $error_out->( $r->NOT_FOUND, 'deleted' ) if $u->is_deleted;
+
+    # Check whether the edge list is forced empty
+    return $error_out->( $r->NOT_FOUND, 'edge lists disabled for this account' ) if exists $LJ::FORCE_EMPTY_SUBSCRIPTIONS{$u->id};
 
     # deal with renamed accounts
     my $renamed_u = $u->get_renamed_user;
@@ -67,13 +71,31 @@ sub edges_handler {
 
     # Load appropriate usernames for different accounts
     my $us;
+    my %args = (
+      limit => 5000,   # limit for each edge
+    );
+
+    my (@trusted, @watched, @trusted_by, @watched_by, @member_of, @maintainers, @moderators, @members) = ();
 
     if ( $u->is_individual ) {
-        $us = LJ::load_userids( $u->trusted_userids, $u->watched_userids, $u->trusted_by_userids, $u->watched_by_userids, $u->member_of_userids );
+        $us = LJ::load_userids(
+            @trusted    = $u->trusted_userids( %args ),
+            @watched    = $u->watched_userids( %args ),
+            @trusted_by = $u->trusted_by_userids( %args ),
+            @watched_by = $u->watched_by_userids( %args ),
+            @member_of  = $u->member_of_userids( %args ),
+        );
     } elsif ( $u->is_community ) {
-        $us = LJ::load_userids( $u->maintainer_userids, $u->moderator_userids, $u->member_userids, $u->watched_by_userids );
+        $us = LJ::load_userids(
+            @maintainers = $u->maintainer_userids,
+            @moderators  = $u->moderator_userids,
+            @members     = $u->member_userids( %args ),
+            @watched_by  = $u->watched_by_userids( %args ),
+        );
     } elsif ( $u->is_syndicated ) {
-        $us = LJ::load_userids( $u->watched_by_userids );
+        $us = LJ::load_userids(
+            @watched_by  = $u->watched_by_userids( %args ),
+        );
     }
 
     # Contruct the JSON response hash
@@ -84,18 +106,18 @@ sub edges_handler {
     $response->{name} = $u->user;
     $response->{display_name} = $u->display_name if $u->is_identity;
     $response->{account_type} = $u->journaltype;
-    $response->{watched_by} = [ $u->watched_by_userids ];
+    $response->{watched_by} = \@watched_by;
 
     # different individual and community edges
-    if ( $u->is_individual ) {
-        $response->{trusted} = [ $u->trusted_userids ];
-        $response->{watched} = [ $u->watched_userids ];
-        $response->{trusted_by} = [ $u->trusted_by_userids ];
-        $response->{member_of} = [ $u->member_of_userids ];
+   if ( $u->is_individual ) {
+        $response->{trusted}    = \@trusted;
+        $response->{watched}    = \@watched;
+        $response->{trusted_by} = \@trusted_by;
+        $response->{member_of}  = \@member_of;
     } elsif ( $u->is_community ) {
-        $response->{maintainer} = [ $u->maintainer_userids ];
-        $response->{moderator} = [ $u->moderator_userids ];
-        $response->{member} = [ $u->member_userids ];
+        $response->{maintainer} = \@maintainers;
+        $response->{moderator}  = \@moderators;
+        $response->{member}     = \@members;
     }
 
     # now dump information about the users we loaded

--- a/cgi-bin/DW/User/Edges/CommMembership.pm
+++ b/cgi-bin/DW/User/Edges/CommMembership.pm
@@ -116,7 +116,11 @@ sub member_of_userids {
     return ()
         unless $u->is_individual;
 
-    return @{ LJ::load_rel_target_cache( $u, 'E' ) || [] };
+    my $limit = $args{limit};
+    my @users = @{ LJ::load_rel_target_cache( $u, 'E' ) || [] };
+    @users = @users[0..$limit-1] if defined $limit && @users > $limit;
+
+    return @users;
 }
 *LJ::User::member_of_userids = \&member_of_userids;
 
@@ -129,7 +133,11 @@ sub member_userids {
     return ()
         unless $u->is_community;
 
-    return @{ LJ::load_rel_user_cache( $u, 'E' ) || [] };
+    my $limit = $args{limit};
+    my @users = @{ LJ::load_rel_user_cache( $u, 'E' ) || [] };
+    @users = @users[0..$limit-1] if defined $limit && @users > $limit;
+
+    return @users;
 }
 *LJ::User::member_userids = \&member_userids;
 


### PR DESCRIPTION
Data obtained by /data/edges can be quite large; limit the data to 5000 edges for most edge types. Also, respect the %LJ::FORCE_EMPTY_SUBSCRIPTIONS configuration option.

This patch also fixes a potential race condition and adds functionality to the member_userids and member_of_userids functions to request a limit to the number of userids returned.

---

This patch still needs testing and I'll be doing that after I make this PR. I would appreciate eyes on this pull request, however - in particular, I'm wondering if it's clear what I'm doing with using and assigning to the various lists inside the parameters to the load_userids calls, or if I should use a more verbose but more readily understandable form. (The reason I use lists in the first place is because there's the remote possibility of a race condition otherwise, if the user list changes between the first and second calls to the *_userids subs.)

I also had to add 'limit' support to member_userids and member_of_userids as they didn't support that before now. I haven't added this support to maintainer_userids and moderator_userids; if it's felt that they should have it, I'll add it in.
