### PR TITLE
[#1058] Convert the 404 page to BML

### DIFF
--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -384,9 +384,9 @@ sub trans
 
     } else { # not is_initial_req
         if ($apache_r->status == 404) {
-            my $fn = $LJ::PAGE_404 || "404-error.bml";
-            my ( $uri, $path ) = resolve_path_for_uri( $apache_r, $fn );
-            return $bml_handler->( $path ) if $path;
+            my $ret = DW::Routing->call( uri => "/internal/local/404" );
+            $ret //= DW::Routing->call( uri => "/internal/404" );
+            return $ret if defined $ret;
         }
     }
 

--- a/cgi-bin/DW/Controller/Misc.pm
+++ b/cgi-bin/DW/Controller/Misc.pm
@@ -38,6 +38,8 @@ DW::Routing->register_string( "/random/index", \&random_personal_handler, app =>
 DW::Routing->register_string( "/community/random/index", \&random_community_handler, app => 1 );
 DW::Routing->register_string( "/beta", \&beta_handler, app => 1 );
 
+DW::Routing->register_static( '/internal/404', 'error/404.tt', app => 1 );
+
 sub beta_handler {
     my ( $opts ) = @_;
 

--- a/doc/config-local.pl.txt
+++ b/doc/config-local.pl.txt
@@ -108,11 +108,6 @@
     # for security reasons, we strongly recommend that this not be on your $DOMAIN
     $EMBED_MODULE_DOMAIN = "embed.my-other-domain.net";
 
-    # 404 page
-    # Uncomment if you don't want the (dw-free) default, 404-error.bml
-    # (Note: you need to provide your own 404-error-local.bml)
-    # $PAGE_404 = "404-error-local.bml";
-
     # merchandise link
     # $MERCH_URL = "http://www.zazzle.com/dreamwidth*";
 

--- a/views/error/404.tt
+++ b/views/error/404.tt
@@ -1,31 +1,17 @@
-<?_c
-#
-# 404-error.bml
-#
-# Stock 404 ErrorDocument
-#
-# Author:
-#      Pau Amma <pauamma@dreamwidth.org>
-#
-# Copyright (c) 2009 by Dreamwidth Studios, LLC.
-#
-# This program is free software; you may redistribute it and/or modify it under
-# the same terms as Perl itself. For a copy of the license, please reference
-# 'perldoc perlartistic' or 'perldoc perlgpl'.
-#
-_c?><?page
-body<=
-<?_code
-{
-    use strict;
-    use warnings;
-    use vars qw( $title $windowtitle $headextra );
+[%# Stock 404 ErrorDocument
 
-    $windowtitle = $title = "We can't find that page";
+Authors:
+    Pau Amma <pauamma@dreamwidth.org>
+    Afuna <coder.dw@afunamatata.com>
 
-    my $ret;
+This program is free software; you may redistribute it and/or modify it under
+the same terms as Perl itself.  For a copy of the license, please reference
+'perldoc perlartistic' or 'perldoc perlgpl'.
+%]
 
-    $ret .= <<PAGE;
+[%- sections.title = "We can't find that page" -%]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
 <p>If you typed the URL directly (or pasted it into your browser's address bar), make sure you didn't typo, paste too little, or paste too much. If you followed a link, report this to the maintainer of the page that linked you here.</p>
 
 <!--
@@ -85,15 +71,3 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 -->
-PAGE
-
-    return $ret;
-}
-_code?>
-<=body
-title=><?_code return $title; _code?>
-windowtitle=><?_code return $windowtitle; _code?>
-head<=
-<?_code return $headextra; _code?>
-<=head
-page?>


### PR DESCRIPTION
- changes the call from loading a BML page to calling
  /internal/local/404 (if it exists) or /internal/404
- anyone choosing to modify their stock 404 page can either edit the one
  in views/error/404.tt
- if there's additional logic, they can register a new
  /internal/local/404 path
