### PR TITLE
[#1222] display user's timezone instead of UTC on S2 entry pages

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2328,6 +2328,7 @@ sub Page
         'layout_url' => $layouturl,
         'time' => DateTime_unix(time),
         'local_time' => $tz_remote ? DateTime_tz( time, $tz_remote ) : DateTime_unix(time),
+        timezone => $tz_remote ? $tz_remote->short_name_for_datetime( DateTime->now() ) : 'UTC',
         'base_url' => $base_url,
         'stylesheet_url' => "$base_url/res/$styleid/stylesheet?$stylemodtime",
         'view_url' => {

--- a/htdocs/stc/entrypage.css
+++ b/htdocs/stc/entrypage.css
@@ -19,7 +19,6 @@ h3.entry-title {
 
 .entry .header {background:none; border:0;}
 .entry .datetime:before { content:"@ ";} /*add the talkread-style elements to the date and time*/
-.entry .datetime:after {content:" UTC";}
 .entry .datetime {font-style: italic;}
 .entry .contents{ margin-left: 30px}
 .entry-wrapper .userpic {display: table-cell; float: none;}

--- a/htdocs/stc/replypage.css
+++ b/htdocs/stc/replypage.css
@@ -22,7 +22,6 @@ h3.entry-title, h4.comment-title {
 
 .entry .header, .comment .header {background:none; border:0;}
 .entry .datetime:before, .comment .datetime:before { content:"@ ";} /*add the talkread-style elements to the date and time*/
-.entry .datetime:after {content:" UTC";}
 .entry .datetime, .comment .datetime {font-style: italic; display:block;}
 .entry .contents, .comment .contents{ margin-left: 30px}
 .comment .header, .screened {background:none; border:0;}

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -613,6 +613,8 @@ class Page
     var readonly DateTime time
     "A DateTime object filled with the time (GMT) when the page was created.";
 
+    var readonly string timezone "The timezone associated with the value of local_time";
+
     var Link{} data_link "Links to various machine-readable data sources relating to this page";
     var string[] data_links_order "An array of data views which can be used to order the data_link hash";
 
@@ -5700,6 +5702,7 @@ function Entry::time_display(string datefmt, string timefmt) : string {
     if ($datefmt != "none") { $ret = $ret + """<span class="date">""" + $this.time->date_format($datefmt, $linkify) + "</span>"; }
     if ($datefmt != "none" and $timefmt != "none") { $ret = $ret + " "; }
     if ($timefmt != "none") { $ret = $ret + """<span class="time">""" + $this.time->time_format($timefmt) + "</span>"; }
+    if ($datefmt != "none") { $ret = $ret + """ <span class="timezone">""" + $p.timezone + "</span>"; }
 
     if ($ret != "") { $ret = """<span class="datetime">$ret</span>"""; }
 


### PR DESCRIPTION
This removes the hardcoded 'UTC' display from CSS in favor of
displaying the correct time zone as set by the user viewing the page.
It does so by adding a new 'timezone' property to the Page class in core2.

I don't know if this is the best approach, but it seems to solve the issue.

Fixes #1222.