### PR TITLE
Links to /banusers.bml from /circle/edit (1400)

### DIFF
--- a/htdocs/manage/circle/edit.bml
+++ b/htdocs/manage/circle/edit.bml
@@ -56,7 +56,7 @@ body<=
 
         $ret .= "<form method='post' name='editFriends' action='edit$getextra'>\n";
         $ret .= LJ::form_auth();
-        $ret .= "<p>" . BML::ml( '.circle.intro', { aopts1 => "href='#editpeople'", aopts2 => "href='#editcomms'", aopts3 => "href='#editfeeds'", aopts4 => "href='$LJ::SITEROOT/manage/settings/?cat=notifications'" }) . "</p>\n\n";
+        $ret .= "<p>" . BML::ml( '.circle.intro2', { aopts1 => "href='#editpeople'", aopts2 => "href='#editcomms'", aopts3 => "href='#editfeeds'", aopts4 => "href='$LJ::SITEROOT/manage/settings/?cat=notifications'", aopts5 => "href='$LJ::SITEROOT/manage/banusers.bml'" }) . "</p>\n\n";
         $ret .= "<p>" . BML::ml( '.circle.intro.feeds', { sitename => "$LJ::SITENAMESHORT", aopts => "href='$LJ::SITEROOT/feeds'" }) . "</p>\n\n";
         $ret .= "<?h2 $ML{'.circle.header'} h2?>\n";
 

--- a/htdocs/manage/circle/edit.bml
+++ b/htdocs/manage/circle/edit.bml
@@ -56,7 +56,7 @@ body<=
 
         $ret .= "<form method='post' name='editFriends' action='edit$getextra'>\n";
         $ret .= LJ::form_auth();
-        $ret .= "<p>" . BML::ml( '.circle.intro2', { aopts1 => "href='#editpeople'", aopts2 => "href='#editcomms'", aopts3 => "href='#editfeeds'", aopts4 => "href='$LJ::SITEROOT/manage/settings/?cat=notifications'", aopts5 => "href='$LJ::SITEROOT/manage/banusers.bml'" }) . "</p>\n\n";
+        $ret .= "<p>" . BML::ml( '.circle.intro2', { aopts1 => "href='#editpeople'", aopts2 => "href='#editcomms'", aopts3 => "href='#editfeeds'", aopts4 => "href='$LJ::SITEROOT/manage/settings/?cat=notifications'", aopts5 => "href='$LJ::SITEROOT/manage/banusers'" }) . "</p>\n\n";
         $ret .= "<p>" . BML::ml( '.circle.intro.feeds', { sitename => "$LJ::SITENAMESHORT", aopts => "href='$LJ::SITEROOT/feeds'" }) . "</p>\n\n";
         $ret .= "<?h2 $ML{'.circle.header'} h2?>\n";
 

--- a/htdocs/manage/circle/edit.bml.text
+++ b/htdocs/manage/circle/edit.bml.text
@@ -37,6 +37,8 @@
 
 .circle.intro=Here are the <a [[aopts1]]>people</a>, <a [[aopts2]]>communities</a>, and <a [[aopts3]]>feeds</a> that are in your circle.  You can change who appears on your Reading Page and who you give access to by using the check boxes.  You can also <a [[aopts4]]>edit your notification tracking options</a>.
 
+.circle.intro2=Here are the <a [[aopts1]]>people</a>, <a [[aopts2]]>communities</a>, and <a [[aopts3]]>feeds</a> that are in your circle.  You can change who appears on your Reading Page and who you give access to by using the check boxes.  You can also <a [[aopts4]]>edit your notification tracking options</a>.  To ban or unban Dreamwidth users from commenting on your posts, visit <a [[aopts5]]>Ban and Unban Accounts</a>.
+
 .circle.intro.feeds=You can also use [[sitename]] as a syndicated feed reader to have posts from other sites show up on your [[sitename]] reading page. To browse existing feeds or add a new one, visit <a [[aopts]]>the list of popular feeds.</a>
 
 .circle.intro.nonpeople=These are the communities and feeds in your Circle. You can use the checkboxes to unsubscribe from these accounts.


### PR DESCRIPTION
/banusers.bml is currently discoverable only from its dedicated FAQ.
This commit adds a link from /circle/edit.