### PR TITLE
[#871] Check $LJ::IS_SSL in CleanHTML instead of passing arguments

### DIFF
--- a/cgi-bin/DW/Controller/Comments.pm
+++ b/cgi-bin/DW/Controller/Comments.pm
@@ -188,7 +188,6 @@ sub received_handler {
                             editor => $r->{props}->{editor},
                             anon_comment => LJ::Talk::treat_as_anon( $pu, $u ),
                             nocss => 1,
-                            proxy_insecure_content => $LJ::IS_SSL,
             } );
 
             my $stylemine = 0;

--- a/cgi-bin/DW/Entry/Moderated.pm
+++ b/cgi-bin/DW/Entry/Moderated.pm
@@ -104,11 +104,10 @@ sub event {
     LJ::CleanHTML::clean_event(\$event, { preformatted  => $raw_data->{props}->{opt_preformatted},
                                           cutpreview    => 1,
                                           cuturl        => '#',
-                                          proxy_insecure_content => $LJ::IS_SSL,
                                      });
 
     # create iframe from <lj-embed> tag
-    LJ::EmbedModule->expand_entry( $self->journal, \$event, proxy_insecure_content => $LJ::IS_SSL ) ;
+    LJ::EmbedModule->expand_entry( $self->journal, \$event ) ;
 
     return $event;
 }

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -823,7 +823,7 @@ sub clean
                     if ($opts->{'extractimages'}) { $img_bad = 1; }
 
                     my $url = canonical_url($hash->{src}, 1);
-                    $url = https_url( $url ) if $opts->{proxy_insecure_content};
+                    $url = https_url( $url ) if $LJ::IS_SSL;
                     $hash->{src} = $url;
 
                     if ($img_bad) {
@@ -1535,7 +1535,6 @@ sub clean_event
         journal => $opts->{journal},
         ditemid => $opts->{ditemid},
         errref => $opts->{errref},
-        proxy_insecure_content => $opts->{proxy_insecure_content},
     });
 }
 
@@ -1613,7 +1612,6 @@ sub clean_comment
         'textonly' => $opts->{'textonly'} ? 1 : 0,
         'remove_positioning' => 1,
         'remove_abs_sizes' => $opts->{anon_comment},
-        proxy_insecure_content => $opts->{proxy_insecure_content},
     });
 }
 

--- a/cgi-bin/LJ/Comment.pm
+++ b/cgi-bin/LJ/Comment.pm
@@ -865,7 +865,6 @@ sub body_html {
     $opts->{preformatted} = $self->prop("opt_preformatted");
     $opts->{anon_comment} = LJ::Talk::treat_as_anon( $self->poster, $self->journal );
     $opts->{editor} = $self->prop( "editor" );
-    $opts->{proxy_insecure_content} = $extra_opts{proxy_insecure_content};
 
     my $body = $self->body_raw;
     LJ::CleanHTML::clean_comment(\$body, $opts) if $body;

--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -885,7 +885,6 @@ sub event_html
 
     LJ::expand_embedded($self->{u}, $self->ditemid, LJ::User->remote, \$event,
         sandbox => $opts->{sandbox},
-        proxy_insecure_content =>  $opts->{proxy_insecure_content}
         );
     return $event;
 }

--- a/cgi-bin/LJ/Event/JournalNewComment.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment.pm
@@ -188,7 +188,7 @@ sub content {
 
     LJ::need_res('js/commentmanage.js');
 
-    my $comment_body = $comment->body_html( proxy_insecure_content => $LJ::IS_SSL );
+    my $comment_body = $comment->body_html;
     my $buttons = $comment->manage_buttons;
     my $dtalkid = $comment->dtalkid;
     my $htmlid  = LJ::Talk::comment_htmlid( $dtalkid );

--- a/cgi-bin/LJ/Event/JournalNewEntry.pm
+++ b/cgi-bin/LJ/Event/JournalNewEntry.pm
@@ -101,7 +101,6 @@ sub content {
                         cuturl => $entry->url,
                         sandbox => 1,
                         preformatted => $entry->prop( "opt_preformatted" ),
-                        proxy_insecure_content => $LJ::IS_SSL,
                     } )
                     . $self->as_html_tags( $target );
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2145,7 +2145,6 @@ sub Entry_from_entryobj
             suspend_msg => $suspend_msg,
             unsuspend_supportid => $suspend_msg ? $entry_obj->prop( 'unsuspend_supportid' ) : 0,
             preformatted => $entry_obj->prop( "opt_preformatted" ),
-            proxy_insecure_content => $LJ::IS_SSL,
         };
 
         # reading pages might need to display image placeholders

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -555,7 +555,7 @@ sub EntryPage_entry
     $comments->{show_readlink} &&= $get_mode eq 'reply';
 
     my $subject = LJ::CleanHTML::quote_html( $entry->subject_html, $get->{nohtml} );
-    my $event = LJ::CleanHTML::quote_html( $entry->event_html( { proxy_insecure_content => $LJ::IS_SSL } ), $get->{nohtml} );
+    my $event = LJ::CleanHTML::quote_html( $entry->event_html, $get->{nohtml} );
 
     # load tags
     my @taglist;

--- a/htdocs/edittags.bml
+++ b/htdocs/edittags.bml
@@ -77,11 +77,10 @@ body<=
     my (%props, %opts);
     LJ::load_log_props2($u->{userid}, [$jitemid], \%props);
     $opts{'preformatted'} = $props{$jitemid}{'opt_preformatted'};
-    $opts{proxy_insecure_content} = $LJ::IS_SSL;
 
     LJ::CleanHTML::clean_subject(\$subj);
     LJ::CleanHTML::clean_event(\$evt, \%opts);
-    LJ::expand_embedded($u, $ditemid, $remote, \$evt, proxy_insecure_content => $LJ::IS_SSL );
+    LJ::expand_embedded($u, $ditemid, $remote, \$evt );
 
     # prevent BML tags interpretation inside post body
     $subj =~ s/<\?/&lt;?/g;

--- a/htdocs/latest.bml
+++ b/htdocs/latest.bml
@@ -162,7 +162,7 @@ EOC
             my $time = LJ::diff_ago_text( $obj->logtime_unix, $now );
             my $url = $obj->url;
             my $truncated;
-            my $evt = $obj->event_html_summary( 2000, { cuturl => $url, preformatted => $obj->prop( 'opt_preformatted' ), proxy_insecure_content => $LJ::IS_SSL }, \$truncated );
+            my $evt = $obj->event_html_summary( 2000, { cuturl => $url, preformatted => $obj->prop( 'opt_preformatted' ) }, \$truncated );
             # put a "(Read more)" link at the end of the text if the entry had to be shortened
             $evt .= ' <a href="' . $url . '">(Read more)</a>' if $truncated; 
             my $comments = $obj->reply_count == 1 ? "1 comment" : ( $obj->reply_count > 0 ? $obj->reply_count . ' comments' : 'no comments' );


### PR DESCRIPTION
We always want to check this based on the value of $LJ::IS_SSL, and not
based on calling context. Also means that we can stop discovering new
places we missed passing in the argument.