### PR TITLE
Fixes #1387, disambiguates the warning strings by journal type.

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1605,3 +1605,10 @@ general widget.betafeature.s2comments.title
 general widget.betafeature.updatepage.off
 general widget.betafeature.updatepage.on
 general widget.betafeature.updatepage.title
+
+contentflag.viewingconcepts.bycommunity
+contentflag.viewingconcepts.byjournal
+contentflag.viewingconcepts.byposter
+contentflag.viewingexplicit.bycommunity
+contentflag.viewingexplicit.byjournal
+contentflag.viewingexplicit.byposter

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -55,17 +55,25 @@ collapsible.expanded=Collapse
 
 comment.rpc.posted=Your comment has been posted.
 
-contentflag.viewingconcepts.bycommunity=You are about to view content that a community administrator has advised should be viewed with discretion.
+contentflag.viewingconcepts.bycommunity.community=You're about to view content that a community administrator has advised should be viewed with discretion.
 
-contentflag.viewingconcepts.byjournal=You're about to view content which the journal owner has advised should be viewed with discretion.
+contentflag.viewingconcepts.byjournal.community=You're about to view content that a community administrator has advised should be viewed with discretion.
 
-contentflag.viewingconcepts.byposter=You're about to view content which the poster has advised should be viewed with discretion.
+contentflag.viewingconcepts.byposter.community=You're about to view content that the poster has advised should be viewed with discretion.
 
-contentflag.viewingexplicit.bycommunity=You're about to view content that a community administrator has marked as possibly inappropriate for anyone under the age of 18.
+contentflag.viewingconcepts.byjournal.personal=You're about to view content that the journal owner has advised should be viewed with discretion.
 
-contentflag.viewingexplicit.byjournal=You're about to view content that a community administrator has marked as possibly inappropriate for anyone under the age of 18.
+contentflag.viewingconcepts.byposter.personal=You're about to view content that the journal owner has advised should be viewed with discretion.
 
-contentflag.viewingexplicit.byposter=You're about to view content that the poster has marked as potentially inappropriate for anyone under the age of 18.
+contentflag.viewingexplicit.bycommunity.community=You're about to view content that a community administrator has marked as possibly inappropriate for anyone under the age of 18.
+
+contentflag.viewingexplicit.byjournal.community=You're about to view content that a community administrator has marked as possibly inappropriate for anyone under the age of 18.
+
+contentflag.viewingexplicit.byposter.community=You're about to view content that the poster has marked as potentially inappropriate for anyone under the age of 18.
+
+contentflag.viewingexplicit.byjournal.personal=You're about to view content that the journal owner has marked as possibly inappropriate for anyone under the age of 18.
+
+contentflag.viewingexplicit.byposter.personal=You're about to view content that the journal owner has marked as possibly inappropriate for anyone under the age of 18.
 
 cprod.directory.text3.v1=Your account level doesn't give you access to the directory.
 

--- a/cgi-bin/DW/Logic/AdultContent.pm
+++ b/cgi-bin/DW/Logic/AdultContent.pm
@@ -64,12 +64,18 @@ sub adult_interstitial_link {
 
     my $entry = $opts{entry};
     my $type = $opts{type};
+    my $journal = $opts{journal};
     return '' unless $entry && $type;
 
     my $url = $entry->url;
     my $msg;
 
     my $markedby = $entry->adult_content_marker;
+    if ( $journal->is_community ) {
+        $markedby .= '.community';
+    } else {
+        $markedby .= '.personal';
+    }
 
     if ( $type eq 'explicit' ) {
         $msg = LJ::Lang::ml( 'contentflag.viewingexplicit.by' . $markedby );


### PR DESCRIPTION
Fixes #1387.

While some of the strings are the same, it means that we can separate them further if needed (as per some of the discussion on #1387). 

Also I may have made some grammar consistency tweaks due to copy-pasta ('You're' vs 'You are' and 'that' vs 'which').