### PR TITLE
(Issue #742) Change Screened Comment Text

### DIFF
--- a/htdocs/talkpost_do.bml
+++ b/htdocs/talkpost_do.bml
@@ -245,19 +245,19 @@ body<=
         my $commentu = $init ? $init->{comment}->{u} : undef;
         if ( $journalu && $journalu->is_community ) {
             if ( $POST{'usertype'} eq 'anonymous' ) {
-                $mlcode = 'success.screened.comm.anon2';
+                $mlcode = 'success.screened.comm.anon3';
             } elsif ( $commentu && $commentu->can_manage( $journalu ) ) {
-                $mlcode = '.success.screened.comm.owncomm3';
+                $mlcode = '.success.screened.comm.owncomm4';
             } else {
-                $mlcode = '.success.screened.comm2';
+                $mlcode = '.success.screened.comm3';
             }
         } else {  # not a community
             if ( $POST{'usertype'} eq 'anonymous' ) {
-                $mlcode = '.success.screened.user.anon2';
+                $mlcode = '.success.screened.user.anon3';
             } elsif ( $commentu && $commentu->equals( $journalu ) ) {
-                $mlcode = '.success.screened.user.ownjournal2';
+                $mlcode = '.success.screened.user.ownjournal3';
             } else {
-                $mlcode = '.success.screened.user2';
+                $mlcode = '.success.screened.user3';
             }
         }
     }

--- a/htdocs/talkpost_do.bml.text
+++ b/htdocs/talkpost_do.bml.text
@@ -90,17 +90,17 @@
 
 .success.message2=Your comment has been added. You can <a [[aopts]]>view it</a>.
 
-.success.screened.comm.anon2=Your anonymous comment has been added and marked as screened; it will be visible only to the community administrators until they choose to unscreen it. <a [[aopts]]>Go back to the comment thread</a>.
+.success.screened.comm.anon3=Your anonymous comment has been added and marked as screened; it will be visible only to any logged-in user to whom you may be replying and the community administrators until they choose to unscreen it. <a [[aopts]]>Go back to the comment thread</a>.
 
-.success.screened.comm.owncomm3=Your comment has been added. According to this community or entry's settings, it was marked as screened, and will be visible only to you and any other community admins until one of you chooses to unscreen it. <a [[aopts]]>View your comment</a>.
+.success.screened.comm.owncomm4=Your comment has been added. According to this community or entry's settings, it was marked as screened, and will be visible only to you, any logged-in user to whom you may be replying, and any other community admins until one of you chooses to unscreen it. <a [[aopts]]>View your comment</a>.
 
-.success.screened.comm2=Your comment has been added and marked as screened; it will be visible only to you and the community administrators until they choose to unscreen it. <a [[aopts]]>View your comment</a>.
+.success.screened.comm3=Your comment has been added and marked as screened; it will be visible only to you, any logged-in user to whom you may be replying, and the community administrators until they choose to unscreen it. <a [[aopts]]>View your comment</a>.
 
-.success.screened.user.anon2=Your anonymous comment has been added. According to this account's settings, it was marked as screened and will be visible only to the account owner until the owner chooses to unscreen it. <a [[aopts]]>Go back to the comment thread</a>.
+.success.screened.user.anon3=Your anonymous comment has been added. According to this account's settings, it was marked as screened and will be visible only to any logged-in user to whom you may be replying and the account owner until the owner chooses to unscreen it. <a [[aopts]]>Go back to the comment thread</a>.
 
-.success.screened.user.ownjournal2=Your comment has been added. According to this journal's settings, it was marked as screened, and will be visible only to you until you choose to unscreen it. <a [[aopts]]>View your comment</a>.
+.success.screened.user.ownjournal3=Your comment has been added. According to this journal's settings, it was marked as screened, and will be visible only to you and any logged-in user to whom you may be replying until you choose to unscreen it. <a [[aopts]]>View your comment</a>.
 
-.success.screened.user2=Your comment has been added. According to this account's settings, it was marked as screened and will be visible only to you and the journal's owner until the owner chooses to unscreen it. <a [[aopts]]>View your comment</a>.
+.success.screened.user3=Your comment has been added. According to this account's settings, it was marked as screened and will be visible only to you, any logged-in user to whom you may be replying, and the journal's owner until the owner chooses to unscreen it. <a [[aopts]]>View your comment</a>.
 
 .success.title=Success
 


### PR DESCRIPTION
Adds the phrase "any logged-in user to whom you may be replying" to the success
message after a screened comment is posted to better reflect that there may be
others who can view the comment text. Credit for wording to jlb. Considered
breaking it out to only display that wording only in cases where there was a parent
comment not left by an anonymous user but figured that was perhaps more complicated
than this warranted. Will reconsider if others disagree.

Also, I did change the wording for individual journals, too -- not just comms. Unless I am
misunderstanding how screened comments are handled?

Fixes #742.
