### PR TITLE
[#1488] Fix 'each' warning in Apache log following upgrade

### DIFF
--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -127,11 +127,10 @@ sub handler
                 next if $cur_mod == $mod;
                 $to_reload{$file} = 1;
             }
-            my @key_del;
-            foreach (my ($key, $file) = each %INC) {
-                push @key_del, $key if $to_reload{$file};
+            foreach my $key ( keys %INC ) {
+                my $file = $INC{$key};
+                delete $INC{$key} if $to_reload{$file};
             }
-            delete $INC{$_} foreach @key_del;
 
             foreach my $file (keys %to_reload) {
                 print STDERR "[$$] Reloading file: $file.\n";


### PR DESCRIPTION
    Use of each() on hash after insertion without resetting hash iterator
    results in undefined behavior, Perl interpreter: 0x7fc2b8f82500 at
    /dreamhack/home/8398-kareila/dw/cgi-bin/Apache/LiveJournal.pm line 131.

Avoid this warning by iterating over the array returned by 'keys'
instead of using the 'each' operator.  This has the happy side effect
of allowing us to delete keys within the loop instead of doing it as
a second step immediately afterward.

Fixes #1488.