### PR TITLE
Remove redundant tag, and fix tag format

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2354,8 +2354,6 @@ sub Page
         $p->{'head_content'} .= '<meta http-equiv="Content-Type" content="text/html; charset=' . $opts->{'saycharset'} . "\" />\n";
     }
 
-    $p->{'head_content'} = '<meta http-equiv="X-UA-Compatible" content="IE=edge">';
-
     if (LJ::Hooks::are_hooks('s2_head_content_extra')) {
         $p->{head_content} .= LJ::Hooks::run_hook('s2_head_content_extra', $remote, $opts->{r});
     }

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -3788,7 +3788,7 @@ function Page::print_meta_tags() {
         print """<meta name="viewport" content="width=device-width, initial-scale=1.0"/>""";
     }
 
-    print """<meta http-equiv="X-UA-Compatible" content="IE=edge">""";
+    print """<meta http-equiv="X-UA-Compatible" content="IE=edge" />""";
 }
 
 function Page::print_header()


### PR DESCRIPTION
- our styles are still in xhtml so we do want this trailing slash
- want this meta tag to be per-style instead of on all styles, just in
  case it's not suitable for one of them
