### PR TITLE
Fixes #1562

### DIFF
--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -125,7 +125,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
   <tr valign='top'>
     <td align='right'><label for='body'><b>[%- '/talkpost.bml.opt.message' | ml -%]</b></td>
     <td colspan='3' style='width: 90%'>
-      <textarea class='textbox' rows='10' cols='50' wrap='soft' name='body' id='body' style='width: 99%'></textarea>
+      <textarea class='textbox' rows='10' cols='50' wrap='soft' name='body' id='body' style='width: 99%; height: 99%'></textarea>
     </td>
   </tr>
 


### PR DESCRIPTION
Fixes #1562

Adds a percentage height to the quickreply text area that stops it from recalculating itself when the font-size changes. I haven't had a chance to test this against lots of devices but it does not seem to affect existing behaviour and seems to fix the specific problem.