### PR TITLE
[#861] Explicitly set the "post as" to remote

### DIFF
--- a/views/entry/module-journal.tt
+++ b/views/entry/module-journal.tt
@@ -70,7 +70,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
                 items = journalselect
             ) -%]
         [% ELSE %]
-            [% journallist.first.ljuser_display%]</span>
+            [% journallist.first.ljuser_display%]
             [% form.hidden( name = "usejournal", id = "usejournal", value = journallist.first.user ) %]
         [% END %]
    </div>


### PR DESCRIPTION
The problem is that we knew the community name we were going to post to,
but we didn't know we were going to post as remote. Because that option
wasn't selected (post as remote), the community name was being hidden by
javascript.

Fix is to make sure there's an explicit value set for post_as, even when
we initialized the entry form using data from another form.

This involves moving the init code for vars upward so there's a little
less duplication of logic.

Fixes #861.
