### PR TITLE
[#1345] restore missing button on dialog to insert image (RTE)

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -3129,6 +3129,8 @@ sub rte_js_vars {
                 }
             }
         }
+
+        var SiteConfig = new Object();
     </script>^;
 
     return $ret;


### PR DESCRIPTION
Restores initialization of the SiteConfig variable, which is used by fck_image.js.

(This just readds a line that was removed in af3dba5 - I realized that the variable was still being referenced elsewhere. It did make the missing button reappear when I tested it.)

Fixes #1345.
