### PR TITLE
[#1527] fix issues with access-only images

### DIFF
--- a/cgi-bin/DW/Media.pm
+++ b/cgi-bin/DW/Media.pm
@@ -110,7 +110,10 @@ sub upload_media {
 
     # set the security
     my $sec = $opts{security} || 'public';
-    $sec = 'usemask' if $sec =~ /^(?:friends|access)$/;
+    if ( $sec =~ /^(?:friends|access)$/ ) {
+        $sec = 'usemask' ;
+        $opts{allowmask} = 1;
+    }
     croak 'Invalid security for uploaded file.'
         unless $sec =~ /^(?:public|private|usemask)$/;
     if ( $sec eq 'usemask' ) {

--- a/cgi-bin/DW/Media.pm
+++ b/cgi-bin/DW/Media.pm
@@ -117,8 +117,8 @@ sub upload_media {
     croak 'Invalid security for uploaded file.'
         unless $sec =~ /^(?:public|private|usemask)$/;
     if ( $sec eq 'usemask' ) {
-        # default allowmask of 1 unless defined otherwise
-        $opts{allowmask} //= 1;
+        # default allowmask of 0 unless defined otherwise
+        $opts{allowmask} //= 0;
     } else {
         $opts{allowmask} = 0;
     }

--- a/cgi-bin/DW/Media.pm
+++ b/cgi-bin/DW/Media.pm
@@ -110,9 +110,15 @@ sub upload_media {
 
     # set the security
     my $sec = $opts{security} || 'public';
+    $sec = 'usemask' if $sec =~ /^(?:friends|access)$/;
     croak 'Invalid security for uploaded file.'
         unless $sec =~ /^(?:public|private|usemask)$/;
-    $opts{allowmask} = 0 unless defined $opts{allowmask} && $sec eq 'usemask';
+    if ( $sec eq 'usemask' ) {
+        # default allowmask of 1 unless defined otherwise
+        $opts{allowmask} //= 1;
+    } else {
+        $opts{allowmask} = 0;
+    }
 
     # now we can cook -- allocate an id and upload
     my $id = LJ::alloc_user_counter( $opts{user}, 'A' )

--- a/cgi-bin/DW/Media/Base.pm
+++ b/cgi-bin/DW/Media/Base.pm
@@ -173,16 +173,19 @@ sub set_security {
     confess 'Invalid argument hash passed to set_security.'
         unless defined $security;
 
-    $security = 'usemask' if $security =~ /^(?:friends|access)$/;
-    confess 'Invalid security type passed to set_security.'
-        unless $security =~ /^(?:private|public|usemask)$/;
-
     my $mask = 0;
     if ( $security eq 'usemask' ) {
         # allowmask must be defined - defaults to 1 (all trusted)
         $opts{allowmask} //= 1;
         $mask = int $opts{allowmask};
     }
+
+    if ( $security =~ /^(?:friends|access)$/ ) {
+        $security = 'usemask';
+        $mask = 1;
+    }
+    confess 'Invalid security type passed to set_security.'
+        unless $security =~ /^(?:private|public|usemask)$/;
 
     my $u = $self->u
         or croak 'Sorry, unable to load the user.';

--- a/cgi-bin/DW/Media/Base.pm
+++ b/cgi-bin/DW/Media/Base.pm
@@ -175,8 +175,8 @@ sub set_security {
 
     my $mask = 0;
     if ( $security eq 'usemask' ) {
-        # allowmask must be defined - defaults to 1 (all trusted)
-        $opts{allowmask} //= 1;
+        # default allowmask of 0 unless defined otherwise
+        $opts{allowmask} //= 0;
         $mask = int $opts{allowmask};
     }
 

--- a/cgi-bin/DW/Media/Base.pm
+++ b/cgi-bin/DW/Media/Base.pm
@@ -170,11 +170,17 @@ sub set_security {
     return 0 if $self->is_deleted;
 
     my $security = $opts{security};
+    confess 'Invalid argument hash passed to set_security.'
+        unless defined $security;
+
+    $security = 'usemask' if $security =~ /^(?:friends|access)$/;
     confess 'Invalid security type passed to set_security.'
         unless $security =~ /^(?:private|public|usemask)$/;
 
     my $mask = 0;
     if ( $security eq 'usemask' ) {
+        # allowmask must be defined - defaults to 1 (all trusted)
+        $opts{allowmask} //= 1;
         $mask = int $opts{allowmask};
     }
 

--- a/t/media-security.t
+++ b/t/media-security.t
@@ -23,7 +23,7 @@ use LJ::Test qw(temp_user);
 use DW::Media;
 
 if ( LJ::mogclient() ) {
-    plan tests => 14;
+    plan tests => 15;
 } else {
     plan skip_all => "MogileFS client unavailable.";
     exit 0;
@@ -71,6 +71,10 @@ if ( defined $obj ) {
     $obj->set_security( security => "usemask", allowmask => 0 );
 
     ok( ! $obj->visible_to( $u2 ), "Trusted user can't view if no allowmask" );
+
+    $obj->set_security( security => "usemask", allowmask => undef );
+
+    ok( ! $obj->visible_to( $u2 ), "Trusted user can't view undef allowmask" );
 
     # make sure "friends" security works (newpost_minsecurity still uses this)
     $obj->set_security( security => "friends" );

--- a/t/media-security.t
+++ b/t/media-security.t
@@ -1,0 +1,104 @@
+# t/media-security.t
+#
+# Test DW::Media access permissions.
+#
+# Authors:
+#      Jen Griffin <kareila@livejournal.com>
+#
+# Copyright (c) 2015 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+use LJ::Test qw(temp_user);
+use DW::Media;
+
+if ( LJ::mogclient() ) {
+    plan tests => 14;
+} else {
+    plan skip_all => "MogileFS client unavailable.";
+    exit 0;
+}
+
+my $u1 = temp_user();
+my $u2 = temp_user();
+
+ok( ! $u1->trusts( $u2 ), "Viewer does not have access to poster" );
+
+# Use an image from dw-free for testing purposes.
+
+my $obj = DW::Media->upload_media(
+    user     => $u1,
+    file     => "htdocs/img/videoplaceholder.png",
+    security => "friends",  # make sure this doesn't fail
+);
+
+ok( $obj, 'Successfully created DW::Media object from test image.' );
+
+if ( defined $obj ) {
+    # first test public security
+    $obj->set_security( security => "public" );
+
+    ok( $obj->visible_to( $u2 ), "Viewer can see public image" );
+
+    # then private
+    $obj->set_security( security => "private" );
+
+    ok( ! $obj->visible_to( $u2 ), "Viewer can't see private image" );
+
+    # test basic access
+    $obj->set_security( security => "usemask", allowmask => 1 );
+
+    ok( ! $obj->visible_to( $u2 ), "Untrusted user can't see access image" );
+
+    # set up trust edge
+    $u1->add_edge( $u2, trust => { nonotify => 1 } );
+
+    ok( $u1->trusts( $u2 ), "Viewer has access to poster" );
+
+    ok( $obj->visible_to( $u2 ), "Trusted user can see access image" );
+
+    # note that undefined or zero value for allowmask will fail
+    $obj->set_security( security => "usemask", allowmask => 0 );
+
+    ok( ! $obj->visible_to( $u2 ), "Trusted user can't view if no allowmask" );
+
+    # make sure "friends" security works (newpost_minsecurity still uses this)
+    $obj->set_security( security => "friends" );
+
+    ok( $obj->visible_to( $u2 ), "Trusted user can view friends security" );
+
+    # create an access group and add the viewer to it
+    my $groupid = $u1->create_trust_group( groupname => 'testing' );
+    $u1->edit_trustmask( $u2, add => $groupid );
+
+    ok( $obj->visible_to( $u2 ), "Member of group can view friends security" );
+
+    # calculate the trustmask (group membership + basic access)
+    my $mask = $groupid << 1;
+    ok( $u1->trustmask( $u2 ) == $mask + 1, 'Validate calculated trustmask' );
+
+    # test access group visibility
+    $obj->set_security( security => "usemask", allowmask => $mask );
+
+    ok( $obj->visible_to( $u2 ), "Member of group can view masked image" );
+    ok( $obj->visible_to( $u1 ), "Owner of image can view masked image" );
+
+    $u1->edit_trustmask( $u2, remove => $groupid );
+    ok( ! $obj->visible_to( $u2 ), "Non-member of group can't see image" );
+
+    # cleanup and exit
+
+    $obj->delete;
+}
+
+1;


### PR DESCRIPTION
Does the right thing with 'friends' setting, which is still used as an option for minimum entry security.  The /file/new path uses that setting when uploading images.

Makes sure if we request 'usemask' security, that the 'allowmask' defaults to 1 (all trusted).

New test file t/media-security.t to make sure things are working as we expect.

Fixes #1527.