### PR TITLE
Hide subscription options for non-visible accounts

### DIFF
--- a/htdocs/manage/tracking/user.bml
+++ b/htdocs/manage/tracking/user.bml
@@ -69,7 +69,7 @@ body<=
             journal => $journal,
             flags   => LJ::Subscription::TRACKING,
         ) if $remote->can_track_all_community_comments( $journal )
-            and $journal->statusvis eq "V";
+            && $journal->statusvis eq "V";
 
     push @{ @$categories[0]->{$cat_title} },
         LJ::Subscription::Pending->new( $remote,

--- a/htdocs/manage/tracking/user.bml
+++ b/htdocs/manage/tracking/user.bml
@@ -70,7 +70,7 @@ body<=
             flags   => LJ::Subscription::TRACKING,
         ) if $remote->can_track_all_community_comments( $journal )
             and $journal->statusvis eq "V";
-    
+
     push @{ @$categories[0]->{$cat_title} },
         LJ::Subscription::Pending->new( $remote,
             event    => "NewUserpic",

--- a/htdocs/manage/tracking/user.bml
+++ b/htdocs/manage/tracking/user.bml
@@ -41,24 +41,20 @@ body<=
 
     # what classes to display on this page
     my $cat_title = 'Track User';
-    my $categories =
-        [
-            { $cat_title =>
-                [
-                    LJ::Subscription::Pending->new( $remote,
-                        event   => "JournalNewEntry",
-                        arg1    => '?',
-                        journal => $journal,
-                        flags   => LJ::Subscription::TRACKING,
-                    ),
-                    LJ::Subscription::Pending->new( $remote,
-                        event   => "JournalNewEntry",
-                        journal => $journal,
-                        flags   => LJ::Subscription::TRACKING,
-                    ),
-                ]
-            },
-        ];
+    my $categories = [ { $cat_title => [ ] }, ];
+
+    push @{ @$categories[0]->{$cat_title} },
+        LJ::Subscription::Pending->new( $remote,
+            event   => "JournalNewEntry",
+            arg1    => '?',
+            journal => $journal,
+            flags   => LJ::Subscription::TRACKING,
+        ),
+        LJ::Subscription::Pending->new( $remote,
+            event   => "JournalNewEntry",
+            journal => $journal,
+            flags   => LJ::Subscription::TRACKING,
+        ) if $journal->statusvis eq "V";
 
     push @{ @$categories[0]->{$cat_title} },
         LJ::Subscription::Pending->new( $remote,
@@ -72,7 +68,8 @@ body<=
             event   => "JournalNewComment",
             journal => $journal,
             flags   => LJ::Subscription::TRACKING,
-        ) if $remote->can_track_all_community_comments( $journal );
+        ) if $remote->can_track_all_community_comments( $journal )
+            and $journal->statusvis eq "V";
     
     push @{ @$categories[0]->{$cat_title} },
         LJ::Subscription::Pending->new( $remote,
@@ -85,7 +82,7 @@ body<=
             event   => "Birthday",
             journal => $journal,
             flags   => LJ::Subscription::TRACKING,
-        );
+        ) if $journal->statusvis eq "V";
 
     # validate referer for ret_url
     my $referer = BML::get_client_header('Referer');


### PR DESCRIPTION
When offering tracking subscription options for an account with a status
other than "visible", only offer notification of when the account is
purged.  In particular, don't offer notification of when a new post with
a specific tag is made, since that includes the list of tags from a
deleted account.

Fixes #1523.