### PR TITLE
[#1389] Add journalid+ditemid to the proxy url

### DIFF
--- a/cgi-bin/DW/Proxy.pm
+++ b/cgi-bin/DW/Proxy.pm
@@ -38,13 +38,21 @@ sub get_url_signature {
 }
 
 sub get_proxy_url {
-    my ( $url ) = @_;
+    my ( $url, %opts ) = @_;
     return undef unless $LJ::PROXY_URL && substr($url, 0, 7) eq 'http://';
 
     my $signature = DW::Proxy::get_url_signature($url);
     return undef unless $signature;
 
-    return join('/', $LJ::PROXY_URL, $signature, substr($url, 7));
+    my $source = "-";
+    if ( $opts{journal} && $opts{ditemid} ) {
+        my $journalu = LJ::load_user($opts{journal});
+        if ( $journalu ) {
+            $source = "$journalu->{userid}-$opts{ditemid}";
+        }
+    }
+
+    return join('/', $LJ::PROXY_URL, $signature, $source, substr($url, 7));
 }
 
 1;

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -826,7 +826,7 @@ sub clean
                     if ($opts->{'extractimages'}) { $img_bad = 1; }
 
                     my $url = canonical_url($hash->{src}, 1);
-                    $url = https_url( $url ) if $LJ::IS_SSL;
+                    $url = https_url( $url, journal => $journal, ditemid => $ditemid ) if $LJ::IS_SSL;
                     $hash->{src} = $url;
 
                     if ($img_bad) {
@@ -1654,7 +1654,7 @@ sub canonical_url {
 }
 
 sub https_url {
-    my ( $url ) = @_;
+    my ( $url, %opts ) = @_;
 
     # no-op if we're not configured to use SSL
     return $url unless $LJ::USE_SSL;
@@ -1668,7 +1668,10 @@ sub https_url {
         return $url;
     }
 
-    return DW::Proxy::get_proxy_url( $url ) || $url;
+    return DW::Proxy::get_proxy_url( $url,
+                                     journal => $opts{journal},
+                                     ditemid => $opts{ditemid}
+                                    ) || $url;
 }
 
 sub break_word {

--- a/src/proxy/main.go
+++ b/src/proxy/main.go
@@ -96,16 +96,18 @@ func main() {
 }
 
 func defaultHandler(w http.ResponseWriter, req *http.Request) {
-	//                        0   /  1  /   2   /  3
-	// http://proxy.dreamwidth.net/TOKEN/foo.com/url?arg=val
-	parts := strings.SplitN(req.URL.RequestURI(), "/", 4)
-	if len(parts) != 4 || parts[0] != "" {
+	//                        0   /  1  /   2  /   3   /  4
+	// http://proxy.dreamwidth.net/TOKEN/SOURCE/foo.com/url?arg=val
+	// SOURCE is ignored programmatically; it's only for admins
+	parts := strings.SplitN(req.URL.RequestURI(), "/", 5)
+
+	if len(parts) != 5 || parts[0] != "" {
 		// Invalid request, treat it as a 404.
 		log.Printf("Invalid request: %s", req.URL.RequestURI())
 		http.NotFound(w, req)
 		return
 	}
-	token, url := parts[1], "http://"+strings.Join(parts[2:], "/")
+	token, url := parts[1], "http://"+strings.Join(parts[3:], "/")
 
 	if !validSignature(token, url) {
 		log.Printf("Invalid signature in request: %s", req.URL.RequestURI())


### PR DESCRIPTION
This additional information allows admins to lookup the entry in
question, without blatantly exposing the journal identity.

Non-entries will have a "-" instead of "journalid-ditemid".

The proxy itself ignores the additional token.

Fixes #1389.