### PR TITLE
Removes whitespace below icons for dw-free layouts

### DIFF
--- a/styles/abstractia/layout.s2
+++ b/styles/abstractia/layout.s2
@@ -1170,6 +1170,8 @@ q {
     overflow: hidden;
 }
 
+.entry .userpic img, .comment .userpic img {display:block;}
+
 .has-userpic .userpic {
     $userpic_css
     padding: 10px;

--- a/styles/bases/layout.s2
+++ b/styles/bases/layout.s2
@@ -754,7 +754,7 @@ border-bottom: 0.083em solid $*color_entry_border; background: $*color_comment_t
 .access-filter, .restrictions {float: left; margin: 0.25em 0.5em 0.25em 0.5em;}
 
 .has-userpic .entry .userpic { border: 0.083em solid $*color_entry_border; padding: 0.2em; margin: 0.5em; background: $*color_entry_background; }
-.entry .userpic img {border: 0;}
+.entry .userpic img {border: 0; display:block;}
 .entry .userpic img:hover {opacity: .7;}
 
 .entry-poster { display: block; border-bottom: 0.083em solid $*color_entry_border; padding: 0.167em 0.833em 0.167em 0.833em;}

--- a/styles/database/layout.s2
+++ b/styles/database/layout.s2
@@ -1342,6 +1342,7 @@ a:hover { text-decoration: underline; }
 .icon-image img,
 .ContextualPopup .Userpic img {
     box-shadow: .1em .1em .4em $*color_userpic_shadow;
+    display: block;
     }
 
 .has-userpic .userpic:hover,

--- a/styles/modular/layout.s2
+++ b/styles/modular/layout.s2
@@ -308,6 +308,8 @@ table.talkform { padding: 1em;
 
 $userpic_css
 
+.entry .userpic img, .comment .userpic img { display:block;}
+
 .entry .userpic {
     margin: -1em 0 .5em 0;
     padding: 0 8px 8px 8px;

--- a/styles/motion/layout.s2
+++ b/styles/motion/layout.s2
@@ -531,6 +531,8 @@ $userpic_css
     border-radius:4px
     }
 
+.entry .userpic img, .comment .userpic img { display:block;}
+
 .module .userpic { float: left;}
 
 .userpic a{ border:0;}

--- a/styles/patsy/layout.s2
+++ b/styles/patsy/layout.s2
@@ -361,7 +361,7 @@ h2#subtitle {
 
 .datetime {  text-transform: uppercase; font-size: smaller; letter-spacing: 0.3em; }
 
-.entry .userpic img, .comment .userpic img  { border: 10px solid $*color_entry_background; }
+.entry .userpic img, .comment .userpic img  { border: 10px solid $*color_entry_background; display:block}
 
 $userpic_css
 

--- a/styles/skittlishdreams/layout.s2
+++ b/styles/skittlishdreams/layout.s2
@@ -939,7 +939,7 @@ html body {
     top: $comment_userpic_shift;
     }
 
-.entry .userpic img, .comment .userpic img {border: none; }
+.entry .userpic img, .comment .userpic img {border: none; display:block;}
 .no-userpic .comment {margin-top: 20px; }
 
 .no-userpic .comment-title {


### PR DESCRIPTION
Changes the display type of the icon from inline to block,
which removes the extra whitespace added automatically for
baseline alignment. The layouts affected were:
-Abstractia
-Bases
-Database
-Modular
-Motion
-Patsy
-Skittlish Dreams

Fixes #1391