### PR TITLE
1568 consistent username length limit

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1612,3 +1612,5 @@ contentflag.viewingconcepts.byposter
 contentflag.viewingexplicit.bycommunity
 contentflag.viewingexplicit.byjournal
 contentflag.viewingexplicit.byposter
+
+general error.usernamelong

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -843,6 +843,8 @@ error.usernameinvalid=This account name contains invalid characters.
 
 error.usernamelong=This account name is too long.  Account names can't be longer than 25 characters.
 
+error.usernamelong1=This account name is too long. Account names can't be longer than [[maxlength]] characters.
+
 error.username_notfound=This account name wasn't found.
 
 error.vhost.noalias=This user's account type doesn't permit domain aliasing.

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -841,8 +841,6 @@ error.unknownmode=Unknown mode.
 
 error.usernameinvalid=This account name contains invalid characters.
 
-error.usernamelong=This account name is too long.  Account names can't be longer than 25 characters.
-
 error.usernamelong1=This account name is too long. Account names can't be longer than [[maxlength]] characters.
 
 error.username_notfound=This account name wasn't found.

--- a/cgi-bin/DW/Controller/Create.pm
+++ b/cgi-bin/DW/Controller/Create.pm
@@ -290,6 +290,8 @@ sub create_handler {
 
         formdata        => $post,
         errors          => $errors,
+
+        username_maxlength => $LJ::USERNAME_MAXLENGTH,
     };
 
     if ( $code_valid && $rate_ok ) {

--- a/cgi-bin/LJ/CreatePage.pm
+++ b/cgi-bin/LJ/CreatePage.pm
@@ -33,8 +33,9 @@ sub verify_username {
     if ($given_username && !$user) {
         $error = LJ::Lang::ml('error.usernameinvalid');
     }
-    if (length $given_username > 25) {
-        $error = LJ::Lang::ml('error.usernamelong');
+    if (length $given_username > $LJ::USERNAME_MAXLENGTH) {
+        $error = LJ::Lang::ml('error.usernamelong1', 
+            { maxlength => $LJ::USERNAME_MAXLENGTH });
     }
 
     my $u = LJ::load_user($user);

--- a/cgi-bin/LJ/CreatePage.pm
+++ b/cgi-bin/LJ/CreatePage.pm
@@ -33,7 +33,7 @@ sub verify_username {
     if ($given_username && !$user) {
         $error = LJ::Lang::ml('error.usernameinvalid');
     }
-    if (length $given_username > $LJ::USERNAME_MAXLENGTH) {
+    if ( length $given_username > $LJ::USERNAME_MAXLENGTH ) {
         $error = LJ::Lang::ml('error.usernamelong1', 
             { maxlength => $LJ::USERNAME_MAXLENGTH });
     }

--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -360,6 +360,9 @@ no strict "vars";
         /latest
         /edittags
     );
+
+    # maximum length of a username (NB do not change without changing width of database fields to match. And perhaps other stuff.
+    $USERNAME_MAXLENGTH = 25;
 }
 
 

--- a/cgi-bin/LJ/Session.pm
+++ b/cgi-bin/LJ/Session.pm
@@ -950,8 +950,8 @@ sub get_cookie_path {
 
 sub get_path_user {
     my ( $path ) = @_;
-    return unless $path =~ m!^/(\w{1,25})\b!;
-    # FIXME: username length should be a named constant (#1568)
+    my $exp = '^/(\w{1,' . $LJ::USERNAME_MAXLENGTH . '})\b';
+    return unless $path =~ /$exp/;
 
     return lc $1;
 }

--- a/cgi-bin/LJ/Session.pm
+++ b/cgi-bin/LJ/Session.pm
@@ -950,8 +950,7 @@ sub get_cookie_path {
 
 sub get_path_user {
     my ( $path ) = @_;
-    my $exp = '^/(\w{1,' . $LJ::USERNAME_MAXLENGTH . '})\b';
-    return unless $path =~ /$exp/;
+    return unless $path =~ m!^/(\w{1,$LJ::USERNAME_MAXLENGTH})\b!;
 
     return lc $1;
 }

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -1242,7 +1242,7 @@ sub canonical_username {
     my $input = lc( $_[0] );
     my $user = "";
     my $exp = '^\s*([a-z0-9_\-]{1,' . $LJ::USERNAME_MAXLENGTH . '})\s*$';
-    if ( $input =~ /$exp/ ) {  # good username
+    if ( $input =~ m/^\s*([a-z0-9_z\-]{1,$LJ::USERNAME_MAXLENGTH})\s*$/ ) {
         $user = $1;
         $user =~ s/-/_/g;
     }

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -1242,7 +1242,7 @@ sub canonical_username {
     my $input = lc( $_[0] );
     my $user = "";
     my $exp = '^\s*([a-z0-9_\-]{1,' . $LJ::USERNAME_MAXLENGTH . '})\s*$';
-    if ( $input =~ $exp ) {  # good username
+    if ( $input =~ /$exp/ ) {  # good username
         $user = $1;
         $user =~ s/-/_/g;
     }

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -1241,7 +1241,8 @@ use Carp;
 sub canonical_username {
     my $input = lc( $_[0] );
     my $user = "";
-    if ( $input =~ /^\s*([a-z0-9_\-]{1,25})\s*$/ ) {  # good username
+    my $exp = '^\s*([a-z0-9_\-]{1,' . $LJ::USERNAME_MAXLENGTH . '})\s*$';
+    if ( $input =~ $exp ) {  # good username
         $user = $1;
         $user =~ s/-/_/g;
     }

--- a/etc/config.pl
+++ b/etc/config.pl
@@ -684,10 +684,6 @@
         comment_html_auth => 0,      # HTML comments from non-anon commenters?
     );
 
-    # Global constant for the max length of a username. Do not change without
-    # checking for implications re database field lengths, etc. In fact, probably
-    # do not change.
-    $USERNAME_MAXLENGTH = 25;   
 
 }
 

--- a/etc/config.pl
+++ b/etc/config.pl
@@ -683,6 +683,12 @@
         comment_html_anon => 1,      # HTML comments from anon commenters?
         comment_html_auth => 0,      # HTML comments from non-anon commenters?
     );
+
+    # Global constant for the max length of a username. Do not change without
+    # checking for implications re database field lengths, etc. In fact, probably
+    # do not change.
+    $USERNAME_MAXLENGTH = 25;   
+
 }
 
 1;

--- a/htdocs/tools/tellafriend.bml
+++ b/htdocs/tools/tellafriend.bml
@@ -187,8 +187,7 @@ _c?>
             : BML::ml( ".email.subject.entrynosubject", { sitenameshort => $LJ::SITENAMESHORT } );
  }
 
- my $exp = '^\w{1,' . $LJ::USERNAME_MAXLENGTH . '}$';
- if ($GET{'user'} =~ /$exp/) {
+ if ($GET{'user'} =~ /^\w{1,$LJ::USERNAME_MAXLENGTH}$/) {
      my $user = $GET{'user'};
      my $uj = LJ::load_user($user);
      my $url = $uj->journal_base;

--- a/htdocs/tools/tellafriend.bml
+++ b/htdocs/tools/tellafriend.bml
@@ -187,7 +187,8 @@ _c?>
             : BML::ml( ".email.subject.entrynosubject", { sitenameshort => $LJ::SITENAMESHORT } );
  }
 
- if ($GET{'user'} =~ /^\w{1,15}$/) {
+ my $exp = '^\w{1,' . $LJ::USERNAME_MAXLENGTH . '}$';
+ if ($GET{'user'} =~ /$exp/) {
      my $user = $GET{'user'};
      my $uj = LJ::load_user($user);
      my $url = $uj->journal_base;

--- a/htdocs/tools/textmessage.bml
+++ b/htdocs/tools/textmessage.bml
@@ -39,7 +39,7 @@ body<=
     unless ($user) {
         $ret .= "<?h1 $ML{'.enter.user.head'} h1?>".
             "<?p " . BML::ml( '.enter.user.text3', { sitenameshort => $LJ::SITENAMESHORT } ) . " p?>".
-            "<div style='margin-left: 40px'><form method='get' action='textmessage'>$ML{'.enter.user.input'} <input type='text' size='15' maxlength='15' name='user' /> <input type='submit' value=\"$ML{'.enter.user.submit'}\" /></form></div>".
+            "<div style='margin-left: 40px'><form method='get' action='textmessage'>$ML{'.enter.user.input'} <input type='text' size='25' maxlength='25' name='user' /> <input type='submit' value=\"$ML{'.enter.user.submit'}\" /></form></div>".
             "<p>".BML::ml('.setup.text', { aopts => "href='$LJ::SITEROOT/manage/profile/'" })."</p>";
         return add_footer( $ret );
     }

--- a/htdocs/tools/textmessage.bml
+++ b/htdocs/tools/textmessage.bml
@@ -40,6 +40,8 @@ body<=
         $ret .= "<?h1 $ML{'.enter.user.head'} h1?>".
             "<?p " . BML::ml( '.enter.user.text3', { sitenameshort => $LJ::SITENAMESHORT } ) . " p?>".
             "<div style='margin-left: 40px'><form method='get' action='textmessage'>$ML{'.enter.user.input'} <input type='text' size='25' maxlength='25' name='user' /> <input type='submit' value=\"$ML{'.enter.user.submit'}\" /></form></div>".
+            #NB the maxlength of the username text box should be based on
+            #LJ::USERNAME_MAXLENGTH, not hardcoded here.
             "<p>".BML::ml('.setup.text', { aopts => "href='$LJ::SITEROOT/manage/profile/'" })."</p>";
         return add_footer( $ret );
     }

--- a/views/create/account.tt
+++ b/views/create/account.tt
@@ -44,9 +44,10 @@ the same terms as Perl itself.  For a copy of the license, please reference
             name = "user"
             id   = "js-user"
 
-            # maxlength 26, so if people don't notice that they hit the limit,
+            # maxlength is one over the actual max, so if people 
+            # don't notice that they hit the limit,
             # we give them a warning. (some people don't notice/proofread)
-            maxlength = 26
+            maxlength = username_maxlength + 1
 
             "aria-required" = "true"
             class = "journaltype-textbox user-textbox"


### PR DESCRIPTION
Partially fixes bug 1568.
- The specific cases that Karelia mentioned now use $LJ::USERNAME_MAXLENGTH instead of a hardcoded value, except for tools/textmessage where I've just hardcoded the new value - I haven't spent the time to do this one properly because I think this should probably have the code machete applied anyway!
- There are other places where the max length is still hardcoded (although at 25 or greater, so it isn't an immediate problem). There's definitely the login dialog, and possibly also when commenting as a user, when searching for a user, when renaming, and when doing other things that I didn't think of. I have not attacked these because I encountered LJ::Widgets and lost the will to live, so you may want to leave the Issue open in case somebody else wants to investigate.

**NB To push to production, you also need to add a line `$USERNAME_MAXLENGTH = 25;` to config.pl.**
