### PR TITLE
[#871] Proxy insecure content for entries on journals

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2145,6 +2145,7 @@ sub Entry_from_entryobj
             suspend_msg => $suspend_msg,
             unsuspend_supportid => $suspend_msg ? $entry_obj->prop( 'unsuspend_supportid' ) : 0,
             preformatted => $entry_obj->prop( "opt_preformatted" ),
+            proxy_insecure_content => $LJ::IS_SSL,
         };
 
         # reading pages might need to display image placeholders

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -555,7 +555,7 @@ sub EntryPage_entry
     $comments->{show_readlink} &&= $get_mode eq 'reply';
 
     my $subject = LJ::CleanHTML::quote_html( $entry->subject_html, $get->{nohtml} );
-    my $event = LJ::CleanHTML::quote_html( $entry->event_html, $get->{nohtml} );
+    my $event = LJ::CleanHTML::quote_html( $entry->event_html( { proxy_insecure_content => $LJ::IS_SSL } ), $get->{nohtml} );
 
     # load tags
     my @taglist;


### PR DESCRIPTION
This passes the argument which CleanHTML know that we're interested in
proxying insecure content from journal pages.

For #871.