### PR TITLE
Hide banned users from profile (fixes #1279)

### DIFF
--- a/htdocs/profile.bml
+++ b/htdocs/profile.bml
@@ -695,6 +695,7 @@ body<=
     my ( @trusted_userids, @trusted_by_userids, @mutually_trusted_userids, @not_mutually_trusted_userids, @not_mutually_trusted_by_userids );
     my ( @watched_userids, @watched_by_userids, @mutually_watched_userids, @not_mutually_watched_userids, @not_mutually_watched_by_userids );
 
+
     # no mutual trust lists for identity accounts since they can't trust anyone
     @trusted_by_userids = $u->trusted_by_userids if $u->is_identity;
 
@@ -742,6 +743,18 @@ body<=
         @posting_access_to_userids, @posting_access_from_userids,
     );
 
+    # pull in list of banned users
+    my $banned = LJ::load_rel_user($u, 'B') || [];
+    my %banned_users = map { $_ => 1 } @$banned;
+
+    # remove banned users from lists to display
+    @$_ = grep ( !defined $banned_users{ $_ }, @$_ )
+        foreach ( \@trusted_userids, \@watched_userids, \@trusted_by_userids, \@watched_by_userids,
+                  \@mutually_trusted_userids, \@mutually_watched_userids, \@mutually_watched_userids,
+                  \@not_mutually_trusted_userids, \@not_mutually_watched_userids,
+                  \@not_mutually_trusted_by_userids, \@not_mutually_watched_by_userids, \@members_userids,
+                  \@member_of_userids, \@admin_of_userids, \@posting_access_to_userids, \@posting_access_from_userids );
+
     # presort various userid arrays
     @$_ = sort { $us->{$a}->display_name cmp $us->{$b}->display_name } @$_
         foreach ( \@trusted_userids, \@watched_userids, \@trusted_by_userids, \@watched_by_userids,
@@ -752,6 +765,7 @@ body<=
 
 ################################################################################
 ##### PEOPLE LISTS
+
 
     my ( $trusted_body, $trusted_by_body, $watched_body, $watched_by_body, $members_body, $posting_access_from_body );
 

--- a/htdocs/profile.bml
+++ b/htdocs/profile.bml
@@ -695,7 +695,6 @@ body<=
     my ( @trusted_userids, @trusted_by_userids, @mutually_trusted_userids, @not_mutually_trusted_userids, @not_mutually_trusted_by_userids );
     my ( @watched_userids, @watched_by_userids, @mutually_watched_userids, @not_mutually_watched_userids, @not_mutually_watched_by_userids );
 
-
     # no mutual trust lists for identity accounts since they can't trust anyone
     @trusted_by_userids = $u->trusted_by_userids if $u->is_identity;
 
@@ -748,7 +747,7 @@ body<=
     my %banned_users = map { $_ => 1 } @$banned;
 
     # remove banned users from lists to display
-    @$_ = grep ( !defined $banned_users{ $_ }, @$_ )
+    @$_ = grep { !exists $banned_users{ $_ }, @$_ }
         foreach ( \@trusted_userids, \@watched_userids, \@trusted_by_userids, \@watched_by_userids,
                   \@mutually_trusted_userids, \@mutually_watched_userids, \@mutually_watched_userids,
                   \@not_mutually_trusted_userids, \@not_mutually_watched_userids,
@@ -765,7 +764,6 @@ body<=
 
 ################################################################################
 ##### PEOPLE LISTS
-
 
     my ( $trusted_body, $trusted_by_body, $watched_body, $watched_by_body, $members_body, $posting_access_from_body );
 


### PR DESCRIPTION
Prevents banned users from appearing in watch/trust/subscribe lists
on profile pages. (Thanks Dre and Jen! <3)