### PR TITLE
Switch to SSL fonts

### DIFF
--- a/styles/ciel/themes.s2
+++ b/styles/ciel/themes.s2
@@ -753,7 +753,7 @@ set color_navlinks_link_hover_background = "#ffb2d0";
 ## Fonts
 ##===============================
 
-set font_sources= "http://fonts.googleapis.com/css?family=Bonbon";
+set font_sources= "https://fonts.googleapis.com/css?family=Bonbon";
 set font_journal_title = "Bonbon";
 
 function Page::print_theme_stylesheet() { """
@@ -963,7 +963,7 @@ set font_management = "'Noticia Text'";
 set font_module_heading = "'Chelsea Market'";
 set font_module_text = "'Noticia Text'";
 set font_navlinks = "'Noticia Text'";
-set font_sources = "http://fonts.googleapis.com/css?family=Noticia+Text:400,400italic|Chelsea+Market";
+set font_sources = "https://fonts.googleapis.com/css?family=Noticia+Text:400,400italic|Chelsea+Market";
 
 
 #NEWLAYER: ciel/chelsealight
@@ -1007,7 +1007,7 @@ set font_management = "'Noticia Text'";
 set font_module_heading = "'Chelsea Market'";
 set font_module_text = "'Noticia Text'";
 set font_navlinks = "'Noticia Text'";
-set font_sources = "http://fonts.googleapis.com/css?family=Noticia+Text:400,400italic|Chelsea+Market";
+set font_sources = "https://fonts.googleapis.com/css?family=Noticia+Text:400,400italic|Chelsea+Market";
 
 
 #NEWLAYER: ciel/chocolatemint
@@ -2036,7 +2036,7 @@ set font_management = "'News Gothic MT'";
 set font_module_heading = "'Germania One'";
 set font_module_text = "'News Gothic MT'";
 set font_navlinks = "'News Gothic MT'";
-set font_sources = "http://fonts.googleapis.com/css?family=Germania+One";
+set font_sources = "https://fonts.googleapis.com/css?family=Germania+One";
 
 
 #NEWLAYER: ciel/enchantedforest
@@ -2488,7 +2488,7 @@ set color_navlinks_link_hover_background = "#ECABFF";
 ## Fonts
 ##===============================
 
-set font_sources= "http://fonts.googleapis.com/css?family=Bonbon";
+set font_sources= "https://fonts.googleapis.com/css?family=Bonbon";
 set font_journal_title = "Bonbon";
 
 function Page::print_theme_stylesheet() { """
@@ -4113,7 +4113,7 @@ set font_management = "Helvetica";
 set font_module_heading = "'Text Me One'";
 set font_module_text = "Helvetica";
 set font_navlinks = "Helvetica";
-set font_sources = "http://fonts.googleapis.com/css?family=Text+Me+One&subset=latin,latin-ext";
+set font_sources = "https://fonts.googleapis.com/css?family=Text+Me+One&subset=latin,latin-ext";
 
 
 #NEWLAYER: ciel/persephone

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -1731,7 +1731,7 @@ property string font_comment_title_units {
 
 property string font_sources {
     des = "Embedded fonts stylesheet URL";
-    note = "The URL must point to a font stylesheet such as 'http://fonts.googleapis.com/css?family=Average+Sans' and not directly at the font file. Embedded fonts can slow page loading time. Blank the field to stop using them.";
+    note = "The URL must point to a font stylesheet such as 'https://fonts.googleapis.com/css?family=Average+Sans' and not directly at the font file. Embedded fonts can slow page loading time. Blank the field to stop using them. The URL should be a secure URL and begin with 'https://'.";
 }
 
 set font_base = "";     # In core, default is not to care. Layouts will probably specify fonts the author likes instead.

--- a/styles/database/layout.s2
+++ b/styles/database/layout.s2
@@ -111,7 +111,7 @@ propgroup fonts_child {
     property use font_sources;
 }
 
-set font_sources = "http://fonts.googleapis.com/css?family=Iceland";
+set font_sources = "https://fonts.googleapis.com/css?family=Iceland";
 set font_base = "Iceland, 'Courier New'";
 set font_fallback = "monospace";
 set font_base_size = "1.3";

--- a/styles/fantaisie/layout.s2
+++ b/styles/fantaisie/layout.s2
@@ -69,7 +69,7 @@ propgroup fonts_child {
     property use font_sources;
 }
 
-set font_sources = "http://fonts.googleapis.com/css?family=Asap|Rochester";
+set font_sources = "https://fonts.googleapis.com/css?family=Asap|Rochester";
 
 set font_base = "Asap";
 set font_fallback = "sans-serif";

--- a/styles/patsy/themes.s2
+++ b/styles/patsy/themes.s2
@@ -173,7 +173,7 @@ set font_fallback = "sans-serif";
 set font_journal_subtitle = "Metamorphous";
 set font_journal_title = "Metamorphous";
 set font_module_heading = "Metamorphous";
-set font_sources = "http://fonts.googleapis.com/css?family=Metamorphous&subset=latin,latin-ext";
+set font_sources = "https://fonts.googleapis.com/css?family=Metamorphous&subset=latin,latin-ext";
 
 function Page::print_theme_stylesheet() {
 """
@@ -395,7 +395,7 @@ set font_fallback = "sans-serif";
 set font_journal_subtitle = "Metamorphous";
 set font_journal_title = "Metamorphous";
 set font_module_heading = "Metamorphous";
-set font_sources = "http://fonts.googleapis.com/css?family=Metamorphous&subset=latin,latin-ext";
+set font_sources = "https://fonts.googleapis.com/css?family=Metamorphous&subset=latin,latin-ext";
 
 function Page::print_theme_stylesheet() {
 """
@@ -580,7 +580,7 @@ set font_fallback = "sans-serif";
 set font_journal_subtitle = "Metamorphous";
 set font_journal_title = "Metamorphous";
 set font_module_heading = "Metamorphous";
-set font_sources = "http://fonts.googleapis.com/css?family=Metamorphous&subset=latin,latin-ext";
+set font_sources = "https://fonts.googleapis.com/css?family=Metamorphous&subset=latin,latin-ext";
 
 function Page::print_theme_stylesheet() {
 """


### PR DESCRIPTION
This switches us to use the Google fonts SSL version, which will fix
mixed content warnings when viewing a Dreamwidth page securely.

Fixes #1551.