### PR TITLE
[#890] Strata: set a background color on more .comment elements

### DIFF
--- a/styles/strata/layout.s2
+++ b/styles/strata/layout.s2
@@ -322,9 +322,9 @@ ul.entry-interaction-links {
     background-color: $*color_comment_title_background;
     color: $*color_comment_title;}
 
-.comment .comment-content { background-color: $*color_entry_background;
-    color: $*color_entry_text !important;
-    color: $*color_page_text;}
+.comment { background-color: $*color_entry_background;
+    color: $*color_entry_text;
+}
 
 .comment .comment-content { clear: left }
 


### PR DESCRIPTION
Set the background color on the .comment element instead of the
.comment-content one, so that partial comments still remain readable on
the page background

Fixes #890.
