### PR TITLE
[#1315] allow spamreports to handle IPv6 addresses

### DIFF
--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -4173,6 +4173,13 @@ EOF
         do_sql( 'DELETE FROM codes WHERE type = "country"' );
         set_dbnote( 'remove_countries_from_codes', 1 );
     }
+
+    # widen ip column for IPv6 addresses
+    if ( column_type("spamreports", "ip") eq "varchar(15)" ) {
+        do_alter( "spamreports",
+                  "ALTER TABLE spamreports ".
+                  "MODIFY ip VARCHAR(39)" );
+    }
 });
 
 

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -4178,7 +4178,7 @@ EOF
     if ( column_type("spamreports", "ip") eq "varchar(15)" ) {
         do_alter( "spamreports",
                   "ALTER TABLE spamreports ".
-                  "MODIFY ip VARCHAR(39)" );
+                  "MODIFY ip VARCHAR(45)" );
     }
 });
 

--- a/htdocs/admin/spamreports.bml
+++ b/htdocs/admin/spamreports.bml
@@ -44,37 +44,6 @@ _c?>
             $extra .
             "</form>";
     };
-    my $verify_ipv6 = sub {
-        my ( $ip ) = @_;
-        # first check for correct set of characters: hex digits and colons
-        return 0 unless $ip =~ /^[:0-9a-f]+$/i;
-
-        # next check for omitted zero values and replace them
-        if ( $ip =~ /::/ ) {
-            # count the number of non-omitted fields
-            my @count = ( $ip =~ m/[0-9a-f]+/gi );
-            my $num_z = 8 - scalar @count;
-            return 0 unless $num_z > 0;
-
-            my $zeroes = join ':', ( split //, '0' x $num_z );
-
-            # this is obnoxious, but necessary to avoid edge cases
-            if   ( $ip =~ /^::$/ ) { $ip =~ s/::/$zeroes/;   }
-            elsif ( $ip =~ /^::/ ) { $ip =~ s/::/$zeroes:/;  }
-            elsif ( $ip =~ /::$/ ) { $ip =~ s/::/:$zeroes/;  }
-            else                   { $ip =~ s/::/:$zeroes:/; }
-        }
-
-        # now make sure we have eight colon-separated hex fields
-        my @digits = split /:/, $ip;
-        return 0 unless scalar @digits == 8;
-
-        foreach my $field ( @digits ) {
-            return 0 unless $field =~ /^[0-9a-f]{1,4}$/i;
-        }
-
-        return 1;  # all our tests passed
-    };
 
     # login check
     my $remote = LJ::get_remote();
@@ -276,7 +245,7 @@ _c?>
             # don't worry about IP format, just do a length check
             # if the IP is in the results table, we consider it valid
             # if it's not, we'll get a noreports error below, so it's all good
-            return $error->('<?_ml .error.noip _ml?>') if length $what > 39;
+            return $error->('<?_ml .error.noip _ml?>') if length $what > 45;
         }
 
         # see if we should call a hook for extra actions?
@@ -340,8 +309,6 @@ _c?>
                     $extra .= "<br/><textarea name='sysban_note' rows='3' cols='60'> ~";
                     $extra .= LJ::ehtml( $remote->username . " @ " . LJ::mysql_time() );
                     $extra .= "</textarea>";
-                } elsif ( $verify_ipv6->( $what ) ) {
-                    $extra = BML::ml( ".report.individual.sysban.ip4only" );
                 } else {
                     $extra = BML::ml( ".report.individual.sysban.ip.invalid" );
                 }

--- a/htdocs/admin/spamreports.bml
+++ b/htdocs/admin/spamreports.bml
@@ -44,6 +44,38 @@ _c?>
             $extra .
             "</form>";
     };
+    my $verify_ipv6 = sub {
+        my ( $ip ) = @_;
+        # first check for correct set of characters: hex digits and colons
+        return 0 unless $ip =~ /^[:0-9a-f]+$/i;
+
+        # next check for omitted zero values and replace them
+        if ( $ip =~ /::/ ) {
+            # count the number of non-omitted fields
+            my @count = ( $ip =~ m/[0-9a-f]+/gi );
+            my $num_z = 8 - scalar @count;
+            return 0 unless $num_z > 0;
+
+            my $zeroes = join ':', ( split //, '0' x $num_z );
+
+            # this is obnoxious, but necessary to avoid edge cases
+            if   ( $ip =~ /^::$/ ) { $ip =~ s/::/$zeroes/;   }
+            elsif ( $ip =~ /^::/ ) { $ip =~ s/::/$zeroes:/;  }
+            elsif ( $ip =~ /::$/ ) { $ip =~ s/::/:$zeroes/;  }
+            else                   { $ip =~ s/::/:$zeroes:/; }
+        }
+
+        # now make sure we have eight colon-separated hex fields
+        my @digits = split /:/, $ip;
+        return 0 unless scalar @digits == 8;
+
+        foreach my $field ( @digits ) {
+            return 0 unless $field =~ /^[0-9a-f]{1,4}$/i;
+        }
+
+        return 1;  # all our tests passed
+    };
+
     # login check
     my $remote = LJ::get_remote();
     return $error->("<?needlogin?>")
@@ -241,8 +273,10 @@ _c?>
             $by = 'posterid';
             $what = $u->{userid};
         } elsif ($by eq 'ip') {
-            # check for right format x.x.x.x, not necessarily a valid IP
-            return $error->('<?_ml .error.noip _ml?>') if $what !~ /^\d+\.\d+\.\d+\.\d+$/ or length $what > 15;
+            # don't worry about IP format, just do a length check
+            # if the IP is in the results table, we consider it valid
+            # if it's not, we'll get a noreports error below, so it's all good
+            return $error->('<?_ml .error.noip _ml?>') if length $what > 39;
         }
 
         # see if we should call a hook for extra actions?
@@ -258,7 +292,9 @@ _c?>
         if ($by eq 'posterid') {
             $title .= " ($state: $count)$extratitle";
         } elsif ($by eq 'ip') {
-            $title = BML::ml( ".view.byip.title2", { ip => $what, state => $state, count => $count} );
+            # IP isn't validated here, so make sure we escape it for display
+            $title = BML::ml( ".view.byip.title2", { ip => LJ::ehtml( $what ),
+                                  state => $state, count => $count } );
         }
 
         unless (@$res) {
@@ -296,8 +332,19 @@ _c?>
                     $extra .= "<br/><textarea name='sysban_note' rows='3' cols='60' readonly='1'>" . LJ::ehtml( $reason->{talk_ip_test}->{note} || "<?_ml .report.individual.syban.nonote _ml?>" ) . "</textarea>";
                 }
             } elsif ( $remote && $remote->has_priv( 'sysban', 'talk_ip_test' ) ) {
-                $extra = LJ::html_check({name => "sysban_ip", value => $what, label => BML::ml( ".report.individual.sysban.ip" )});
-                $extra .= "<br/><textarea name='sysban_note' rows='3' cols='60'> ~" . LJ::ehtml( $remote->username . " @ " . LJ::mysql_time() ) . "</textarea>";
+                # here is where we need to make sure we don't sysban an invalid IP
+                # for now, only allow IPv4 addresses to be sysbanned
+                if ( $what =~ /^\d+\.\d+\.\d+\.\d+$/ ) {
+                    $extra = LJ::html_check( { name => "sysban_ip", value => $what,
+                             label => BML::ml( ".report.individual.sysban.ip" ) } );
+                    $extra .= "<br/><textarea name='sysban_note' rows='3' cols='60'> ~";
+                    $extra .= LJ::ehtml( $remote->username . " @ " . LJ::mysql_time() );
+                    $extra .= "</textarea>";
+                } elsif ( $verify_ipv6->( $what ) ) {
+                    $extra = BML::ml( ".report.individual.sysban.ip4only" );
+                } else {
+                    $extra = BML::ml( ".report.individual.sysban.ip.invalid" );
+                }
             }
         }
 

--- a/htdocs/admin/spamreports.bml.text
+++ b/htdocs/admin/spamreports.bml.text
@@ -33,6 +33,8 @@
 .report.individual.sysban.anon=anonymous spamreports
 .report.individual.sysban.done=Already talk_ip_test banned
 .report.individual.sysban.ip=Also Sysban IP?
+.report.individual.sysban.ip4only=(only IPv4 addresses may be sysbanned)
+.report.individual.sysban.ip.invalid=(sysban unavailable: invalid IP address)
 .report.individual.sysban.nonote=(no note)
 
 .reports.anon=anonymous

--- a/htdocs/admin/spamreports.bml.text
+++ b/htdocs/admin/spamreports.bml.text
@@ -33,7 +33,6 @@
 .report.individual.sysban.anon=anonymous spamreports
 .report.individual.sysban.done=Already talk_ip_test banned
 .report.individual.sysban.ip=Also Sysban IP?
-.report.individual.sysban.ip4only=(only IPv4 addresses may be sysbanned)
 .report.individual.sysban.ip.invalid=(sysban unavailable: invalid IP address)
 .report.individual.sysban.nonote=(no note)
 


### PR DESCRIPTION
This patch does two things:

1. Widens the column for IP addresses in the spamreports table from 15 characters to 39.
An IPv6 address may contain 8 16-bit colon-separated hexadecimal codes for a maximum
width of 8*5-1 = 39 characters.

2. Allows the spamreport page to load for any given IP value that is 39 characters or less.
If the IP does not exist in the spamreports database, the "noreports" error will be shown.
If the IP exists, the report may be viewed and closed, but the sysban option will not be
presented unless it is a valid IPv4 address.  Once we verify sysban support for IPv6,
this clause may be removed.

Fixes #1315.