### PR TITLE
[#1264] Separate out the DB configuration for tests

### DIFF
--- a/cgi-bin/LJ/Config.pm
+++ b/cgi-bin/LJ/Config.pm
@@ -26,6 +26,7 @@ $LJ::CACHE_CONFIG_MODTIME = 0;
 # anything.
 @LJ::CONFIG_FILES = $LJ::_T_CONFIG ?
     ( ( map { LJ::resolve_file($_) } qw(
+        t/config-test-private.pl
         t/config-test.pl
     ) ) , ( map { $LJ::HOME . "/" . $_ } qw(
         cgi-bin/LJ/Global/Defaults.pm

--- a/t/config-test-private.pl
+++ b/t/config-test-private.pl
@@ -1,0 +1,30 @@
+{
+  ### Copy this file into ext/local/t to contain custom database information
+  package DW::PRIVATE;
+
+  %DBINFO = (
+    master => {
+      dbname => "test_master",
+      user => "testuser",
+      pass => "",
+    },
+
+    c01 => {
+      dbname => "test_c01",
+      user => "testuser",
+      pass => "",
+    },
+
+    c02 => {
+      dbname => "test_c02",
+      user => "testuser",
+      pass => "",
+    },
+
+    theschwartz => {
+      dbname => "test_schwartz",
+      user => "testuser",
+      pass => "",
+    }
+  );
+}

--- a/t/config-test.pl
+++ b/t/config-test.pl
@@ -6,9 +6,9 @@
              'master' => {
                           'host' => "localhost",
                           'port' => 3306,
-                          'user' => "testuser",
-                          'pass' => "",
-                          'dbname' => "test_master",
+                          'user' => $DW::PRIVATE::DBINFO{master}->{user},
+                          'pass' => $DW::PRIVATE::DBINFO{master}->{pass},
+                          'dbname' => $DW::PRIVATE::DBINFO{master}->{dbname},
                           'role' => {
                                 slow => 1,
                             },
@@ -16,9 +16,9 @@
                 'c01' => {
                     'host' => "localhost",
                     'port' => 3306,
-                    'user' => "testuser",
-                    'pass' => "",
-                    'dbname' => 'test_c01',
+                    'user' => $DW::PRIVATE::DBINFO{c01}->{user},
+                    'pass' => $DW::PRIVATE::DBINFO{c01}->{pass},
+                    'dbname' => $DW::PRIVATE::DBINFO{c01}->{dbname},
                     'role' => {
                         'cluster1' => 1,
                     },
@@ -27,9 +27,9 @@
                 'c02' => {
                     'host' => "localhost",
                     'port' => 3306,
-                    'user' => "testuser",
-                    'pass' => "",
-                    'dbname' => 'test_c02',
+                    'user' => $DW::PRIVATE::DBINFO{c02}->{user},
+                    'pass' => $DW::PRIVATE::DBINFO{c02}->{pass},
+                    'dbname' => $DW::PRIVATE::DBINFO{c02}->{dbname},
                     'role' => {
                         'cluster2' => 1,
                     },
@@ -40,9 +40,9 @@
     $DEFAULT_CLUSTER = [ 1, 2 ];
     @THESCHWARTZ_DBS = (
                       {
-                       dsn => "dbi:mysql:test_schwartz;host=localhost",
-                       user => "testuser",
-                       pass => "",
+                       dsn => "dbi:mysql:$DW::PRIVATE::DBINFO{theschwartz}->{dbname};host=localhost",
+                       user => $DW::PRIVATE::DBINFO{theschwartz}->{user},
+                       pass => $DW::PRIVATE::DBINFO{theschwartz}->{pass},
                       }
                      );
 


### PR DESCRIPTION
This allows overriding just the DB configuration, without overriding all
the other test-related variables. For the sake of people on shared
servers where the database name must vary.

(Note: they'll still need to create the DBs to use, or have the DBs
created for them)

Fixes #1264.