### PR TITLE
[#1258] Don't remove border, instead shift elements 1px left

### DIFF
--- a/htdocs/scss/pages/entry/new.scss
+++ b/htdocs/scss/pages/entry/new.scss
@@ -103,8 +103,8 @@
     }
 
     li + li {
-        input, button {
-            border-left: none;
+        input, button, .fancy-select-output {
+            margin-left: -1px;
         }
     }
 
@@ -134,7 +134,6 @@
     @media #{$medium-up} {
         .fancy-select-output {
             width: auto;
-            border-left: none;
         }
     }
 }


### PR DESCRIPTION
This fixes the border disappearing when the select wraps onto the next
line (as can happen on smaller screens, or with the sidebar)

Fixes #1258.