### PR TITLE
Restore beta update page strings

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1253,9 +1253,6 @@ general widget.accountstatistics.tags
 general widget.addqotd.extratext
 general widget.addqotd.extratext.note
 general widget.addqotd.is_special
-general widget.betafeature.updatepage.off
-general widget.betafeature.updatepage.on
-general widget.betafeature.updatepage.title
 general widget.browse.directorysearch
 general widget.browse.directorysearch.communities
 general widget.browse.directorysearch.users

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -4494,6 +4494,21 @@ widget.betafeature.s2comments.on<<
 
 widget.betafeature.s2comments.title=New S2 Comment Pages
 
+
+widget.betafeature.updatepage.off<<
+<p>Activate the testing version of the new Create Entries management page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion. It is <b>not complete</b>, but is reasonably full-featured and will work for most if not all updating purposes.</p>
+
+<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?></p>.
+.
+
+widget.betafeature.updatepage.on<<
+<p>You are currently testing the Create Entries management page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion. It is <b>not complete</b>, but is reasonably full-featured and will work for most if not all updating purposes.</p>
+
+<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?></p>.
+.
+
+widget.betafeature.updatepage.title=New Create Entries Page
+
 widget.comms.notavailable=This list is currently unavailable.
 
 widget.comms.recentactive=Recently Active Communities


### PR DESCRIPTION
It turns out the beta update page strings are still required.  Add them back, this time with https links.

This resolves @anall's [observation in #1443 that these strings are still needed](https://github.com/dreamwidth/dw-free/pull/1443#issuecomment-115513072).