### PR TITLE
[#1544] fix package name and site name to allow to display and be pla…

### DIFF
--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -56,7 +56,7 @@ $domaintosite{"pinboard.in"} = DW::External::Site->new("20", "www.pinboard.in", 
 $domaintosite{"fanfiction.net"} = DW::External::Site->new("21", "www.fanfiction.net", "fanfiction.net", "FanFiction", "FanFiction");
 $domaintosite{"pinterest.com"} = DW::External::Site->new("22", "www.pinterest.com", "pinterest.com", "Pinterest", "pinterest");
 $domaintosite{"youtube.com"} = DW::External::Site->new("23", "www.youtube.com", "youtube.com", "YouTube", "yt");
-$domaintosite{"github.com"} = DW::External::Site->new("24", "www.github.com", "github.com", "github", "gh"); 
+$domaintosite{"github.com"} = DW::External::Site->new("24", "www.github.com", "github.com", "GitHub", "gh"); 
 # three-part domain name
 $domaintosite{"lj.rossia.org"} = DW::External::Site->new("25", "lj.rossia.org", "lj.rossia.org", "LJRossia", "lj"); 
 

--- a/cgi-bin/DW/External/Site/GitHub.pm
+++ b/cgi-bin/DW/External/Site/GitHub.pm
@@ -1,8 +1,8 @@
 #!/usr/bin/perl
 #
-# DW::External::Site::github
+# DW::External::Site::GitHub
 #
-# Class to support github user linking.
+# Class to support GitHub user linking.
 #
 # Authors:
 #      Mark Smith <mark@dreamwidth.org>
@@ -16,7 +16,7 @@
 # 'perldoc perlartistic' or 'perldoc perlgpl'.
 #
 
-package DW::External::Site::github;
+package DW::External::Site::GitHub;
 
 use strict;
 use base 'DW::External::Site';


### PR DESCRIPTION
…ced correctly.

The name github changed to GitHub, including the file name, package name, and the service name as defined in DW::External::Site.