### PR TITLE
Insert JS-injected control strip to the *top* of the page

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -3221,7 +3221,7 @@ jQuery(function(jQ){
     if (jQ("#lj_controlstrip").length == 0) {
         jQ.getJSON("/$user/__rpc_controlstrip?user=$user&host=$host&uri=$uri&args=$args&view=$view", {},
             function(data) {
-                jQ("<div></div>").html(data.control_strip).appendTo("body");
+                jQ("<div></div>").html(data.control_strip).prependTo("body");
             }
         );
     }


### PR DESCRIPTION
It's being inserted at the bottom, which was fine when this was then
absolutely positioned to the top. But we want the control strip to be in
the document flow and act like a regular element, so let's put this at
the top in the HTML
