### PR TITLE
Tweak whitespace for queues (used in moderation entry queue)

### DIFF
--- a/htdocs/scss/components/queues.scss
+++ b/htdocs/scss/components/queues.scss
@@ -3,13 +3,15 @@ $include-html-classes: false;
 
 .queue {
     list-style: none;
+    margin: 0;
 
     .queue-item {
-        padding: ($base-line-height * 1em) 0em;
+        padding: ($base-line-height * 1em) 1.25rem;
         margin-bottom: 4px;
 
         .timestamp {
             font-size: smaller;
+            text-align: right;
         }
 
         .queue-action {

--- a/views/communities/queue/entries.tt
+++ b/views/communities/queue/entries.tt
@@ -22,7 +22,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- IF entries.size > 0 -%]
     <ul class="queue">
         [%- FOREACH entry = entries -%]
-        <li class="row queue-item">
+        <li class="queue-item"><div class="row">
             <div class="columns large-3">[%- entry.poster -%]</div>
             <div class="columns large-7"><a href="[%- entry.url -%]" class="queue-action">
             [%- IF entry.subject -%]
@@ -32,7 +32,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
             [%- END -%]
             </a></div>
             <div class="columns large-2 timestamp">[%- entry.time  -%]</div>
-        </li>
+        </div></li>
         [%- END -%]
     </ul>
 [%- ELSE -%]

--- a/views/dev/style-guide.tt
+++ b/views/dev/style-guide.tt
@@ -210,16 +210,18 @@
   <div class="large-6 columns">
 
   <ul class="queue">
-    <li class="row queue-item">
+    <li class="queue-item">
+    <div class="row">
+      <div class="columns large-3">[%- INCLUDE ljuser user="user" -%]</div>
+      <div class="columns large-7"><a href="">entry subject</a></div>
+      <div class="columns large-2 timestamp">timestamp</div>
+    </div>
+    </li>
+    <li class="queue-item"><div class="row">
         <div class="columns large-3">[%- INCLUDE ljuser user="user" -%]</div>
         <div class="columns large-7"><a href="">entry subject</a></div>
         <div class="columns large-2 timestamp">timestamp</div>
-    </li>
-    <li class="row queue-item">
-        <div class="columns large-3">[%- INCLUDE ljuser user="user" -%]</div>
-        <div class="columns large-7"><a href="">entry subject</a></div>
-        <div class="columns large-2 timestamp">timestamp</div>
-    </li>
+    </div></li>
   </ul>
 
   </div>


### PR DESCRIPTION
- move the .row class inside the li.queue-item in order to keep the
  whitespace to the left and right
- add padding to the left/right of the queue item
- remove the margin from ul.queue
