### PR TITLE
Adds journal sub+title to beta update previews

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1260,8 +1260,7 @@ sub preview_handler {
         $r->note( "journalid"   => $u->{userid} );
 
         # load necessary props
-        $u->preload_props( qw( s2_style ) );
-
+        $u->preload_props( qw( s2_style journaltitle journalsubtitle ) );
 
         # determine style system to preview with
         $ctx = LJ::S2::s2_context( $u->{s2_style} );


### PR DESCRIPTION
The "preview entry" page for entries created using the beta update page displayed user's set name (default for S2 where no journal title or subtitle are set) instead of journal title and subtitle if they are present.

This fix:
- means that journal subtitle + title are used if present
- if title but no subtitle, title is displayed
- if subtitle but no title, the user's set name is displayed in the "title" location and the subtitle is also displayed
- if neither, the user's set name is displayed
