### PR TITLE
Return an explicit value (1/0) instead of potentially undef

### DIFF
--- a/cgi-bin/DW/Setting/MobileView.pm
+++ b/cgi-bin/DW/Setting/MobileView.pm
@@ -35,7 +35,7 @@ sub is_selected {
         if defined $r->note( 'no_mobile_post_value' );
 
     # normal page load, check the cookie
-    return $r->cookie( 'no_mobile' );
+    return $r->cookie( 'no_mobile' ) ? 1 : 0;
 }
 
 sub option {


### PR DESCRIPTION
To avoid an "Odd number of elements in anonymous hash" warning
