### PR TITLE
(Bug 784) Whitelist NPR Videos

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -91,6 +91,9 @@ my %host_path_match = (
     "episodecalendar.com"   => qr!^/icalendar/!,
 
     "www.flickr.com"        => qr!/player/$!,
+
+    "www.npr.org"           => qr!^/templates/event/embeddedVideo\.php!,
+
 );
 
 LJ::Hooks::register_hook( 'allow_iframe_embeds', sub {

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 48;
+use Test::More tests => 49;
 
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { require 'ljlib.pl'; }
@@ -127,6 +127,8 @@ note( "misc" );
     test_good_url( "http://episodecalendar.com/icalendar/sampleuser\@example.com/abcde/", "Will 404, but correctly-formed" );
 
     test_good_url( "https://www.flickr.com/photos/cards_by_krisso/13983859958/player/" );
+
+    test_good_url( "http://www.npr.org/templates/event/embeddedVideo.php?storyId=326182003&mediaId=327658636" );
 }
 
 


### PR DESCRIPTION
Whitelists NPR videos. Fixes #784. Note audio NPR clips use a different format.
