### PR TITLE
[#1381] Close resp.Body after we're done with it

### DIFF
--- a/src/proxy/main.go
+++ b/src/proxy/main.go
@@ -171,6 +171,7 @@ func getProxyFile(token, url string) (string, error) {
 		log.Printf("Failed to fetch %s: %s", url, err)
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	// If it's too large, we don't want it!
 	if resp.ContentLength > MAXIMUM_SIZE {


### PR DESCRIPTION
So that we don't risk leaking file descriptors.

Fixes #1381.