### PR TITLE
Remove obsolete print_meta_viewport function declaration

### DIFF
--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -647,9 +647,6 @@ class Page
     function print_module_jump_link()
     "Print a link to jump to modules below the entries";
 
-    function print_meta_viewport_tag()
-    "OBSOLETE. Use print_meta_tags() instead";
-
     function print_meta_tags()
     "Print meta tags. Needs to be within the first 512 bytes to work.";
 


### PR DESCRIPTION
Normally wouldn't want to just remove obsolete functions, but realized
that becasue this doesn't have a function definition, it'll cause an
error if you try to use it. So you know, might as well get rid of
clutter from something that was so short-lived
