### PR TITLE
Refactor text on beta features page

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1596,3 +1596,12 @@ general widget.search.msn
 general /manage/profile/index.bml.chat.msnusername
 general /profile.bml.im.msn
 general /profile.bml.label.msnusername
+
+general widget.betafeature.btn.off
+general widget.betafeature.btn.on
+general widget.betafeature.s2comments.off
+general widget.betafeature.s2comments.on
+general widget.betafeature.s2comments.title
+general widget.betafeature.updatepage.off
+general widget.betafeature.updatepage.on
+general widget.betafeature.updatepage.title

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -4476,39 +4476,6 @@ widget.accountstatistics.tags2=[[num_comma]] <a [[aopts]]>[[?num_raw|Tag|Tags]]<
 
 widget.accountstatistics.title=Account Stats
 
-widget.betafeature.btn.off=Turn OFF beta testing
-
-widget.betafeature.btn.on=Turn ON beta testing
-
-widget.betafeature.s2comments.off<<
-<p>Activate the testing version of the sitescheme comments and reply pages. This is a complete rewrite of the existing pages into S2, the scripting language we use for journalstyles, which is more modern and flexible than the old code. It should be complete and a close match to old reply pages, but some bugs may still remain.</p>
-
-<p>To report bugs with the new comment and reply pages, leave a comment in <?ljuser dw_beta ljuser?></p>.
-.
-
-widget.betafeature.s2comments.on<<
-<p>You are currently testing the the sitescheme comments and reply pages. This is a complete rewrite of the existing pages into S2, the scripting language we use for journalstyles, which is more modern and flexible than the old code. It should be complete and a close match to old reply pages, but some bugs may still remain.</p>
-
-<p>To report bugs with the new comment and reply pages, leave a comment in <?ljuser dw_beta ljuser?></p>.
-.
-
-widget.betafeature.s2comments.title=New S2 Comment Pages
-
-
-widget.betafeature.updatepage.off<<
-<p>Activate the testing version of the new Create Entries management page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion. It is <b>not complete</b>, but is reasonably full-featured and will work for most if not all updating purposes.</p>
-
-<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?></p>.
-.
-
-widget.betafeature.updatepage.on<<
-<p>You are currently testing the Create Entries management page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion. It is <b>not complete</b>, but is reasonably full-featured and will work for most if not all updating purposes.</p>
-
-<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?></p>.
-.
-
-widget.betafeature.updatepage.title=New Create Entries Page
-
 widget.comms.notavailable=This list is currently unavailable.
 
 widget.comms.recentactive=Recently Active Communities

--- a/views/beta.tt
+++ b/views/beta.tt
@@ -38,31 +38,31 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <div class="row"><div class="columns">
 
     [%- IF handler.is_active -%]
-        <h2>[%- "widget.betafeature.${handler.key}.title" | ml -%]</h2>
+        <h2>[%- ".betafeature.${handler.key}.title" | ml -%]</h2>
     [%- END -%]
 
     [%- IF handler.is_active && handler.user_can_add( remote ) -%]
         [%- SET submit_actions = handler.is_optout ? [ "on", "off" ] : [ "off", "on" ] -%]
         [%- IF remote.is_in_beta( handler.key ) -%]
             <div class="row"><div class="columns">
-                [% replace_ljuser_tag( dw.ml( "widget.betafeature.${handler.key}.on", handler.args_list ) ) -%]
+                [% replace_ljuser_tag( dw.ml( ".betafeature.${handler.key}.on", handler.args_list ) ) -%]
             </div></div>
             <div class="row"><div class="columns">
-                [%- form.submit( name = "off", value = dw.ml( "widget.betafeature.btn.$submit_actions.0" ), class = "secondary submit" ) -%]
+                [%- form.submit( name = "off", value = dw.ml( ".betafeature.btn.$submit_actions.0" ), class = "secondary submit" ) -%]
             </div></div>
         [%- ELSE -%]
             <div class="row"><div class="columns">
-                [% replace_ljuser_tag( dw.ml( "widget.betafeature.${handler.key}.off", handler.args_list ) ) -%]
+                [% replace_ljuser_tag( dw.ml( ".betafeature.${handler.key}.off", handler.args_list ) ) -%]
             </div></div>
             <div class="row"><div class="columns">
-                [%- form.submit( name = "on", value = dw.ml( "widget.betafeature.btn.$submit_actions.1" ) ) -%]
+                [%- form.submit( name = "on", value = dw.ml( ".betafeature.btn.$submit_actions.1" ) ) -%]
             </div></div>
         [%- END -%]
 
         [%- form.hidden( name = "feature", value = handler.key ) -%]
         [%- form.hidden( name = "user", value = remote.user ) -%]
     [%- ELSIF ! handler.user_can_add( remote ) -%]
-        [%- "widget.betafeature.${handler.key}.cantadd" | ml -%]
+        [%- ".betafeature.${handler.key}.cantadd" | ml -%]
     [%- END -%]
 </div></div>
 </form>

--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -1,4 +1,40 @@
 ;; -*- coding: utf-8 -*-
+.betafeature.btn.off=Turn OFF beta testing
+
+.betafeature.btn.on=Turn ON beta testing
+
+.betafeature.s2comments.cantadd=Sorry, your account is not eligible to test this feature.
+
+.betafeature.s2comments.off<<
+<p>Activate the testing version of the sitescheme comments and reply pages. This is a complete rewrite of the existing pages into S2, the scripting language we use for journalstyles, which is more modern and flexible than the old code. It should be complete and a close match to old reply pages, but some bugs may still remain.</p>
+
+<p>To report bugs with the new comment and reply pages, leave a comment in <?ljuser dw_beta ljuser?>.</p>
+.
+
+.betafeature.s2comments.on<<
+<p>You are currently testing the the sitescheme comments and reply pages. This is a complete rewrite of the existing pages into S2, the scripting language we use for journalstyles, which is more modern and flexible than the old code. It should be complete and a close match to old reply pages, but some bugs may still remain.</p>
+
+<p>To report bugs with the new comment and reply pages, leave a comment in <?ljuser dw_beta ljuser?>.</p>
+.
+
+.betafeature.s2comments.title=New S2 Comment Pages
+
+.betafeature.updatepage.cantadd=Sorry, your account is not eligible to test this feature.
+
+.betafeature.updatepage.off<<
+<p>Activate the testing version of the new Create Entries management page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion. It is <b>not complete</b>, but is reasonably full-featured and will work for most if not all updating purposes.</p>
+
+<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?>.</p>
+.
+
+.betafeature.updatepage.on<<
+<p>You are currently testing the Create Entries management page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion. It is <b>not complete</b>, but is reasonably full-featured and will work for most if not all updating purposes.</p>
+
+<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?>.</p>
+.
+
+.betafeature.updatepage.title=New Create Entries Page
+
 .nofeatures=There are no features currently available for beta testing.
 
 .staytuned.newscomm=Stay tuned to [[news]] for upcoming testing opportunities. Thank you.


### PR DESCRIPTION
- Moved existing strings from en.dat to views/beta.tt.text. Confirmed
they were not referenced elsewhere in the code before doing so.

- Added referenced but undefined strings for `.betafeature.${handler.key}.cantadd`.

- Corrected placement of period after closing paragraph tag.