### PR TITLE
Correct Google Spreadsheets whitelist regex

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -61,7 +61,7 @@ my %host_path_match = (
     "www.google.com"        => [ qr!^/calendar/!, 1 ],
     # drawings do not need to be whitelisted as they are images.
     # forms arent being allowed for security concerns.
-    "docs.google.com"       => [ qr!^/(document|spreadsheet|presentation)/!, 1 ],
+    "docs.google.com"       => [ qr!^/(document|spreadsheets?|presentation)/!, 1 ],
 
     "www.kickstarter.com"   => [ qr!/widget/[a-zA-Z]+\.html$!, 1 ],
 

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 54;
+use Test::More tests => 55;
 
 use lib "$ENV{LJHOME}/cgi-bin";
 BEGIN { $LJ::_T_CONFIG = 1; require 'ljlib.pl'; }
@@ -87,6 +87,7 @@ note( "misc" );
     test_good_url( "http://maps.google.com/maps?f=q&source=s_q&hl=en&geocode=&q=somethingsomething&aq=0&sll=00.000,-00.0000&sspn=0.00,0.0&vpsrc=0&ie=UTF8&hq=&hnear=somethingsomething&z=0&ll=0,-00&output=embed" );
     test_good_url( "https://www.google.com/calendar/b/0/embed?showPrint=0&showTabs=0&showCalendars=0&showTz=0&height=600&wkst=1&bgcolor=%23FFFFFF&src=foo%40group.calendar.google.com" );
     test_good_url( "https://docs.google.com/spreadsheet/pub?key=0ArL0HD_lYDPadEkxSi1DTzJDa09GUmtzWEEwUDd4WFE&output=html&widget=true" );
+    test_good_url( "https://docs.google.com/spreadsheets/d/1P84CUNTo5O4ZW7R58Gl1ksCknFx3p59XzzQa7y67IaI/pubhtml?gid=23737011&single=true&widget=true&headers=false" );
     test_good_url( "https://docs.google.com/document/d/1Bo38jRzUWrEAHT6oaNyeGLlluscRY6TS2lE2E1T94dQ/pub?embedded=true" );
     test_good_url( "https://docs.google.com/presentation/d/1AxZkO9k4ISxku0__jRD8Im6mJC9xv5i4MgETEJ_MnA8/embed?start=false&loop=false&delayms=3000" );
 


### PR DESCRIPTION
The regex for allowing Google Spreadsheets to be embedded in posts should refer to docs.google.com/spreadsheets, which is the actual path used by Google.  Fix it so it does, and add a test to cover the behaviour.

Fixes #1344