### PR TITLE
[#1356] remove "identity_posting" userprop and related checks

### DIFF
--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -221,7 +221,7 @@ userproplist.disable_comm_promo:
   indexed: 0
   multihomed: 0
   prettyname: Administratively disable community promo features for a user
-  
+
 userproplist.displaydate_check:
   cldversion: 4
   datatype: bool
@@ -509,14 +509,6 @@ userproplist.icq:
   indexed: 1
   multihomed: 1
   prettyname: ICQ
-
-userproplist.identity_posting:
-  cldversion: 4
-  datatype: bool
-  des: Whether to allow identity users to post entries to this journal
-  indexed: 0
-  multihomed: 0
-  prettyname: Entries from Identity Users
 
 userproplist.import_job:
   cldversion: 4

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -538,12 +538,12 @@ sub sendmessage
 
     my @msg;
     BML::set_language('en'); # FIXME
-    
+
     foreach my $to (@to) {
         my $tou = LJ::load_user($to);
         return fail($err, 100, $to)
             unless $tou;
-        
+
         my $msguserpic;
         $msguserpic = $req->{'userpic'} if defined $req->{'userpic'};
 
@@ -1218,9 +1218,8 @@ sub postevent
     return fail($err,306) unless $dbh && $dbcm && $uowner->writer;
     return fail($err,200) unless $req->{'event'} =~ /\S/;
 
-    ### make sure community or identity journals don't post
+    ### make sure community journals don't post
     return fail($err,150) if $u->is_community;
-    return fail($err,150) if ! $importer_bypass && ! $uowner->prop( "identity_posting" ) && $u->is_identity;
 
     # suspended users can't post
     return fail($err,305) if ! $importer_bypass && $u->is_suspended;

--- a/cgi-bin/LJ/Tags.pm
+++ b/cgi-bin/LJ/Tags.pm
@@ -480,7 +480,7 @@ sub can_add_tags {
     # we don't allow identity users to add tags, even when tag permissions would otherwise allow any user on the site
     # exception are communities that explicitly allow identity users to post in them
     # FIXME: perhaps we should restrict on all users, but allow for more restrictive settings such as members?
-    return undef unless $remote->is_personal || $remote->is_identity && $u->prop( 'identity_posting' );
+    return undef unless $remote->is_individual;
     return undef if $u->has_banned( $remote );
 
     # get permission hashref and check it; note that we fall back to the control
@@ -500,7 +500,7 @@ sub can_add_entry_tags {
     return undef unless $remote && $entry;
 
     my $journal = $entry->journal;
-    return undef unless $remote->is_personal || $remote->is_identity && $journal->prop( 'identity_posting' );
+    return undef unless $remote->is_individual;
     return undef if $journal->has_banned( $remote );
 
     my $perms = LJ::Tags::get_permission_levels( $journal );
@@ -536,7 +536,7 @@ sub can_control_tags {
     my $u = LJ::want_user(shift);
     my $remote = LJ::want_user(shift);
     return undef unless $u && $remote;
-    return undef unless $remote->is_personal || $remote->is_identity && $u->prop( 'identity_posting' );
+    return undef unless $remote->is_individual;
     return undef if $u->has_banned( $remote );
 
     # get permission hashref and check it


### PR DESCRIPTION
The legacy userprop "identity_posting" was intended to allow community admins to opt into allowing OpenID users to post entries and manage tags.  Since we decided to allow this for all OpenID users across the site, this set of changes removes the userprop and all the permission checks that were failing as a result of it not being set.

The relevant tests in protocol.t have been updated, but that test suite is still set to be skipped because of inconsistent results in other parts of the test suite.

Fixes #1356.