### PR TITLE
Preserve sticky-entry value when module unloaded

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1129,7 +1129,7 @@ sub _do_edit {
         if ( $form_req->{sticky_entry} ) {
             $journal->sticky_entry_new( $ditemid )
                 unless $is_sticky_entry;
-        } else {
+        } elsif ( $form_req->{sticky_select} ) {
             $journal->sticky_entry_remove( $ditemid )
                 if $is_sticky_entry;
         }

--- a/views/entry/module-sticky.tt
+++ b/views/entry/module-sticky.tt
@@ -13,6 +13,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <fieldset>
 <h3>[% ".header" | ml %]</h3>
 <div class='inner'>
+[%- form.hidden( id = "sticky_select", name = "sticky_select", value = 1 ) -%]
 
     <div class="row"><div class="columns">
         <span class="right">


### PR DESCRIPTION
Before, there was no way to distinguish between "user left checkbox
unticked" and "checkbox doesn't exist" for the sticky-entry checkbox,
resulting in formerly-sticky entries losing their status.  This fix
wraps the remove logic in another if statement, so that it will only
perform the remove if the checkbox existed to be unticked.

Fixes #1343