### PR TITLE
(Bug 822) Misspelling in /admin/capedit

### DIFF
--- a/views/admin/capedit.tt
+++ b/views/admin/capedit.tt
@@ -44,4 +44,4 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <p><input type="submit" value="Save"></p>
 </form>
 [% END %]
-<p>[%- '.note' | ml(payments = "href='/admin/pay'", priv = "href='/admin/priv/?priv=payments'") -%]</p>
+<p>[%- '.note1' | ml(payments = "href='/admin/pay'", priv = "href='/admin/priv/?priv=payments'") -%]</p>

--- a/views/admin/capedit.tt.text
+++ b/views/admin/capedit.tt.text
@@ -3,6 +3,6 @@
 
 .admin.text=For editing user capabilities.
 
-.note=Note: to change a user's status, you should use the <a [[payments]]>Payment Managements tool</a> instead. This requires you to have the 'payments' priviledge so you may need to <a [[priv]]>grant it to yourself first</a>.
+.note1=Note: to change a user's status, you should use the <a [[payments]]>Payment Managements tool</a> instead. This requires you to have the 'payments' privilege so you may need to <a [[priv]]>grant it to yourself first</a>.
 
 .title=Capability Class Management


### PR DESCRIPTION
Fixes spelling of 'privilege'. Fixes Bug #822.
