### PR TITLE
Add poster name to Edit Tags page

### DIFF
--- a/htdocs/edittags.bml
+++ b/htdocs/edittags.bml
@@ -103,6 +103,9 @@ body<=
     $ret .= "<script type='text/javascript'> var cur_taglist = '$logtagstr'; </script>";
 
     $ret .= '<table summary="" class="edittbl" cellpadding="0" cellspacing="0" width="50%">';
+    if ( $u->is_community ) {
+        $ret .= "<tr><td class='l'>$ML{'.poster'}</td><td>" . $ent->poster->ljuser_display . "</td></tr>";
+    }
     $ret .= "<tr><td class='l'>$ML{'.subject'}</td><td>$subj</td></tr>" if $subj;
 
     $ret .= '<form method="POST" action="/edittags" id="edit_tagform">';

--- a/htdocs/edittags.bml.text
+++ b/htdocs/edittags.bml.text
@@ -25,6 +25,8 @@
 
 .permissions.none=(You don't have permission to edit tags on this entry.)
 
+.poster=Poster:
+
 .readonly.journal=This journal is read-only.  Its entry tags can't be edited.
 
 .readonly.poster=This poster is read-only; the tags for this entry can't be edited.


### PR DESCRIPTION
Fixes #1509.

Provides name of poster on dedicated Edit Tags page - useful/
of interest when managing community tags.

This is still BML and I should learn to fix it.