### PR TITLE
Better status field in support history page

### DIFF
--- a/cgi-bin/LJ/Support.pm
+++ b/cgi-bin/LJ/Support.pm
@@ -203,6 +203,20 @@ sub fill_request_with_cat
     $sp->{_cat} = $cats->{$sp->{'spcatid'}};
 }
 
+sub open_request_status {
+    my ($timetouched, $timelasthelp) = @_;
+    my $status;
+    if ($timelasthelp > $timetouched+5) {
+        $status = "awaiting close";
+    } elsif ($timelasthelp &&
+             $timetouched > $timelasthelp+5) {
+        $status = "still needs help";
+    } else {
+        $status = "open";
+    }
+    return $status;
+}
+
 sub is_poster {
     my ($sp, $remote, $auth) = @_;
 

--- a/htdocs/support/help.bml
+++ b/htdocs/support/help.bml
@@ -295,20 +295,22 @@ body<=
      LJ::Support::fill_request_with_cat($sp, $cats);
      next unless (LJ::Support::can_read($sp, $remote));
 
-     my $status = "open";
-     my $barbg = "green";
-     if ($sp->{'timeclosed'}) {
-         $status = "closed";
+     my $status = $sp->{'state'} eq "closed" ? "closed" :
+                  LJ::Support::open_request_status($sp->{'timetouched'},
+                                                   $sp->{'timelasthelp'});
+     my $barbg;
+     if ($status eq "open") {
+         $barbg = "green";
+     } elsif ($status eq "closed") {
          $barbg = "red";
-     }
-     elsif ($sp->{'timelasthelp'} > $sp->{'timetouched'}+5) {
-         $status = "answered<br />awaiting close";
+     } elsif ($status eq "awaiting close") {
+         $status = "answered<br/>awaiting close";
          $barbg = "yellow";
-     }
-     elsif ($sp->{'timelasthelp'} && $sp->{'timetouched'} > $sp->{'timelasthelp'}+5) {
-         $status = "answered<br /><b>still needs help</b>";
+     } elsif ($status eq "still needs help") {
+         $status = "answered<br/><strong>still needs help</strong>";
          $barbg = "green";
      }
+
      my $original_barbg = $barbg;
      $barbg = 'clicked' if ( $GET{closeall} && $original_barbg eq 'yellow' )
                         || $marked{$sp->{spid}};

--- a/htdocs/support/history.bml
+++ b/htdocs/support/history.bml
@@ -91,7 +91,7 @@ body<=
                     state => $row->[2],
                     spcatid => $row->[3],
                     requserid => $row->[4],
-                    timecreate => LJ::mysql_time($row->[5]),
+                    timecreate => $row->[5],
                     reqemail => LJ::ehtml($row->[6]),
                 };
                 push @userids, $row->[4] if $row->[4];
@@ -121,7 +121,9 @@ body<=
                 $ret .= "</td>\n";
                 $ret .= "<td align='center'>$cats->{$reqs{$id}->{spcatid}}{catname}</td>\n<td align='center'>";
                 $ret .= $reqs{$id}->{requserid} ? LJ::ljuser($us->{$reqs{$id}->{requserid}}) : $reqs{$id}->{reqemail};
-                $ret .= "</td>\n<td align='center'>$reqs{$id}->{timecreate}</td>\n";
+                $ret .= "</td>\n<td align='center'>";
+                $ret .= LJ::mysql_time($reqs{$id}->{timecreate});
+                $ret .= "</td>\n";
                 $ret .= '</tr>';
             }
             $ret .= '</table><br /><br />';

--- a/htdocs/support/history.bml
+++ b/htdocs/support/history.bml
@@ -113,11 +113,14 @@ body<=
                 # verify user can see this category (public_read or has supportread in it)
                 next unless $cats->{$reqs{$id}->{spcatid}}{public_read} ||
                     LJ::Support::can_read_cat($cats->{$reqs{$id}->{spcatid}}, $remote);
+                my $status = $reqs{$id}->{state} eq "closed" ? "closed" :
+                             LJ::Support::open_request_status($reqs{$id}->{timetouched},
+                                                              $reqs{$id}->{timelasthelp});
 
                 # print out this request row
                 $ret .= '<tr>';
                 $ret .= "<td><a href=\"see_request?id=$reqs{$id}->{spid}\">$reqs{$id}->{subject}</a></td>\n";
-                $ret .= "<td align='center'>$reqs{$id}->{state}</td>\n";
+                $ret .= "<td align='center'>$status</td>\n";
                 $ret .= '<td align="center">';
                 if ($reqs{$id}->{state} eq 'closed' && $reqs{$id}->{winner}) {
                     $ret .= LJ::ljuser($reqs{$id}->{winner}) . " ($reqs{$id}->{points})";

--- a/htdocs/support/history.bml
+++ b/htdocs/support/history.bml
@@ -39,9 +39,11 @@ body<=
                 && ( $fullsearch || $remote->id == $userid );
             $ret .= "<h2>Viewing support requests for " .
                     LJ::ljuser( LJ::get_username( $userid ) ) . "</h2>\n";
-            $reqlist = $dbr->selectall_arrayref('SELECT spid, subject, state, spcatid, requserid, timecreate, reqemail ' .
-                                                'FROM support WHERE reqtype = \'user\' AND requserid = ?',
-                                                undef, $userid);
+            $reqlist = $dbr->selectall_arrayref(
+                'SELECT spid, subject, state, spcatid, requserid, ' .
+                       'timecreate, timetouched, timelasthelp, reqemail ' .
+                'FROM support WHERE reqtype = \'user\' AND requserid = ?',
+                undef, $userid);
         } elsif ($GET{email}) {
             # try by email, note that this gets requests opened by users and anonymous
             # requests, so we can view them all
@@ -61,9 +63,11 @@ body<=
                 && ( $fullsearch || $user_emails{$email} );
             $ret .= "<h2>Viewing support requests for " .
                     LJ::ehtml( $email ) . "</h2>\n";
-            $reqlist = $dbr->selectall_arrayref('SELECT spid, subject, state, spcatid, requserid, timecreate, reqemail ' .
-                                                'FROM support WHERE reqemail = ?',
-                                                undef, $email);
+            $reqlist = $dbr->selectall_arrayref(
+                'SELECT spid, subject, state, spcatid, requserid, ' .
+                       'timecreate, timetouched, timelasthelp, reqemail ' .
+                'FROM support WHERE reqemail = ?',
+                undef, $email);
         }
 
         if (@{$reqlist || []}) {
@@ -92,7 +96,9 @@ body<=
                     spcatid => $row->[3],
                     requserid => $row->[4],
                     timecreate => $row->[5],
-                    reqemail => LJ::ehtml($row->[6]),
+                    timetouched => $row->[6],
+                    timelasthelp => $row->[7],
+                    reqemail => LJ::ehtml($row->[8]),
                 };
                 push @userids, $row->[4] if $row->[4];
             }


### PR DESCRIPTION
As well as "open" and "closed", this will mean the list of tickets at <http://dreamwidth.org/support/history> also includes "awaiting close" and "still needs help" in the status column.

This fixes #1402, which @kaberett passed over to me for the actual coding bit. I've implemented it as @rahaeli requested, moving the code to determine this state to a function that can be called from elsewhere, and do that.

I haven't done the English stripping bit, because the entire files need English stripping (and/or converting away from BML), and I believe @kaberett is going to put that up somewhere as a good introductory job for a newbie dev.