### PR TITLE
[#1007] Use https:// for system-generated links in emails we send

### DIFF
--- a/bin/worker/paidstatus
+++ b/bin/worker/paidstatus
@@ -69,6 +69,14 @@ my $alert = sub {
     return undef;
 };
 
+# set additional site variables
+if ( $LJ::USE_HTTPS_EVERYWHERE ) {
+    # use https:// for system-generated links
+    $LJ::IS_SSL = 1;
+    LJ::use_ssl_site_variables();
+}
+
+
 while ( 1 ) {
     $log->( 'Main loop beginning...' );
 

--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -371,21 +371,13 @@ sub trans
 
     # only allow certain pages over SSL
     if ($is_ssl) {
-        $LJ::SITEROOT = $LJ::SSLROOT;
-        $LJ::IMGPREFIX = $LJ::SSLIMGPREFIX;
-        $LJ::STATPREFIX = $LJ::SSLSTATPREFIX;
-        $LJ::STATPREFIX = $LJ::SSLSTATPREFIX;
-        $LJ::JSPREFIX = $LJ::SSLJSPREFIX;
-        $LJ::WSTATPREFIX = $LJ::SSLWSTATPREFIX;
-        $LJ::USERPIC_ROOT = $LJ::SSLICONPREFIX;
+        LJ::use_ssl_site_variables();
     } elsif (LJ::Hooks::run_hook("set_alternate_statimg")) {
         # do nothing, hook did it.
     } else {
         $LJ::DEBUG_HOOK{'pre_restore_bak_stats'}->() if $LJ::DEBUG_HOOK{'pre_restore_bak_stats'};
 
-        # restore original siteroot, etc
-        ${$LJ::{$_}} = $LJ::_ORIG_CONFIG{$_}
-            foreach qw(IMGPREFIX JSPREFIX STATPREFIX WSTATPREFIX USERPIC_ROOT SITEROOT);
+        LJ::use_config_site_variables();
     }
 
     # let foo.com still work, but redirect to www.foo.com

--- a/cgi-bin/DW/Routing.pm
+++ b/cgi-bin/DW/Routing.pm
@@ -605,7 +605,7 @@ sub _apply_defaults {
     $hash->{user}         = $opts->{user} || 0;
     $hash->{api}          = $opts->{api}  || 0;
     $hash->{format}     ||= $opts->{format} || 'html';
-    $hash->{prefer_ssl}   = $opts->{prefer_ssl} // ($hash->{app} ? $LJ::USE_SSL_EVERYWHERE : 0);
+    $hash->{prefer_ssl}   = $opts->{prefer_ssl} // ($hash->{app} ? $LJ::USE_HTTPS_EVERYWHERE : 0);
     $hash->{no_cache}     = $opts->{no_cache} || 0;
 
     my $formats = $opts->{formats} || [ $hash->{format} ];

--- a/cgi-bin/DW/Routing/CallInfo.pm
+++ b/cgi-bin/DW/Routing/CallInfo.pm
@@ -156,7 +156,7 @@ Should prefer SSL if possible.
 
 =cut
 
-sub prefer_ssl { return $_[0]->{__hash}->{prefer_ssl} // $LJ::USE_SSL_EVERYWHERE; }
+sub prefer_ssl { return $_[0]->{__hash}->{prefer_ssl} // $LJ::USE_HTTPS_EVERYWHERE; }
 
 =head2 C<< $self->no_cache >>
 

--- a/cgi-bin/LJ/NotificationMethod/Email.pm
+++ b/cgi-bin/LJ/NotificationMethod/Email.pm
@@ -69,6 +69,14 @@ sub notify {
     croak "'notify' is an object method"
         unless ref $self eq __PACKAGE__;
 
+    # use https:// for system-generated links in notification emails
+    local $LJ::IS_SSL;
+    local ${$LJ::{$_}} foreach LJ::site_variables_list();
+    if ( $LJ::USE_HTTPS_EVERYWHERE ) {
+        $LJ::IS_SSL = 1;
+        LJ::use_ssl_site_variables();
+    }
+
     my $u = $self->u;
     my $lang = $u->prop('browselang');
     my $vars = { sitenameshort => $LJ::SITENAMESHORT, sitename => $LJ::SITENAME, siteroot => $LJ::SITEROOT };

--- a/cgi-bin/LJ/URI.pm
+++ b/cgi-bin/LJ/URI.pm
@@ -33,7 +33,7 @@ sub redirect_to_https {
     my ( $class, $apache_r, $uri ) = @_;
 
     my $host = $apache_r->headers_in->{"Host"};
-    if ( $LJ::USE_SSL_EVERYWHERE && !$LJ::IS_SSL
+    if ( $LJ::USE_HTTPS_EVERYWHERE && !$LJ::IS_SSL
             && ( # temporary
                 !$LJ::SSL_DISABLED_URI{$uri}
                 && $host ne $LJ::EMBED_MODULE_DOMAIN

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -641,6 +641,32 @@ sub end_request
     return 1;
 }
 
+sub site_variables_list {
+    return qw(IMGPREFIX JSPREFIX STATPREFIX WSTATPREFIX USERPIC_ROOT SITEROOT);
+}
+
+sub use_ssl_site_variables {
+    # save a backup of the original config value
+    unless ( %LJ::_ORIG_CONFIG ) {
+        %LJ::_ORIG_CONFIG = ();
+        $LJ::_ORIG_CONFIG{$_} = ${$LJ::{$_}}
+            foreach LJ::site_variables_list();
+    }
+
+    $LJ::SITEROOT = $LJ::SSLROOT;
+    $LJ::IMGPREFIX = $LJ::SSLIMGPREFIX;
+    $LJ::STATPREFIX = $LJ::SSLSTATPREFIX;
+    $LJ::JSPREFIX = $LJ::SSLJSPREFIX;
+    $LJ::WSTATPREFIX = $LJ::SSLWSTATPREFIX;
+    $LJ::USERPIC_ROOT = $LJ::SSLICONPREFIX;
+}
+
+sub use_config_site_variables {
+    # restore original siteroot, etc
+    ${$LJ::{$_}} = $LJ::_ORIG_CONFIG{$_}
+        foreach qw(IMGPREFIX JSPREFIX STATPREFIX WSTATPREFIX USERPIC_ROOT SITEROOT);
+}
+
 # <LJFUNC>
 # name: LJ::flush_cleanup_handlers
 # des: Runs all cleanup handlers registered in @LJ::CLEANUP_HANDLERS

--- a/cgi-bin/modperl_subs.pl
+++ b/cgi-bin/modperl_subs.pl
@@ -109,11 +109,6 @@ require "$LJ::HOME/cgi-bin/modperl_subs-local.pl"
 # the hooks to be run
 LJ::Hooks::_load_hooks_dir() unless LJ::is_from_test();
 
-# save a backup of the original config value
-%LJ::_ORIG_CONFIG = ();
-$LJ::_ORIG_CONFIG{$_} = ${$LJ::{$_}}
-    foreach qw(IMGPREFIX JSPREFIX STATPREFIX WSTATPREFIX USERPIC_ROOT SITEROOT);
-
 package LJ::ModPerl;
 
 # pull in a lot of useful stuff before we fork children


### PR DESCRIPTION
* ESN notifications now always use https

* paidstatus worker now always uses https (needs setting in worker
  because this uses send_mail directly)

* emails sent from various pages (e.g., password reset): link protocol
  depends on whether the viewed page uses http or https. This should be
  a non-issue once we turn on https everywhere

* refactors the setting of site variables (to start with http or https)
  because it's now used in multiple places

* renames $LJ::USE_SSL_EVERYWHERE to $LJ::USE_HTTPS_EVERYWHERE as a more
  descriptive variable name

Fixes #1007.