### PR TITLE
(Bug 710) Warn when icons do not have keywords

### DIFF
--- a/htdocs/editicons.bml
+++ b/htdocs/editicons.bml
@@ -492,6 +492,21 @@ use strict;
                 <div class='EditIconsStatus'>
             };
 
+        # Check for default userpic keywords
+        my $nokeywords = 0;
+        foreach my $pic ( @userpics ) {
+            my $keywords = $pic->keywords;
+            if ( substr( $keywords, 0, 4 ) eq "pic#" ) {
+                $nokeywords = 1;
+            }
+        }
+
+        if ( $nokeywords ) {
+            $body .= "<div class='highlight-box' id='no_keywords'>";
+            $body .= BML::ml('.error.nokeywords');
+            $body .= "</div>";
+        }            
+
         $body .= "<p><strong>" . BML::ml( '.piclimitstatus', { current => scalar @userpics, max => $max } ) . "</strong> ";
         $body .= BML::ml( '.view.allicons', { aopts => "href='" . $u->allpics_base . "'" } ) . "</p>";
         if (scalar @userpics >= $max) {

--- a/htdocs/editicons.bml.text
+++ b/htdocs/editicons.bml.text
@@ -33,6 +33,8 @@
 
 .error.multipleresize=Error: only one image requiring resizing may be sent.
 
+.error.nokeywords=WARNING: You have not added keywords for one or more of your icons. They have been assigned an automated keyword, in the form of "pic#__". Icons with automated keywords can be used in posts and comments, but may behave strangely. We strongly recommand that you assign keywords to your icons before using them.
+
 .error.nofile=You must choose a file to upload
 
 .error.nomediauploads.delete=Unable to delete icons at this time.


### PR DESCRIPTION
Adds a warning to the /editicons page if icons still have default keywords. Fixes #710.
