### PR TITLE
Human-friendly messages about closed spam reports

### DIFF
--- a/cgi-bin/DW/Controller/Admin/SpamReports.pm
+++ b/cgi-bin/DW/Controller/Admin/SpamReports.pm
@@ -323,7 +323,7 @@ sub main_controller {
         return error_ml( "$scope.error.db.failure", { dberr => $dbh->errstr } )
             if $dbh->err;
 
-        $rv->{count} = $count;
+        $rv->{count} = $count + 0;
         $rv->{ret} = $post->{ret};  # already escaped
 
         return DW::Template->render_template( 'admin/spamreports/closed.tt', $rv );


### PR DESCRIPTION
If you're attempting to close a spam report that someone else has
already closed you now get the human-friendly error message
"Reports were already closed" rather than "Closed 0E0 reports".

Fixes #1560.

(And now I know a little more about how anti-spam works, hurrah!)