### PR TITLE
[#312] Allow multiple stickies

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1187,6 +1187,8 @@ general setting.sms.option.advanced
 general setting.sms.option.carrier
 general setting.sms.option.carrier.selectone
 general setting.sms.option.phone
+general setting.stickyentry.error.invalid
+general setting.stickyentry.label
 general setting.stylealwaysmine.label
 general setting.stylealwaysmine.option
 general setting.xpost.option.footer.vars.comment_image.alttext

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2915,9 +2915,17 @@ setting.sitescheme.label=Site Skin
 
 setting.sitescheme.label=Site Scheme
 
-setting.stickyentry.error.invalid=Invalid Dreamwidth entry ID or URL entered.
+setting.stickyentry.details.label=Note: blank entries will be ignored.
+
+setting.stickyentry.error.invalid2=Invalid Dreamwidth entry ID or URL entered for Sticky [[stickyid]].
+
+setting.stickyentry.error.duplicate=Duplicate ID or URL entered for Sticky [[stickyid]].
 
 setting.stickyentry.label=ID or URL of entry to make sticky
+
+setting.stickyentry.label2=IDs or URLs of Sticky Entries
+
+setting.stickyentryi.label=Sticky [[stickyid]]
 
 setting.stylemine.label=Comment Pages
 

--- a/cgi-bin/DW/Setting/StickyEntry.pm
+++ b/cgi-bin/DW/Setting/StickyEntry.pm
@@ -14,14 +14,13 @@
 package DW::Setting::StickyEntry;
 use base 'LJ::Setting';
 use strict;
-use warnings;
 
 sub should_render {
     $_[1] ? 1 : 0;
 }
 
 sub label {
-    $_[0]->ml( 'setting.stickyentry.label' );
+    $_[0]->ml( 'setting.stickyentry.label2' );
 }
 
 sub option {
@@ -30,17 +29,40 @@ sub option {
     my $key = $class->pkgkey;
     my $ret;
 
-    $ret .= LJ::html_text({
-        name  => "${key}stickyid",
-        id    => "${key}stickyid",
-        class => "text",
-        value => $errs ? $class->get_arg( $args, "stickyid" ) : $u->sticky_entry,
-        size  => 30,
-        maxlength => 100,
-    });
+    my @stickies = $u->sticky_entries;
+    my $username = $u->user;
 
+    foreach my $i ( 1...$u->count_max_stickies ) {
+        my $url = "";
+        my $placeholder = "";
+        my $e = $stickies[$i - 1];
+        if ( $e ) {
+            $url = $e->url;
+        } else {
+            $placeholder = $u->journal_base . "/1234.html" if $i == 1;
+        }
+        my $textentry = $errs ? $class->get_arg( $args, "stickyid${i}" ) : $url;
+
+        $ret .= "<label for='${key}stickyid${i}'>" . $class->ml( 'setting.stickyentryi.label', { stickyid => $i } ) . " </label>";
+        $ret .= LJ::html_text({
+            name  => "${key}stickyid${i}",
+            id    => "${key}stickyid${i}",
+            class => "text",
+            value => $textentry,
+            placeholder => $textentry ? "" : $placeholder,
+            size  => 50,
+            maxlength => 100,
+        });
+        $ret .= q{ - <a href='} . $e->url . q{'>} . ( $e->subject_html || "(no subject)" ) . q{</a>} if $e;
+        $ret .= "<br>";
+
+    }
+
+    # returns an error if any of the stickies are incorrectly formatted.
     my $errdiv = $class->errdiv( $errs, "stickyid" );
-    $ret .= "<br />$errdiv" if $errdiv;
+    $ret .= "$errdiv<br>" if $errdiv;
+
+    $ret .= "<em>" . $class->ml( 'setting.stickyentry.details.label' ) . "</em>";
 
     return $ret;
 }
@@ -48,11 +70,36 @@ sub option {
 sub save {
     my ( $class, $u, $args ) = @_;
 
-    my $sticky = $class->get_arg( $args, "stickyid" ) || '';
-    $sticky = LJ::text_trim( $sticky, 0, 100 );
-    unless ( $u->sticky_entry ( $sticky ) ) {
-        $class->errors( "stickyid" => $class->ml( 'setting.stickyentry.error.invalid' ) ) ;
+    my $max_sticky_count = $u->count_max_stickies;
+    my @stickies;
+    # Create a hash that we will use to check for duplicate entries.
+    my %unique = ();
+    my $username = $u->user;
+
+    for my $i ( 1 ... $max_sticky_count ) {
+        my $stickyi = $class->get_arg( $args, "stickyid${i}" ) || '';
+
+        # blank form entry
+        next unless $stickyi;
+
+        $stickyi = LJ::text_trim( $stickyi, 0, 100 );
+        my $e = LJ::Entry->new_from_url_or_ditemid( $stickyi, $u );
+        if ( $e ) {
+            my $ditemid = $e->ditemid;
+            if ( $unique{$ditemid} ) {
+                $class->errors( "stickyid" => ( $class->ml( 'setting.stickyentry.error.duplicate', { stickyid => $i } ) ) ) ;
+                return 1;
+            }
+            push @stickies,  $ditemid;
+            $unique{$ditemid} = 1;
+        } else {
+            # As soon as we detect a problem with a sticky we break out of the subroutine.
+            $class->errors( "stickyid" => ( $class->ml( 'setting.stickyentry.error.invalid2', { stickyid => $i } ) ) ) ;
+            return 1;
+        }
     }
+
+    $u->sticky_entries( \@stickies );
     return 1;
 }
 

--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -215,6 +215,18 @@ sub new_from_url {
     return undef;
 }
 
+sub new_from_url_or_ditemid {
+    my ( $class, $input, $u ) = @_;
+
+    my $e = LJ::Entry->new_from_url( $input );
+
+    # couldn't be parsed as a URL, try as a ditemid
+    $e ||= LJ::Entry->new( $u, ditemid => $input )
+        if $input =~ /^(?:\d+)$/;
+
+    return $e && $e->valid ? $e : undef;
+}
+
 sub new_from_row {
     my ( $class, %row ) = @_;
 

--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -593,6 +593,26 @@ var postForm = (function($) {
         });
     };
 
+    var initSticky = function($form) {
+        $form.bind("journalselect-full", function(e, journal) {
+            if ( journal.name && journal.isremote ) {
+                if ( journal.iscomm ) {
+                    $(".components-columns .sticky-component:not(.inactive-component)").hide();
+                } else {
+                    $(".components-columns  .sticky-component:not(.inactive-component)").show();
+                }
+
+                $(".sticky-component")
+                    .filter(":visible")
+                        .find("input").removeAttr("disabled")
+                    .end().end()
+                    .filter(":not(:visible)")
+                        .find("input").attr("disabled", "");
+            }
+        });
+
+    };
+
     var init = function(formData) {
         $("#nojs").val(0);
 
@@ -612,6 +632,7 @@ var postForm = (function($) {
         initTags(entryForm);
         initDate(entryForm);
         initCrosspost(entryForm);
+        initSticky(entryForm);
 
         $("#js-usejournal").triggerHandler("change");
     };

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -314,7 +314,7 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
 
     [%- BLOCK components forCommunity = 0 %]
         [% FOREACH component = items %]
-        [%- IF forCommunity -%]<div class='columns medium-6 large-4'>[%- END -%]
+        [%- IF forCommunity -%]<div class='columns medium-6 large-4 [% IF loop.count == items.size %]end[% END %]'>[%- END -%]
 
         <div class='panel component [% component %]-component[% UNLESS forCommunity || panels.show.$component -%] inactive-component[%- END -%]'
              data-collapse='[% component %]' data-collapse-state='[% panels.collapsed.$component ? "collapsed" : "expanded" %]'>
@@ -356,7 +356,7 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
         </div>
         <div class="row components">
             [%- PROCESS components forCommunity = 1
-                    items = [ "community-flags" ] -%]
+                    items = [ "community-flags", "sticky" ] -%]
         </div>
     </div>
     [%- END -%]

--- a/views/entry/module-sticky.tt
+++ b/views/entry/module-sticky.tt
@@ -1,0 +1,38 @@
+[%# Module for sticky / metadata in the entry form
+
+Authors:
+  Louise Dennis
+  Afuna <coder.dw@afunamatata.com>
+
+Copyright (c) 2015 by Dreamwidth Studios, LLC.
+
+This program is free software; you may redistribute it and/or modify it under
+the same terms as Perl itself.  For a copy of the license, please reference
+'perldoc perlartistic' or 'perldoc perlgpl'.
+-%]
+<fieldset>
+<h3>[% ".header" | ml %]</h3>
+<div class='inner'>
+
+    <div class="row"><div class="columns">
+        <span class="right">
+            [%- INCLUDE "components/icon-link-decorative.tt"
+                    link = {
+                        url = sticky_url
+                        newwindow = 1
+                    }
+                    icon = "wrench"
+                    text = dw.ml( ".settings.link" )
+            -%]
+        </span>
+
+        [%- form.checkbox_nested( label = dw.ml( ".label.sticky" )
+            name ="sticky_entry"
+
+            value = 1
+            default = sticky_entry
+        ) -%]
+    </div></div>
+
+</div>
+</fieldset>

--- a/views/entry/module-sticky.tt.text
+++ b/views/entry/module-sticky.tt.text
@@ -1,0 +1,6 @@
+;; -*- coding: utf-8 -*-
+.header=Sticky Entry
+
+.label.sticky=Sticky to top of journal
+
+.settings.link=Reorder

--- a/views/entry/success.tt.text
+++ b/views/entry/success.tt.text
@@ -37,3 +37,5 @@
 .new.links.tags=Edit this entry's tags
 
 .new.links.view=View the entry
+
+.sticky.max=This entry was not made sticky because you've reached your limit of [[limit]] for sticky entries.


### PR DESCRIPTION
* Allows multiple stickies to be set both in the post forms via a sticky
  module, and in the Display tab under Manage Account

* Allows for different sticky allocations depending upon account type
  and attempts to handle switching between account types elegantly

Much thanks to @annariel for her initial work on this.