### PR TITLE
[#1277] Recognize as end of message any line with <$LJ::BOGUS_EMAIL>

### DIFF
--- a/cgi-bin/DW/CleanEmail.pm
+++ b/cgi-bin/DW/CleanEmail.pm
@@ -41,8 +41,8 @@ sub nonquoted_text {
         # but this can be in various languages, so  not hardcoding the text
         last if m/^\s*-{3,}[^-]+-{3,}\s*$/;
 
-        # --- (some text), the bogus email we sent the comments as
-        last if m/^\s*-{3,}.*<$LJ::BOGUS_EMAIL>/;
+        # the bogus email we sent the comments as wrapped in <>
+        last if m/<$LJ::BOGUS_EMAIL>/;
 
         $num_lines++;
     }

--- a/t/cleanemail.t
+++ b/t/cleanemail.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 15;
+use Test::More tests => 16;
 
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }
@@ -179,6 +179,20 @@ Datum: Donnerstag, 25. April, 2013 21:15 Uhr
 
     is( $nonquoted, q{
 foo}, "\$LJ::BOGUS_EMAIL")
+}
+
+{
+    my $nonquoted = DW::CleanEmail->nonquoted_text(qq{
+foo
+
+Von: etc - DW Comment <$LJ::BOGUS_EMAIL>
+Betreff: Reply to your comment. [ exampleusername - 12345 ]
+Datum: Donnerstag, 25. April, 2013 21:15 Uhr
+});
+
+    is( $nonquoted, q{
+foo
+}, "\$LJ::BOGUS_EMAIL")
 }
 
 {


### PR DESCRIPTION
That is, the email we sent from wrapped in "<>"

Fixes #1277.