### PR TITLE
[#1113] Show the read comments link when you reply via QR

### DIFF
--- a/cgi-bin/LJ/S2/FriendsPage.pm
+++ b/cgi-bin/LJ/S2/FriendsPage.pm
@@ -248,6 +248,7 @@ sub FriendsPage
         my $entry = Entry_from_entryobj( $u, $entry_obj, $opts );
 
         $entry->{_ymd} = join('-', map { $entry->{'time'}->{$_} } qw(year month day));
+        $entry->{comments}->{show_readlink_hidden} = 1;
 
         push @{$p->{'entries'}}, $entry;
         $eventnum++;

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -114,6 +114,9 @@ jQuery(document).ready(function($) {
                                         $iconSelect.trigger("change");
                                     }
 
+                                    // for the 0 -> 1 case, when the link starts out hidden
+                                    $readLink.parent().show();
+
                                     $readLink
                                         .ajaxtip() // init
                                         .ajaxtip("success", data.message) // success message

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -258,6 +258,7 @@ class CommentInfo
     var bool maxcomments "Set to true if entry has reached a comment maximum.";
     var bool show_postlink "Indicates whether the Post Comment link for this entry should be shown.";
     var bool show_readlink "Indicates whether the Read Comments link for this entry should be shown.";
+    var bool show_readlink_hidden "Indicates whether to show the Read Comments link for this entry, but hidden, to be shown my JS.";
 
     function print
     "Print all comment related links";
@@ -6143,7 +6144,12 @@ function CommentInfo::print(Entry e, string{} opts) {
       """<li class="entry-readlink">""";
       $this->print_readlink();
       "</li>\n";
+  } elseif ($.show_readlink_hidden) {
+    """<li class="entry-readlink" style="display:none">""";
+    $this->print_readlink();
+    "</li>\n";
   }
+
   if ($.show_postlink and $.enabled) {
       """<li class="entry-replylink">""";
       if (isnull $e) {

--- a/styles/database/layout.s2
+++ b/styles/database/layout.s2
@@ -517,10 +517,15 @@ function CommentInfo::print(Entry e, string{} opts) {
         """<li class="entry-permalink first-item"><a href="$.read_url"><img src="$*image_link" alt="$*text_permalink" title="$*text_permalink" /></a></li>""";
     }
     if ($.show_readlink) {
-        """<li class="entry-readlink first-item">""";
+        """<li class="entry-readlink">""";
+        $this->print_readlink();
+        "</li>";
+    } elseif ($.show_readlink_hidden) {
+        """<li class="entry-readlink" style="display:none">""";
         $this->print_readlink();
         "</li>";
     }
+
     if ($.show_postlink and $.enabled) {
         """<li class="entry-replylink">""";
         if (isnull $e) {


### PR DESCRIPTION
-- this is for the case where we go from 0 -> 1 comment, and we used to
not display a link (because we had nothing to display)

Fixes #1113.