### PR TITLE
[#848] Add a minimum acceptable width to the comment content

### DIFF
--- a/styles/abstractia/layout.s2
+++ b/styles/abstractia/layout.s2
@@ -1214,6 +1214,16 @@ q {
 .entry-content ul:first-child li, .entry-content ol:first-child li {
     list-style-position: inside;
 }
+
+/* ensure comment content stretches out horizontally so it's readable */
+.comment-content:before {
+    content: "";
+    display: block;
+    overflow: hidden;
+    width: 10em;
+}
+.comment-content { border-top: 1px transparent solid; } /* for firefox */
+
 /* To constrain the width and prevent layout breaking */
 .entry-content img, .comment-content img {
     max-width: 100%;

--- a/styles/bases/layout.s2
+++ b/styles/bases/layout.s2
@@ -544,6 +544,15 @@ ul ul {list-style: circle;}
 .entry-content a img:hover {border-color: $*color_entry_link_hover; }
 .entry-content .userpic, #comments .userpic {background: $*color_entry_background;}
 
+/* ensure comment content stretches out horizontally so it's readable */
+.comment-content:before {
+    content: "";
+    display: block;
+    overflow: hidden;
+    width: 10em;
+}
+.comment-content { border-top: 1px transparent solid; } /* for firefox */
+
 /* To constrain the width and prevent layout breaking */
 .entry-content img, .comment-content img {
     max-width: 100%;

--- a/styles/blanket/layout.s2
+++ b/styles/blanket/layout.s2
@@ -666,6 +666,15 @@ h3.entry-title a {
     text-transform: uppercase;
     }
 
+/* ensure comment content stretches out horizontally so it's readable */
+.comment-content:before {
+    content: "";
+    display: block;
+    overflow: hidden;
+    width: 10em;
+}
+.comment-content { border-top: 1px transparent solid; } /* for firefox */
+
 /* To prevent overlapping when icon's on the left */
 /* and list is the first thing in content */
 .entry-content li,

--- a/styles/brittle/layout.s2
+++ b/styles/brittle/layout.s2
@@ -564,6 +564,15 @@ li.page-separator { display: none; }
 
 .entry-content { margin: 10px 0 0 0; }
 
+/* ensure comment content stretches out horizontally so it's readable */
+.comment-content:before {
+    content: "";
+    display: block;
+    overflow: hidden;
+    width: 10em;
+}
+.comment-content { border-top: 1px transparent solid; } /* for firefox */
+
 /* To constrain the width and prevent layout breaking */
 .entry-content img, .comment-content img {
     max-width: 100%;

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -516,6 +516,15 @@ h2#pagetitle {
 .entry a:hover { $entry_link_hover_colors }
 .entry a:active { $entry_link_active_colors }
 
+/* ensure comment content stretches out horizontally so it's readable */
+.comment-content:before {
+    content: "";
+    display: block;
+    overflow: hidden;
+    width: 10em;
+}
+.comment-content { border-top: 1px transparent solid; } /* for firefox */
+
 /* To prevent overlapping when icon's on the left */
 /* and list is the first thing in content */
 .entry-content li,

--- a/styles/drifting/layout.s2
+++ b/styles/drifting/layout.s2
@@ -711,6 +711,15 @@ function Page::print_default_stylesheet()
         color: $*color_entry_text;
     }
 
+    /* ensure comment content stretches out horizontally so it's readable */
+    .comment-content:before {
+        content: "";
+        display: block;
+        overflow: hidden;
+        width: 10em;
+    }
+    .comment-content { border-top: 1px transparent solid; } /* for firefox */
+
     /* To prevent overlapping when icon's on the left */
     /* and list is the first thing in content */
     .entry-content li,

--- a/styles/easyread/layout.s2
+++ b/styles/easyread/layout.s2
@@ -600,6 +600,15 @@ h2.module-header a {
     $entrytitle_padding
 }
 
+/* ensure comment content stretches out horizontally so it's readable */
+.comment-content:before {
+    content: "";
+    display: block;
+    overflow: hidden;
+    width: 10em;
+}
+.comment-content { border-top: 1px transparent solid; } /* for firefox */
+
 /* To constrain the width and prevent layout breaking */
 .entry-content img, .comment-content img {
     max-width: 100%;

--- a/styles/negatives/layout.s2
+++ b/styles/negatives/layout.s2
@@ -568,6 +568,15 @@ function Page::print_default_stylesheet()
         color: $*color_entry_link_hover;
     }
 
+    /* ensure comment content stretches out horizontally so it's readable */
+    .comment-content:before {
+        content: "";
+        display: block;
+        overflow: hidden;
+        width: 10em;
+    }
+    .comment-content { border-top: 1px transparent solid; } /* for firefox */
+
     /* To prevent overlapping when icon's on the left */
     /* and list is the first thing in content */
     .entry-content li,

--- a/styles/skittlishdreams/layout.s2
+++ b/styles/skittlishdreams/layout.s2
@@ -953,6 +953,15 @@ html body {
     padding: 10px 0;
     }
 
+/* ensure comment content stretches out horizontally so it's readable */
+.comment-content:before {
+    content: "";
+    display: block;
+    overflow: hidden;
+    width: 10em;
+}
+.comment-content { border-top: 1px transparent solid; } /* for firefox */
+
 /* To constrain the width and prevent layout breaking */
 .entry-content img, .comment-content img {
     max-width: 100%;


### PR DESCRIPTION
So that if it's narrower than a certain size, even the first few lines
drop below the icon instead of being squeezed by it.

This technique, however, ensures that the icon can still float beside
the comment text when the comment is wide enough that the words will
still be readable
