### PR TITLE
Make consistent creating of the authas form

### DIFF
--- a/cgi-bin/DW/Controller.pm
+++ b/cgi-bin/DW/Controller.pm
@@ -73,7 +73,7 @@ sub render_success {
 # Supported arguments: (1 stands for any true value, 0 for any false value)
 # - anonymous => 1 -- lets anonymous (not logged in) visitors view the page
 # - anonymous => 0 -- doesn't (default)
-# - authas => 1 -- allows ?authas= in URL, generates authas form (not permitted
+# - authas => 1  or { args } -- allows ?authas= in URL, generates authas form (not permitted
 #                  if anonymous => 1 specified)
 # - authas => 0 -- doesn't (default)
 # - specify_user => 1 -- allows ?user= in URL (Note: requesting both authas and
@@ -150,7 +150,16 @@ sub controller {
     if ( $args{authas} ) {
         $vars->{u} = LJ::get_authas_user( $r->get_args->{authas} || $vars->{remote}->user )
             or return $fail->( error_ml( 'error.invalidauth' ) );
+
+        my $authas_args = $args{authas} == 1 ? {} : $args{authas};
+
+        # older pages
         $vars->{authas_html} = LJ::make_authas_select( $vars->{remote}, { authas => $vars->{u}->user } );
+
+        # foundation pages
+        $vars->{authas_form} = "<form action='" . LJ::create_url() . "' method='get'>"
+                                . LJ::make_authas_select( $vars->{remote}, { authas => $vars->{u}->user, foundation => 1, %{$authas_args || {}} } )
+                                . "</form>";
     }
 
     # check user is suitably privved

--- a/cgi-bin/DW/Controller/Dev.pm
+++ b/cgi-bin/DW/Controller/Dev.pm
@@ -20,16 +20,27 @@ use strict;
 use warnings;
 use DW::Routing;
 use DW::SiteScheme;
+use DW::Controller;
 
 use LJ::JSON;
 
-DW::Routing->register_static( '/dev/style-guide', 'dev/style-guide.tt', app => 1 );
+DW::Routing->register_string( '/dev/style-guide', \&style_guide_handler, app => 1 );
 
 if ( $LJ::IS_DEV_SERVER ) {
     DW::Routing->register_string( '/dev/tests/index', \&tests_index_handler, app => 1 );
     DW::Routing->register_regex( '^/dev/tests/([^/]+)(?:/(.*))?$', \&tests_handler, app => 1 );
 
     DW::Routing->register_string( '/dev/testhelper/jsondump', \&testhelper_json_handler, app => 1, format => "json" );
+}
+
+sub style_guide_handler {
+    my ( $ok, $rv ) = controller( anonymous => 1 );
+    return $rv unless $ok;
+
+    my $authas_form = "<form action='" . LJ::create_url() . "' method='get'>"
+                            . LJ::make_authas_select( LJ::load_user( "system" ), { authas => "", foundation => 1 } )
+                            . "</form>";
+    return DW::Template->render_template( 'dev/style-guide.tt', { authas_form => $authas_form } );
 }
 
 sub tests_index_handler {

--- a/cgi-bin/DW/Controller/Settings.pm
+++ b/cgi-bin/DW/Controller/Settings.pm
@@ -40,16 +40,13 @@ DW::Routing->register_string( "/changepassword", \&changepassword_handler, app =
 sub account_status_handler {
     my ( $opts ) = @_;
 
-    my ( $ok, $rv ) = controller( form_auth => 1 );
+    my ( $ok, $rv ) = controller( form_auth => 1, authas => { show_all => 1 } );
     return $rv unless $ok;
 
     my $r = $rv->{r};
     my $remote = $rv->{remote};
+    my $u = $rv->{u};
     my $get = $r->get_args;
-
-    my $authas = $get->{authas} || $remote->{user};
-    my $u = LJ::get_authas_user( $authas );
-    return error_ml( 'error.invalidauth' ) unless $u;
 
     my $ml_scope = "/settings/accountstatus.tt";
     my @statusvis_options = $u->is_suspended
@@ -198,6 +195,8 @@ sub account_status_handler {
         messages => $messages,
         warnings => $warnings,
         formdata => $post,
+
+        authas_form => $rv->{authas_form},
     };
     return DW::Template->render_template( 'settings/accountstatus.tt', $vars );
 }

--- a/cgi-bin/DW/Template/Plugin.pm
+++ b/cgi-bin/DW/Template/Plugin.pm
@@ -147,20 +147,6 @@ sub img {
     return LJ::img(@_);
 }
 
-=head2 authas
-
-Print out the authas select dropdown
-
-=cut
-sub authas {
-    my ( $self, $args ) = @_;
-
-    my $r = DW::Request->get;
-    return "<form action='" . LJ::create_url() . "' method='get'>"
-            . LJ::make_authas_select( LJ::get_remote(), { authas => $r->get_args->{authas}, foundation => 1, %{$args || {}} } )
-        . "</form>"
-}
-
 =head2 scoped_include
 
 Easy way to handle changing the ml scope around an INCLUDE block.

--- a/views/dev/style-guide.tt
+++ b/views/dev/style-guide.tt
@@ -512,12 +512,13 @@ dw.need_res( { group => "foundation" },
 <h2>Authas</h2>
 <div class="row">
   <div class="columns">
-    [%- dw.authas() -%]
+    [%- authas_form -%]
   </div>
 </div>
 <div class="row"><div class="columns">
   [%- WRAPPER code -%]
-    dw.authas()
+    # variable from controller()
+    authas_form
   [%- END -%]
 </div></div>
 <h2>Alert Boxes</h2>

--- a/views/settings/accountstatus.tt
+++ b/views/settings/accountstatus.tt
@@ -11,7 +11,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- sections.title = ".title" | ml -%]
 [%- CALL dw.active_resource_group( "foundation" ) -%]
 
-[%- dw.authas( showall = 1 ) -%]
+[%- authas_form -%]
 
 [%- IF messages.exist -%]
     [%- FOREACH msg = messages.get_all -%]


### PR DESCRIPTION
- prefered is to pass in authas => 1 or authas => { show_all => 1 } (or
  whatever args) to controller(). For foundation pages, use
  $rv->{authas_form}, where the authas is wrapped in an actual form. For
  non-foundation pages, use $rv->{authas_html} which only has the select
  HTML. This means that we don't have to worry about checking for
  authas, so long as we make sure to use $rv->{u} versus $rv->{remote}
  where it matters
- remove now-obsolete plugin authas function
