### PR TITLE
[#1149] Determine protocol in $u->journal_base from $LJ::IS_SSL

### DIFF
--- a/cgi-bin/DW/Media/Base.pm
+++ b/cgi-bin/DW/Media/Base.pm
@@ -107,7 +107,7 @@ sub url {
             ( $self->{url_height} // $self->{height} ) . '/';
     }
 
-    return $self->u->journal_base( ssl => $LJ::IS_SSL ) . '/file/' . $extra . $self->{displayid} .
+    return $self->u->journal_base . '/file/' . $extra . $self->{displayid} .
         '.' . $self->{ext};
 }
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -128,7 +128,7 @@ sub make_journal
 
     foreach ("name", "url", "urlname") { LJ::text_out(\$u->{$_}); }
 
-    $u->{'_journalbase'} = $u->journal_base( vhost => $opts->{'vhost'}, ssl => $LJ::IS_SSL );
+    $u->{'_journalbase'} = $u->journal_base( vhost => $opts->{'vhost'} );
 
     my $view2class = {
         lastn    => "RecentPage",

--- a/cgi-bin/LJ/User.pm
+++ b/cgi-bin/LJ/User.pm
@@ -9375,7 +9375,7 @@ sub journal_base
 {
     my ($user, %opts) = @_;
     my $vhost = $opts{vhost};
-    my $protocol = $opts{ssl} ? "https" : "http";
+    my $protocol = $LJ::IS_SSL ? "https" : "http";
 
     my $u = LJ::isu( $user ) ? $user : LJ::load_user( $user );
     $user = $u->user if $u;


### PR DESCRIPTION
Instead of passing in an argument for all instances thereof. This makes
sure that if you're on an https page, all DW-generated journal links
from there aso point to https, and same for http.

This does not affect comment notification emails that are sent (those
are always http)

Fixes #1149.