### PR TITLE
[#1222] don't display 'UTC' for entry times with unknown timezone

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2647,6 +2647,8 @@ sub sitescheme_secs_to_iso {
     my $has_tz = defined $s2_datetime ? "(local)" : "UTC";
     # if timezone execution failed, use GMT
     $s2_datetime = DateTime_unix( $secs ) unless defined $s2_datetime;
+    # but don't display timezone unless it was requested
+    $has_tz = '' unless $opts{tz};
 
     my @s2_args = ( $s2_ctx, $s2_datetime );
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2642,13 +2642,18 @@ sub sitescheme_secs_to_iso {
 
     # convert date to S2 object
     my $s2_ctx = [];  # fake S2 context object
+
+    my $s2_datetime;
+    my $has_tz = '';  # don't display timezone unless requested below
+
     # if opts has a true tz key, get the remote user's timezone if possible
-    my $s2_datetime = $opts{tz} ? DateTime_tz( $secs, $remote ) : undef;
-    my $has_tz = defined $s2_datetime ? "(local)" : "UTC";
+    if ( $opts{tz} ) {
+        $s2_datetime = DateTime_tz( $secs, $remote );
+        $has_tz = defined $s2_datetime ? "(local)" : "UTC";
+    }
+
     # if timezone execution failed, use GMT
     $s2_datetime = DateTime_unix( $secs ) unless defined $s2_datetime;
-    # but don't display timezone unless it was requested
-    $has_tz = '' unless $opts{tz};
 
     my @s2_args = ( $s2_ctx, $s2_datetime );
 

--- a/htdocs/stc/entrypage.css
+++ b/htdocs/stc/entrypage.css
@@ -19,7 +19,6 @@ h3.entry-title {
 
 .entry .header {background:none; border:0;}
 .entry .datetime:before { content:"@ ";} /*add the talkread-style elements to the date and time*/
-.entry .datetime:after {content:" UTC";}
 .entry .datetime {font-style: italic;}
 .entry .contents{ margin-left: 30px}
 .entry-wrapper .userpic {display: table-cell; float: none;}

--- a/htdocs/stc/replypage.css
+++ b/htdocs/stc/replypage.css
@@ -22,7 +22,6 @@ h3.entry-title, h4.comment-title {
 
 .entry .header, .comment .header {background:none; border:0;}
 .entry .datetime:before, .comment .datetime:before { content:"@ ";} /*add the talkread-style elements to the date and time*/
-.entry .datetime:after {content:" UTC";}
 .entry .datetime, .comment .datetime {font-style: italic; display:block;}
 .entry .contents, .comment .contents{ margin-left: 30px}
 .comment .header, .screened {background:none; border:0;}


### PR DESCRIPTION
This removes the hardcoded 'UTC' display from CSS and from the
function LJ::S2::sitescheme_secs_to_iso (used to display the
entry time when previewing a comment).  The entry time is
not associated with a timezone, being arbitrarily chosen by the poster.

Fixes #1222.