### PR TITLE
Remove uses of smartmatch

### DIFF
--- a/cgi-bin/DW/Controller/Feeds.pm
+++ b/cgi-bin/DW/Controller/Feeds.pm
@@ -70,7 +70,7 @@ sub index_handler {
         if ( $url ne "" ) {
             my $uri = URI->new( $url );
             return error_ml( '/feeds/index.tt.invalid.url' )
-                unless $uri->scheme ~~ [ qw/ http https / ] && $uri->host;
+                unless $uri->scheme =~ m/^(http|https)$/ && $uri->host;
 
             my $hostname = $uri->host;
             my $port = $uri->port;

--- a/cgi-bin/DW/FeedCanonicalizer.pm
+++ b/cgi-bin/DW/FeedCanonicalizer.pm
@@ -36,7 +36,7 @@ sub canonicalize {
     $uri_string = $uri_string->[0] if ref $uri_string eq 'ARRAY';
 
     my $uri = URI->new( $uri_string )->canonical;
-    return undef unless $uri->scheme ~~ [ qw/ http https / ];
+    return undef unless $uri->scheme =~ m/^(http|https)$/;
     
     $uri->userinfo( undef );
 
@@ -49,49 +49,49 @@ sub canonicalize {
 
     my $uri_str = $uri->as_string;
 
-    given ( $uri_str ) {
+    {
         # Let's see if this looks "LJ-ish".
-        when( m!^https?://(?:users|community|syndicated)\.([^/]+)/+([a-z0-9\-_]+)/$LJISH_URL_PART$!i ) {
+        if ( $uri_str =~ m!^https?://(?:users|community|syndicated)\.([^/]+)/+([a-z0-9\-_]+)/$LJISH_URL_PART$!i ) {
             my ( $host, $sub, $feed, $extra, $spare ) = ( $1, $2, $3, $4, $5 );
-            continue if $feed ~~ m/^rss/i && ! $LJISH_SITES{$host};
-            continue if $spare && ! $LJISH_SITES{$host};
-            return make_ljish( $host, $sub, $feed, $orig_uri, $extra );
+            return make_ljish( $host, $sub, $feed, $orig_uri, $extra ) unless 0
+                or $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
+                or $spare && ! $LJISH_SITES{$host};
         }
 
-        when( m!^https?://([a-z0-9\-_]+)\.([^/]+)/+$LJISH_URL_PART$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-_]+)\.([^/]+)/+$LJISH_URL_PART$!i ) {
             my ( $sub, $host, $feed, $extra, $spare ) = ( $1, $2, $3, $4, $5 );
-            continue if $sub eq 'www';
-            continue if $feed ~~ m/^rss/i && ! $LJISH_SITES{$host};
-            continue if $spare && ! $LJISH_SITES{$host};
-            return make_ljish( $host, $sub, $feed, $orig_uri, $extra );
+            return make_ljish( $host, $sub, $feed, $orig_uri, $extra ) unless 0
+                or $sub eq 'www'
+                or $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
+                or $spare && ! $LJISH_SITES{$host};
         }
         
-        when( m!^https?://(?:www\.)?([^/]+)/+~([a-z0-9\-_]+)/$LJISH_URL_PART!i ) {
+        if ( $uri_str =~ m!^https?://(?:www\.)?([^/]+)/+~([a-z0-9\-_]+)/$LJISH_URL_PART!i ) {
             my ( $host, $sub, $feed, $extra, $spare ) = ( $1, $2, $3, $4, $5 ); 
-            continue if $feed ~~ m/^rss/i && ! $LJISH_SITES{$host};
-            continue if $spare && ! $LJISH_SITES{$host};
-            return make_ljish( $host, $sub, $feed, $orig_uri, $extra );
+            return make_ljish( $host, $sub, $feed, $orig_uri, $extra ) unless 0
+                or $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
+                or $spare && ! $LJISH_SITES{$host};
         }
         
-        when( m!^https?://(?:www\.)?([^/]+)/+(?:users|community|syndicated)/([a-z0-9\-_]+)/$LJISH_URL_PART$!i ) {
+        if ( $uri_str =~ m!^https?://(?:www\.)?([^/]+)/+(?:users|community|syndicated)/([a-z0-9\-_]+)/$LJISH_URL_PART$!i ) {
             my ( $host, $sub, $feed, $extra, $spare ) = ( $1, $2, $3, $4, $5 );
-            continue if $feed ~~ m/^rss/i && ! $LJISH_SITES{$host};
-            continue if $spare && ! $LJISH_SITES{$host};
-            return make_ljish( $host, $sub, $feed, $orig_uri, $extra );
+            return make_ljish( $host, $sub, $feed, $orig_uri, $extra ) unless 0
+                or $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
+                or $spare && ! $LJISH_SITES{$host};
         }
 
         # InsaneJournal decided to call communities something different
-        when( m!^https?://(?:asylums)\.insanejournal\.com/+([a-z0-9\-_]+)/$LJISH_URL_PART$!i ) {
+        if ( $uri_str =~ m!^https?://(?:asylums)\.insanejournal\.com/+([a-z0-9\-_]+)/$LJISH_URL_PART$!i ) {
             return make_ljish( "insanejournal.com", $1, $2, $orig_uri, $3 );
         }
 
-        when( m!^https?://([a-z0-9\-\_]+)\.tumblr\.com/+rss(?:/|\.xml)?$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_]+)\.tumblr\.com/+rss(?:/|\.xml)?$!i ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
             return "tumblr://$username";
         }
         
-        when( m!^https?://([a-z0-9\-\_]+)\.tumblr\.com/+tagged/([^/\?#]+)/rss(?:/|\.xml)?$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_]+)\.tumblr\.com/+tagged/([^/\?#]+)/rss(?:/|\.xml)?$!i ) {
             my $tag = uri_escape( uri_unescape( $2 ) );
             my $username = lc($1);
             $username =~ s/-/_/g;
@@ -99,53 +99,54 @@ sub canonicalize {
         }
 
         # Also handles blogspot and domains hosted on blogger/blogspot
-        when ( m!^https?://(?:www\.)?blogger\.com/+feeds/([0-9]+)/(posts|comments|[0-9]+/comments)/(default|full)/?$!i ) {
+        if ( $uri_str =~ m!^https?://(?:www\.)?blogger\.com/+feeds/([0-9]+)/(posts|comments|[0-9]+/comments)/(default|full)/?$!i ) {
             return "blogger://$1/$2" . ( $3 eq 'full' ? '/full' : '' );
         }
         
-        when ( m!^https?://(?:www\.)?blogger\.com/+feeds/([0-9]+)/posts/(default|full)/?$!i ) {
+        if ( $uri_str =~ m!^https?://(?:www\.)?blogger\.com/+feeds/([0-9]+)/posts/(default|full)/?$!i ) {
             return "blogger://$1/posts" . ( $2 eq 'full' ? '/full' : '' );
         }
 
-        when ( m!^https?://feeds[0-9]*\.feedburner\.com/+(.+)$!i ) {
+        if ( $uri_str =~ m!^https?://feeds[0-9]*\.feedburner\.com/+(.+)$!i ) {
             return "feedburner://$1";
         }
 
-        when ( m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/*$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/*$!i ) {
             my %query = $orig_uri->query_form;
 
-            continue unless $query{feed} ~~ ['rss', 'atom'];
+            my $username = lc($1);
 
+            if ( $query{feed} =~ m/^(rss|atom)$/ ) {
+                $username =~ s/-/_/g;
+                return "wordpress://$username";
+            }
+        }
+
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+(?:rss|atom).xml$!i ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
             return "wordpress://$username";
         }
 
-        when ( m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+(?:rss|atom).xml$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+(?:rss|atom)/?$!i ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
             return "wordpress://$username";
         }
 
-        when ( m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+(?:rss|atom)/?$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+feed(?:/rss|/atom)?/?$!i ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
             return "wordpress://$username";
         }
 
-        when ( m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+feed(?:/rss|/atom)?/?$!i ) {
-            my $username = lc($1);
-            $username =~ s/-/_/g;
-            return "wordpress://$username";
-        }
-
-        when ( m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+comments/feed(?:/rss|/atom)?/?$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+comments/feed(?:/rss|/atom)?/?$!i ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
             return "wordpress://$username/comments";
         }
 
-        when ( m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+tag/([a-z0-9\-\_]+)/feed(?:/rss|/atom)?/?$!i ) {
+       if ( $uri_str =~ m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+tag/([a-z0-9\-\_]+)/feed(?:/rss|/atom)?/?$!i ) {
             my $username = lc($1);
             my $tag = lc($2);
 
@@ -155,7 +156,7 @@ sub canonicalize {
             return "wordpress://$username/tag/$tag";
         }
 
-        when ( m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+category/([a-z0-9\-\_]+)/feed(?:/rss|/atom)?/?$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+category/([a-z0-9\-\_]+)/feed(?:/rss|/atom)?/?$!i ) {
             my $username = lc($1);
             my $category = lc($2);
 
@@ -165,7 +166,7 @@ sub canonicalize {
             return "wordpress://$username/category/$category";
         }
 
-        when ( m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+author/([a-z0-9\-\_]+)/feed(?:/rss|/atom)?/?$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+author/([a-z0-9\-\_]+)/feed(?:/rss|/atom)?/?$!i ) {
             my $username = lc($1);
             my $author = lc($2);
 
@@ -175,7 +176,7 @@ sub canonicalize {
             return "wordpress://$username/author/$author";
         }
 
-        when ( m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+([0-9]{4}/[0-9]{2}/[0-9]{2})/([a-z0-9\-\_]+)/feed(?:/rss|/atom)?/?$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9\-\_\.]+)\.wordpress\.com/+([0-9]{4}/[0-9]{2}/[0-9]{2})/([a-z0-9\-\_]+)/feed(?:/rss|/atom)?/?$!i ) {
             my $username = lc($1);
             my $datepart = $2;
             my $article = lc($3);
@@ -187,47 +188,46 @@ sub canonicalize {
         }
 
         # Unfortunately, these two twitter ones cannot go away (yet)
-        when ( m!^https?://(?:www\.)?twitter\.com/+statuses/user_timeline/([a-z][a-z0-9\-_]*)\.rss$!i ) {
+        if ( $uri_str =~ m!^https?://(?:www\.)?twitter\.com/+statuses/user_timeline/([a-z][a-z0-9\-_]*)\.rss$!i ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
 
             return "twitter://$username";
         }
 
-        when ( m!^https?://api\.twitter\.com/1/statuses/user_timeline\.rss$!i ) {
+        if ( $uri_str =~ m!^https?://api\.twitter\.com/1/statuses/user_timeline\.rss$!i ) {
             my %query = $orig_uri->query_form;
 
-            continue if $query{id};
+            if ( ! $query{id} ) {
+                my $username = lc( $query{screen_name} );
 
-            my $username = lc( $query{screen_name} );
-            continue if $username =~ m/,/;
-            continue unless $username;
-
-            $username =~ s/-/_/g;
-
-            return "twitter://$username";
+                if ( $username and $username !~ m/,/ ) {
+                    $username =~ s/-/_/g;
+                    return "twitter://$username";
+                }
+            }
         }
 
         # twfeed.com replacement feed service
-        when ( m!^https?://(?:www\.)twfeed\.com/+(?:rss|atom)/([a-z][a-z0-9\-_]*)$!i ) {
+        if ( $uri_str =~ m!^https?://(?:www\.)?twfeed\.com/+(?:rss|atom)/([a-z][a-z0-9\-_]*)$!i ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
 
             return "twitter://$username";
         }
 
-        when ( m!^https?://blog\.myspace\.com/+([a-z][a-z0-9\-_]*)/?!i && $src eq 'link' ) {
+        if ( $uri_str =~ m!^https?://blog\.myspace\.com/+([a-z][a-z0-9\-_]*)/?!i && $src eq 'link' ) {
             my $username = lc($1);
             $username =~ s/-/_/g;
 
             return "myspace://$username";
         }
     
-        when ( m!^https?://(?:www\.)?archiveofourown\.org/tags/([0-9]+)/feed\.(?:atom|rss)/?!i ) {
+        if ( $uri_str =~ m!^https?://(?:www\.)?archiveofourown\.org/tags/([0-9]+)/feed\.(?:atom|rss)/?!i ) {
             return "ao3://tag/$1";
         }
 
-        when ( m!^https?://feeds\.pinboard\.in/rss(?:/secret:[a-f0-9]+)?((?:/[a-z]:[^/]+?)+)(?:/public)?/?$! ) {
+        if ( $uri_str =~ m!^https?://feeds\.pinboard\.in/rss(?:/secret:[a-f0-9]+)?((?:/[a-z]:[^/]+?)+)(?:/public)?/?$! ) {
             my @parts = split('/', $1);
             my $url_end;
             foreach my $part ( @parts ) {
@@ -235,26 +235,25 @@ sub canonicalize {
                     $url_end .= "/" . lc($part);
                 }
             }
-            continue unless $url_end;
-            return "pinboard:/" . $url_end;
+            return "pinboard:/" . $url_end if $url_end;
         }
         
-        when ( m!^https?://feeds\.pinboard\.in/rss/popular(/[^/]+)?/?$!i ) {
+        if ( $uri_str =~ m!^https?://feeds\.pinboard\.in/rss/popular(/[^/]+)?/?$!i ) {
             return "pinboard://popular$1";
         }
 
-        when ( m!^https?://gdata\.youtube\.com/feeds/base/users/([a-z0-9]+)/uploads/?$!i ) {
+        if ( $uri_str =~ m!^https?://gdata\.youtube\.com/feeds/base/users/([a-z0-9]+)/uploads/?$!i ) {
             return "youtube://users/$1/uploads";
         }
         
-        when ( m!^https?://gdata\.youtube\.com/feeds/(?:api|base)/videos/-/(.+?)/?$!i ) {
+        if ( $uri_str =~ m!^https?://gdata\.youtube\.com/feeds/(?:api|base)/videos/-/(.+?)/?$!i ) {
             my $rv = join( '/', sort(
                 map { join('|', sort( split(/\|/,$_ ) ) ) } # sort |'d together terms
                 grep { $_ } split('/',$1) ) );
             return "youtube://videos/$rv";
         }
 
-        when ( m!^https?://([a-z0-9_-]+)\.typepad\.com/+([^/]+)/(?:atom|rss)\.xml$!i ) {
+        if ( $uri_str =~ m!^https?://([a-z0-9_-]+)\.typepad\.com/+([^/]+)/(?:atom|rss)\.xml$!i ) {
             return "typepad://$1/$2";
         }
     }
@@ -277,14 +276,14 @@ sub canonicalize_id {
     my ( $id, $uri, $orig_uri ) = @_;
 
     my $uri_str = $uri->as_string;
-    given ( $id ) {
-        when ( m!^tag:blogger\.com,1999:blog-([0-9]+)(\.comments)?$!i ) {
+    {
+        if ( $uri_str =~ m!^tag:blogger\.com,1999:blog-([0-9]+)(\.comments)?$!i ) {
             my $url_bit = "blogger://$1/" . ( $2 eq '.comments' ? 'comments' : 'posts' );
             my ( $full ) = $uri_str =~ m!/(default|full)/?$!i;
             return $url_bit . ( $full eq 'full' ? '/full' : '' );
         }
         
-        when ( m!^tag:blogger\.com,1999:blog-([0-9]+)\.post([0-9]+)\.\.comments$!i ) {
+        if ( $uri_str =~ m!^tag:blogger\.com,1999:blog-([0-9]+)\.post([0-9]+)\.\.comments$!i ) {
             my $url_bit = "blogger://$1/$2/comments";
             my ( $full ) = $uri_str =~ m!/(default|full)/?$!i;
             return $url_bit . ( $full eq 'full' ? '/full' : '' );
@@ -299,7 +298,7 @@ sub last_ditch {
         $arg = $arg->[0] if ref $arg eq 'ARRAY';
 
         my $uri = URI->new( $arg )->canonical;
-        next unless $uri->scheme ~~ [ qw/ http https / ];
+        next unless $uri->scheme =~ m/^(http|https)$/;
 
         $uri->fragment(undef);
         $uri->userinfo(undef);
@@ -320,8 +319,8 @@ sub make_ljish {
     $username =~ s/-/_/g;
 
     my $extra = "";
-    if ( $feed ~~ m/customview$/i ) {
-        $extra = $extra_raw if $extra_raw ~~ m!^/!;
+    if ( $feed =~ m/customview$/i ) {
+        $extra = $extra_raw if $extra_raw =~ m!^/!;
         return LJ::create_url("/$username/customview$extra",
             proto => "ljish",
             host => $domain,
@@ -329,7 +328,7 @@ sub make_ljish {
             keep_args => [ qw/ styleid show filter / ] );
     } else {
         my $extra;
-        $extra = "/friends" if $feed ~~ /friends$/;
+        $extra = "/friends" if $feed =~ /friends$/;
 
         my %query = $uri->query_form;
 

--- a/cgi-bin/DW/FeedCanonicalizer.pm
+++ b/cgi-bin/DW/FeedCanonicalizer.pm
@@ -53,31 +53,31 @@ sub canonicalize {
         # Let's see if this looks "LJ-ish".
         if ( $uri_str =~ m!^https?://(?:users|community|syndicated)\.([^/]+)/+([a-z0-9\-_]+)/$LJISH_URL_PART$!i ) {
             my ( $host, $sub, $feed, $extra, $spare ) = ( $1, $2, $3, $4, $5 );
-            return make_ljish( $host, $sub, $feed, $orig_uri, $extra ) unless 0
-                or $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
-                or $spare && ! $LJISH_SITES{$host};
+            return make_ljish( $host, $sub, $feed, $orig_uri, $extra )
+                unless $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
+                    or $spare && ! $LJISH_SITES{$host};
         }
 
         if ( $uri_str =~ m!^https?://([a-z0-9\-_]+)\.([^/]+)/+$LJISH_URL_PART$!i ) {
             my ( $sub, $host, $feed, $extra, $spare ) = ( $1, $2, $3, $4, $5 );
-            return make_ljish( $host, $sub, $feed, $orig_uri, $extra ) unless 0
-                or $sub eq 'www'
-                or $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
-                or $spare && ! $LJISH_SITES{$host};
+            return make_ljish( $host, $sub, $feed, $orig_uri, $extra )
+                unless $sub eq 'www'
+                    or $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
+                    or $spare && ! $LJISH_SITES{$host};
         }
         
         if ( $uri_str =~ m!^https?://(?:www\.)?([^/]+)/+~([a-z0-9\-_]+)/$LJISH_URL_PART!i ) {
             my ( $host, $sub, $feed, $extra, $spare ) = ( $1, $2, $3, $4, $5 ); 
-            return make_ljish( $host, $sub, $feed, $orig_uri, $extra ) unless 0
-                or $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
-                or $spare && ! $LJISH_SITES{$host};
+            return make_ljish( $host, $sub, $feed, $orig_uri, $extra )
+                unless $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
+                    or $spare && ! $LJISH_SITES{$host};
         }
         
         if ( $uri_str =~ m!^https?://(?:www\.)?([^/]+)/+(?:users|community|syndicated)/([a-z0-9\-_]+)/$LJISH_URL_PART$!i ) {
             my ( $host, $sub, $feed, $extra, $spare ) = ( $1, $2, $3, $4, $5 );
-            return make_ljish( $host, $sub, $feed, $orig_uri, $extra ) unless 0
-                or $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
-                or $spare && ! $LJISH_SITES{$host};
+            return make_ljish( $host, $sub, $feed, $orig_uri, $extra )
+                unless $feed =~ m/^rss/i && ! $LJISH_SITES{$host}
+                    or $spare && ! $LJISH_SITES{$host};
         }
 
         # InsaneJournal decided to call communities something different

--- a/t/feed-canonicalizer.t
+++ b/t/feed-canonicalizer.t
@@ -1,0 +1,118 @@
+# t/feed-canonicalizer.t
+#
+# Feed Canonicalizer
+#
+# Authors:
+#      Andrea Nall <anall@andreanall.com>
+#
+# Copyright (c) 2015 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+use strict;
+use warnings;
+use Test::More;
+
+use lib "$ENV{LJHOME}/cgi-bin";
+BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }
+use DW::FeedCanonicalizer;
+
+# FIXME: We should probably test things LOTS BETTER
+my @pairs = map {
+      $_->[0] =~ m!^//\.(.+)$! ? (
+        [ "http://$1" , $_->[1] ], [ "https://$1", $_->[1] ],
+        [ "http://www.$1" , $_->[1] ], [ "https://www.$1", $_->[1] ], )
+    : $_->[0] =~ m!^(https?)://\.(.+)$! ? ( [ "$1://$2" , $_->[1] ], [ "$1://www.$2", $_->[1] ] )
+    : $_->[0] =~ m!^//! ? ( [ "http:$_->[0]" , $_->[1] ], [ "https:$_->[0]", $_->[1] ] )
+    : $_
+} (
+    [ "//username.fakejournal.com/data/rss", "ljish://fakejournal.com/username"],
+    [ "http://username.fakejournal.com/data/rss.xml", "ljish://fakejournal.com/username"],
+
+    [ "http://username.fakejournal.com/data/atom", "ljish://fakejournal.com/username"],
+    [ "http://username.fakejournal.com/data/atom.xml", "ljish://fakejournal.com/username"],
+    
+    [ "http://username.fakejournal.com/data/rss_friends", "ljish://fakejournal.com/username/friends"],
+    [ "http://username.fakejournal.com/data/atom_friends", "ljish://fakejournal.com/username/friends"],
+
+    [ "http://username.fakejournal.com/data/rss?tag=cupcakes", "ljish://fakejournal.com/username?tag=cupcakes"],
+    [ "http://username.fakejournal.com/data/atom?tag=cupcakes", "ljish://fakejournal.com/username?tag=cupcakes"],
+
+    [ "http://username.fakejournal.com/data/rss?tag=cupcakes", "ljish://fakejournal.com/username?tag=cupcakes"],
+    [ "http://username.fakejournal.com/data/atom?tag=cupcakes", "ljish://fakejournal.com/username?tag=cupcakes"],
+
+    [ "http://username.fakejournal.com/data/customview?styleid=1&show=2&filter=3", "ljish://fakejournal.com/username/customview?filter=3&show=2&styleid=1"],
+
+    # These only work on lj-ish sites    
+    [ "http://username.livejournal.com/rss", "ljish://livejournal.com/username"],
+    [ "http://username.livejournal.com/rss/friends", "ljish://livejournal.com/username/friends"],    
+    [ "http://.livejournal.com/~username/rss", "ljish://livejournal.com/username"],
+
+    [ "http://username.fakejournal.com/rss/friends", undef],
+    [ "http://username.fakejournal.com/rss", undef],
+    [ "http://.fakejournal.com/~username/rss", undef],
+
+    # LJish, legacy users/community/syndicated
+    ( map { 
+        [ "//$_.fakejournal.com/username/data/rss", "ljish://fakejournal.com/username"],
+
+        [ "//.fakejournal.com/$_/username/data/rss", "ljish://fakejournal.com/username"],
+    } qw( users community syndicated ) ),
+
+    [ "//username.fakejournal.com/data/rss", "ljish://fakejournal.com/username"],
+    [ "//.fakejournal.com/~username/data/rss", "ljish://fakejournal.com/username"],
+
+    [ "//.fakejournal.com/~username/data/rss", "ljish://fakejournal.com/username"],
+
+    [ "//.fakejournal.com/~username/data/rss", "ljish://fakejournal.com/username"],
+    
+    [ "//asylums.insanejournal.com/username/data/rss", "ljish://insanejournal.com/username"],
+
+    [ "//username.tumblr.com/rss", "tumblr://username" ],
+    [ "//username.tumblr.com/rss/", "tumblr://username" ],
+    [ "//username.tumblr.com/rss.xml", "tumblr://username" ],
+
+    [ "//username.tumblr.com/tagged/cupcakes/rss", "tumblr://username/tagged/cupcakes" ],
+
+    [ "//.blogger.com/feeds/0123456789/posts/default", "blogger://0123456789/posts" ],
+    [ "//.blogger.com/feeds/0123456789/posts/full", "blogger://0123456789/posts/full" ],
+    [ "//.blogger.com/feeds/0123456789/comments/full", "blogger://0123456789/comments/full" ],
+    [ "//.blogger.com/feeds/0123456789/1234/comments/full", "blogger://0123456789/1234/comments/full" ],
+
+    [ "//feeds1.feedburner.com/burnme", "feedburner://burnme" ],
+
+    [ "//username.wordpress.com", undef ],
+    [ "//username.wordpress.com?feed=rss", "wordpress://username" ],
+    [ "//username.wordpress.com?feed=atom", "wordpress://username" ],
+
+    # FIXME: Skipping simple wordpress feeds
+
+    # Twitter is legacy:
+    [ "//.twitter.com/statuses/user_timeline/username.rss", "twitter://username" ],
+    [ "//.twitter.com/statuses/user_timeline/username.rss", "twitter://username" ],
+
+    [ "//api.twitter.com/1/statuses/user_timeline.rss", undef ],
+    [ "//api.twitter.com/1/statuses/user_timeline.rss?screen_name=username,cupcakes", undef ],
+    [ "//api.twitter.com/1/statuses/user_timeline.rss?screen_name=username", "twitter://username" ],
+
+    [ "//.twfeed.com/rss/username", "twitter://username" ],
+    [ "//.twfeed.com/atom/username", "twitter://username" ],
+
+    # FIXME: Myspace requires special case
+
+    [ "//.archiveofourown.org/tags/1234567/feed.atom", "ao3://tag/1234567" ],
+    [ "//.archiveofourown.org/tags/1234567/feed.rss", "ao3://tag/1234567" ],
+
+    # FIXME: Skipping pinboard, need sample to figure out WTF that is doing
+    
+    # FIXME: gdata youtube and typepad
+);
+
+
+plan tests => scalar @pairs;
+
+foreach my $pair ( @pairs ) {
+    is ( DW::FeedCanonicalizer::canonicalize( $pair->[0] ), $pair->[1], $pair->[0] );
+}


### PR DESCRIPTION
Smartmatch got used before I knew it was not something we wanted in the codebase.
Recent Perls complain loudly about this feature, so remove it.

Also adds a test of the feed canonicalizer to make sure I didn't regress something.