### PR TITLE
(Issue #1185) - Fixes bad link on /admin/console/index

### DIFF
--- a/cgi-bin/DW/Controller/Admin/Console.pm
+++ b/cgi-bin/DW/Controller/Admin/Console.pm
@@ -65,7 +65,7 @@ sub console_handler {
 
 
     my $vars = {
-        reference_url   => LJ::create_url( $r->uri . 'reference' ),
+        reference_url   => LJ::create_url( "/admin/console/reference" ),
         form_url        => LJ::create_url( undef ),
 
         show_extended_description => ! $r->did_post,


### PR DESCRIPTION
Fixes issue #1185 by hardcoding the URL. If there's a design reason this shouldn't be done, please let me know.