### PR TITLE
(Issue #738) Add "..." to end of truncated moderation queue subjects

### DIFF
--- a/cgi-bin/DW/Controller/Community.pm
+++ b/cgi-bin/DW/Controller/Community.pm
@@ -984,6 +984,7 @@ sub entry_queue_handler {
                 time    => LJ::diff_ago_text( LJ::mysqldate_to_time( $_->{logtime} ) ),
                 poster  => $users{$_->{posterid}}->ljuser_display,
                 subject => $_->{subject},
+                subject_maxlength => ( length( $_->{subject} ) >= 29 ) ? 1 : 0,
                 url     => $cu->moderation_queue_url( $_->{modid} ),
             }
         } @queue;

--- a/views/communities/queue/entries.tt
+++ b/views/communities/queue/entries.tt
@@ -29,6 +29,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
             <div class="columns large-7"><a href="[%- entry.url -%]" class="queue-action">
             [%- IF entry.subject -%]
                 [%- entry.subject | html -%]
+                [%- IF entry.subject_maxlength -%]
+                    ...
+                [%- END -%]
             [%- ELSE -%]
                 [%- ".no_subject" | ml -%]
             [%- END -%]


### PR DESCRIPTION
Checks if subject line is 29 characters or greater (since if last character
is a space it's not really stored in the SQL database) and adds "..." to the
end of the subject line in the moderation queue if so. Will be incorrect for
the edge cases where the subject line is exactly 29-30 characters.

Fixes issue #738.