### PR TITLE
clean and display subject instead of escaping all HTML

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1040,10 +1040,14 @@ sub _do_post {
                 ditemid => $ditemid,
         );
 
+        # use the HTML cleaner on the entry subject if one exists
+        my $subject = $form_req->{subject};
+        LJ::CleanHTML::clean_subject( \$subject ) if $subject;
+
         my $extradata = {
             security => $form_req->{security},
             security_ml => "",
-            subject => $form_req->{subject},
+            subject => $subject,
         };
         if ( $extradata->{security} eq "usemask" ) {
             if ( $form_req -> {allowmask} == 1 ) {

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1181,10 +1181,14 @@ sub _do_edit {
         editurl => $edit_url,
     );
 
+    # use the HTML cleaner on the entry subject if one exists
+    my $subject = $form_req->{subject};
+    LJ::CleanHTML::clean_subject( \$subject ) if $subject;
+
     my $extradata = {
         security => $form_req->{security},
         security_ml => "",
-        subject => LJ::ehtml( $form_req->{subject} ),
+        subject => $subject,
     };
     if ( $extradata->{security} eq "usemask" ) {
         if ( $form_req -> {allowmask} == 1 ) {

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -363,7 +363,18 @@ body<=
                         $result .="<p>$ML{'.extradata.sec.public'}</p>";
                     }
 
-                    $result .="<?p " . BML::ml('.extradata.subject', { subject => LJ::ehtml( $req{"subject"} ) }) . " p?>";
+                    my $subject = $req{subject};
+
+                    if ( length $subject > 0 ) {
+                        # use the HTML cleaner on the entry subject,
+                        # then display it without escaping
+                        LJ::CleanHTML::clean_subject( \$subject );
+                     } else {
+                        # display (no subject) if subject is empty
+                        $subject = $ML{'.extradata.subj.no_subject'};
+                     }
+
+                    $result .= "<?p " . $ML{'.extradata.subj'} . " $subject p?>";
                 }
 
                 $result .= "<div id='fromhere'>$ML{'.success.fromhere'}<ul>";

--- a/htdocs/editjournal.bml.text
+++ b/htdocs/editjournal.bml.text
@@ -13,6 +13,16 @@
 
 .error.nofind=Could not find selected journal entry.
 
+.extradata.sec.access=The entry was posted with circle access.
+
+.extradata.sec.custom=The entry was posted with custom access.
+
+.extradata.sec.private=The entry was posted privately.
+
+.extradata.sec.public=The entry was posted publicly.
+
+.extradata.subject=The entry was posted with the following subject: [[subject]]
+
 .in=In community:
 
 .invalid_encoding=This entry may contain unknown characters, which have been replaced with a "?". Please ensure the entry is exactly as intended before posting.
@@ -57,14 +67,3 @@
 .title=Edit Entries
 
 .viewwhat=View Which Entries:
-
-.extradata.sec.public=The entry was posted publicly.
-
-.extradata.sec.access=The entry was posted with circle access.
-
-.extradata.sec.private=The entry was posted privately.
-
-.extradata.sec.custom=The entry was posted with custom access.
-
-.extradata.subject=The entry was posted with the following subject: [[subject]]
-

--- a/htdocs/editjournal.bml.text
+++ b/htdocs/editjournal.bml.text
@@ -21,7 +21,9 @@
 
 .extradata.sec.public=The entry was posted publicly.
 
-.extradata.subject=The entry was posted with the following subject: [[subject]]
+.extradata.subj=The entry was posted with the following subject:
+
+.extradata.subj.no_subject=(no subject)
 
 .in=In community:
 

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -469,7 +469,7 @@ _c?>
 
                     my @after_entry_post_extra_options = LJ::Hooks::run_hooks('after_entry_post_extra_options', user => $ju, itemlink => $itemlink);
                     my $after_entry_post_extra_options = join('', map {$_->[0]} @after_entry_post_extra_options) || '';
-                    
+
                     if ($req{"security"} eq "private") {
                         $$body .=" p?><?p $ML{'.extradata.sec.private'}";
                     } elsif ($req{"security"} eq "usemask") {
@@ -483,9 +483,14 @@ _c?>
                     } else {
                         $$body .=" p?><?p $ML{'.extradata.sec.public'}";
                     }
-                
-                    if ( length($req{"subject"}) > 0 ) {
-                        $$body .=" p?><?p " . $ML{'.extradata.subj'} . LJ::ehtml( $req{"subject"} );
+
+                    my $subject = $req{subject};
+
+                    if ( length $subject > 0 ) {
+                        # use the HTML cleaner on the entry subject,
+                        # then display it without escaping
+                        LJ::CleanHTML::clean_subject( \$subject );
+                        $$body .=" p?><?p " . $ML{'.extradata.subj'} . $subject;
                     } else {
                         $$body .=" p?><?p " . $ML{'.extradata.subj'} . $ML{'.extradata.subject.no_subject'};
                     }

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -28,7 +28,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <p>[% extradata.security_ml | ml %]</p>
 <p>[% ".extradata.subj" | ml %]
     [% IF extradata.subject.length > 0 %]
-        [% extradata.subject | html %]
+        [%# cleaned subject should render HTML #%]
+        [% extradata.subject %]
     [% ELSE %]
         [% ".extradata.subject.no_subject" | ml %]
     [% END %]</p>


### PR DESCRIPTION
Fixes #1656 for both legacy and beta update success pages, in both post and edit mode.