### PR TITLE
Fix max-width of track dialog.

### DIFF
--- a/htdocs/js/jquery.esn.js
+++ b/htdocs/js/jquery.esn.js
@@ -283,7 +283,6 @@ _create: function() {
                     document.location = $ele.attr("href");
                 }
             },
-            maxWidth: "80%",
             width: 500
         });
     });

--- a/htdocs/stc/esn.css
+++ b/htdocs/stc/esn.css
@@ -268,6 +268,10 @@ span.Pages input {
 
 
 /**** ESN AJAX ****/
+.track-dialog {  /* outer div */
+    max-width: 80%;
+}
+
 .trackdialog .track_title, .ippu .track_title {
     font-weight: bold;
     margin: 4px;


### PR DESCRIPTION
jQuery dialog's maxWidth only takes an int as pixels per their docs; I
don't see how percentage would ever have suceeded there.

Fixes: #1333

I haven't yet submitted a CLA but will do so today.