### PR TITLE
adding .form.subject

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1605,3 +1605,5 @@ general widget.betafeature.s2comments.title
 general widget.betafeature.updatepage.off
 general widget.betafeature.updatepage.on
 general widget.betafeature.updatepage.title
+
+general /mobile/post.bml.form.subject


### PR DESCRIPTION
getting rid of the extra colon on the mobile post page, now with more translation. 