### PR TITLE
fix HTML tags being mismatched after doing LJ::html_trim

### DIFF
--- a/cgi-bin/LJ/TextUtil.pm
+++ b/cgi-bin/LJ/TextUtil.pm
@@ -653,8 +653,10 @@ sub html_trim {
 
         } elsif ($type eq 'E') {
             # end tag
-            pop @open_tags;
-            $out .= "</$tag>";
+            if ( $open_tags[-1] eq $tag ) {
+                pop @open_tags;
+                $out .= "</$tag>";
+            }
         }
     }
 

--- a/t/htmltrim.t
+++ b/t/htmltrim.t
@@ -18,7 +18,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 3;
+use Test::More tests => 10;
 
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }
@@ -44,6 +44,32 @@ BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }
     $test_string_trunc = qq {<br /><input type="button" value="button" />123};
 
     is(LJ::html_trim($test_string, 3), $test_string_trunc, "Truncating with poorly-formed HTML");
+
+    $test_string = qq{<table><tr><td>test</table>};
+    $test_string_trunc = qq{<table><tr><td>test</td>
+</tr>
+</table>};
+    is(LJ::html_trim($test_string, length($test_string)), $test_string_trunc, "Truncating with table tags");
+
+    $test_string = qq{<h1>a<h2>b<h3>c</h1>d</h2>e</h3>};
+    is(LJ::html_trim($test_string, 1), qq{<h1>a<h2>b</h2>
+</h1>}, "Truncating [1] with mismatched tags");
+    is(LJ::html_trim($test_string, 2), qq{<h1>a<h2>b<h3>c</h3>
+</h2>
+</h1>}, "Truncating [2] with mismatched tags");
+    is(LJ::html_trim($test_string, 3), qq{<h1>a<h2>b<h3>cd</h3>
+</h2>
+</h1>}, "Truncating [3] with mismatched tags");
+
+    my $cleaned_test_string = $test_string;
+    LJ::CleanHTML::clean_event( \$cleaned_test_string );
+    is(LJ::html_trim($cleaned_test_string, 1), qq{<h1>a<h2>b</h2>
+</h1>}, "Truncating [1] with mismatched tags (pre-cleaned)");
+    is(LJ::html_trim($cleaned_test_string, 2), qq{<h1>a<h2>b<h3>c</h3>
+</h2>
+</h1>}, "Truncating [2] with mismatched tags (pre-cleaned)");
+        is(LJ::html_trim($cleaned_test_string, 3), qq{<h1>a<h2>b<h3>c</h3></h2></h1>de}, "Truncating [3] with mismatched tags");
+
 }
 
 1;


### PR DESCRIPTION
Primary problem was that in some cases closing tags are optional (such
as with tr/td) and so if you had input such as the first given test
case:

    <table><tr><td>test</table>

You'd get:

     <table><tr><td>test</table>[</tr></table>]

Note the unnecessary added ending tags in the bracket.

This patch changes html_trim so we only pop / append the ending tag
in-text when it matches the last opened tag in the stack.

Then we close all open tags in the stack at the end.

It also adds a couple test cases that demonstrate the behavior of
htmltrim when HTML tags are mismatched.