### PR TITLE
Removes extra lines caused by list nesting in Tectonic

### DIFF
--- a/styles/tectonic/layout.s2
+++ b/styles/tectonic/layout.s2
@@ -559,6 +559,8 @@ ul.module-list li {
 
 ul.module-list li:hover {background: $*color_module_list_background_hover;}
 
+.module-tags_multilevel li li {border:0; padding-bottom: 0px; padding-left: .5em;}
+
 .module-navlinks, .module-navlinks a {
     color: $*color_module_title;
     font-family: $*font_module_heading;


### PR DESCRIPTION
Removes extra border lines caused by list-nesting in
the tags module of Tectonic, when the tag style is set to
multilevel. Leading whitespace on nested items has been
increased slightly so that hierarchy is clearer. Designer
intent did not take into account DW's hierarchical tag
ability in the initial design.

Fixes #1372