### PR TITLE
Bug 5242 - update all events to use LJ::Event::raw_subscriptions

### DIFF
--- a/cgi-bin/LJ/Event/ImportStatus.pm
+++ b/cgi-bin/LJ/Event/ImportStatus.pm
@@ -164,29 +164,10 @@ sub _optsref {
 # a subscription object for the user
 sub raw_subscriptions {
     my ( $class, $self, %args ) = @_;
-    my $cid = delete $args{'cluster'};
-    croak("Cluser id (cluster) must be provided") unless defined $cid;
 
-    my $scratch = delete $args{'scratch'}; # optional
+    $args{ntypeid} = LJ::NotificationMethod::Inbox->ntypeid; # Inbox
 
-    croak("Unknown options: " . join(', ', keys %args)) if %args;
-    croak("Can't call in web context") if LJ::is_web_context();
-
-    my @subs;
-    my $u = $self->u;
-    return unless $cid == $u->clusterid;
-
-    my $row = { userid  => $self->u->id,
-                ntypeid => LJ::NotificationMethod::Inbox->ntypeid, # Inbox
-                etypeid => $class->etypeid,
-              };
-
-    push @subs, LJ::Subscription->new_from_row($row);
-
-    push @subs, eval { LJ::Event::raw_subscriptions( $class, $self,
-        cluster => $cid, scratch => $scratch ) };
-
-    return @subs;
+    return $class->_raw_always_subscribed( $self, %args );
 }
 
 sub get_subscriptions {

--- a/cgi-bin/LJ/Event/SecurityAttributeChanged.pm
+++ b/cgi-bin/LJ/Event/SecurityAttributeChanged.pm
@@ -131,29 +131,10 @@ sub is_significant { 1 }
 # a subscription object for the user
 sub raw_subscriptions {
     my ( $class, $self, %args ) = @_;
-    my $cid = delete $args{'cluster'};
-    croak("Cluser id (cluster) must be provided") unless defined $cid;
 
-    my $scratch = delete $args{'scratch'}; # optional
+    $args{ntypeid} = LJ::NotificationMethod::Email->ntypeid; # Email
 
-    croak("Unknown options: " . join(', ', keys %args)) if %args;
-    croak("Can't call in web context") if LJ::is_web_context();
-
-    my @subs;
-    my $u = $self->u;
-    return unless $cid == $u->clusterid;
-
-    my $row = { userid  => $self->u->id,
-                ntypeid => LJ::NotificationMethod::Email->ntypeid, # Email
-                etypeid => $class->etypeid,
-              };
-
-    push @subs, LJ::Subscription->new_from_row($row);
-
-    push @subs, eval { LJ::Event::raw_subscriptions( $class, $self,
-        cluster => $cid, scratch => $scratch ) };
-
-    return @subs;
+    return $class->_raw_always_subscribed( $self, %args );
 }
 
 sub get_subscriptions {

--- a/cgi-bin/LJ/Event/UserMessageRecvd.pm
+++ b/cgi-bin/LJ/Event/UserMessageRecvd.pm
@@ -110,7 +110,7 @@ sub as_html {
     my $pichtml = display_pic($msg, $other_u);
     my $subject = $msg->subject;
 
-    if ( $other_u->is_suspended ) { 
+    if ( $other_u->is_suspended ) {
         $subject = "(Reply from suspended user)";
     }
 
@@ -195,34 +195,14 @@ sub content_summary {
     return $ret;
 }
 
-# override parent class sbuscriptions method to always return
+# override parent class subscriptions method to always return
 # a subscription object for the user
 sub raw_subscriptions {
-    my ($class, $self, %args) = @_;
-    my $cid   = delete $args{'cluster'};
-    croak("Cluser id (cluster) must be provided") unless defined $cid;
+    my ( $class, $self, %args ) = @_;
 
-    my $scratch = delete $args{'scratch'}; # optional
+    $args{ntypeid} = LJ::NotificationMethod::Inbox->ntypeid; # Inbox
 
-    croak("Unknown options: " . join(', ', keys %args)) if %args;
-    croak("Can't call in web context") if LJ::is_web_context();
-
-    my @subs;
-    my $u = $self->u;
-    return unless ( $cid == $u->clusterid );
-
-    my $row = { userid  => $self->u->{userid},
-                ntypeid => LJ::NotificationMethod::Inbox->ntypeid, # Inbox
-                etypeid => $class->etypeid,
-              };
-
-    push @subs, LJ::Subscription->new_from_row($row);
-
-    push @subs, eval { LJ::Event::raw_subscriptions($class, $self,
-        cluster => $cid, scratch => $scratch ) };
-
-
-    return @subs;
+    return $class->_raw_always_subscribed( $self, %args );
 }
 
 sub get_subscriptions {

--- a/cgi-bin/LJ/Event/UserMessageSent.pm
+++ b/cgi-bin/LJ/Event/UserMessageSent.pm
@@ -92,21 +92,25 @@ sub content_summary {
     return $ret;
 }
 
-# override parent class sbuscriptions method to always return
+# override parent class subscriptions method to always return
 # a subscription object for the user
-sub subscriptions {
-    my ($self, %args) = @_;
-    my $cid   = delete $args{'cluster'};  # optional
-    my $limit = delete $args{'limit'};    # optional
+sub raw_subscriptions {
+    my ( $class, $self, %args ) = @_;
+    my $cid = delete $args{'cluster'};
+    croak("Cluser id (cluster) must be provided") unless defined $cid;
+
+    my $scratch = delete $args{'scratch'}; # optional
+
     croak("Unknown options: " . join(', ', keys %args)) if %args;
     croak("Can't call in web context") if LJ::is_web_context();
 
     my @subs;
     my $u = $self->u;
-    return unless ( $cid == $u->clusterid );
+    return unless $cid == $u->clusterid;
 
-    my $row = { userid  => $self->u->{userid},
+    my $row = { userid  => $self->u->id,
                 ntypeid => LJ::NotificationMethod::Inbox->ntypeid, # Inbox
+                etypeid => $class->etypeid,
               };
 
     push @subs, LJ::Subscription->new_from_row($row);

--- a/cgi-bin/LJ/Event/UserMessageSent.pm
+++ b/cgi-bin/LJ/Event/UserMessageSent.pm
@@ -96,26 +96,11 @@ sub content_summary {
 # a subscription object for the user
 sub raw_subscriptions {
     my ( $class, $self, %args ) = @_;
-    my $cid = delete $args{'cluster'};
-    croak("Cluser id (cluster) must be provided") unless defined $cid;
 
-    my $scratch = delete $args{'scratch'}; # optional
+    $args{ntypeid} = LJ::NotificationMethod::Inbox->ntypeid; # Inbox
+    $args{skip_parent} = 1;
 
-    croak("Unknown options: " . join(', ', keys %args)) if %args;
-    croak("Can't call in web context") if LJ::is_web_context();
-
-    my @subs;
-    my $u = $self->u;
-    return unless $cid == $u->clusterid;
-
-    my $row = { userid  => $self->u->id,
-                ntypeid => LJ::NotificationMethod::Inbox->ntypeid, # Inbox
-                etypeid => $class->etypeid,
-              };
-
-    push @subs, LJ::Subscription->new_from_row($row);
-
-    return @subs;
+    return $class->_raw_always_subscribed( $self, %args );
 }
 
 sub get_subscriptions {

--- a/cgi-bin/LJ/Event/VgiftApproved.pm
+++ b/cgi-bin/LJ/Event/VgiftApproved.pm
@@ -110,33 +110,14 @@ sub is_visible { 0 }
 
 sub always_checked { 1 }
 
-# override parent class subscription methods to always return
-# a subscription object for the user - copied from LJ::Event::XPostSuccess
+# override parent class subscriptions method to always return
+# a subscription object for the user
 sub raw_subscriptions {
     my ( $class, $self, %args ) = @_;
-    my $cid = delete $args{'cluster'};
-    croak("Cluser id (cluster) must be provided") unless defined $cid;
 
-    my $scratch = delete $args{'scratch'}; # optional
+    $args{ntypeid} = LJ::NotificationMethod::Inbox->ntypeid; # Inbox
 
-    croak("Unknown options: " . join(', ', keys %args)) if %args;
-    croak("Can't call in web context") if LJ::is_web_context();
-
-    my @subs;
-    my $u = $self->u;
-    return unless $cid == $u->clusterid;
-
-    my $row = { userid  => $self->u->id,
-                ntypeid => LJ::NotificationMethod::Inbox->ntypeid, # Inbox
-                etypeid => $class->etypeid,
-              };
-
-    push @subs, LJ::Subscription->new_from_row($row);
-
-    push @subs, eval { LJ::Event::raw_subscriptions( $class, $self,
-        cluster => $cid, scratch => $scratch ) };
-
-    return @subs;
+    return $class->_raw_always_subscribed( $self, %args );
 }
 
 sub get_subscriptions {

--- a/cgi-bin/LJ/Event/VgiftApproved.pm
+++ b/cgi-bin/LJ/Event/VgiftApproved.pm
@@ -112,10 +112,13 @@ sub always_checked { 1 }
 
 # override parent class subscription methods to always return
 # a subscription object for the user - copied from LJ::Event::XPostSuccess
-sub subscriptions {
-    my ( $self, %args ) = @_;
-    my $cid   = delete $args{'cluster'};  # optional
-    my $limit = delete $args{'limit'};    # optional
+sub raw_subscriptions {
+    my ( $class, $self, %args ) = @_;
+    my $cid = delete $args{'cluster'};
+    croak("Cluser id (cluster) must be provided") unless defined $cid;
+
+    my $scratch = delete $args{'scratch'}; # optional
+
     croak("Unknown options: " . join(', ', keys %args)) if %args;
     croak("Can't call in web context") if LJ::is_web_context();
 
@@ -125,12 +128,13 @@ sub subscriptions {
 
     my $row = { userid  => $self->u->id,
                 ntypeid => LJ::NotificationMethod::Inbox->ntypeid, # Inbox
+                etypeid => $class->etypeid,
               };
 
     push @subs, LJ::Subscription->new_from_row($row);
 
-    push @subs, eval { $self->SUPER::subscriptions(cluster => $cid,
-                                                   limit   => $limit) };
+    push @subs, eval { LJ::Event::raw_subscriptions( $class, $self,
+        cluster => $cid, scratch => $scratch ) };
 
     return @subs;
 }

--- a/cgi-bin/LJ/Event/VgiftDelivered.pm
+++ b/cgi-bin/LJ/Event/VgiftDelivered.pm
@@ -163,33 +163,14 @@ sub subscription_as_html {
     return LJ::Lang::ml( 'event.vgift.delivery' );
 }
 
-# override parent class subscription methods to always return
-# a subscription object for the user - copied from LJ::Event::XPostSuccess
+# override parent class subscriptions method to always return
+# a subscription object for the user
 sub raw_subscriptions {
     my ( $class, $self, %args ) = @_;
-    my $cid = delete $args{'cluster'};
-    croak("Cluser id (cluster) must be provided") unless defined $cid;
 
-    my $scratch = delete $args{'scratch'}; # optional
+    $args{ntypeid} = LJ::NotificationMethod::Inbox->ntypeid; # Inbox
 
-    croak("Unknown options: " . join(', ', keys %args)) if %args;
-    croak("Can't call in web context") if LJ::is_web_context();
-
-    my @subs;
-    my $u = $self->u;
-    return unless $cid == $u->clusterid;
-
-    my $row = { userid  => $self->u->id,
-                ntypeid => LJ::NotificationMethod::Inbox->ntypeid, # Inbox
-                etypeid => $class->etypeid,
-              };
-
-    push @subs, LJ::Subscription->new_from_row($row);
-
-    push @subs, eval { LJ::Event::raw_subscriptions( $class, $self,
-        cluster => $cid, scratch => $scratch ) };
-
-    return @subs;
+    return $class->_raw_always_subscribed( $self, %args );
 }
 
 sub get_subscriptions {

--- a/cgi-bin/LJ/Event/XPostFailure.pm
+++ b/cgi-bin/LJ/Event/XPostFailure.pm
@@ -146,34 +146,14 @@ sub available_for_user  {
     return $u->is_personal ? 1 : 0,
 }
 
-# override parent class sbuscriptions method to always return
+# override parent class subscriptions method to always return
 # a subscription object for the user
 sub raw_subscriptions {
-    my ($class, $self, %args) = @_;
-    my $cid   = delete $args{'cluster'};
-    croak("Cluser id (cluster) must be provided") unless defined $cid;
+    my ( $class, $self, %args ) = @_;
 
-    my $scratch = delete $args{'scratch'}; # optional
+    $args{ntypeid} = LJ::NotificationMethod::Inbox->ntypeid; # Inbox
 
-    croak("Unknown options: " . join(', ', keys %args)) if %args;
-    croak("Can't call in web context") if LJ::is_web_context();
-
-    my @subs;
-    my $u = $self->u;
-    return unless $cid == $u->clusterid;
-
-    my $row = { userid  => $self->u->id,
-                ntypeid => LJ::NotificationMethod::Inbox->ntypeid, # Inbox
-                etypeid => $class->etypeid,
-              };
-
-    push @subs, LJ::Subscription->new_from_row($row);
-
-    push @subs, eval { LJ::Event::raw_subscriptions($class, $self,
-        cluster => $cid, scratch => $scratch ) };
-
-
-    return @subs;
+    return $class->_raw_always_subscribed( $self, %args );
 }
 
 sub get_subscriptions {


### PR DESCRIPTION
This is a cleanup project I undertook following Dre's work to remove legacy notification code and have everything use ESN.  I never submitted a pull request for it because of all the various projects-in-progress I have cluttering up my dreamhack, preventing me from pulling down a recent develop branch to test with.

That said, it's straightforward refactoring and should be OK to merge.  The first commit updates the method call and the second commit refactors common code into a shared method.  The only thing I haven't done is to see if any new events have been added in the intervening time that would benefit from similar changes.