### PR TITLE
(Issue #1200) Whitelist jigsawplanet.com

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -131,6 +131,10 @@ LJ::Hooks::register_hook( 'allow_iframe_embeds', sub {
     if ( $uri_host eq "commons.wikimedia.org" ) {
         return ( 1, 1 ) if $uri_path =~ m!^/wiki/File:! && $parsed_uri->query =~ m/embedplayer=yes/;
     }
+    
+    if ( $uri_host eq "www.jigsawplanet.com" ) {
+	return ( 1, 1 ) if $parsed_uri->query =~ m/rc=play/;
+    }
 
     return 0;
 

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 53;
+use Test::More tests => 54;
 
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }
@@ -135,6 +135,9 @@ note( "misc" );
     test_bad_url( "https://vine.co/v/bjHh0zHdgZT/embed/postcard" );
     test_bad_url( "https://vine.co/v/bjHh0zHdgZT/embed" );
     test_bad_url( "https://vine.co/v/abc/embed/simple" );
+
+    test_good_url( "//www.jigsawplanet.com/?rc=play&amp;pid=35458f1355c4&amp;view=iframe" );
+
 }
 
 


### PR DESCRIPTION
Tests for 'rc=play' in the URL. Fixes #1200.