### PR TITLE
[#1451] Nest questions in an extra hash to avoid namespace conflicts

### DIFF
--- a/cgi-bin/DW/Controller/Support/Faq.pm
+++ b/cgi-bin/DW/Controller/Support/Faq.pm
@@ -87,7 +87,7 @@ sub faq_handler {
             next unless $q;
             $q =~ s/^\s+//; $q =~ s/\s+$//;
             $q =~ s!\n!<br />!g;
-            push @{ $vars->{$faqcat}->{faqqs} }, {
+            push @{ $vars->{questions}->{$faqcat}->{faqqs} }, {
                 q => $q,
                 faqid => $faqid };
         }

--- a/views/support/faq.tt
+++ b/views/support/faq.tt
@@ -45,7 +45,7 @@ the same terms as Perl itself. For a copy of the license, please reference
     <h2>[% faqcategory.faqcatname | html %] (<a href='faqbrowse?faqcat=[% faqcategory.faqcat %]' name='[% faqcategory.faqcat %]'>[% '.view.all' | ml %]</a>)</h2>
     <ol class='faqlist'>
     [% faqcatid = faqcategory.faqcat %]
-    [% FOREACH faqq = $faqcatid.faqqs %]
+    [% FOREACH faqq = questions.$faqcatid.faqqs %]
         <li><a href='faqbrowse?faqid=[% faqq.faqid %]'>
             [% faqq.q %]
         </a></li>


### PR DESCRIPTION
"site" is used as a reserved top-level variable name in TT pages, e.g.,
"site.root". So when we tried to use "site" (the category name) as a
top-level variable, it was overshadowed. This moves the categories off
the top-level to avoid namespace conflicts

Fixes #1451.