### PR TITLE
[#1502] in setTimeToNow(), don't multiply minutes by 100

### DIFF
--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -579,7 +579,7 @@ var postForm = (function($) {
                         ].join("-");
             $("#js-entrytime-date").val(date).trigger("change");
 
-            var time = [ zeropad(now.getHours()), zeropad(now.getMinutes() * 100) ];
+            var time = [ zeropad(now.getHours()), zeropad(now.getMinutes()) ];
             $("#js-entrytime-time").val(time).trigger("change");
 
             $("#js-trust-datetime").val(1);


### PR DESCRIPTION
The lion's share of the credit for this fix goes to AlexSeanchai
for pattern recognition and exor674 for diagnosing.

Fixes #1502.