### PR TITLE
fix refundtopoints error message for case where use attempted twice within 30 days

### DIFF
--- a/cgi-bin/DW/Controller/Shop.pm
+++ b/cgi-bin/DW/Controller/Shop.pm
@@ -342,6 +342,12 @@ sub shop_refund_to_points_handler {
         $rv->{points} = $rv->{blocks} * $rv->{rate};
     }
 
+    unless ( $rv->{can_refund} ) {
+        # tell them how long they have to wait for their next refund.
+        my $last = $rv->{remote}->prop( "shop_refund_time" );
+        $rv->{next_refund} = LJ::mysql_date( $last + 86400 * 30 ) if $last;
+    }
+
     my $r = DW::Request->get;
     return DW::Template->render_template( 'shop/refundtopoints.tt', $rv )
         unless $r->did_post && $rv->{can_refund};

--- a/etc/config.pl
+++ b/etc/config.pl
@@ -390,6 +390,7 @@
             '_key' => 'paid_user', # Some things expect that key name
             '_visible_name' => 'Paid Account',
             '_account_type' => 'paid',
+            '_refund_points' => 30,
             'activeentries' => 1,
             'bookmark_max' => 500,
             'checkfriends' => 1,
@@ -446,6 +447,7 @@
             '_key' => 'premium_user',
             '_visible_name' => 'Premium Paid Account',
             '_account_type' => 'premium',
+            '_refund_points' => 41,
             'activeentries' => 1,
             'bookmark_max' => 1000,
             'checkfriends' => 1,

--- a/views/shop/refundtopoints.tt
+++ b/views/shop/refundtopoints.tt
@@ -32,6 +32,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [% ELSIF NOT can_refund %]
 
 <p><strong>[% '.toosoon' | ml %]</strong></p>
+<p>[% IF next_refund; '.nextrefund' | ml(date = next_refund); END %]</p>
 
 [% ELSIF NOT points %]
 

--- a/views/shop/refundtopoints.tt
+++ b/views/shop/refundtopoints.tt
@@ -29,13 +29,13 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 <p><strong>[% '.noteligible' | ml %]</strong></p>
 
-[% ELSIF NOT points %]
-
-<p><strong>[% '.toofew' | ml %]</strong><p>
-
 [% ELSIF NOT can_refund %]
 
 <p><strong>[% '.toosoon' | ml %]</strong></p>
+
+[% ELSIF NOT points %]
+
+<p><strong>[% '.toofew' | ml %]</strong><p>
 
 [% ELSE %]
 

--- a/views/shop/refundtopoints.tt.text
+++ b/views/shop/refundtopoints.tt.text
@@ -9,6 +9,8 @@
 
 .complete=Your exchange has been completed.
 
+.nextrefund=You won't be able to convert paid time to points again until after [[date]].
+
 .noteligible=Sorry, your account type is not eligible for a points conversion.
 
 .refund=You are eligible to exchange <strong>[[days]] days</strong> of [[type]] for <strong>[[points]] [[sitename]] Points</strong>.

--- a/views/shop/refundtopoints.tt.text
+++ b/views/shop/refundtopoints.tt.text
@@ -21,4 +21,4 @@
 
 .toofew=Sorry, you have less than 30 days of paid time on your account.
 
-.toosoon=Sorry, you can only refund paid time once every thirty days.
+.toosoon=Sorry, you can only convert paid time once every thirty days.


### PR DESCRIPTION
The first commit corrects the error message, the second commit adds config values needed to test the fix, and the third commit adds the requested date info.

Fixes #1340.