### PR TITLE
Remove redundant multisearch nav code

### DIFF
--- a/cgi-bin/DW/Controller/Search/Multisearch.pm
+++ b/cgi-bin/DW/Controller/Search/Multisearch.pm
@@ -203,8 +203,7 @@ sub multisearch_handler {
     };
 
     # set up dispatch table
-    my $dispatch = { nav          => $f_nav,
-                     nav_and_user => $f_nav,
+    my $dispatch = { nav_and_user => $f_nav,
                      user         => $f_user,
                      int          => $f_int,
                      email        => $f_email,

--- a/views/multisearch.tt
+++ b/views/multisearch.tt
@@ -13,29 +13,6 @@
 
 [%- sections.title=".title.$type" | ml -%]
 
-[%- IF type == 'nav' -%]
-   [%- FOREACH cats -%]
-        <h2>[% ".head.$name" | ml %]</h2>
-        <p>[% ".text.$name" | ml(query = query, sitename = site.nameshort) %]</p>
-        <ul class="bullet-list">
-        [%- FOREACH dst = list;
-              link_title = dst.title | html;
-              link_url = dst.url | html;
-              lju = dst.ljuser -%]
-
-          [%- IF lju -%]
-              [%- IF lju.is_visible -%]
-                <li>[% lju.ljuser_display %] - [% link_title %]</li>
-              [%- END -%]
-          [%- ELSE -%]
-                <li><a href="[% link_url %]">[% link_title %]</a></li>
-          [%- END -%]
-
-        [%- END -%]
-        </ul>
-   [%- END -%]
-[%- END -%]
-
 [%- IF type == 'im'; results; END -%]
 
 [%- IF type == 'region';


### PR DESCRIPTION
c292ef5 seems to have removed all calls to `multisearch` that had
`type=nav`.  Certainly there aren't any such calls now, anyway.  Remove
code that's now redundant as a result.

Fixes #1079 

I've not tested this: I obviously can't test dead code, but I'd like to have done a basic sanity check that I've not broken anything else in this area, but I just can't find where this code is used on the site. Instead, I've discussed this with @anall on #dreamwidth-dev, who thinks the code looks fine (and has promised me a pony if it breaks things to boot).