### PR TITLE
Use user display name in circle page

### DIFF
--- a/views/circle/individual-edit.tt
+++ b/views/circle/individual-edit.tt
@@ -10,7 +10,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
 
-[%- sections.windowtitle = ".title" | ml( user => u.username ) -%]
+[%- sections.windowtitle = ".title" | ml( user => u.display_name ) -%]
 [%- sections.title = '.title' | ml ( user => u.ljuser_display( head_size = "24x24" ) ) -%]
 [%- CALL dw.active_resource_group( "foundation" ) -%]
 


### PR DESCRIPTION
Use user's display name, rather than their user name, on the page for
editing circle membership.  This isn't the display name according to the
profile page; it means that for Dreamwidth users, their username appears
in the title, but for OpenID users, rather than "ext_{number}"
appearing, their OpenID URL appears.

Fixes #1608.