### PR TITLE
[#1134] Use protocol-relative URL for image objects in S2

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2442,6 +2442,9 @@ sub Image_std
     my $name = shift;
     my $ctx = $LJ::S2::CURR_CTX or die "No S2 context available ";
 
+    my $imgprefix = $LJ::IMGPREFIX;
+    $imgprefix =~ s/^https?://;
+
     unless ($LJ::S2::RES_MADE++) {
         $LJ::S2::RES_CACHE = {};
         my $textmap = {
@@ -2456,7 +2459,7 @@ sub Image_std
         foreach ( keys %$textmap ) {
             my $i = $LJ::Img::img{$_};
             $LJ::S2::RES_CACHE->{$_} =
-                Image( "$LJ::IMGPREFIX$i->{src}",
+                Image( "$imgprefix$i->{src}",
                        $i->{width}, $i->{height},
                        $ctx->[S2::PROPS]->{ $textmap->{$_} } );
         }
@@ -2469,7 +2472,7 @@ sub Image_std
         foreach ( @ic ) {
             my $i = $LJ::Img::img{$_};
             $LJ::S2::RES_CACHE->{$_} =
-                Image( "$LJ::IMGPREFIX$i->{src}",
+                Image( "$imgprefix$i->{src}",
                        $i->{width}, $i->{height},
                        LJ::Lang::ml( $i->{alt} ) );
         }


### PR DESCRIPTION
This means that we cache it as "//" rather than "http://" or "https://"
so it works both pages.

A bit hacky, but makes sure we're limited in scope to website-only
(journals only), and not affecting stuff like email.

Fixes #1134.