### PR TITLE
[#886] Planet Caravan: don't move icon up on small screens

### DIFF
--- a/styles/planetcaravan/layout.s2
+++ b/styles/planetcaravan/layout.s2
@@ -447,11 +447,11 @@ h2#pagetitle, h2#subtitle {font-weight: normal; padding:.25em; margin:0; color: 
     }
 
 .entry .userpic {
-    margin-top: -2em;
     margin-bottom: 1em;
     }
 @media $medium_media_query {
     .entry .userpic, .comment .userpic {
+        margin-top: -2em;
         border-width: 20px;
         margin-bottom: 0;
         }


### PR DESCRIPTION
We want to move it up on larger screens because it's off to the side.
But on smaller screens, we just leave it in its current position in the
flow.

Fixes #886.
