### PR TITLE
[#1368] more detailed explanation of options when renaming an account

### DIFF
--- a/cgi-bin/DW/Controller/Rename.pm
+++ b/cgi-bin/DW/Controller/Rename.pm
@@ -113,6 +113,7 @@ sub rename_handler {
             $vars->{formdata} = {
                 authas      => $authas,
                 journaltype => $get_args->{type},
+                journalname => $get_args->{type} eq "P" ? $remote->user : "communityname",
                 journalurl  => $get_args->{type} eq "P" ? $remote->journal_base : LJ::journal_base( "communityname", vhost => "community" ),
                 pageurl     => "/rename?giventoken=" . $token->token,
                 token       => $token->token,

--- a/views/rename.tt
+++ b/views/rename.tt
@@ -53,10 +53,10 @@ the same terms as Perl itself.  For a copy of the license, please reference
             <div class="formfield">
                 <fieldset>
                 <legend>[%- '.form.rename.oldusername.header.' _ form.data.journaltype | ml -%]</legend>
-                <input type="radio" name="redirect" value="forward" id="redirect_forward" [% 'checked="checked"' IF form.data.redirect == "forward" %]/><label for="redirect_forward">[%- '.form.rename.forward.label.' _ form.data.journaltype | ml %]</label>
-                <p class='detail'>[%- '.form.rename.forward.note.' _ form.data.journaltype | ml( journalurl = form.data.journalurl ) %]</p>
-                <input type="radio" name="redirect" value="disconnect" id="redirect_disconnect" [% 'checked="checked"' IF form.data.redirect == 'disconnect' %]/><label for="redirect_disconnect">[%- '.form.rename.disconnect.label.' _ form.data.journaltype | ml %]</label>
-                <p class='detail'>[%- '.form.rename.disconnect.note.' _ form.data.journaltype | ml( journalurl = form.data.journalurl ) %]</p>
+                <input type="radio" name="redirect" value="forward" id="redirect_forward" [% 'checked="checked"' IF form.data.redirect == "forward" %]/><em><label for="redirect_forward">[%- '.form.rename.forward.label.' _ form.data.journaltype | ml %]</label></em>
+                <p class='detail'>[%- '.form.rename.forward.note2.' _ form.data.journaltype | ml( journalurl = form.data.journalurl, journalname = form.data.journalname ) %]</p>
+                <input type="radio" name="redirect" value="disconnect" id="redirect_disconnect" [% 'checked="checked"' IF form.data.redirect == 'disconnect' %]/><em><label for="redirect_disconnect">[%- '.form.rename.disconnect.label.' _ form.data.journaltype | ml %]</label></em>
+                <p class='detail'>[%- '.form.rename.disconnect.note2.' _ form.data.journaltype | ml( journalurl = form.data.journalurl, journalname = form.data.journalname ) %]</p>
                 </fieldset>
             </div>
         </fieldset>

--- a/views/rename.tt.text
+++ b/views/rename.tt.text
@@ -43,17 +43,17 @@
 
 .form.rename.disconnect.label.p=Disconnect your old username from your new username, leaving the old username free to use
 
-.form.rename.disconnect.note.c=[[journalurl]] will not point to the new username.
+.form.rename.disconnect.note2.c=[[journalurl]] will not point to the new username, and URLs that link to the old username will no longer work.  If you choose this option, [[journalname]] will eventually become available to be used again.
 
-.form.rename.disconnect.note.p=[[journalurl]] will not point to your new username; comments and community entries that you posted will still show your new username.
+.form.rename.disconnect.note2.p=[[journalurl]] will not point to your new username; comments and community entries that you posted with your old username will update to show your new username, but URLs that link to your old username will no longer work.  If you choose this option, [[journalname]] will eventually become available to be used again.
 
 .form.rename.forward.label.c=Forward your community's old username to the new username
 
 .form.rename.forward.label.p=Forward your old username to your new username
 
-.form.rename.forward.note.c=[[journalurl]] will automatically redirect to your community's new username.
+.form.rename.forward.note2.c=[[journalurl]] will automatically redirect to your community's new username, so that URLs that link to the community's old username will continue to work. If you choose this option, [[journalname]] will not become available for you or anyone else to register again in the future, and <strong>no one</strong> (including you) will be able to rename another account to [[journalname]].
 
-.form.rename.forward.note.p=[[journalurl]] will automatically redirect to your new username.
+.form.rename.forward.note2.p=[[journalurl]] will automatically redirect to your new username, so that URLs that link to your old username will continue to work. If you choose this option, [[journalname]] will not become available for you or anyone else to register again in the future, and <strong>no one</strong> (including you) will be able to rename another account to [[journalname]].
 
 .form.rename.fromuser.label=Rename from
 


### PR DESCRIPTION
Thought about adding an interstitial page or pop-up, but this was easiest.

Fixes #1368.