### PR TITLE
[#877] Add rounded corners to .comment in Ciel

### DIFF
--- a/styles/ciel/layout.s2
+++ b/styles/ciel/layout.s2
@@ -242,7 +242,7 @@ $userpic_css
 
 /* Comments */
 
-.comment { min-height: 138px; $entry_colors }
+.comment { min-height: 138px; $entry_colors border-radius: 2em; }
 
 .comment-pages { text-align:center;}
 


### PR DESCRIPTION
To keep consistent with the appearance when it's deep enough that the
comment overflows the primary column

Fixes #877.
