### PR TITLE
Add sandbox attribute to our embed iframes

### DIFF
--- a/cgi-bin/LJ/EmbedModule.pm
+++ b/cgi-bin/LJ/EmbedModule.pm
@@ -593,8 +593,9 @@ sub module_iframe_tag {
                     ? '<div><a href="' . $url . '">' .  $linktext . '</a></div>' : '';
     my $auth_token = LJ::eurl(LJ::Auth->sessionless_auth_token('embedcontent', moduleid => $moduleid, journalid => $journalid, preview => $preview,));
     my $iframe_link = qq{//$LJ::EMBED_MODULE_DOMAIN/?journalid=$journalid&moduleid=$moduleid&preview=$preview&auth_token=$auth_token};
-    my $iframe_tag = qq {<div class="lj_embedcontent-wrapper" style="$wrapper_style"><div class="lj_embedcontent-ratio" style="$ratio_style"><iframe src="$iframe_link" }
-        . qq{width="$width$width_unit" height="$height$height_unit" allowtransparency="true" frameborder="0" class="lj_embedcontent" id="$id" name="$name"></iframe></div></div>}
+    my $iframe_tag = qq {<div class="lj_embedcontent-wrapper" style="$wrapper_style"><div class="lj_embedcontent-ratio" style="$ratio_style"><iframe src="$iframe_link"}
+        . qq{ sandbox="allow-same-origin allow-scripts allow-forms" width="$width$width_unit" height="$height$height_unit" allowtransparency="true" frameborder="0"}
+        . qq{ class="lj_embedcontent" id="$id" name="$name"></iframe></div></div>}
         . qq{$direct_link};
 
     my $remote = LJ::get_remote();


### PR DESCRIPTION
The current set should allow/disallow the same things as before, with
the exception of full-page redirects (not allowed)