### PR TITLE
Turn off autocomplete on the date

### DIFF
--- a/views/entry/module-displaydate.tt
+++ b/views/entry/module-displaydate.tt
@@ -32,6 +32,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
             title = entrytime_title
             default = "$displaydate.year-$displaydate.month-$displaydate.day"
+
+            autocomplete = "off"
         ) -%]
 
         [%- entrytime_title = ".title.entrytime_hr" | ml;
@@ -45,6 +47,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
             title = entrytime_title
             default = displaydate.hour
+
+            autocomplete = "off"
         ) ~%]
         :
         [%- entrytime_title = ".title.entrytime_min" | ml;
@@ -58,6 +62,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
             title = entrytime_title
             default = displaydate.minute
+
+            autocomplete = "off"
         ) -%]
 
         [% # update year so it doesn't look dated


### PR DESCRIPTION
Just in case -- we have some complaints of the same date being used over
and over again. Possibly this is autocomplete at work?
