### PR TITLE
[#1363] Optionally treat "+" as spaces

### DIFF
--- a/htdocs/js/journals/jquery.tag-nav.js
+++ b/htdocs/js/journals/jquery.tag-nav.js
@@ -102,11 +102,12 @@ jQuery(document).ready(function() {
 var hash = location.hash;
 if ( hash.indexOf( "#tagnav-" ) == 0 ) {
     $(window).load(function() {
-        var tag = hash.slice(8);
+        var tagnav_tag = hash.slice(8);
 
         $(".tag-nav-trigger").click();
         $(".tag a").filter(function() {
-            return $(this).text() === tag;
+            var text = $(this).text();
+            return text === tagnav_tag || text.replace(' ', '+') === tagnav_tag;
         }).click();
     })
 }

--- a/htdocs/js/journals/jquery.tag-nav.js
+++ b/htdocs/js/journals/jquery.tag-nav.js
@@ -102,7 +102,7 @@ jQuery(document).ready(function() {
 var hash = location.hash;
 if ( hash.indexOf( "#tagnav-" ) == 0 ) {
     $(window).load(function() {
-        var tagnav_tag = hash.slice(8);
+        var tagnav_tag = decodeURI(hash.slice(8));
 
         $(".tag-nav-trigger").click();
         $(".tag a").filter(function() {


### PR DESCRIPTION
DW's urlencode function does percent encoding for most special
characters except spaces; make the JS match this behavior.

Fixes #1363.