### PR TITLE
Fix bogus rejections of OpenID comments.

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -3040,9 +3040,10 @@ sub init {
                 ### see if the user is banned from posting here
                 $mlerr->("$SC.error.banned$iscomm") if $journalu->has_banned( $up );
 
-                # TEMP until we have better openid support
-                if ($up->is_identity && $journalu->{'opt_whocanreply'} eq "reg") {
-                    $mlerr->("$SC.error.noopenid");
+                # Reject OpenIDs that are neither validated nor granted access by the user
+                if ($up->is_identity && $journalu->{'opt_whocanreply'} eq "reg"
+                        && ! ( $up->is_validated || $journalu->trusts( $remote ) ) ) {
+                    $mlerr->("$SC.error.noopenidpost", { aopts1 => "href='$LJ::SITEROOT/changeemail'", aopts2 => "href='$LJ::SITEROOT/register'" })
                 }
 
                 unless ( $up->is_person || ( $up->is_identity && $cookie_auth ) ) {

--- a/htdocs/talkpost_do.bml.text
+++ b/htdocs/talkpost_do.bml.text
@@ -39,6 +39,8 @@
 
 .error.noopenid=OpenID users aren't authorized to reply to this entry.
 
+.error.noopenidpost=You must <a [[aopts1]]>set</a> and <a [[aopts2]]>confirm</a> your email address before you can comment.
+
 .error.noparent=Cannot reply to a non-existent comment.
 
 .error.notafriend=You aren't on [[user]]'s Access List; only members of [[user]]'s Access List can reply to entries in this journal.


### PR DESCRIPTION
This makes a difference from the reading page (with a theme with
non-broken quick reply support) and from the entry page without a
verified email; see issue for details.

Fixes: #1577 - see copious details and tables of cases on that issue.