### PR TITLE
[#1385] Use protocol-relative SITEROOT for PALIMGROOT

### DIFF
--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -68,8 +68,9 @@ no strict "vars";
     $WSTATPREFIX ||= "$SITEROOT/stc";
     $JSPREFIX ||= "$SITEROOT/js";
     $USERPIC_ROOT ||= "$LJ::SITEROOT/userpic";
-    $PALIMGROOT ||= "$LJ::SITEROOT/palimg";
+
     $RELATIVE_SITEROOT ||= "//$DOMAIN_WEB";
+    $PALIMGROOT ||= "$RELATIVE_SITEROOT/palimg";
 
     # path to sendmail and any necessary options
     $SENDMAIL ||= "/usr/sbin/sendmail -t -oi";


### PR DESCRIPTION
Should be fine to have this be protocol-relative, because we use the URL
on our own pages (not sent to external locations such as email).

Fixes #1385.