### PR TITLE
[#1303] Trigger the dialog onload not onready

### DIFF
--- a/htdocs/js/journals/jquery.tag-nav.js
+++ b/htdocs/js/journals/jquery.tag-nav.js
@@ -95,14 +95,18 @@
 
 jQuery(document).ready(function() {
     $(".tag-text[data-journal]").tagnav();
+});
 
-    var hash = location.hash;
-    if ( hash.indexOf( "#tagnav-" ) == 0 ) {
+// we do this later, because we want to make sure the whole page is loaded
+// properly, so the position is calculated accurately
+var hash = location.hash;
+if ( hash.indexOf( "#tagnav-" ) == 0 ) {
+    $(window).load(function() {
         var tag = hash.slice(8);
 
         $(".tag-nav-trigger").click();
         $(".tag a").filter(function() {
             return $(this).text() === tag;
         }).click();
-    }
-});
+    })
+}


### PR DESCRIPTION
This ensures that the DOM has been calculated properly by the time we
try to figure out whether to display the tags or not.

This fixes the tag nav showing up inconsistently positioned in
Chrome/Safari.

Fixes #1303.