### PR TITLE
Use absolute font url instead of relative

### DIFF
--- a/htdocs/scss/components/foundation-icons.scss
+++ b/htdocs/scss/components/foundation-icons.scss
@@ -13,8 +13,8 @@ $include-html-fi-icon-classes: true !default;
     src: url("/stc/fonts/foundation-icons.eot");
     src: url("/stc/fonts/foundation-icons.eot?#iefix") format("embedded-opentype"),
        url("/stc/fonts/foundation-icons.woff") format("woff"),
-       url("stc/fonts/foundation-icons.ttf") format("truetype"),
-       url("stc/fonts/foundation-icons.svg#fontcustom") format("svg");
+       url("/stc/fonts/foundation-icons.ttf") format("truetype"),
+       url("/stc/fonts/foundation-icons.svg#fontcustom") format("svg");
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
Fixes 404 issue when loading these font file formats.