### PR TITLE
Provide title text for tag navigation button

### DIFF
--- a/htdocs/js/journals/jquery.tag-nav.js
+++ b/htdocs/js/journals/jquery.tag-nav.js
@@ -8,6 +8,7 @@
     function collapsed($trigger) {
         $trigger.attr("aria-expanded", "false");
         $trigger.attr("alt", "Show tag navigation");
+        $trigger.attr("title", "Tag navigation: Select this button, then a tag, then use the arrows displayed to navigate through entries with that tag.");
         $trigger.attr("src", Site.imgprefix + "/silk/site/add.png");
     }
 


### PR DESCRIPTION
The little green tag navigation button doesn't have any title text.  It
would be nice if there were something there to explain how to use the
thing, which will hopefully pop up on mouseover in browsers.  Let's add
that.

Fixes #1332