### PR TITLE
replace deprecated dwscoalition.org with dreamwidth.[net/org] #1620 

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -15,7 +15,7 @@ use Module::Build;
 # Requirements
 # See bin/checkconfig.pl
 # as explained in:
-# http://wiki.dwscoalition.org/notes/Dreamwidth_Scratch_Installation#Make_sure_things_are_working_with_checkconfig.pl
+# http://wiki.dreamwidth.net/notes/Dreamwidth_Scratch_Installation#Make_sure_things_are_working_with_checkconfig.pl
 
 # Setting Up
 # Run this script to generate the Build script:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ rolling along:
 This will check out the various repositories that we use and put them in the
 appropriate place.
 
-Please [see our wiki for more information](http://wiki.dwscoalition.org/).
+Please [see our wiki for more information](http://wiki.dreamwidth.net/).
 
 Thanks!

--- a/bin/bootstrap.pl
+++ b/bin/bootstrap.pl
@@ -96,4 +96,4 @@ sub configure_dw_upstream {
 
 # finished :-)
 say "Done! You probably want to set up the MySQL database next:";
-say "http://wiki.dwscoalition.org/notes/Dreamwidth_Scratch_Installation#Database_setup";
+say "http://wiki.dreamwidth.net/notes/Dreamwidth_Scratch_Installation#Database_setup";

--- a/bin/dev/newtheme.pl
+++ b/bin/dev/newtheme.pl
@@ -218,6 +218,6 @@ if ( @images ) {
     }
 print "Theme also needs a preview screenshot. Resize to 150x114px and put in:\n";
 print "$ENV{LJHOME}/htdocs/img/customize/previews/$layout_name/$theme_name.png\n\n";
-print "(for additional reference on cleaning themes, see http://wiki.dwscoalition.org/notes/Newbie_Guide_for_People_Patching_Styles#Adding_a_New_Color_Theme )\n";
+print "(for additional reference on cleaning themes, see http://wiki.dreamwidth.net/notes/Newbie_Guide_for_People_Patching_Styles#Adding_a_New_Color_Theme )\n";
 
 

--- a/bin/worker-manager
+++ b/bin/worker-manager
@@ -2,7 +2,7 @@
 #
 # Dreamwidth worker manager
 #
-# Written by Mark Smith <mark@dwscoalition.org>.
+# Written by Mark Smith <mark@dreamwidth.org>.
 #
 # This maintains a group of workers for ESN and the like.  It can manage any
 # process that can be run and needs to be restarted if it dies.  Configuration

--- a/htdocs/site/opensource.bml.text
+++ b/htdocs/site/opensource.bml.text
@@ -9,7 +9,7 @@
 
 .development.header=Development
 
-.development.main2=Information about installing and maintaining a Dreamwidth-powered site can be found at <a href="http://wiki.dwscoalition.org">the Dreamwidth Wiki</a>. If you'd like to submit a patch to us, or see a list of the bugs available for someone to work on, check out our <a href="http://github.com/dreamwidth/dw-free">GitHub repository</a>.
+.development.main2=Information about installing and maintaining a Dreamwidth-powered site can be found at <a href="http://wiki.dreamwidth.net">the Dreamwidth Wiki</a>. If you'd like to submit a patch to us, or see a list of the bugs available for someone to work on, check out our <a href="http://github.com/dreamwidth/dw-free">GitHub repository</a>.
 
 .licensing.header=Licensing Information:
 

--- a/htdocs/support/see_request.bml.text
+++ b/htdocs/support/see_request.bml.text
@@ -68,7 +68,7 @@
 
 <?p [[sitenameshort]] Support is an open-source project run by a community of volunteers. If you think you know the answer to this question, you're welcome to submit an answer in the box below. Your answer will be screened and evaluated by senior support volunteers for content. If your answer is first and correct, it will be sent to the person who submitted the question. p?>
 
-<?p If you have questions about Support, please read the <a href="http://wiki.dwscoalition.org/notes/Category:Support">Support Wiki category</a> for more information. p?>
+<?p If you have questions about Support, please read the <a href="http://wiki.dreamwidth.net/notes/Category:Support">Support Wiki category</a> for more information. p?>
 
 <?p Thank you! p?>
 .

--- a/t/clean-event.t
+++ b/t/clean-event.t
@@ -4,7 +4,7 @@
 #
 # Authors:
 #      Afuna <coder.dw@afunamatata.com>
-#      Mark Smith <mark@dwscoalition.org>
+#      Mark Smith <mark@dreamwidth.org>
 #      Allen Petersen <allen@suberic.net>
 #
 # Copyright (c) 2013 by Dreamwidth Studios, LLC.

--- a/t/emailpost.t
+++ b/t/emailpost.t
@@ -4,7 +4,7 @@
 #
 # Authors:
 #      Afuna <coder.dw@afunamatata.com>
-#      Mark Smith <mark@dwscoalition.org>
+#      Mark Smith <mark@dreamwidth.org>
 #
 # Copyright (c) 2013 by Dreamwidth Studios, LLC.
 #


### PR DESCRIPTION
- searched entire develop branch for dwscoalition.org
- one commit replaces wiki.dwscoalition.org with wiki.dreamwidth.net
- the latter commit replaces Mark's dwscoalition.org email with dreamwidth.org as requested in issue #102 in dw-nonfree https://github.com/dreamwidth/dw-nonfree/issues/102
- checked my work for spelling errors
- did another query for denise but could not find deprecated url in the** latest release branch** or the develop branch.