### PR TITLE
Additional information on entry splash page

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1028,6 +1028,23 @@ sub _do_post {
                 editurl => $edititemlink,
                 ditemid => $ditemid,
         );
+        
+        my $extradata = {
+            security => $form_req->{security},
+            security_ml => "",
+            subject => LJ::ehtml( $form_req->{subject} ),
+        };
+        if ( $extradata->{security} eq "usemask" ) {
+            if ( $form_req -> {allowmask} == 1 ) {
+                $extradata->{security_ml} = ".extradata.sec.access";
+            } else {
+                $extradata->{security_ml} = ".extradata.sec.custom";
+            }
+        } elsif ( $extradata->{security} eq "private" ) {
+            $extradata->{security_ml} = ".extradata.sec.private";
+        } else {
+            $extradata->{security_ml} = ".extradata.sec.public";
+        }
 
         # set sticky
         if ( $form_req->{sticky_entry} && $u->can_manage( $ju ) ) {
@@ -1042,6 +1059,7 @@ sub _do_post {
                 crossposts  => \@crossposts,# crosspost status list
                 links       => \@links,
                 links_header => ".new.links",
+                extradata   => $extradata,
             }
         );
     }
@@ -1147,7 +1165,24 @@ sub _do_edit {
         ditemid => $ditemid,
         editurl => $edit_url,
     );
-
+        
+    my $extradata = {
+        security => $form_req->{security},
+        security_ml => "",
+        subject => LJ::ehtml( $form_req->{subject} ),
+    };
+    if ( $extradata->{security} eq "usemask" ) {
+        if ( $form_req -> {allowmask} == 1 ) {
+            $extradata->{security_ml} = ".extradata.sec.access";
+        } else {
+            $extradata->{security_ml} = ".extradata.sec.custom";
+        }
+    } elsif ( $extradata->{security} eq "private" ) {
+        $extradata->{security_ml} = ".extradata.sec.private";
+    } else {
+        $extradata->{security_ml} = ".extradata.sec.public";
+    }
+    
     my $poststatus = { ml_string => $poststatus_ml };
     $render_ret = DW::Template->render_template(
         'entry/success.tt', {
@@ -1156,6 +1191,7 @@ sub _do_edit {
             crossposts  => \@crossposts,# crosspost status list
             links       => \@links,
             links_header => '.edit.links',
+            extradata   => $extradata,
         }
     );
 

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -346,6 +346,22 @@ body<=
                         $result .= "<?p " . BML::ml('.success.editedstillsuspended', { aopts => "href='$LJ::SITEROOT/abuse/report'" }) . " p?>";
                     }
                 }
+                
+                if ($req{"security"} eq "private") {
+                    $result .="<p>$ML{'.extradata.sec.private'}</p>";
+                } elsif ($req{"security"} eq "usemask") {
+                    if ($req{"allowmask"} == 0) { # custom security with no group -- essentially private
+                        $result .="<p>$ML{'.extradata.sec.private'}</p>";
+                    } elsif ($req{"allowmask"} > 1) { # custom group
+                        $result .="<p>$ML{'.extradata.sec.custom'}</p>";
+                    } else { # friends only
+                        $result .="<p>$ML{'.extradata.sec.access'}</p>";
+                    }
+                } else {
+                    $result .="<p>$ML{'.extradata.sec.public'}</p>";
+                }
+                
+                $result .="<?p " . BML::ml('.extradata.subject', { subject => LJ::ehtml( $req{"subject"} ) }) . " p?>";
 
                 $result .= "<div id='fromhere'>$ML{'.success.fromhere'}<ul>";
                 $result .= "<li><a href='$entry_url'>$ML{'.success.fromhere.viewentry'}</a></li>" unless $deleted;

--- a/htdocs/editjournal.bml.text
+++ b/htdocs/editjournal.bml.text
@@ -58,3 +58,13 @@
 
 .viewwhat=View Which Entries:
 
+.extradata.sec.public=The entry was posted publicly.
+
+.extradata.sec.access=The entry was posted with circle access.
+
+.extradata.sec.private=The entry was posted privately.
+
+.extradata.sec.custom=The entry was posted with custom access.
+
+.extradata.subject=The entry was posted with the following subject: [[subject]]
+

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -469,6 +469,22 @@ _c?>
 
                     my @after_entry_post_extra_options = LJ::Hooks::run_hooks('after_entry_post_extra_options', user => $ju, itemlink => $itemlink);
                     my $after_entry_post_extra_options = join('', map {$_->[0]} @after_entry_post_extra_options) || '';
+                    
+                    if ($req{"security"} eq "private") {
+                        $$body .=" p?><?p $ML{'.extradata.sec.private'}";
+                    } elsif ($req{"security"} eq "usemask") {
+                        if ($req{"allowmask"} == 0) { # custom security with no group -- essentially private
+                            $$body .=" p?><?p $ML{'.extradata.sec.private'}";
+                        } elsif ($req{"allowmask"} > 1) { # custom group
+                            $$body .=" p?><?p $ML{'.extradata.sec.custom'}";
+                        } else { # friends only
+                            $$body .=" p?><?p $ML{'.extradata.sec.access'}";
+                        }
+                    } else {
+                        $$body .=" p?><?p $ML{'.extradata.sec.public'}";
+                    }
+                
+                    $$body .=" p?><?p " . BML::ml('.extradata.subject', { subject =>LJ::ehtml( $req{"subject"} ) });
 
                     my $backdatedlink = '';
                     if ( $POST{prop_opt_backdated} or $GET{prop_opt_backdated} ) {

--- a/htdocs/update.bml.text
+++ b/htdocs/update.bml.text
@@ -139,3 +139,13 @@
 
 .username=Account name:
 
+.extradata.sec.public=The entry was posted publicly.
+
+.extradata.sec.access=The entry was posted with circle access.
+
+.extradata.sec.private=The entry was posted privately.
+
+.extradata.sec.custom=The entry was posted with custom access.
+
+.extradata.subject=The entry was posted with the following subject: [[subject]]
+

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -20,7 +20,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- END -%]
 
 [%- IF poststatus -%]
-<p>[% poststatus.ml_string | ml( url => poststatus.url )%]</p>
+<p>[% poststatus.ml_string | ml( url => poststatus.url)%]</p>
+<p>[% extradata.security_ml | ml %]</p>
+<p>[% ".extradata.subject" | ml( subject => extradata.subject) %]</p>
 [%- END -%]
 
 [%- IF warnings.exist -%]

--- a/views/entry/success.tt.text
+++ b/views/entry/success.tt.text
@@ -39,3 +39,13 @@
 .new.links.view=View the entry
 
 .sticky.max=This entry was not made sticky because you've reached your limit of [[limit]] for sticky entries.
+
+.extradata.sec.public=The entry was posted publicly.
+
+.extradata.sec.access=The entry was posted with circle access.
+
+.extradata.sec.private=The entry was posted privately.
+
+.extradata.sec.custom=The entry was posted with custom access.
+
+.extradata.subject=The entry was posted with the following subject: [[subject]]


### PR DESCRIPTION
Pulls in the posted security level and subject for the entry and displays them to the user on the splash page. Functional for both old and new-style update pages.

Fixes #1231