### PR TITLE
Removes MSN Messenger from profile (and a few other places)

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1563,6 +1563,6 @@ general poll.security.none_remote
 general poll.security.trusted
 
 general widget.search.msn
-general htdocs/manage/profile/index.bml.chat.msnusername
-general htdocs/profile.bml.im.msn
-general htdocs/profile.bml.label.msnusername
+general /manage/profile/index.bml.chat.msnusername
+general /profile.bml.im.msn
+general /profile.bml.label.msnusername


### PR DESCRIPTION
Fixes #918. Turns out MSN Messenger was referenced in a bunch of places
other than just the profile (most specifically, the directory and in
multisearch.bml) so this gets most of it, including no longer trying
to import MSN details from LJ when importing from LJ. Tested lightly
but not exhaustively, but it doesn't seem to break anything. (Knock wood.)