### PR TITLE
[#1628] check for userids, not IP addresses

### DIFF
--- a/cgi-bin/DW/Controller/Admin/SpamReports.pm
+++ b/cgi-bin/DW/Controller/Admin/SpamReports.pm
@@ -186,14 +186,14 @@ sub main_controller {
         foreach ( sort { $b <=> $a } keys %revhits ) {
             my $r = $revhits{$_};
             foreach ( @$r ) {
-                if ( /\./ ) {  # ip report
-                    push @rows, [ $hits{$_}, $_,
-                                  $viewlink->( 'ip', $_, 'open', $times{$_} )
-                                ];
-                } else {  # user report
+                if ( /^\d+$/ ) {  # userid
                     my $u = LJ::load_userid( $_ );
                     push @rows, [ $hits{$_}, LJ::ljuser($u),
                                   $viewlink->( 'posterid', $_, 'open', $times{$_} )
+                                ];
+                } else {  # assumed to be IP address
+                    push @rows, [ $hits{$_}, $_,
+                                  $viewlink->( 'ip', $_, 'open', $times{$_} )
                                 ];
                 }
             }


### PR DESCRIPTION
This changes the conditional for deciding whether an antispam report
is for a user or an IP address.  The old regexp only looked for
the existence of a period, which worked for IPv4 but not IPv6.

Since userids are only digits, use a regexp that checks for those
instead and assume anything else should be treated as an IP address.

Fixes #1628.