### PR TITLE
[#887] Planet Caravan: tweak footer on small screens

### DIFF
--- a/styles/planetcaravan/layout.s2
+++ b/styles/planetcaravan/layout.s2
@@ -508,10 +508,18 @@ div#archive-year > div.inner > div.year > div.inner > div.month-wrapper:nth-of-t
     margin-left: -5px;
     }
 
-ul.entry-management-links, ul.comment-management-links {
-    text-align: left;
+.entry .footer, .comment .footer {
     background: $*color_entry_footer_background;
     padding: .75em;
+}
+.entry .footer:after, .comment .footer:after { /* clearfix */
+  content: "";
+  display: table;
+  clear: both;
+}
+
+ul.entry-management-links, ul.comment-management-links {
+    text-align: left;
     font-size: smaller;
     text-transform:lowercase;
     margin: 0;
@@ -519,11 +527,16 @@ ul.entry-management-links, ul.comment-management-links {
 
 ul.entry-interaction-links, ul.comment-interaction-links {
     float:right;
-    padding: .75em;
-    margin: -2.9em 0 0;
+    margin: 0 0 0 .75em;
     font-size: smaller;
     text-transform:lowercase;
     }
+
+@media $medium_media_query {
+    ul.entry-interaction-links, ul.comment-interaction-links {
+        margin-top: -1.4em;
+    }
+}
 
 .text-links a {    color: $*color_entry_interaction_links; text-decoration: none; font-weight:normal;}
 .text-links a:hover {text-decoration: underline; color: $*color_entry_interaction_links_hover;}


### PR DESCRIPTION
- on large screens, where the interaction links are unlikely to overlap
  the management links, move the interaction links up to to the same
  level as the management links. On small screens, keep them on two
  lines
- put the background on the footer and make sure footer expands around
  all floated elements so that the background is around everything it
  should be
- tweak padding in footer to be for the whole footer rather than for the
  contained elements

Fixes #887.
