### PR TITLE
[#879] Fix wrapping of long journal titles in Drifting

### DIFF
--- a/styles/drifting/layout.s2
+++ b/styles/drifting/layout.s2
@@ -460,16 +460,22 @@ function Page::print_default_stylesheet()
     /* Header
     ***************************************************************************/
     #header {
-        height: 4.7em;
         margin-bottom: 10px;
         border: 1px solid $*color_module_border;
         $header_background
     }
 
+    #header:after {
+      content: "";
+      display: table;
+      clear: both;
+    }
+
     .header-left {
         background-image: url($image_header_left_url);
+        background-position: 0 100%;
         background-repeat: no-repeat;
-        height: 4.7em;
+        min-height: 4.7em;
     }
 
     #header h1#title {
@@ -503,9 +509,12 @@ function Page::print_default_stylesheet()
             float: left;
             width: 60%;
         }
+    }
 
+    @media $large_media_query {
         .header-right {
             background-image: url($image_header_right_url);
+            background-position: 0 100%;
             height: 4.7em;
             float: right;
             width: 250px;

--- a/styles/drifting/themes.s2
+++ b/styles/drifting/themes.s2
@@ -15,7 +15,7 @@ set color_page_link_visited = "#234163";
 set color_page_subtitle = "#5a799d";
 set color_page_text = "#234163";
 set color_page_title = "#fff";
-set color_header_background = "#5a799d";
+set color_header_background = "#7997BD";
 
 ##===============================
 ## Entry Colors
@@ -37,7 +37,8 @@ set color_module_title = "#5a799d";
 ## Images
 ##===============================
 
-set image_background_header_repeat = "repeat";
+set image_background_header_position = "0 100%";
+set image_background_header_repeat = "repeat-x";
 set image_background_header_url = "drifting/hdr_bg.jpg";
 set image_header_left = "drifting/hdr_left.jpg";
 set image_header_right = "drifting/hdr_right.jpg";


### PR DESCRIPTION
- set a min-height instead of absolute height for the header, which lets
  the header expand around text instead of abrutply running out
- make sure that header encloses .header-left instead of having its own
  height (to avoid instances of the header left image becoming
  disconnected from the header)
- set the background color of the header to match the topmost row of the
  header image, for a seamless transition upward once we run out of
  image, and then make sure we only repeat the header background image
  horizontally
- only show the right header on big screens, to avoid having it encroach
  on the title

Fixes #879.
