### PR TITLE
More detailed subject on Success landing page

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1038,7 +1038,7 @@ sub _do_post {
         my $extradata = {
             security => $form_req->{security},
             security_ml => "",
-            subject => LJ::ehtml( $form_req->{subject} ),
+            subject => $form_req->{subject},
         };
         if ( $extradata->{security} eq "usemask" ) {
             if ( $form_req -> {allowmask} == 1 ) {

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -484,7 +484,11 @@ _c?>
                         $$body .=" p?><?p $ML{'.extradata.sec.public'}";
                     }
                 
-                    $$body .=" p?><?p " . BML::ml('.extradata.subject', { subject =>LJ::ehtml( $req{"subject"} ) });
+                    if ( length($req{"subject"}) > 0 ) {
+                        $$body .=" p?><?p " . $ML{'.extradata.subj'} . LJ::ehtml( $req{"subject"} );
+                    } else {
+                        $$body .=" p?><?p " . $ML{'.extradata.subj'} . $ML{'.extradata.subject.no_subject'};
+                    }
 
                     my $backdatedlink = '';
                     if ( $POST{prop_opt_backdated} or $GET{prop_opt_backdated} ) {

--- a/htdocs/update.bml.text
+++ b/htdocs/update.bml.text
@@ -147,5 +147,6 @@
 
 .extradata.sec.custom=The entry was posted with custom access.
 
-.extradata.subject=The entry was posted with the following subject: [[subject]]
+.extradata.subj=The entry was posted with the following subject: 
 
+.extradata.subject.no_subject=(no subject)

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -24,8 +24,14 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- END -%]
 
 [%- IF poststatus.ml_string != ".edit.delete" -%]
+
 <p>[% extradata.security_ml | ml %]</p>
-<p>[% ".extradata.subject" | ml( subject => extradata.subject) %]</p>
+<p>[% ".extradata.subj" | ml %]
+    [% IF extradata.subject.length > 0 %]
+        [% extradata.subject | html %]
+    [% ELSE %]
+        [% ".extradata.subject.no_subject" | ml %]
+    [% END %]</p>
 [%- END -%]
 
 [%- IF warnings.exist -%]

--- a/views/entry/success.tt.text
+++ b/views/entry/success.tt.text
@@ -48,4 +48,6 @@
 
 .extradata.sec.custom=The entry was posted with custom access.
 
-.extradata.subject=The entry was posted with the following subject: [[subject]]
+.extradata.subj=The entry was posted with the following subject: 
+
+.extradata.subject.no_subject=(no subject)


### PR DESCRIPTION
Adds "(no subject)" to extradata line for subject if entry
has no subject, instead of leaving blank.