### PR TITLE
Remove extra info on deletion success

### DIFF
--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -346,22 +346,24 @@ body<=
                         $result .= "<?p " . BML::ml('.success.editedstillsuspended', { aopts => "href='$LJ::SITEROOT/abuse/report'" }) . " p?>";
                     }
                 }
-                
-                if ($req{"security"} eq "private") {
-                    $result .="<p>$ML{'.extradata.sec.private'}</p>";
-                } elsif ($req{"security"} eq "usemask") {
-                    if ($req{"allowmask"} == 0) { # custom security with no group -- essentially private
+               
+                if (!$deleted) {
+                    if ($req{"security"} eq "private") {
                         $result .="<p>$ML{'.extradata.sec.private'}</p>";
-                    } elsif ($req{"allowmask"} > 1) { # custom group
-                        $result .="<p>$ML{'.extradata.sec.custom'}</p>";
-                    } else { # friends only
-                        $result .="<p>$ML{'.extradata.sec.access'}</p>";
+                    } elsif ($req{"security"} eq "usemask") {
+                        if ($req{"allowmask"} == 0) { # custom security with no group -- essentially private
+                            $result .="<p>$ML{'.extradata.sec.private'}</p>";
+                        } elsif ($req{"allowmask"} > 1) { # custom group
+                            $result .="<p>$ML{'.extradata.sec.custom'}</p>";
+                        } else { # friends only
+                            $result .="<p>$ML{'.extradata.sec.access'}</p>";
+                        }
+                    } else {
+                        $result .="<p>$ML{'.extradata.sec.public'}</p>";
                     }
-                } else {
-                    $result .="<p>$ML{'.extradata.sec.public'}</p>";
+                    
+                    $result .="<?p " . BML::ml('.extradata.subject', { subject => LJ::ehtml( $req{"subject"} ) }) . " p?>";
                 }
-                
-                $result .="<?p " . BML::ml('.extradata.subject', { subject => LJ::ehtml( $req{"subject"} ) }) . " p?>";
 
                 $result .= "<div id='fromhere'>$ML{'.success.fromhere'}<ul>";
                 $result .= "<li><a href='$entry_url'>$ML{'.success.fromhere.viewentry'}</a></li>" unless $deleted;

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -21,6 +21,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- IF poststatus -%]
 <p>[% poststatus.ml_string | ml( url => poststatus.url)%]</p>
+[%- END -%]
+
+[%- IF poststatus.ml_string != ".edit.delete" -%]
 <p>[% extradata.security_ml | ml %]</p>
 <p>[% ".extradata.subject" | ml( subject => extradata.subject) %]</p>
 [%- END -%]


### PR DESCRIPTION
When entries have been deleted they don't need extra data
for security and subject.

Fixes #1445.