### PR TITLE
[#892] Tectonic: fix modules in one-column mode small screen

### DIFF
--- a/styles/tectonic/layout.s2
+++ b/styles/tectonic/layout.s2
@@ -483,16 +483,13 @@ li.page-separator {
 /*--- Sidebar aka Modules ---*/
 #secondary, #tertiary { text-align: center; }
 .module {
-    display: inline-block;
-    vertical-align: top;
-    width: $*modules_per_row;
     text-align:left;
     }
-
 @media $medium_media_query {
-    .multiple-columns .module {
-        display: block;
-        width: auto;
+    .one-column .module {
+        display: inline-block;
+        vertical-align: top;
+        width: $*modules_per_row;
     }
 }
 


### PR DESCRIPTION
On one-column mode in larger screens, we want the modules to be beside
one another.

On one-column mode in smaller screens, we want the modules to be stacked
on top of one another.

This makes it so

Fixes #892.
