### PR TITLE
fixes for atom-post.t and post.t

### DIFF
--- a/t/atom-post.t
+++ b/t/atom-post.t
@@ -38,6 +38,8 @@ use DW::Routing;
 # so that entries can be posted to community journals
 $LJ::EVERYONE_VALID = 1;
 
+$LJ::USE_SSL = 1 if $LJ::USE_HTTPS_EVERYWHERE && $LJ::SSLROOT;
+
 my $u = temp_user();
 my $pass = "foopass";
 $u->set_password( $pass );
@@ -53,11 +55,12 @@ sub do_request {
     my $remote = delete $opts{remote} || $u;
     my $password = delete $opts{password} || $remote->password;
 
-    $uri =~ m!http://([^.]+)!;
+    $uri =~ m!https?://([^.]+)!;
     my $user_subdomain = $1 eq "www" ? "" : $1;
 
     my %routing_data = ();
     $routing_data{username} = $user_subdomain if $user_subdomain;
+    $routing_data{ssl} = 1 if $LJ::USE_SSL;
 
     my $input = delete $data->{input};
 

--- a/t/post.t
+++ b/t/post.t
@@ -145,8 +145,11 @@ note( "Logged in - init" );
     $u->update_self( { moodthemeid => $customtheme->id } );
     $u = LJ::load_user($u->user, 'force');
 
-    # pick a mood, any mood
-    my $testmoodid = (keys %$moods)[0];
+    # we used to pick a random mood here - whichever moodid was the
+    # first one returned from the keys array - but the test would
+    # fail if we picked a mood that had other moods inherit from it,
+    # so now we pick a mood that is known to be childless
+    my $testmoodid = 105;  # quixotic
     my $err;
     $customtheme->set_picture( $testmoodid, { picurl => "http://example.com/moodpic", width => 10, height => 20 }, \$err );
 


### PR DESCRIPTION
When I enabled $LJ::USE_HTTPS_EVERYWHERE in my test config, atom-post.t started failing dramatically, so I investigated and found a few small changes that needed to be made to the test suite to allow it to function as expected.

Simultaneously but unrelatedly, I started noticing occasional non-deterministic failures in post.t caused by the random selection of a mood to test. I think this wasn't always failing before because the order of the array returned by the keys function is more randomized now than it used to be, starting with Perl 5.18.