### PR TITLE
[#772] English-stripping and refactoring for OpenID account creation

### DIFF
--- a/htdocs/openid/login.bml
+++ b/htdocs/openid/login.bml
@@ -31,7 +31,7 @@ _c?>
         unless LJ::OpenID::consumer_enabled();
 
     my $query_args = $POST{'continue_to'} ? "?continue_to=" .  LJ::eurl( $POST{'continue_to'} ) : "";
-    
+
     my $return_to = "$LJ::SITEROOT/openid/login" . $query_args;
 
     my $remote = LJ::get_remote();
@@ -52,18 +52,12 @@ _c?>
         }
 
         if ($GET{'openid.return_to'} && $GET{'openid.return_to'} !~ /^\Q$return_to\E/) {
-            return $err->(BML::ml( '.error.invalidparam', { item => "return_to" } ) );
+            return $err->( BML::ml( '.error.invalidparameter', { item => "return_to" } ) );
         }
 
-        my $vident = eval { $csr->verified_identity; };
-        return $err->($@) if $@;
-        return $err->($csr->err) unless $vident;
-
-        my $url = $vident->url;
-        return $err->( $ML{'.error.invalidchars'} ) if $url =~ /[\<\>\s]/;
-
-        my $u = LJ::User::load_identity_user("O", $url, $vident);
-        return $err->( BML::ml( '.error.notvivified', { url => LJ::ehtml( $url ) } ) ) unless $u;
+        my $errmsg;
+        my $u = LJ::User::load_from_consumer( $csr, \$errmsg );
+        return $err->( $errmsg ) unless $u;
 
         my $sess_opts = {
             'exptype' => 'short',

--- a/htdocs/openid/login.bml.text
+++ b/htdocs/openid/login.bml.text
@@ -1,13 +1,15 @@
 ;; -*- coding: utf-8 -*-
 .error.cantuseownsite=You can't use a [[sitename]] OpenID account on [[sitename]]:  <a href='/login.bml'>go log in</a> with your actual [[sitename]] account.
 
-.error.invalidchars=Invalid characters in identity URL.
+.error.invalidcharacters=Unable to continue: the provided OpenID URL contains invalid characters.
 
-.error.invalidparam=Invalid [[param]]
+.error.invalidparameter=There was a problem loading the page: invalid parameter [[item]]
 
 .error.logout.content=Hello, [[user]]. Before logging in with <a href='http://openid.net/'>OpenID</a>, you must first <a href='/logout.bml'>log out</a>.
 
 .error.logout.heading=Already logged in
+
+.error.notverified=Can't verify OpenID: [[error]]
 
 .error.notvivified=We couldn't load your account, but we verified your identity as [[url]]. Please try logging in again later, and contact us if this error keeps happening.
 

--- a/htdocs/talkpost_do.bml
+++ b/htdocs/talkpost_do.bml
@@ -48,7 +48,7 @@ body<=
     # POST hash as if they never left.  Watch and see
     if (($GET{'openid.mode'} eq 'id_res' || $GET{'openid.mode'} eq 'cancel') && $GET{'jid'} && $GET{'pendcid'}) {
 
-        return LJ::bad_input("OpenID support not enabled")
+        return LJ::bad_input( BML::ml( '/openid/login.bml.error.no_support' ) )
             unless LJ::OpenID::consumer_enabled();
 
         my $csr = LJ::OpenID::consumer(\%GET);
@@ -56,18 +56,13 @@ body<=
         if ($GET{'openid.mode'} eq 'id_res') { # Verify their identity
 
             unless ( LJ::check_referer('/talkpost_do.bml', $GET{'openid.return_to'}) ) {
-                return LJ::bad_input("Invalid return_to");
+                return LJ::bad_input( BML::ml( '/openid/login.bml.error.invalidparameter',
+                                               { item => "return_to" } ) );
             }
 
-            my $vident = $csr->verified_identity;
-            return LJ::bad_input("Can't verify identity: ".$csr->err) unless $vident;
-
-            my $url = $vident->url;
-            return LJ::bad_input("Invalid characters in identity URL.") if $url =~ /[\<\>\s]/;
-
-            my $uo = LJ::User::load_identity_user("O", $url, $vident);
-            return LJ::bad_input("Couldn't vivify your account (but we verified that you're " . LJ::ehtml($url) . ")")
-                unless $uo;
+            my $errmsg;
+            my $uo = LJ::User::load_from_consumer( $csr, \$errmsg );
+            return LJ::bad_input( $errmsg ) unless $uo;
 
             LJ::set_remote($uo);
             $skip_form_auth = 1;  # wouldn't have form auth at this point


### PR DESCRIPTION
It was pointed out that some obscure OpenID account creation errors
were English-stripped in one place (/openid/login.bml) and not another
(/talkpost_do.bml).  This updates the English-stripping in both places
to be consistent and slightly more user-comprehensible.

Some of the validation process has been refactored into a new class
function, LJ::User::load_from_consumer, to reduce code duplication.

Fixes #772.