### PR TITLE
[#1053] Ensure we always have an id so we can link form element to label

### DIFF
--- a/cgi-bin/DW/Template/Plugin/FormHTML.pm
+++ b/cgi-bin/DW/Template/Plugin/FormHTML.pm
@@ -58,6 +58,7 @@ sub new {
         data     => $data,
         errors   => $errors,
         did_post => $r && $r->did_post,
+        _id_gen_counter => 0,
     }, $class;
 
     return $self;
@@ -114,6 +115,7 @@ sub checkbox {
 
     $args->{labelclass} ||= "checkboxlabel";
     $args->{class} ||= "checkbox";
+    $args->{id} ||= $self->generate_id( $args );
 
     # makes the form element use the default or an explicit value...
     my $label_html = $self->_process_value_and_label( $args, use_as_value => "selected", noautofill => 1 );
@@ -200,6 +202,7 @@ sub radio {
 
     $args->{labelclass} ||= "radiolabel";
     $args->{class} ||= "radio";
+    $args->{id} ||= $self->generate_id( $args );
 
     # makes the form element use the default or an explicit value...
     my $label_html = $self->_process_value_and_label( $args, use_as_value => "selected", noautofill => 1 );
@@ -250,6 +253,7 @@ sub select {
 
     my $items = delete $args->{items};
     $args->{class} ||= "select";
+    $args->{id} ||= $self->generate_id( $args );
 
     my $ret = "";
     $ret .= $self->_process_value_and_label( $args, use_as_value => "selected" );
@@ -284,6 +288,7 @@ sub textarea {
     my ( $self, $args ) = @_;
 
     $args->{class} ||= "text";
+    $args->{id} ||= $self->generate_id( $args );
 
     my $ret = "";
     $ret .= $self->_process_value_and_label( $args );
@@ -315,6 +320,7 @@ sub textbox {
 
     $args->{class} ||= "text";
     $args->{class} .= " error" if @errors;
+    $args->{id} ||= $self->generate_id( $args );
 
     my $ret = "";
     $ret .= $self->_process_value_and_label( $args );
@@ -343,6 +349,7 @@ sub password {
     $args->{type} = "password";
     $args->{class} ||= "text";
     $args->{class} .= " error" if @errors;
+    $args->{id} ||= $self->generate_id( $args );
 
     my $ret = "";
     $ret .= $self->_process_value_and_label( $args, noautofill => 1 );
@@ -356,6 +363,12 @@ sub password {
 
 }
 
+# generates a unique id for a form element
+# ensures that we can easily associate the form element to its label
+sub generate_id {
+    my ( $self, $args ) = @_;
+    return "id-" . $args->{name} . "-" . $self->{_id_gen_counter}++;
+}
 
 # populate the element's value, modifying the $args hashref
 # return the label HTML if applicable
@@ -380,7 +393,8 @@ sub _process_value_and_label {
     my $label_html = "";
     my $label = delete $args->{label};
     my $labelclass = delete $args->{labelclass} || "";
-    $label_html = LJ::labelfy( $args->{id} || "", LJ::ehtml( $label ), $labelclass )
+
+    $label_html = LJ::labelfy( $args->{id}, LJ::ehtml( $label ), $labelclass )
         if defined $label;
 
     return $label_html || "";

--- a/views/admin/console/index.tt
+++ b/views/admin/console/index.tt
@@ -26,7 +26,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <form method="POST" action="[%- form_url -%]">
     [%- dw.form_auth -%]
     [%- form.textarea( label = dw.ml( ".entercommands" )
-        id = "console"
         name = "commands"
         rows = 10
         cols = 70

--- a/views/admin/propedit.tt
+++ b/views/admin/propedit.tt
@@ -19,7 +19,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <div class="columns">
     [%- form.textbox(
         label = "Username"
-        id = 'username_input'
         name = 'username'
         maxlength = 50
         size = 25

--- a/views/admin/supportcat/category.tt
+++ b/views/admin/supportcat/category.tt
@@ -22,26 +22,26 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [% dw.form_auth %]
     <input type="hidden" name="newcat" value="[% newcat | html %]" />
     [% IF newcat %]
-        <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.catkey.label2' ), name="catkey", id="catkey", maxlength=25 ) %]</div>
+        <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.catkey.label2' ), name="catkey", maxlength=25 ) %]</div>
         <div class="medium-8 large-8 column"><small>[% '.field.catkey.note' | ml %]</small></div></div>
     [% ELSE %]
-        [% form.hidden( name="catkey", id="catkey" ) %]
+        [% form.hidden( name="catkey" ) %]
     [% END %]
-    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.catname.label2' ), name="catname", id="catname", maxlength=80, size=50 ) %]</div>
+    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.catname.label2' ), name="catname", maxlength=80, size=50 ) %]</div>
     <div class="medium-8 large-8 column"><small>[% '.field.catname.note' | ml %]</small></div></div>
-    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.sortorder.label2' ), name="sortorder", id="sortorder", maxlength=8 ) %]</div>
+    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.sortorder.label2' ), name="sortorder", maxlength=8 ) %]</div>
     <div class="medium-8 large-8 column"><small>[% '.field.sortorder.note' | ml %]</small></div></div>
-    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.basepoints.label2' ), name="basepoints", id="basepoints", maxlength=3 ) %]</div>
+    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.basepoints.label2' ), name="basepoints", maxlength=3 ) %]</div>
     <div class="medium-8 large-8 column"><small>[% '.field.basepoints.note' | ml %]</small></div></div>
     [% FOREACH checkbox IN [ 'is_selectable' 'public_read' 'public_help' 'allow_screened' 'hide_helpers' 'user_closeable' ] %]
-        <div class="row"><div class="medium-4 large-4 column">[% form.checkbox_nested( label=dw.ml( ".field.${checkbox}.label2" ), name=checkbox, id=checkbox, value=1, selected=formdata.$checkbox ) %]</div>
+        <div class="row"><div class="medium-4 large-4 column">[% form.checkbox_nested( label=dw.ml( ".field.${checkbox}.label2" ), name=checkbox, value=1, selected=formdata.$checkbox ) %]</div>
         <div class="medium-8 large-8 column"><small>[% ".field.${checkbox}.note" | ml %]</small></div></div>
     [% END %]
-    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.replyaddress.label2' ), name="replyaddress", id="replyaddress", maxlength=50 ) %]</div>
+    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.replyaddress.label2' ), name="replyaddress", maxlength=50 ) %]</div>
     <div class="medium-8 large-8 column"><small>[% '.field.replyaddress.note' | ml %]</small></div></div>
-    <div class="row"><div class="medium-4 large-4 column">[% form.checkbox_nested( label=dw.ml( '.field.no_autoreply.label2' ), name="no_autoreply", id="no_autoreply", value=1, selected=formdata.no_autoreply ) %]</div>
+    <div class="row"><div class="medium-4 large-4 column">[% form.checkbox_nested( label=dw.ml( '.field.no_autoreply.label2' ), name="no_autoreply", value=1, selected=formdata.no_autoreply ) %]</div>
     <div class="medium-8 large-8 column"><small>[% '.field.no_autoreply.note' | ml %]</small></div></div>
-    <div class="row"><div class="medium-4 large-4 column">[% form.select( label=dw.ml( '.field.scope.label2' ), name="scope", id="scope", selected=formdata.scope, items=[ 'general', dw.ml( '.field.scope.option.general' ), 'local', dw.ml( '.field.scope.option.local' ) ] ) %]</div>
+    <div class="row"><div class="medium-4 large-4 column">[% form.select( label=dw.ml( '.field.scope.label2' ), name="scope", selected=formdata.scope, items=[ 'general', dw.ml( '.field.scope.option.general' ), 'local', dw.ml( '.field.scope.option.local' ) ] ) %]</div>
     <div class="medium-8 large-8 column"><small>[% '.field.scope.note' | ml %]</small></div></div>
     <div class="row"><div class="column">[% form.submit( name="submit", value=dw.ml( '.button' ) ) %]</div></div>
     </form>

--- a/views/communities/members/edit.tt
+++ b/views/communities/members/edit.tt
@@ -97,7 +97,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <div class="row collapse">
       <div class="large-8 columns">
         [%- form.textbox( name="q"
-                          id="q"
                           label=dw.ml( ".find.label" ),
                           labelclass="hidden" ) -%]
       </div>

--- a/views/communities/new.tt
+++ b/views/communities/new.tt
@@ -43,7 +43,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
                 label = dw.ml( '.form.comminfo.title.label' )
                 hint = dw.ml( '.form.comminfo.title.hint' )
                 name  = "title"
-                id    = "title"
                 maxlength = 80
             ) -%]
     </fieldset>

--- a/views/communities/queue/entries/edit.tt
+++ b/views/communities/queue/entries/edit.tt
@@ -65,7 +65,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- IF entry.poster.is_validated -%]
         [% form.textarea(
             name  = "message"
-            id    = "message"
             label = dw.ml( ".form.label.message" )
         ) %]
         [%- END -%]

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -182,7 +182,6 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
         <div class="row"><div class="columns">
             <div class='subject-container'>
                 [%- form.textbox( label = dw.ml(".subject.label")
-                        id = "subject"
                         name = "subject"
 
                         maxlength = limits.subject_length
@@ -198,7 +197,6 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
         <div class="row"><div class="columns">
             <div class='event-container'>
                 [%- form.textarea( label = dw.ml(".event.label")
-                    id = "event"
                     name = "event"
 
                     cols = "50"

--- a/views/entry/login.tt
+++ b/views/entry/login.tt
@@ -26,7 +26,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%- form.textbox(
         label = dw.ml( 'sitescheme.accountlinks.login.username' )
         name = "username"
-        id = "post-entry-username"
         size = "20"
         maxlength = "27"
         "aria-required" = "true"
@@ -35,7 +34,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
         label = dw.ml( 'sitescheme.accountlinks.login.password' )
         type = "password"
         name = "password"
-        id = "post-entry-password"
         size = "20"
         "aria-required" = "true"
     ) -%]

--- a/views/settings/accountstatus.tt
+++ b/views/settings/accountstatus.tt
@@ -35,7 +35,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%- form.select(
         label = dw.ml( ".journalstatus.select.head" )
         name = "statusvis"
-        id = "statusvis"
         selected = u.statusvis
         items = statusvis_options
     ) -%]
@@ -45,7 +44,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%- form.textbox(
         label = dw.ml( '.reason.head' )
         name = 'reason'
-        id = 'reason'
         value = delete_reason
         maxlength = 255
         hint = dw.ml( u.is_community ? '.reason.about.comm' : '.reason.about' )


### PR DESCRIPTION
- exceptions are radio_nested and checkbox_nested (don't need a label to
  associate the form element with the parent); hidden, submit (label not
  applicable)
- remove unneeded ids which were there only to associate the form
  element with the label (doesn't include js-\* ids, ids used to provide
  a description via aria-describedby, etc)
  Fixes #1053.
