### PR TITLE
[#825] Fix URL for renames

### DIFF
--- a/cgi-bin/DW/Controller/Rename.pm
+++ b/cgi-bin/DW/Controller/Rename.pm
@@ -29,7 +29,7 @@ use DW::Shop;
 DW::Routing->register_string( "/rename/swap", \&swap_handler, app => 1 );
 
 # token is now passed as a get argument
-DW::Routing->register_string( "/rename", \&rename_handler, app => 1 );
+DW::Routing->register_string( "/rename/index", \&rename_handler, app => 1 );
 
 DW::Routing->register_string( "/admin/rename/index", \&rename_admin_handler, app => 1 );
 DW::Routing->register_string( "/admin/rename/edit", \&rename_admin_edit_handler, app => 1 );

--- a/cgi-bin/DW/Shop/Item/Rename.pm
+++ b/cgi-bin/DW/Shop/Item/Rename.pm
@@ -60,7 +60,7 @@ sub name_text {
 # override
 sub name_html {
     return $_[0]->token && $_[0]->from_userid == $_[0]->t_userid
-        ? LJ::Lang::ml( 'shop.item.rename.name.hastoken', { token => $_[0]->token, aopts => "href='$LJ::SITEROOT/rename/" . $_[0]->token . "'" } )
+        ? LJ::Lang::ml( 'shop.item.rename.name.hastoken', { token => $_[0]->token, aopts => "href='$LJ::SITEROOT/rename?giventoken=" . $_[0]->token . "'" } )
         : LJ::Lang::ml( 'shop.item.rename.name.notoken', { points => $_[0]->cost_points } );
 }
 


### PR DESCRIPTION
* makes /rename/ work (note the ending slash)

* updates the URL in the receipt