### PR TITLE
[#1500] fix retrieval of previously selected security level in JS

### DIFF
--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -296,7 +296,7 @@ var postForm = (function($) {
             }
 
             var $security = $("#js-security");
-            var oldval = $security.data("lastselected");
+            var oldval = $security.closest('select').find('option').filter(':selected').val();
             var rank = { "public": "0", "access": "1", "private": "2", "custom": "3" };
 
             $security.empty();

--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -195,10 +195,6 @@ var postForm = (function($) {
             } else {
                 $custom_edit_button.hide();
             }
-
-            if ( !init ) {
-                $this.data("lastselected", $this.val());
-            }
         }).triggerHandler("change", rememberInitialValue);
 
         // update the list of people who can see the entry


### PR DESCRIPTION
The existing syntax wasn't successfully defining the variable.

I figured out a working syntax using StackOverflow.  HURRAY.

Fixes #1500.