### PR TITLE
Additional link on sent-PM splash page

### DIFF
--- a/cgi-bin/LJ/NotificationInbox.pm
+++ b/cgi-bin/LJ/NotificationInbox.pm
@@ -140,6 +140,14 @@ sub usermsg_sent_items {
     return $self->subset_items(@events);
 }
 
+sub usermsg_sent_last_items {
+    my $self = shift;
+
+    my @events = ( 'UserMessageSent' );
+
+    return $self->subset_items(@events);
+}
+
 sub birthday_items {
     my $self = shift;
 
@@ -604,6 +612,8 @@ sub delete_all {
         @items = $self->bookmark_items;
     } elsif ( $view eq 'usermsg_sent' ) {
         @items = $self->usermsg_sent_items;
+    } elsif ( $view eq 'usermsg_sent_last' ) {
+        @items = $self->usermsg_sent_last_items;
     } elsif ( $view eq 'singleentry' && $args{itemid} ) {
         my $itemid = $args{itemid} + 0;
         return unless $itemid;
@@ -658,6 +668,8 @@ sub mark_all_read {
         @items = $self->bookmark_items;
     } elsif ( $view eq 'usermsg_sent' ) {
         @items = $self->usermsg_sent_items;
+    } elsif ( $view eq 'usermsg_sent_last' ) {
+        @items = $self->usermsg_sent_last_items;
     } elsif ( $view eq 'singleentry' && $args{itemid} ) {
         my $itemid = $args{itemid} + 0;
         return unless $itemid;

--- a/cgi-bin/LJ/Widget/InboxFolder.pm
+++ b/cgi-bin/LJ/Widget/InboxFolder.pm
@@ -204,6 +204,8 @@ sub render_body {
             my $expanded = $expand && $expand == $qid;
             $expanded ||= $remote->prop('esn_inbox_default_expand');
             $expanded = 0 if $inbox_item->read;
+            
+            $expanded = 1 if ( $view eq "usermsg_sent_last" && $i == $starting_index );
 
             my $expand_img = $expanded ? "inbox_expand" : "inbox_collapse";
 

--- a/htdocs/inbox/compose.bml
+++ b/htdocs/inbox/compose.bml
@@ -172,6 +172,7 @@ body<=
                 unless (@errors) {
                     $body .= $ML{'.message.sent'};
                     $body .= "<?p $ML{'.message.sent.options'} <ul>";
+                    $body .= "<li><a href='$LJ::SITEROOT/inbox/?page=0&view=usermsg_sent_last'>$ML{'.link.view.message'}</a></li>";
                     $body .= "<li><a href='$LJ::SITEROOT/inbox/compose'>$ML{'.link.send.message'}</a></li>";
                     $body .= "<li><a href='$LJ::SITEROOT/inbox/'>$ML{'.link.inbox'}</a></li>";
                     $body .= "<li><a href='$LJ::SITEROOT/'>$ML{'.link.home'}</a></li>";

--- a/htdocs/inbox/compose.bml
+++ b/htdocs/inbox/compose.bml
@@ -172,7 +172,7 @@ body<=
                 unless (@errors) {
                     $body .= $ML{'.message.sent'};
                     $body .= "<?p $ML{'.message.sent.options'} <ul>";
-                    $body .= "<li><a href='$LJ::SITEROOT/inbox/?page=0&view=usermsg_sent_last'>$ML{'.link.view.message'}</a></li>";
+                    $body .= "<li><a href='$LJ::SITEROOT/inbox/?page=0&view=usermsg_sent_last'>$ML{'.link.view.message'}</a> $ML{'.link.view.warning'}</li>";
                     $body .= "<li><a href='$LJ::SITEROOT/inbox/compose'>$ML{'.link.send.message'}</a></li>";
                     $body .= "<li><a href='$LJ::SITEROOT/inbox/'>$ML{'.link.inbox'}</a></li>";
                     $body .= "<li><a href='$LJ::SITEROOT/'>$ML{'.link.home'}</a></li>";

--- a/htdocs/inbox/compose.bml.text
+++ b/htdocs/inbox/compose.bml.text
@@ -23,6 +23,8 @@
 
 .link.send.message=Send a new message
 
+.link.view.message=View your message
+
 .message.sent=Your message has been sent successfully.
 
 .message.sent.options=From here you can:

--- a/htdocs/inbox/compose.bml.text
+++ b/htdocs/inbox/compose.bml.text
@@ -25,6 +25,8 @@
 
 .link.view.message=View your message
 
+.link.view.warning=(If your message doesn't appear yet, please wait a few minutes and refresh the page.)
+
 .message.sent=Your message has been sent successfully.
 
 .message.sent.options=From here you can:


### PR DESCRIPTION
Provides an additional link on the splash page that occurs after sending
a PM, that redirects to an inbox view for the just-sent message.
Explicit override on the expand/collapse view expands the first sent
message even though it's marked as read.

Known Issue: If the user clicks through too quickly, the page will load
before the worker has finished sending the PM. A refresh will cause the
new PM to show up.

Fixes #1232