### PR TITLE
[#1374] allow rename swaps to use tokens from either account

### DIFF
--- a/cgi-bin/DW/User/Rename.pm
+++ b/cgi-bin/DW/User/Rename.pm
@@ -229,10 +229,14 @@ sub swap_usernames {
     my $admin = LJ::isu( $opts{user} ) ? $opts{user} : $u1;
     my @tokens = @{ $opts{tokens} || [] };
 
+    # tokens can be owned by $admin (remote user),
+    # $u1 (authas user), or $u2 (intended target)
+    my $check_uids = { $admin->id => 1, $u1->id => 1, $u2->id => 1 };
+
     foreach my $token ( @tokens ) {
         $errors->add( 'token', 'rename.error.tokeninvalid' )
             unless $token && $token->isa( "DW::RenameToken" )
-                && $token->ownerid == $admin->userid;
+                && $check_uids->{$token->ownerid};
 
         $errors->add( 'token', 'rename.error.tokenapplied' )
             if $token->applied || $token->revoked;

--- a/t/rename.t
+++ b/t/rename.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 153;
+use Test::More tests => 154;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Test qw( temp_user temp_comm );
@@ -530,6 +530,16 @@ note( "-- two username swap (personal to personal)" );
 
     is( $u1->userid, $u1id, "Id of u1 remains the same after rename." );
     is( $u2->userid, $u2id, "Id of u2 remains the same after rename." );
+}
+
+note( "-- two username swap (personal to personal), one token owned by each user" );
+{
+    my ( $u1, $u2 ) = $create_users->( match => 1, validated => 1 );
+
+    ok( $u1->swap_usernames(
+        $u2,
+        tokens => [ new_token( $u1 ), new_token( $u2 ) ]
+     ), "Swap usernames with one token owned by each account" );
 }
 
 note( "-- two username swap (one user is suspended)" );

--- a/views/rename/swap.tt
+++ b/views/rename/swap.tt
@@ -20,7 +20,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
 ) -%]
 
 <p>[% '.intro' | ml %]</p>
-[% IF numtokens >= 2 %]
     <form id="renameform" method="POST">
         [% dw.form_auth %]
         <div class='formfield'>
@@ -37,8 +36,3 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
         <input type='submit' value="[% '.form.button' | ml | html %]" />
     </form>
-[% ELSE %]
-    [%- '.numtokens.toofew' | ml(aopts = "href='/shop/renames?for=self'") -%]
-[% END %]
-
-


### PR DESCRIPTION
Updates DW::User::Rename::swap_usernames to validate tokens from any
of the (up to three) accounts involved in a username swap, instead
of only using the available tokens for the logged in account.

Also redesigns the /rename/swap page to present the form immediately,
and treat the "too few tokens" error like any other form processing
error.  This was necessary in order to check the requested target
account(s) for available tokens.

Fixes #1374.