### PR TITLE
Correct rename token email link format. Fixes #825

### DIFF
--- a/cgi-bin/DW/Shop/Item/Rename.pm
+++ b/cgi-bin/DW/Shop/Item/Rename.pm
@@ -125,7 +125,7 @@ sub cart_state_changed {
         my $vars = {
             sitename => $LJ::SITENAME,
             touser   => $u->user,
-            tokenurl => "$LJ::SITEROOT/rename/$token",
+            tokenurl => "$LJ::SITEROOT/rename?giventoken=$token",
         };
 
         if ( $u->equals( $fu ) ) {


### PR DESCRIPTION
So I finally noticed I forgot to track the rename URL format change in the email the user gets when buying a token. This fixes that.
