### PR TITLE
Fix some tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ src/proxy/proxy
 .sass-cache
 # Ignore compiled CSS
 htdocs/stc/css
+
+# Ignore test stuff
+t-theschwartz.sqlite

--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -14,6 +14,7 @@
 
 use strict;
 use warnings;
+use lib "$ENV{LJHOME}/extlib/lib/perl5";
 
 use Test::Most;
 use File::Temp;
@@ -36,6 +37,9 @@ my %SKIP = (
 
     'cgi-bin/modperl.pl' => "Special file",
     'cgi-bin/modperl_subs.pl' => "Special file",
+
+    'LJ/ConfCheck.pm' => 'omit defined warnings',
+    'LJ/ConfCheck/General.pm' => 'omit defiend warnings',
 );
 
 my @scripts = File::Find::Rule->file->name('*.pl')->in('cgi-bin');

--- a/t/formerrors.t
+++ b/t/formerrors.t
@@ -9,6 +9,8 @@
 
 use strict;
 use Test::More tests => 8;
+
+use lib "$ENV{LJHOME}/extlib/lib/perl5";
 use lib "$ENV{LJHOME}/cgi-bin";
 
 use DW::FormErrors;

--- a/t/parsefeed-atom-link.t
+++ b/t/parsefeed-atom-link.t
@@ -20,6 +20,7 @@ use warnings;
 
 use Test::More tests => 3;
 
+use lib "$ENV{LJHOME}/extlib/lib/perl5";
 use lib "$ENV{LJHOME}/cgi-bin";
 use LJ::ParseFeed;
 BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }

--- a/t/parsefeed-atom-link2.t
+++ b/t/parsefeed-atom-link2.t
@@ -20,6 +20,7 @@ use warnings;
 
 use Test::More tests => 8;
 
+use lib "$ENV{LJHOME}/extlib/lib/perl5";
 use lib "$ENV{LJHOME}/cgi-bin";
 use LJ::ParseFeed;
 BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }

--- a/t/parsefeed-atom-link3.t
+++ b/t/parsefeed-atom-link3.t
@@ -20,6 +20,7 @@ use warnings;
 
 use Test::More tests => 12;
 
+use lib "$ENV{LJHOME}/extlib/lib/perl5";
 use lib "$ENV{LJHOME}/cgi-bin";
 use LJ::ParseFeed;
 BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }

--- a/t/parsefeed-atom-types.t
+++ b/t/parsefeed-atom-types.t
@@ -20,6 +20,7 @@ use warnings;
 
 use Test::More;
 
+use lib "$ENV{LJHOME}/extlib/lib/perl5";
 use lib "$ENV{LJHOME}/cgi-bin";
 use LJ::ParseFeed;
 BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }

--- a/t/textutil.t
+++ b/t/textutil.t
@@ -18,6 +18,7 @@ use warnings;
 
 use Test::More tests => 22;
 
+use lib "$ENV{LJHOME}/extlib/lib/perl5";
 use lib "$ENV{LJHOME}/cgi-bin";
 use LJ::TextUtil;
 

--- a/t/use-strict.t
+++ b/t/use-strict.t
@@ -38,6 +38,7 @@ foreach my $repo ( LJ::get_all_directories( ".git" ) ) {
         next unless $path =~ /\.(pl|pm)$/;
         # skip stuff we're less concerned about or don't control
         next if $path =~ m:\b(doc|etc|fck|miscperl|src|s2|extlib)/:;
+        next if $path =~ m/config-test\.pl$/;
         $check{$path} = 1;
     }
 }


### PR DESCRIPTION
Make these tests also respect extlib, which makes it possible
for people to test new modules on a Dreamhack or other shared
coding environment without having to wait for system modules
to be installed.

extlib was already supported in the codebase in general, but
some tests did not respect it.