### PR TITLE
[#1453] FormHTML functions automatically ehtml their arguments

### DIFF
--- a/views/search.tt
+++ b/views/search.tt
@@ -44,8 +44,7 @@
     %]
 
     <br>
-    [% eq = q | html;
-       form.textbox( name = "query", maxlength = "255", size = "60", value = eq );
+    [% form.textbox( name = "query", maxlength = "255", size = "60", value = q );
        " ";
        form.submit( value = dw.ml( '.button.search' ) );
     %]
@@ -135,7 +134,7 @@
                 IF result.total > offsetm -%]
                     <form method="POST" action='[% site.root %]/search?offset=[% offsetm %]'>
                     [% dw.form_auth %]
-                    [% form.hidden( name = 'query', value = eq );
+                    [% form.hidden( name = 'query', value = q );
                        form.hidden( name = 'mode', value = su ? su.user : '' );
                        form.hidden( name = 'sort_by', value = sort_by );
                        form.hidden( name = 'with_comments', value = wc );


### PR DESCRIPTION
The BML version of this page used hand-coded HTML which necessitated
manually escaping the displayed query text using LJ::ehtml. However,
the TT version uses form.textbox and form.hidden, which escape their
values automatically.  Using both together resulted in doubly escaped
text, so we should no longer manually escape the query text.

Fixes #1453.