### PR TITLE
Fix for minimal set of system-installed libraries

### DIFF
--- a/bin/checkconfig.pl
+++ b/bin/checkconfig.pl
@@ -99,7 +99,7 @@ my %modules = (
                    opt => 'Required for OpenID consumer support.'
                },
                "Net::OAuth" => {
-                   opt => 'Required for OAuth support.'
+                   #opt => 'Required for OAuth support.' # FIXME: Not optional
                },
                "URI::URL" => { 'deb' => 'liburi-perl' },
                "HTML::Tagset" => { 'deb' => 'libhtml-tagset-perl' },
@@ -143,7 +143,6 @@ my %modules = (
                "IO::WrapTie" => { 'deb' => 'libio-stringy-perl' },
                "XML::Atom" => {
                    'deb' => 'libxml-atom-perl',
-                   'opt' => 'Required for Atom API support.',
                },
                "Math::BigInt::GMP" => {
                    'deb' => 'libmath-bigint-gmp-perl',
@@ -199,12 +198,12 @@ my %modules = (
                "GTop" => {},
                "Apache2::RequestRec"   => {
                    'deb' => "libapache2-mod-perl2",
-                   'opt' => "Required for modperl2",
+                   #'opt' => "Required for modperl2",   # FIXME: actually required
                    'system' => 1, # don't cpanm this
                },
                "Apache2::Request"      => {
                    'deb' => "libapache2-request-perl",
-                   'opt' => "Required for Apache2",
+                   #'opt' => "Required for Apache2",    # FIXME: actually required
                    'system' => 1, # don't cpanm this
                },
                "Test::More" => {
@@ -258,7 +257,6 @@ my %modules = (
                "TheSchwartz::Worker::PubSubHubbubPublish" => {},
                "File::Type" => {
                    deb => 'libfile-type-perl',
-                   opt => 'For media storage',
                },
                "JSON" => {
                    deb => 'libjson-perl',
@@ -271,6 +269,7 @@ my %modules = (
                "MIME::Base64::URLSafe" => {
                    deb => 'libmime-base64-urlsafe-perl',
                },
+               "List::MoreUtils" => {},
               );
 
 
@@ -293,7 +292,8 @@ sub check_modules {
             }
             if ($opt_cpanm) {
                 push @debs, $dt->{'deb'} if $dt->{'deb'} && $dt->{'system'};
-                push @mods, $mod;
+                push @mods, $mod unless $dt->{system};
+                die "Cannot use system module: $_" if $dt->{system} and ! $dt->{deb};
             } else {
                 push @debs, $dt->{'deb'} if $dt->{'deb'};
             }

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -26,6 +26,8 @@ BEGIN {
     die "No \$LJ::HOME set, or not a directory!\n"
         unless $LJ::HOME && -d $LJ::HOME;
 
+    use lib ( $LJ::HOME || $ENV{LJHOME} ) . "/extlib/lib/perl5";
+
     # Please do not change this to "LJ::Directories"
     require $LJ::HOME . "/cgi-bin/LJ/Directories.pm";
 }
@@ -33,7 +35,6 @@ BEGIN {
 # now that the library is setup, we can start pulling things in.  start with
 # the configuration library we need.
 use lib "$LJ::HOME/cgi-bin";
-use lib "$LJ::HOME/extlib/lib/perl5";
 use LJ::Config;
 
 BEGIN {


### PR DESCRIPTION
Mark actually required libraries as required, move extlib call to before LJ/Directory.pm
otherwise we cannot find List::MoreUtils

Is there any problem with swapping the order in `@INC` of cgi-bin and extlib?
