### PR TITLE
Fix OpenID login error on live site

### DIFF
--- a/cgi-bin/LJ/OpenID.pm
+++ b/cgi-bin/LJ/OpenID.pm
@@ -196,7 +196,7 @@ sub blocked_hosts {
     return do { my $dummy = 0; \$dummy; } if $LJ::IS_DEV_SERVER;
 
     my $tried_local_id = 0;
-    $csr->ua->blocked_hosts(
+    $csr->ua->blocked_hosts( [
                             sub {
                                 my $dest = shift;
 
@@ -205,7 +205,7 @@ sub blocked_hosts {
                                     return 1;
                                 }
                                 return 0;
-                            });
+                            } ] );
     return \$tried_local_id;
 }
 


### PR DESCRIPTION
Per discussion in #1355, trying to log in with OpenID in production currently
results in the following error:

    Not an ARRAY reference at /home/dw/current/extlib/lib/perl5/Net/DNS/Paranoid.pm line 91.

My understanding of the problem is that LWP::UserAgent::Paranoid has a different argument
format for its blocked_hosts method than LWPx::ParanoidAgent did, and the arguments need
to be enclosed in an arrayref.  I can't reproduce the error exactly in testing on my
development environment, but I believe this will at least get us back to where we were
before, where at least non-SSL OpenID logins would still work.