### PR TITLE
[#1252] Map "UK" to be the same as "GB"

### DIFF
--- a/cgi-bin/DW/Countries.pm
+++ b/cgi-bin/DW/Countries.pm
@@ -48,6 +48,7 @@ sub load {
     foreach my $code ( all_country_codes() ) {
         $countries->{ uc $code } = code2country( $code );
     }
+    $countries->{UK} = $countries->{GB};
 }
 
 1;


### PR DESCRIPTION
We store it as "UK" but the list of countries has it as "GB"

Fixes #1252.