### PR TITLE
Remember status of "Use post time" checkbox.

### DIFF
--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -221,6 +221,14 @@ userproplist.disable_comm_promo:
   indexed: 0
   multihomed: 0
   prettyname: Administratively disable community promo features for a user
+  
+userproplist.displaydate_check:
+  cldversion: 4
+  datatype: bool
+  des: Use time of posting by default for this user.
+  indexed: 0
+  multihomed: 0
+  prettyname: Automatically sets entry page to use time of posting for timestamp.
 
 userproplist.dismissed_page_notices:
   cldversion: 4

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -293,6 +293,7 @@ sub _init {
     my $panels;
     my $formwidth;
     my $min_animation;
+    my $displaydate_check;
     if ( $u ) {
         # icons
         @icons = grep { ! ( $_->inactive || $_->expunged ) } LJ::Userpic->load_user_userpics( $u );
@@ -344,6 +345,7 @@ sub _init {
         $panels = $u->entryform_panels;
         $formwidth = $u->entryform_width;
         $min_animation = $u->prop( "js_animations_minimal" ) ? 1 : 0;
+        $displaydate_check = $u->displaydate_check ? 1 : 0;
     } else {
         $panels = LJ::User::default_entryform_panels( anonymous => 1 );
     }
@@ -451,6 +453,7 @@ sub _init {
         sticky_entry => $form_opts->{sticky_entry},
 
         displaydate => \%displaydate,
+        displaydate_check => $displaydate_check,
 
 
         can_spellcheck => $LJ::SPELLER,
@@ -789,6 +792,8 @@ sub _form_to_backend {
         $req->{hour}    = $hour;
         $req->{min}     = $min;
     }
+    
+    $req->{update_displaydate} = $post->{update_displaydate};
 
     # crosspost
     $req->{crosspost_entry} = $post->{crosspost_entry} ? 1 : 0;
@@ -1203,6 +1208,8 @@ sub _persist_props {
     my ( $u, $form ) = @_;
 
     return unless $u;
+    
+    $u->displaydate_check($form->{update_displaydate} ? 1 : 0);
 # FIXME:
 #
 #                 # persist the default value of the disable auto-formatting option

--- a/cgi-bin/LJ/User/Permissions.pm
+++ b/cgi-bin/LJ/User/Permissions.pm
@@ -527,6 +527,16 @@ sub disable_auto_formatting {
     return $u->prop( 'disable_auto_formatting' ) ? 1 : 0;
 }
 
+sub displaydate_check {
+    my ( $u, $value ) = @_;
+    if ( defined $value && $value =~ /[01]/ ) {
+        $u->set_prop( displaydate_check => $value );
+        return $value;
+    }
+
+    return $u->prop( 'displaydate_check' ) ? 1 : 0;
+}
+
 sub exclude_from_own_stats {
     my $u = shift;
 

--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -673,6 +673,7 @@ var postForm = (function($) {
         initSticky(entryForm);
 
         $("#js-usejournal").triggerHandler("change");
+        $("#js-entrytime-autoupdate").triggerHandler("click");
     };
 
     return {

--- a/views/entry/module-displaydate.tt
+++ b/views/entry/module-displaydate.tt
@@ -77,7 +77,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
             [%- form.checkbox_nested( label = dw.ml( ".label.autoupdate" )
                 name = "update_displaydate"
                 id = "js-entrytime-autoupdate"
-
+                
+                default = displaydate_check
                 value = "1"
             ) -%]
         </div>


### PR DESCRIPTION
A new userprop: displaydate_check which tracks what the last status of
this checkbox was, and sets the initial state on new/edited entry
appropriately.

Fixes #1229