### PR TITLE
Fixes #1306, adds quickreply to day, recent and network

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2670,6 +2670,15 @@ sub sitescheme_secs_to_iso {
 sub current_box_type {}
 sub curr_page_supports_ebox { 0 }
 
+# Convenience method since it gets checked multiple times
+sub has_quickreply
+{
+    my ($page) = @_;
+    my $view = $page->{view};
+    # Also needs adding to the list in core2.s2
+    return $view eq 'entry' || $view eq 'read' || $view eq 'day' || $view eq 'recent' || $view eq 'network';
+}
+
 
 ###############
 
@@ -3663,7 +3672,7 @@ sub _print_quickreply_link
         $onclick = "onclick='$onclick'";
     }
 
-    $onclick = "" unless $page->{view} eq 'entry' || $page->{view} eq 'read';
+    $onclick = "" unless LJ::S2::has_quickreply($page);
     $onclick = "" unless LJ::is_enabled('s2quickreply');
     $onclick = "" if $page->{'_u'}->does_not_allow_comments_from( $remote );
 
@@ -3675,7 +3684,7 @@ sub _print_reply_container
     my ($ctx, $this, $opts) = @_;
 
     my $page = get_page();
-    return unless $page->{view} eq 'entry' || $page->{view} eq 'read';
+    return unless LJ::S2::has_quickreply($page);
 
     my $target = $opts->{target} || '';
     undef $target unless $target =~ /^[\w-]+$/;
@@ -3692,24 +3701,20 @@ sub _print_reply_container
     $class = $class ? "class=\"$class\"" : "";
 
     $S2::pout->("<div $class id=\"ljqrt$target\" data-quickreply-container=\"$target\" style=\"display: none;\"></div>");
-
     # unless we've already inserted the big qrdiv ugliness, do it.
     unless ($ctx->[S2::SCRATCH]->{'quickreply_printed_div'}++) {
-        if ( $page->{view} eq "entry" || $page->{view} eq "read" ) {
-            my $u = $page->{'_u'};
-            my $ditemid = $page->{'entry'}{'itemid'} || $this->{itemid} || 0;
-
-            my $userpic = LJ::ehtml($page->{'_picture_keyword'}) || "";
-            my $thread = "";
-            $thread = $page->{_viewing_thread_id} + 0
-                if defined $page->{_viewing_thread_id};
-            $S2::pout->( LJ::create_qr_div( $u, $ditemid,
-                    style_opts => $page->{_styleopts},
-                    userpic => $userpic,
-                    thread => $thread,
-                    minimal => $page->{view} eq "read",
-                ) );
-        }
+        my $u = $page->{'_u'};
+        my $ditemid = $page->{'entry'}{'itemid'} || $this->{itemid} || 0;
+        my $userpic = LJ::ehtml($page->{'_picture_keyword'}) || "";
+        my $thread = "";
+        $thread = $page->{_viewing_thread_id} + 0
+            if defined $page->{_viewing_thread_id};
+        $S2::pout->( LJ::create_qr_div( $u, $ditemid,
+                style_opts => $page->{_styleopts},
+                userpic => $userpic,
+                thread => $thread,
+                minimal => $page->{view} ne "entry",
+            ) );
     }
 }
 

--- a/cgi-bin/LJ/S2/DayPage.pm
+++ b/cgi-bin/LJ/S2/DayPage.pm
@@ -33,6 +33,16 @@ sub DayPage
         $p->{'head_content'} .= LJ::robot_meta_tags();
     }
 
+    # load for quick reply
+    LJ::need_res( { group => "jquery" }, qw(
+            js/jquery/jquery.ui.core.js
+            stc/jquery/jquery.ui.core.css
+            js/jquery/jquery.ui.widget.js
+            js/jquery.quickreply.js
+            stc/css/components/quick-reply.css
+            js/jquery.threadexpander.js
+        ) );
+
     # load for ajax cuttag
     LJ::need_res( 'js/cuttag-ajax.js' );
     LJ::need_res( { group => "jquery" }, qw(

--- a/cgi-bin/LJ/S2/RecentPage.pm
+++ b/cgi-bin/LJ/S2/RecentPage.pm
@@ -36,6 +36,16 @@ sub RecentPage
     $p->{filter_name} = "";
     $p->{filter_tags} = 0;
 
+    # load for quick reply
+    LJ::need_res( { group => "jquery" }, qw(
+            js/jquery/jquery.ui.core.js
+            stc/jquery/jquery.ui.core.css
+            js/jquery/jquery.ui.widget.js
+            js/jquery.quickreply.js
+            stc/css/components/quick-reply.css
+            js/jquery.threadexpander.js
+        ) );
+
     # Link to the friends page as a "group", for use with OpenID "Group Membership Protocol"
     {
         my $is_comm = $u->is_community;

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -5545,7 +5545,7 @@ function Entry::print_interaction_links(string target)
         if ($count > 0) {
             "</ul>";
         }
-    } elseif ($p.view == "read") {
+    } elseif ($p.view == "read" or $p.view == "day" or $p.view == "recent" or $p.view == "network") {
         $this.comments->print($this, { "linktext" => $*text_post_comment_friends, "target" => $this.dom_id + "-reply" });
     } else {
         $this.comments->print();


### PR DESCRIPTION
Fixes #1306.

Added a convenience method for checking if a page should have quickreply added, added the needed bits to the s2 core layout. Hopefully that's everything!

Note that I've used minimal everywhere except entry (so existing behaviour is unchanged) as it's styled better for inline replies in lists of entries.

It may well be that we don't need to check which view we're on anymore, but I've taken a cautious approach as it's likely there are scenarios I haven't considered.