### PR TITLE
change 'Submit' to 'Post Comment' in comment preview

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -3694,7 +3694,7 @@ sub make_preview {
             unless $_ eq 'body' || $_ eq 'subject' || $_ eq 'prop_opt_preformatted' || $_ eq 'editreason';
     }
 
-    $ret .= "<br /><input type='submit' value='$BML::ML{'/talkpost_do.bml.preview.submit'}' />\n";
+    $ret .= "<br /><input type='submit' value='$BML::ML{'/talkpost_do.bml.preview.postcomment'}' />\n";
     $ret .= "<input type='submit' name='submitpreview' value='$BML::ML{'talk.btn.preview'}' />\n";
     $ret .= "<span id='moreoptions-container'></span>\n";
     if ($LJ::SPELLER) {

--- a/htdocs/talkpost_do.bml.text
+++ b/htdocs/talkpost_do.bml.text
@@ -82,7 +82,7 @@
 .preview.unauthenticated_openid=[[openid]] (not yet authenticated)
 .preview.subject=<strong>Subject: </strong>
 
-.preview.submit=Submit
+.preview.postcomment=Post Comment
 
 .preview.title=Preview
 


### PR DESCRIPTION
* replace .preview.submit=Submit in htdocs/talkpost_do.tml.text with .preview.postcomment=Post Comment

* change .preview.submit where it's called in cgi-bin/LJ/Talk.pm to .preview.postcomment to match.

Fixes #1550 