### PR TITLE
Limit the old form of the icon url recognized by the contextualhover

### DIFF
--- a/htdocs/js/contextualhover.js
+++ b/htdocs/js/contextualhover.js
@@ -49,8 +49,8 @@ ContextualPopup.setup = function () {
     // attach to all userpics
     if (Site.ctx_popup_icons) {
         var images = document.getElementsByTagName("img") || [];
-        var old_icon_path = '/userpic';
-        var url_prefix = "(^" + Site.iconprefix + "|" + old_icon_path + ")";
+        var old_icon_url = 'www\\.dreamwidth\\.org/userpic';
+        var url_prefix = "(^" + Site.iconprefix + "|" + old_icon_url + ")";
         var re = new RegExp( url_prefix + "/\\d+\/\\d+$" );
         Array.prototype.forEach.call(images, function (image) {
             // if the image url matches a regex for userpic urls then attach to it

--- a/htdocs/js/jquery.contextualhover.js
+++ b/htdocs/js/jquery.contextualhover.js
@@ -37,10 +37,10 @@ function _initUserhead(context) {
 }
 
 function _initIcons(context) {
-    var old_icon_path = '/userpic';
-    var url_prefix = "(^" + Site.iconprefix + "|" + old_icon_path + ")";
+    var old_icon_url = 'www\\.dreamwidth\\.org/userpic';
+    var url_prefix = "(^" + Site.iconprefix + "|" + old_icon_url + ")";
     var re = new RegExp( url_prefix + "/\\d+\/\\d+$" );
-    $("img[src^='"+Site.iconprefix+"'],img[src*='"+old_icon_path+"']",context).each(function() {
+    $("img[src^='"+Site.iconprefix+"'],img[src*='"+old_icon_url+"']",context).each(function() {
         var $icon = $(this);
         if (!$icon.data("no-ctx") && this.src.match(re)) {
             $icon.contextualhover({ "icon_url": this.src, type: "icon" });
@@ -87,7 +87,6 @@ _create: function() {
         if ( parent.length > 0 )
             self.element = parent;
     }
-
     var trigger = self.element;
     trigger.addClass("ContextualPopup-trigger");
 


### PR DESCRIPTION
We should only recognize the old dreamwidth url, not one for any other
site