### PR TITLE
Give the user a hand fixing UTF-8 errors

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -7,7 +7,7 @@ Backlink=[<a href="[[link]]">&lt;&lt;</a> [[text]]]
 
 bml.badcontent.body=One or more errors occurred processing your request.  Please go back, correct the necessary information, and submit your data again.
 
-bml.badinput.body=Your browser sent some text which isn't recognised as valid text in the UTF-8 encoding. This might happen if you forced your browser to view the previous page in some encoding other than UTF-8. It may also indicate a bug in the browser. If you can't get around this error, contact us.
+bml.badinput.body1=Your browser sent some text which isn't recognised as valid text in the UTF-8 encoding. This might happen if you forced your browser to view the previous page in some encoding other than UTF-8. It may also indicate a bug in the browser. Try copying the text into a text editor such as Notepad, then copying it back into the text box. If you still can't get around this error, contact us.
 
 bml.badinput.head=Bad Unicode Input
 

--- a/cgi-bin/DW/Controller/Community.pm
+++ b/cgi-bin/DW/Controller/Community.pm
@@ -197,7 +197,7 @@ sub new_handler {
     my $post;
     my $get;
 
-    return error_ml( 'bml.badinput.body' ) unless LJ::text_in( $post );
+    return error_ml( 'bml.badinput.body1' ) unless LJ::text_in( $post );
     return error_ml( '/communities/new.tt.error.notactive' ) unless $remote->is_visible;
     return error_ml( '/communities/new.tt.error.notconfirmed', {
             confirm_url => "$LJ::SITEROOT/register",

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -159,7 +159,7 @@ sub new_handler {
         my $mode_preview    = $post->{"action:preview"} ? 1 : 0;
         my $mode_spellcheck = $post->{"action:spellcheck"} ? 1 : 0;
 
-        $errors->add( undef, 'bml.badinput.body' )
+        $errors->add( undef, 'bml.badinput.body1' )
             unless LJ::text_in( $post );
 
         my $okay_formauth = ! $remote || LJ::check_form_auth( $post->{lj_form_auth} );
@@ -513,7 +513,7 @@ sub _edit {
         my $mode_spellcheck = $post->{"action:spellcheck"} ? 1 : 0;
         my $mode_delete     = $post->{"action:delete"} ? 1 : 0;
 
-        $errors->add( undef, 'bml.badinput.body' )
+        $errors->add( undef, 'bml.badinput.body1' )
             unless LJ::text_in( $post );
 
 

--- a/cgi-bin/DW/Controller/Search/Interests.pm
+++ b/cgi-bin/DW/Controller/Search/Interests.pm
@@ -30,7 +30,7 @@ sub interest_handler {
     my $r = DW::Request->get;
     my $did_post = $r->did_post;
     my $args = $did_post ? $r->post_args : $r->get_args;
-    return error_ml( 'bml.badinput.body' ) unless LJ::text_in( $args );
+    return error_ml( 'bml.badinput.body1' ) unless LJ::text_in( $args );
     return error_ml( 'error.invalidform' )
         if $did_post && ! LJ::check_form_auth( $args->{lj_form_auth} );
 

--- a/cgi-bin/bml/scheme/global.look
+++ b/cgi-bin/bml/scheme/global.look
@@ -32,7 +32,7 @@ ENTRYFORMCSS<=
 
 BADINPUT<=
 <?h1 <?_ml bml.badinput.head _ml?> h1?>
-<?p <?_ml bml.badinput.body _ml?> p?>
+<?p <?_ml bml.badinput.body1 _ml?> p?>
 <=BADINPUT
 
 REQUIREPOST=><?_ml bml.requirepost _ml?>


### PR DESCRIPTION
When displaying an error due to UTF-8 encoding errors in submitted
strings, rather than just punting the user straight to support, give
them a hand to fix the problem themselves.

Fixes #1384