### PR TITLE
Fixes #1482. Clarify header options for Heads Up and Core2

### DIFF
--- a/cgi-bin/LJ/S2Theme/headsup.pm
+++ b/cgi-bin/LJ/S2Theme/headsup.pm
@@ -17,9 +17,10 @@ sub header_props {
     my $self = shift;
     my @props = qw(
         image_foreground_header_url
-        int image_foreground_header_height
-        string image_foreground_header_alignment
+        image_foreground_header_height
+        image_foreground_header_width
         image_foreground_header_position
+        string image_foreground_header_alignment
         image_foreground_header_alt
     );
     return $self->_append_props( "header_props", @props );

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -1796,7 +1796,7 @@ property string image_background_header_position {
 }
 # FIXME: This should be grouped, but then it doesn't get a label.
 property int image_background_header_height {
-    des = "The height of your header, in pixels.  Use 0 for default.";
+    des = "The height of your header background image, in pixels. Use 0 for default.";
     example = "50";
     size = 6;
 }

--- a/styles/headsup/layout.s2
+++ b/styles/headsup/layout.s2
@@ -47,33 +47,35 @@ propgroup colors_child {
 propgroup images_child {
 
 property string image_foreground_header_url {
-   des = "The URL to the header image (this style does not automatically resize images)";
+    des = "The URL to the additional header image";
+    note = "This image goes on top of the background one if it exists.";
 }
 
 property int image_foreground_header_height {
-    des = "The height of your header image, in pixels.";
+    des = "The height of your additional header image, in pixels.";
     example = "100";
     size = 6;
 }
 
 property int image_foreground_header_width {
-    des = "The width of your header image, in pixels.";
+    des = "The width of your additional header image, in pixels.";
     example = "600";
     size = 6;
 }
 
+property string image_foreground_header_position {
+    values = "before|above journal header text|after|below journal header text|inline|inline with journal header text";
+    des = "Position of the additional header image";
+    note = "'Inline' may cause text to overlap the header image.";
+}
+
 property string image_foreground_header_alignment {
-    des = "The alignment of the header image in its area.";
+    des = "The alignment of the additional header image in its area.";
     values = "left|left|center|center|right|right";
 }
 
-property string image_foreground_header_position {
-    values = "before|above journal header text|after|below journal header text|inline|inline with journal header text";
-    des = "Position of header image (inline may cause text to overlap the header image)";
-}
-
 property string image_foreground_header_alt {
-    des = "Alt text for your header image, for screen readers.";
+    des = "Alt text for your additional header image, for screen readers.";
     example = "A sunset.";
 }
 
@@ -225,12 +227,14 @@ var string header_background_height;
     }
 
 var string headerimage_area_height;
-    if ($*image_foreground_header_height > 0) {
+    if ($*image_foreground_header_height > 0 and $*image_foreground_header_url != "") {
         $headerimage_area_height = """
             min-height: """ + $*image_foreground_header_height + """px;""";
     }
     var string header_margintop;
-    if ($*image_foreground_header_height > 0 and $*image_foreground_header_position == "inline" ) {
+    if ($*image_foreground_header_height > 0
+        and $*image_foreground_header_position == "inline"
+        and $*image_foreground_header_url != "") {
         $header_margintop = """
             margin-top: -""" + $*image_foreground_header_height + """px;""";
     }


### PR DESCRIPTION
Fixes #1482 
Better property descriptions in Heads Up and Core2
Don't set height if there's no foreground image
Switch option order for better clarity
Sort width option into Header  w/ other options
Move noted to note field
Remove unneeded note (there's no reason to expect pics to be resized)
