### PR TITLE
Add barebones Amazon SES SMTP sender

### DIFF
--- a/bin/checkconfig.pl
+++ b/bin/checkconfig.pl
@@ -269,6 +269,7 @@ my %modules = (
                },
                "List::MoreUtils" => {},
                "Locale::Country" => { ver => '3.32' },
+               "Net::SMTPS" => {},
               );
 
 

--- a/bin/worker/send-email-ses
+++ b/bin/worker/send-email-ses
@@ -1,0 +1,121 @@
+#!/usr/bin/perl
+#
+# send-email-ses -- worker for sending email through Amazon SES
+#
+# This is a replacement for the direct sending email client, this module uses
+# Amazon's SES to deliver the email for us so we don't have to manage
+# reputation, etc. Much easier.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2015 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use lib "$ENV{LJHOME}/extlib/lib/perl5";
+use lib "$ENV{LJHOME}/cgi-bin";
+BEGIN {
+    require 'ljlib.pl';
+}
+
+use Carp qw/ croak /;
+use LJ::Worker::TheSchwartz;
+
+croak 'SES is not configured. What do!'
+    unless $LJ::EMAIL_VIA_SES{hostname};
+
+schwartz_decl('TheSchwartz::Worker::SendEmail');
+schwartz_on_idle(sub {
+    $0 = "send-email [idle]";
+});
+schwartz_work();
+
+# ============================================================================
+package TheSchwartz::Worker::SendEmail;
+use base 'TheSchwartz::Worker';
+use Carp qw/ croak /;
+use Net::SMTPS;
+
+my $_SMTP = undef;
+
+sub work {
+    my ( $class, $job ) = @_;
+    my $args = $job->arg;
+    my $hstr = $job->handle->as_string;
+
+    my $smtp = $_SMTP || Net::SMTPS->new(
+        $LJ::EMAIL_VIA_SES{hostname},
+        doSSL   => 'starttls',
+        Port    => 587,
+        Timeout => 60,
+    );
+    $smtp->auth($LJ::EMAIL_VIA_SES{username}, $LJ::EMAIL_VIA_SES{password});
+
+    my $env_from = $args->{env_from};  # Envelope From
+    my $rcpts    = $args->{rcpts};     # arrayref of recipients
+    my $body     = $args->{data};
+
+    # remove bcc
+    $body =~ s/^(.+?\r?\n\r?\n)//s;
+    my $headers = $1;
+    $headers =~ s/^bcc:.+\r?\n//mig;
+
+    # unless they specified a message ID, let's prepend our own:
+    unless ($headers =~ m!^message-id:.+!mi) {
+        my ($this_domain) = $env_from =~ /\@(.+)/;
+        $headers = "Message-ID: <sch-$hstr\@$this_domain>\r\n" . $headers;
+    }
+
+    my $details = sub {
+        return eval {
+            $smtp->code . " " . $smtp->message;
+        }
+    };
+
+    my $not_ok = sub {
+        my $cmd = $_[0];
+        if ($smtp->status == 5) {
+            $job->permanent_failure("Permanent failure during $cmd phase to [@$rcpts]: " . $details->());
+            $_SMTP = undef;
+            return;
+        }
+        croak "Error during $cmd phase to [@$rcpts]: " . $details->();
+    };
+
+    return $not_ok->("MAIL") unless $smtp->mail($env_from);
+
+    my $got_an_okay = 0;
+    foreach my $rcpt (@$rcpts) {
+        if ( $smtp->to($rcpt) ) {
+            $got_an_okay = 1;
+            next;
+        }
+        next if $smtp->status == 5;
+
+        croak "Error during TO phase to [@$rcpts]: " . $details->();
+    }
+
+    unless ($got_an_okay) {
+        $job->permanent_failure("Permanent failure TO [@$rcpts]: " . $details->() . "\n");
+        return;
+    }
+
+    return $not_ok->("DATA")     unless $smtp->data;
+    return $not_ok->("DATASEND") unless $smtp->datasend($headers . $body);
+    return $not_ok->("DATAEND")  unless $smtp->dataend;
+
+    $job->completed;
+}
+
+sub keep_exit_status_for { 0 }
+sub grab_for { 500 }
+sub max_retries { 5 * 24 }  # 5 days * 24 hours
+sub retry_delay {
+    my ($class, $fails) = @_;
+    return ((5*60, 5*60, 15*60, 30*60)[$fails] || 3600);
+}

--- a/doc/config-private.pl.txt
+++ b/doc/config-private.pl.txt
@@ -147,8 +147,17 @@
 
     # If you are going to be using the external content proxy system, you should
     # define a file here that contains your private salt.
-    $PROXY_URL = "https://proxy.myhost.net";
-    $PROXY_SALT_FILE = "$HOME/etc/proxy-salt";
+    # $PROXY_URL = "https://proxy.myhost.net";
+    # $PROXY_SALT_FILE = "$HOME/etc/proxy-salt";
+
+    # If you want to use Amazon SES (e.g. bin/worker/send-email-ses) then you
+    # need to do a lot of setup on the Amazon side and then fill this out. The
+    # settings are from the SMTP Settings page in SES.
+    # %EMAIL_VIA_SES = (
+    #     hostname => '...',
+    #     username => '...',
+    #     password => '...',
+    # );
 }
 
 {


### PR DESCRIPTION
This uses Net::SMTPS to send email over TLS encrypted SMTP via Amazon's
SES service. This worker is a drop-in replacement, once configured you
can just spin this one up instead of the other send-email and it will
route email through SES instead of directly to the targets.