### PR TITLE
Fixes #1225 Opera Presto confused by Foundation namespaces

### DIFF
--- a/schemes/celerity.tt
+++ b/schemes/celerity.tt
@@ -105,6 +105,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
                     .find(".top-bar-section").removeClass( "top-bar-section" ).end()
             }
           });
+          Foundation.global.namespace = '';
           $(document).foundation();
         </script>
     </body>

--- a/schemes/common.tt
+++ b/schemes/common.tt
@@ -314,6 +314,7 @@ the table based way can be removed when the entire site is Foundation-based.
                     .find(".top-bar-section").removeClass( "top-bar-section" ).end()
             }
           });
+          Foundation.global.namespace = '';
           $(document).foundation();
         </script>
     </body>


### PR DESCRIPTION
Opera Presto not loading Foundation. FWIW Foundation is only supporting Opera Presto (<=12) by accident at this point; expect continued degradation. Refs http://ilikekillnerds.com/2014/07/foundation-v5-unrecognized-expression-syntax-namespace-fix/ https://github.com/zurb/foundation/issues/5661