### PR TITLE
[#1463] Add code for parsing lj.rossia.org results to DW::External::Userinfo

### DIFF
--- a/cgi-bin/DW/External/Userinfo.pm
+++ b/cgi-bin/DW/External/Userinfo.pm
@@ -168,6 +168,12 @@ sub atomtype {
 
     # this is simple enough not to bother with an XML parser
     my $text = $res->content || '';
+
+    # first look for lj.rossia.org - different from other LJ sites
+    my ( $ljr ) = $text =~
+        m@<link rel='alternate' type='text/html' href='http://lj.rossia.org/([^/]+)@i;
+    return $ljr if $ljr; # community or users
+
     my ( $str ) = $text =~ m@<(?:lj|dw):journal ([^/]*)/>@i;
     return undef unless $str;
 
@@ -212,6 +218,7 @@ sub check_remote {
                 personal   => 'P',
                 syndicated => 'Y',
                 user       => 'P',
+                users      => 'P',
                );
 
     # invalid users don't always 404, so we also detect from title


### PR DESCRIPTION
Their atom feeds look different than those from other LJ-related sites,
so look at a different portion of the metadata to discover the URL
for determining journal type.  Still easier than parsing their
profile pages, which are in Cyrillic...

Related to but separate from work being done in DW::External::Site (#1506)
to support this site in our external user tags.