### PR TITLE
Fix typo in siteskins.blueshift.alt

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3775,7 +3775,7 @@ siteskins.celerity.alt=Celerity: Black text on white background; olive color hig
 
 siteskins.celerity.desc=Default-sized sans-serif font; vertical, fixed, non-expanding menus.
 
-siteskins.blueshift.alt=Blueshift: Black text ond white background; blue highlights
+siteskins.blueshift.alt=Blueshift: Black text on white background; blue highlights
 
 siteskins.blueshift.desc=Vertical, fixed, non-expanding menus.
 


### PR DESCRIPTION
Fixes #1407.

Unfortunately changing the name of the text string isn't an option:
it's referenced only from cgi-bin/LJ/Settings/SiteScheme.pm via

$scheme_alt_ml ||= "siteskins.$scheme->{scheme}.alt"
    if LJ::Lang::string_exists( "siteskins.$scheme->{scheme}.alt" );