### PR TITLE
Add different formatting for unavailable commands

### DIFF
--- a/cgi-bin/LJ/Console.pm
+++ b/cgi-bin/LJ/Console.pm
@@ -197,7 +197,9 @@ sub command_reference_html {
 
         $ret .= "<hr /><div class='$style'><h2 id='cmd.$cmd'><code><b>$cmd</b> ";
         $ret .= LJ::ehtml($class->usage);
-        $ret .= "</code></h2>\n";
+        $ret .= "</code>";
+        $ret .= " (unavailable)" unless $class->can_execute;
+        $ret .= "</h2>\n";
         $ret .= "<p><em><?_ml error.console.notpermitted _ml?></em></p>" unless $class->can_execute;
 
         $ret .= $class->desc;

--- a/htdocs/scss/skins/_skin-colors.scss
+++ b/htdocs/scss/skins/_skin-colors.scss
@@ -119,6 +119,10 @@ li.token {
     }
 }
 
+// Enabled and disabled text
+div.enabled, div.enabled * { color: $text-color; }
+div.disabled, div.disabled * { color: scale-color($text-color, $lightness: 50%); }
+
 // date and time picker
 .picker__holder {
     background-color: $reveal-modal-bg;


### PR DESCRIPTION
Apply different formatting in the Admin Console for enabled and disabled
commands, to help differentiate the two.

This is the free part of the fix for #1398