### PR TITLE
Notifications should provide HTTPS links

### DIFF
--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -641,6 +641,11 @@ sub is_syndicated {
 }
 
 
+sub journal_base {
+    return LJ::journal_base( @_ );
+}
+
+
 sub journaltype {
     return $_[0]->{journaltype};
 }
@@ -1327,6 +1332,77 @@ sub isu {
     if (ref $_[0] eq "HASH" && $_[0]->{userid}) {
         carp "User HASH objects are deprecated from use." if $LJ::IS_DEV_SERVER;
         return 1;
+    }
+}
+
+# <LJFUNC>
+# name: LJ::journal_base
+# des: Returns URL of a user's journal.
+# info: The tricky thing is that users with underscores in their usernames
+#       can't have some_user.example.com as a hostname, so that's changed into
+#       some-user.example.com.
+# args: uuser, vhost?
+# des-uuser: User hashref or username of user whose URL to make.
+# des-vhost: What type of URL.  Acceptable options: "users", to make a
+#            http://user.example.com/ URL; "tilde" for http://example.com/~user/;
+#            "community" for http://example.com/community/user; or the default
+#            will be http://example.com/users/user.  If unspecified and uuser
+#            is a user hashref, then the best/preferred vhost will be chosen.
+# returns: scalar; a URL.
+# </LJFUNC>
+sub journal_base {
+    my ($user, %opts) = @_;
+    my $vhost = $opts{vhost};
+    my $protocol = ( $LJ::USE_HTTPS_EVERYWHERE || $LJ::IS_SSL ) ? "https" : "http";
+
+    my $u = LJ::isu( $user ) ? $user : LJ::load_user( $user );
+    $user = $u->user if $u;
+
+    if ( $u && LJ::Hooks::are_hooks("journal_base") ) {
+        my $hookurl = LJ::Hooks::run_hook("journal_base", $u, $vhost);
+        return $hookurl if $hookurl;
+
+        unless (defined $vhost) {
+            if ($LJ::FRONTPAGE_JOURNAL eq $user) {
+                $vhost = "front";
+            } elsif ( $u->is_person ) {
+                $vhost = "";
+            } elsif ( $u->is_community ) {
+                $vhost = "community";
+            }
+        }
+    }
+
+    if ( $LJ::ONLY_USER_VHOSTS ) {
+        my $rule = $u ? $LJ::SUBDOMAIN_RULES->{$u->journaltype} : undef;
+        $rule ||= $LJ::SUBDOMAIN_RULES->{P};
+
+        # if no rule, then we don't have any idea what to do ...
+        die "Site misconfigured, no %LJ::SUBDOMAIN_RULES."
+            unless $rule && ref $rule eq 'ARRAY';
+
+        if ( $rule->[0] && $user !~ /^\_/ && $user !~ /\_$/ ) {
+            $user =~ s/_/-/g;
+            return "$protocol://$user.$LJ::DOMAIN";
+        } else {
+            return "$protocol://$rule->[1]/$user";
+        }
+    }
+
+    if ($vhost eq "users") {
+        my $he_user = $user;
+        $he_user =~ s/_/-/g;
+        return "$protocol://$he_user.$LJ::USER_DOMAIN";
+    } elsif ($vhost eq "tilde") {
+        return "$LJ::SITEROOT/~$user";
+    } elsif ($vhost eq "community") {
+        return "$LJ::SITEROOT/community/$user";
+    } elsif ($vhost eq "front") {
+        return $LJ::SITEROOT;
+    } elsif ($vhost =~ /^other:(.+)/) {
+        return "$protocol://$1";
+    } else {
+        return "$LJ::SITEROOT/users/$user";
     }
 }
 

--- a/cgi-bin/LJ/User/Styles.pm
+++ b/cgi-bin/LJ/User/Styles.pm
@@ -434,7 +434,7 @@ use Carp;
 sub journal_base {
     my ($user, %opts) = @_;
     my $vhost = $opts{vhost};
-    my $protocol = $LJ::IS_SSL ? "https" : "http";
+    my $protocol = ( $LJ::USE_HTTPS_EVERYWHERE || $LJ::IS_SSL ) ? "https" : "http";
 
     my $u = LJ::isu( $user ) ? $user : LJ::load_user( $user );
     $user = $u->user if $u;


### PR DESCRIPTION
Fixes #1354.

Changes the test condition for when to use https:// in
journal_base in preference to http://, in an extremely naive
fashion; presumably I should in fact be nesting conditions
because we want to preserve LJ::IS_SSL as a test?

Perhaps by analogy to line 35 of https://github.com/dreamwidth/dw-free/blob/29dadd1d2281129247b0e5cc696ea570004c4d0b/cgi-bin/LJ/URI.pm ?