### PR TITLE
[#1117] Use protocol relative links when possible

### DIFF
--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -69,6 +69,7 @@ no strict "vars";
     $JSPREFIX ||= "$SITEROOT/js";
     $USERPIC_ROOT ||= "$LJ::SITEROOT/userpic";
     $PALIMGROOT ||= "$LJ::SITEROOT/palimg";
+    $RELATIVE_SITEROOT ||= "//$DOMAIN_WEB";
 
     # path to sendmail and any necessary options
     $SENDMAIL ||= "/usr/sbin/sendmail -t -oi";
@@ -93,7 +94,7 @@ no strict "vars";
     # this option can be a boolean or a URL, but internally we want a URL
     # (which can also be a boolean)
     if ($LJ::OPENID_SERVER && $LJ::OPENID_SERVER == 1) {
-        $LJ::OPENID_SERVER = "$LJ::SITEROOT/openid/server";
+        $LJ::OPENID_SERVER = $LJ::USE_HTTPS_EVERYWHERE ? "$LJ::SSLROOT/openid/server" : "$LJ::SITEROOT/openid/server";
     }
 
     # set default capability limits if the site maintainer hasn't.

--- a/doc/config-local.pl.txt
+++ b/doc/config-local.pl.txt
@@ -142,7 +142,7 @@
     # bookmarks on user subdomains (or anything else rendered through
     # S2). This file is not part of the dw-free installation, and is
     # therefore disabled by default.
-    #$APPLE_TOUCH_ICON = "$LJ::SITEROOT/apple-touch-icon.png";
+    #$APPLE_TOUCH_ICON = "$LJ::RELATIVE_SITEROOT/apple-touch-icon.png";
 
 
 


### PR DESCRIPTION
* updates sample APPLE_TOUCH_ICON config to use a protocol relative
  siteroot

* updates OPENID_SERVER config to use https vs http

Fixes #1117.