### PR TITLE
Implement console command to revoke rename token.

### DIFF
--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -3147,6 +3147,7 @@ CREATE TABLE renames (
     fromuser CHAR(25),
     touser CHAR(25),
     rendate INT UNSIGNED,
+    status CHAR(1) NOT NULL DEFAULT 'A',
 
     INDEX (ownerid)
 )
@@ -4307,6 +4308,13 @@ EOF
 
         do_sql( 'UNLOCK TABLES' );
         set_dbnote( "init_media_versions_dimensions", 1 );
+    }
+
+    if ( column_type( "renames", "status" ) eq '' ) {
+        do_alter( 'renames',
+            "ALTER TABLE renames " .
+            "ADD COLUMN status CHAR(1) NOT NULL DEFAULT 'A'" );
+        do_sql( 'UPDATE renames SET status="U" WHERE renuserid = 0' );
     }
 });
 

--- a/cgi-bin/DW/Console/Command/RevokeRenameToken.pm
+++ b/cgi-bin/DW/Console/Command/RevokeRenameToken.pm
@@ -1,0 +1,56 @@
+#!/usr/bin/perl
+#
+# DW::Console::Command::RevokeRenameToken
+#
+# Console command for revoking rename tokens
+#
+# Authors:
+#      Pau Amma <pauamma@dreamwidth.org>
+#
+# Copyright (c) 2014 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+package DW::Console::Command::RevokeRenameToken;
+use strict;
+
+use base qw/ LJ::Console::Command /;
+
+sub cmd { 'revoke_rename_token' }
+sub desc { 'Revoke rename token.' }
+sub args_desc {
+    [
+        'token' => 'Token to revoke.',
+        'reason' => 'Reason for revoking it.',
+    ]
+}
+sub usage { '<token> <reason>' }
+sub can_execute {
+    my $remote = LJ::get_remote();
+    return $remote && $remote->has_priv( "siteadmin", "rename" );
+}
+
+sub execute {
+    my ( $self, $tokenstring, $reason ) = @_;
+
+    my $token = DW::RenameToken->new( token => $tokenstring );
+    return $self->error( 'Invalid token' ) unless $token;
+    return $self->error( 'Token already applied or revoked' )
+        if $token->applied || $token->revoked;
+
+    return $self->error( 'You didn\'t supply a reason' ) unless $reason;
+
+    if ( $token->revoke ) {
+        LJ::statushistory_add( $token->ownerid, LJ::get_remote(),
+                               'rename_token', "$tokenstring revoked: $reason" );
+        $self->print( 'Token successfully revoked' );
+    } else {
+        return $self->error( 'Unable to revoke token' )
+    }
+
+    return 1;
+}
+
+1;

--- a/cgi-bin/DW/Controller/Rename.pm
+++ b/cgi-bin/DW/Controller/Rename.pm
@@ -86,7 +86,7 @@ sub rename_handler {
     }
 
     if ( $token ) {
-        if ( $token->applied ) {
+        if ( $token->applied || $token->revoked ) {
             $vars->{usedtoken} = $token->token;
         } else {
             $vars->{token} = $token;
@@ -123,7 +123,7 @@ sub rename_handler {
         }
     }
 
-    if ( ! $token || ( $token && $token->applied ) ) {
+    if ( ! $token || ( $token && $token->applied ) || ( $token && $token->revoked ) ) {
         # grab a list of tokens they can use in case they didn't provide a usable token
         # assume we always have a remote because our controller is registered as requiring a remote (default behavior)
         $vars->{unused_tokens} = DW::RenameToken->by_owner_unused( userid => $remote->userid );

--- a/cgi-bin/DW/Hooks/PrivList.pm
+++ b/cgi-bin/DW/Hooks/PrivList.pm
@@ -99,8 +99,8 @@ LJ::Hooks::register_hook( 'privlist-add', sub {
                           entry_action email_changed expunge_userpic
                           impersonate journal_status logout_user
                           mass_privacy paid_from_invite paidstatus
-                          privadd privdel reset_email reset_password
-                          s2lid_remap set_badpassword shop_points
+                          privadd privdel rename_token reset_email
+                          reset_password s2lid_remap set_badpassword shop_points
                           suspend sysban_add sysban_mod synd_create
                           synd_edit synd_merge sysban_add sysban_modify
                           sysban_trig unsuspend vgifts viewall /;

--- a/cgi-bin/DW/User/Rename.pm
+++ b/cgi-bin/DW/User/Rename.pm
@@ -196,7 +196,7 @@ sub rename {
     my $remote = LJ::isu( $opts{user} ) ? $opts{user} : $self;
     push @$errref, LJ::Lang::ml( 'rename.error.tokeninvalid' )
         unless $opts{token} && $opts{token}->isa( "DW::RenameToken" );
-    push @$errref, LJ::Lang::ml( 'rename.error.tokenapplied' ) if $opts{token} && $opts{token}->applied;
+    push @$errref, LJ::Lang::ml( 'rename.error.tokenapplied' ) if $opts{token} && ( $opts{token}->applied || $opts{token}->revoked );
 
     my $can_rename_to = $self->can_rename_to( $tousername, %opts );
 
@@ -230,7 +230,7 @@ sub swap_usernames {
                 && $token->ownerid == $admin->userid;
 
         push @$errref, LJ::Lang::ml( 'rename.error.tokenapplied' )
-            if $token->applied;
+            if $token->applied || $token->revoked;
     }
 
     if ( scalar @tokens >= 2 ) {


### PR DESCRIPTION
Fixes #826
- Introduce new field, status, in rename table (U-nused, A-pplied, R-evoked)
- Add methods to DW::RenameToken to revoke, test for revokedness
- Change implementation of ->apply and ->applied to use status
- Call ->revoked wherever needed (just about everywhere ->applied is called)
- New module DW::Console::Command::RevokeRenameToken implements console
  command revoke_rename_token
