### PR TITLE
[#940] Make the no_mobile cookie stick around for 10 years

### DIFF
--- a/cgi-bin/DW/Setting/MobileView.pm
+++ b/cgi-bin/DW/Setting/MobileView.pm
@@ -55,7 +55,8 @@ sub save {
         $r->add_cookie(
             name    => 'no_mobile',
             domain  => ".$LJ::DOMAIN",
-            value   => 1
+            value   => 1,
+            expires => time() + 86400 * 365 * 10, # 10 years
         );
         $r->note( 'no_mobile_post_value', 1 );
     } else {


### PR DESCRIPTION
Fixes #940.
