### PR TITLE
[#1468] check for SKIP_PARANOID_USERAGENT instead of IS_DEV_SERVER

### DIFF
--- a/cgi-bin/LJ/OpenID.pm
+++ b/cgi-bin/LJ/OpenID.pm
@@ -64,7 +64,7 @@ sub consumer {
     my $get_args = shift || {};
 
     my $ua;
-    unless ($LJ::IS_DEV_SERVER) {
+    unless ( $LJ::SKIP_PARANOID_USERAGENT ) {
         $ua = LJ::get_useragent( role => "OpenID",
                                  timeout => 10,
                                  max_size => 1024*300, );
@@ -193,7 +193,7 @@ sub hmac {
 sub blocked_hosts {
     my $csr = shift;
 
-    return do { my $dummy = 0; \$dummy; } if $LJ::IS_DEV_SERVER;
+    return do { my $dummy = 0; \$dummy; } if $LJ::SKIP_PARANOID_USERAGENT;
 
     my $tried_local_id = 0;
     $csr->ua->blocked_hosts( [

--- a/etc/config.pl
+++ b/etc/config.pl
@@ -801,6 +801,11 @@
     $OPENID_SERVER = 1;
     $OPENID_CONSUMER = 1;
 
+    # Uncomment this if you want LJ::OpenID functions to use LWP::UserAgent
+    # instead of LWP::UserAgent::Paranoid, for example if you want to access
+    # a URL that resolves to a private IP for testing purposes.
+    # $SKIP_PARANOID_USERAGENT = 1;
+
     # how many days to store random users for; after this many days they fall out of the table.
     # high traffic sites probably want a reasonably low number, whereas lower traffic sites might
     # want to set this higher to give a larger sample of users to select from.


### PR DESCRIPTION
For certain LJ::OpenID functions that require a UserAgent object,
use LWP::UserAgent::Paranoid instead of the default LWP::UserAgent,
unless $LJ::SKIP_PARANOID_USERAGENT is enabled in the site config.

Fixes #1468.