### PR TITLE
Check in business stats

### DIFF
--- a/bin/worker/paidstatus
+++ b/bin/worker/paidstatus
@@ -111,6 +111,7 @@ sub main_loop {
     return $log->( 'Database error cleaning carts: %s', $dbh->errstr )
         if $dbh->err;
     $log->( 'Cleaned %d carts that were unused for more than 30 days.', $ct+0 );
+    DW::Stats::increment( 'dw.shop.cart.expired', $ct );
 
 ## PHASE 1) PROCESS PAYMENTS
 
@@ -230,6 +231,8 @@ sub warn_user {
     }
 
     return 1 unless defined $mail;
+
+    DW::Stats::increment( 'dw.shop.paid_account.warn_' . $mail, 1 );
 
     if ( $u->is_community ) {
         # send an email to every maintainer

--- a/cgi-bin/DW/Pay.pm
+++ b/cgi-bin/DW/Pay.pm
@@ -412,6 +412,7 @@ sub expire_user {
     $u->delete_email_alias;
 
     # happy times
+    DW::Stats::increment( 'dw.shop.paid_account.expired', 1 );
     return 1;
 }
 

--- a/cgi-bin/DW/Shop.pm
+++ b/cgi-bin/DW/Shop.pm
@@ -42,6 +42,12 @@ our $STATE_REFUNDED    = 7;    # we have refunded this cart and reversed it
 our $STATE_CLOSED      = 8;    # carts can go from OPEN -> CLOSED
 our $STATE_DECLINED    = 9;    # payment entity declined the fundage
 
+# state names, just for helping
+our %STATE_NAMES = (
+    1 => 'open', 2 => 'checkout', 3 => 'pend_paid', 4 => 'paid', 5 => 'processed',
+    6 => 'pend_refund', 7 => 'refunded', 8 => 'closed', 9 => 'declined'
+);
+
 # documentation of valid state transitions...
 #
 #   OPEN -> CHECKOUT     user has decided to purchase this and we have sent the

--- a/cgi-bin/DW/Shop/Cart.pm
+++ b/cgi-bin/DW/Shop/Cart.pm
@@ -199,6 +199,9 @@ sub new_cart {
     $cart->save;
     $u->{_cart} = $cart if $u;
 
+    DW::Stats::increment( 'dw.shop.cart.new', 1,
+            [ 'anonymous:' . ( $u ? 'no' : 'yes' ) ] );
+
     # we're done
     return $cart;
 }
@@ -454,6 +457,9 @@ sub state {
     $_->cart_state_changed( $newstate ) foreach @{$self->items};
 
     LJ::Hooks::run_hooks( 'shop_cart_state_change', $self, $newstate );
+    DW::Stats::increment( 'dw.shop.cart.state_change', 1,
+            [ 'from_state:' . $DW::Shop::STATE_NAMES{$self->{state}},
+              'to_state:' . $DW::Shop::STATE_NAMES{$newstate} ] );
 
     $self->_notify_buyer_paid if $newstate == $DW::Shop::STATE_PROCESSED;
 

--- a/cgi-bin/DW/Shop/Item/Icons.pm
+++ b/cgi-bin/DW/Shop/Item/Icons.pm
@@ -94,6 +94,9 @@ sub _apply_userid {
     LJ::statushistory_add( $u, $fu, 'bonus_icons',
             sprintf( '%d icons added; item #%d', $self->icons, $self->id ) );
 
+    DW::Stats::increment( 'dw.shop.icons.applied', $self->icons,
+            [ 'gift:' . ( $fu->equals( $u ) ? 'no' : 'yes' ) ] );
+
     # we're applied now, regardless of what happens with the email
     $self->{applied} = 1;
 

--- a/cgi-bin/DW/Shop/Item/Points.pm
+++ b/cgi-bin/DW/Shop/Item/Points.pm
@@ -95,6 +95,9 @@ sub _apply_userid {
     # now try to add the points
     $u->give_shop_points( amount => $self->points, reason => 'ordered; item #' . $self->id );
 
+    DW::Stats::increment( 'dw.shop.points.applied', $self->points,
+            [ 'gift:' . ( $fu->equals( $u ) ? 'no' : 'yes' ) ] );
+
     # we're applied now, regardless of what happens with the email
     $self->{applied} = 1;
 

--- a/cgi-bin/DW/Shop/Item/Rename.pm
+++ b/cgi-bin/DW/Shop/Item/Rename.pm
@@ -137,6 +137,10 @@ sub cart_state_changed {
             $from = "anon";
         }
 
+        DW::Stats::increment( 'dw.shop.rename_tokens.created', 1,
+                [ 'gift:' . ( $from eq 'self' ? 'no' : 'yes' ),
+                  'anonymous:' . ( $from eq 'anon' ? 'yes' : 'no' ) ] );
+
         LJ::send_mail( {
             to => $u->email_raw,
             from => $LJ::ACCOUNTS_EMAIL,

--- a/cgi-bin/DW/Stats.pm
+++ b/cgi-bin/DW/Stats.pm
@@ -1,0 +1,60 @@
+#!/usr/bin/perl
+#
+# DW::Stats
+#
+# This module is used for sending statistics off to a statistics interface,
+# which might publish statistics somewhere. This is mostly used for business
+# metrics of events.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2013 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+package DW::Stats;
+
+use strict;
+use IO::Socket::INET;
+use Time::HiRes qw/ tv_interval /;
+
+my $sock;
+
+# Usage: DW::Stats::setup( host, port )
+#
+# Enables the stats system to start posting statistics to the given host and
+# port. This must be called in order for the other methods in this module to
+# actually do anything.
+sub setup {
+    die "Not enough arguments to setup\n"
+        unless scalar( @_ ) == 2;
+
+    $sock = IO::Socket::INET->new(
+        Proto    => 'udp',
+        PeerAddr => $_[0],
+        PeerPort => $_[1],
+    );
+    warn "DW::Stats initialized.\n";
+}
+
+# Usage: DW::Stats::increment( 'my.metric', $incrby, $tags, $sample_rate )
+#
+# Metric must be a string. $incrby must be a number or undef. $tags must be an
+# arrayref or undef. $sample_rate must be undef or a number 0..1.
+sub increment {
+    return unless $sock;
+
+    my ( $metric, $incrby, $tags, $sample_rate ) = @_;
+    $incrby //= 1;
+
+    if ( !defined $sample_rate || rand() < $sample_rate ) {
+        $sample_rate = defined $sample_rate ? "|\@$sample_rate" : "";
+        $tags = ref $tags eq 'ARRAY' ? '|#' . join( ',', @$tags ) : '';
+        $sock->send( "$metric:$incrby|c$sample_rate$tags" );
+    }
+}
+
+1;

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -177,6 +177,8 @@ sub do_request
     $apache_r->notes->{codepath} = "protocol.$method"
         if $apache_r && ! $apache_r->notes->{codepath};
 
+    DW::Stats::increment( 'dw.protocol_request', 1, [ "method:$method" ] );
+
     if ($method eq "login")            { return login(@args);            }
     if ($method eq "getfriendgroups")  { return getfriendgroups(@args);  }
     if ($method eq "gettrustgroups")   { return gettrustgroups(@args);   }
@@ -1717,6 +1719,9 @@ sub postevent
     LJ::mark_user_active($u, 'post');
     LJ::mark_user_active($uowner, 'post') unless $u->equals( $uowner );
 
+    DW::Stats::increment( 'dw.action.entry.post', 1,
+            [ 'journal_type:' . $uowner->journaltype_readable ] );
+
     $res->{'itemid'} = $jitemid;  # by request of mart
     $res->{'anum'} = $anum;
     $res->{'url'} = $entry->url;
@@ -2170,6 +2175,9 @@ sub editevent
 
     my $entry = LJ::Entry->new($ownerid, jitemid => $itemid);
     LJ::EventLogRecord::EditEntry->new($entry)->fire;
+
+    DW::Stats::increment( 'dw.action.entry.edit', 1,
+            [ 'journal_type:' . $uowner->journaltype_readable ] );
 
     # fired to copy the post over to the Sphinx search database
     if ( @LJ::SPHINX_SEARCHD && ( my $sclient = LJ::theschwartz() ) ) {

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -3529,6 +3529,9 @@ sub post_comment {
     # cluster tracking
     LJ::mark_user_active($comment->{u}, 'comment');
 
+    DW::Stats::increment( 'dw.action.comment.post', 1, [ "journal_type:" . $journalu->journaltype_readable,
+            "poster_type:" . ( ref $comment->{u} ? $comment->{u}->journaltype_readable : 'anonymous' ) ] );
+
     LJ::Hooks::run_hooks('new_comment', $journalu->{userid}, $item->{itemid}, $jtalkid);
 
     return 1;
@@ -3604,6 +3607,9 @@ sub edit_comment {
 
         $sclient->insert_jobs( @jobs );
     }
+
+    DW::Stats::increment( 'dw.action.comment.edit', 1, [ "journal_type:" . $journalu->journaltype_readable,
+            "poster_type:" . $pu ? $pu->journaltype_readable : 'anonymous' ] );
 
     LJ::Hooks::run_hooks('edit_comment', $journalu->{userid}, $item->{itemid}, $comment->{talkid});
 

--- a/cgi-bin/LJ/User.pm
+++ b/cgi-bin/LJ/User.pm
@@ -154,6 +154,8 @@ sub create {
              undef, $userid);
 
     my $u = LJ::load_userid( $userid, "force" ) or return;
+    DW::Stats::increment( 'dw.action.account.create', 1,
+            [ 'journal_type:' . $u->journaltype_readable ] );
 
     my $status   = $opts{status}   || ($LJ::EVERYONE_VALID ? 'A' : 'N');
     my $name     = $opts{name}     || $username;

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -21,7 +21,6 @@ BEGIN {
     # ljlib.pl (via require, ick!).  so this lets them know if it's recursive.
     # we REALLY need to move the rest of this crap to .pm files.
 
-
     # ensure we have $LJ::HOME, or complain very vigorously
     $LJ::HOME ||= $ENV{LJHOME};
     die "No \$LJ::HOME set, or not a directory!\n"
@@ -98,6 +97,7 @@ use LJ::Capabilities;
 use DW::Mood;
 use LJ::Global::Img;  # defines LJ::Img
 use DW::Media;
+use DW::Stats;
 
 # make Unicode::MapUTF8 autoload:
 sub Unicode::MapUTF8::AUTOLOAD {
@@ -220,6 +220,10 @@ if ($SIG{'HUP'}) {
     $SIG{'HUP'} = \&LJ::clear_caches;
 }
 
+# Initialize our statistics reporting library if needed
+if ( $LJ::STATS{host} && $LJ::STATS{port} ) {
+    DW::Stats::setup( $LJ::STATS{host}, $LJ::STATS{port} );
+}
 
 sub get_blob_domainid
 {

--- a/doc/config-private.pl.txt
+++ b/doc/config-private.pl.txt
@@ -141,6 +141,14 @@
     #     },
     # );
 
+    # If you want to enable DW::Stats business metrics reporting, uncomment
+    # this structure and set it up. This was originally implemented to work
+    # with the local dogstatsd daemon from datadog.com, but it should work
+    # with any system that follows the same protocol.
+    # %STATS = (
+    #     host => '127.0.0.1',
+    #     port => 8125,
+    # );
 }
 
 {

--- a/htdocs/login.bml
+++ b/htdocs/login.bml
@@ -258,6 +258,7 @@ _c?>
 
         if ($do_logout) {
             $logout_remote->();
+            DW::Stats::increment( 'dw.action.session.logout' );
             $title = BML::ml(".login.title", { 'sitename' => $LJ::SITENAMESHORT} );
         }
 
@@ -266,6 +267,8 @@ _c?>
             $bindip = BML::get_remote_ip()
                 if $POST{'bindip'} eq "yes";
 
+            DW::Stats::increment( 'dw.action.session.update', 1, [ 'bindip:' . $bindip ? 'yes' : 'no',
+                    'exptype:' . $POST{expire} eq 'never' ? 'long' : 'short' ] );
             $cursess->set_ipfixed($bindip) or die "failed to set ipfixed";
             $cursess->set_exptype($POST{expire} eq 'never' ? 'long' : 'short') or die "failed to set exptype";
             $cursess->update_master_cookie;
@@ -290,6 +293,7 @@ _c?>
                 return if $want_fail_redirect->("database_readonly");
 
                 $body = LJ::bad_input("The database is temporarily in read-only mode, so creating new login sessions is temporarily down.  Please try again later.");
+                DW::Stats::increment( 'dw.action.session.login_failed', 1, [ 'reason:database_readonly' ] );
                 return;
             }
 
@@ -306,6 +310,7 @@ _c?>
                 return if $want_fail_redirect->("banned_ip");
 
                 $body = LJ::bad_input("Your IP address is temporarily banned for exceeding the login failure rate.");
+                DW::Stats::increment( 'dw.action.session.login_failed', 1, [ 'reason:banned_ip' ] );
                 return;
             }
 
@@ -321,6 +326,8 @@ _c?>
                 if $u && $u->is_locked;
 
             if (@errors) {
+                DW::Stats::increment( 'dw.action.session.login_failed', 1, [ "reason:$_->[0]" ] )
+                    foreach @errors; # Many errors, increment a failure for each reason.
                 $login_html->();
                 return;
             }
@@ -334,6 +341,9 @@ _c?>
             $u->make_login_session($exptype, $bindip);
             LJ::Hooks::run_hook('user_login', $u);
             $cursess = $u->session;
+
+            DW::Stats::increment( 'dw.action.session.login_ok', 1, [ 'bindip:' . $bindip ? 'yes' : 'no',
+                    "exptype:$exptype" ] );
 
             return if $want_success_redirect->();
 


### PR DESCRIPTION
This was hacked together to provide some quick and dirty 'event count'
metric reporting for Dreamwidth. This was implemented to work with the
Datadog service, but it should be pretty easy to convert the DW::Stats
module to have support for more services.
