### PR TITLE
(Issue #1188) Standardize use of $LJ::HOME/htdocs vs $LJ::HTDOCS

### DIFF
--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -603,7 +603,7 @@ sub trans
 
             my $file = LJ::Hooks::run_hook("profile_bml_file");
             $file ||= $LJ::PROFILE_BML_FILE || "profile.bml";
-            return $bml_handler->("$LJ::HOME/htdocs/$file");
+            return $bml_handler->("$LJ::HTDOCS/$file");
         }
 
         if ($opts->{'mode'} eq "update") {
@@ -828,7 +828,7 @@ sub trans
 
         } elsif ($func eq "cssproxy") {
 
-            return $bml_handler->("$LJ::HOME/htdocs/extcss/index.bml");
+            return $bml_handler->("$LJ::HTDOCS/extcss/index.bml");
 
         } elsif ($func eq 'support') {
             return redir($apache_r, "$LJ::SITEROOT/support/");

--- a/cgi-bin/Apache/LiveJournal/PalImg.pm
+++ b/cgi-bin/Apache/LiveJournal/PalImg.pm
@@ -35,7 +35,7 @@ sub handler
     $apache_r->notes->{codepath} = "img.palimg";
     return 404 unless $base && $base !~ m!\.\.!;
 
-    my $disk_file = "$LJ::HOME/htdocs/palimg/$base.$ext";
+    my $disk_file = "$LJ::HTDOCS/palimg/$base.$ext";
     return 404 unless -e $disk_file;
 
     my @st = stat(_);

--- a/cgi-bin/DW/Hooks/NavStrip.pm
+++ b/cgi-bin/DW/Hooks/NavStrip.pm
@@ -89,7 +89,7 @@ LJ::Hooks::register_hook( 'control_strip_stylesheet_link', sub {
     if ( $color ) {
         LJ::need_res("stc/controlstrip-$color.css");
         LJ::need_res("stc/controlstrip-${color}-local.css")
-            if -e "$LJ::HOME/htdocs/stc/controlstrip-${color}-local.css";
+            if -e "$LJ::HTDOCS/stc/controlstrip-${color}-local.css";
     }
 });
 

--- a/cgi-bin/LJ/URI.pm
+++ b/cgi-bin/LJ/URI.pm
@@ -24,7 +24,7 @@ sub bml_handler {
     my ($class, $apache_r, $filename) = @_;
 
     $apache_r->handler("perl-script");
-    $apache_r->notes->{bml_filename} = "$LJ::HOME/htdocs/$filename";
+    $apache_r->notes->{bml_filename} = "$LJ::HTDOCS/$filename";
     $apache_r->push_handlers(PerlHandler => \&Apache::BML::handler);
     return OK;
 }

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -906,7 +906,7 @@ sub load_include {
     }
 
     # hit it up from the file, if it exists
-    my $filename = "$LJ::HOME/htdocs/inc/$file";
+    my $filename = "$LJ::HTDOCS/inc/$file";
     return unless -e $filename;
 
     # get it and return it


### PR DESCRIPTION
Changes the following files to use $LJ::HTDOCS intsead of $LJ::HOME/htdocs:
- cgi-bin/Apache/LiveJournal.pm
- cgi-bin/Apache/LiveJournal/PalImg.pm
- cgi-bin/DW/Hooks/NavStrip.pm
- cgi-bin/LJ/URI.pm
- cgi-bin/ljlib.pl

Did not see a reference in bin/upgrading/import-includes.pl. Fixes #1188.