### PR TITLE
[#1468] let LJ::OpenID always use the paranoid useragent

### DIFF
--- a/cgi-bin/LJ/OpenID.pm
+++ b/cgi-bin/LJ/OpenID.pm
@@ -63,12 +63,10 @@ sub server {
 sub consumer {
     my $get_args = shift || {};
 
-    my $ua;
-    unless ($LJ::IS_DEV_SERVER) {
-        $ua = LJ::get_useragent( role => "OpenID",
-                                 timeout => 10,
-                                 max_size => 1024*300, );
-    }
+    # always use a paranoid useragent
+    my $ua = LJ::get_useragent( role => "OpenID",
+                                timeout => 10,
+                                max_size => 1024*300, );
 
     my $cache = undef;
     if (! $LJ::OPENID_STATELESS && scalar(@LJ::MEMCACHE_SERVERS)) {
@@ -193,7 +191,8 @@ sub hmac {
 sub blocked_hosts {
     my $csr = shift;
 
-    return do { my $dummy = 0; \$dummy; } if $LJ::IS_DEV_SERVER;
+    # uncomment this if you need to bypass this check for testing purposes
+    # return do { my $dummy = 0; \$dummy; } if $LJ::IS_DEV_SERVER;
 
     my $tried_local_id = 0;
     $csr->ua->blocked_hosts( [


### PR DESCRIPTION
This removes the IS_DEV_SERVER special casing that resulted in the
paranoid useragent only being used in production for some functions
of LJ::OpenID.

The bypass for the blocked_hosts check is left intact as a comment,
in case it is needed for testing purposes at a later date.

Fixes #1468.