### PR TITLE
Remove duplicate "about" from Support views

### DIFF
--- a/htdocs/support/act.bml
+++ b/htdocs/support/act.bml
@@ -81,7 +81,7 @@ body<=
      # textarea for their message body
      $ret .= '<tr valign="top"><td align="right">' . $ML{'.message'} . '</td><td colspan="2">';
      $ret .= '<textarea rows="10" cols="50" name="body"></textarea><br />';
-     $ret .= "\n<?de $ML{'.no.html.allowed'} de?><br />\n";
+     $ret .= "\n<?de $ML{'.no.html.allowed2'} de?><br />\n";
      $ret .= '<input type="submit" name="submitpost" value="'. $ML{'.postbutton'} . '" />';
      $ret .= "\n</td></tr></table></form>";
 

--- a/htdocs/support/act.bml.text
+++ b/htdocs/support/act.bml.text
@@ -25,7 +25,7 @@
 
 .more.info=More Information:
 
-.no.html.allowed=No HTML is allowed.  Don't worry about about escaping &lt; and &gt;<br />URLs are automatically link-ified, so just reference those.
+.no.html.allowed2=No HTML is allowed.  Don't worry about escaping &lt; and &gt;<br />URLs are automatically link-ified, so just reference those.
 
 .not.allowed.request=You aren't allowed to lock this request.
 

--- a/htdocs/support/see_request.bml.text
+++ b/htdocs/support/see_request.bml.text
@@ -89,7 +89,7 @@
 
 .no=No
 
-.no.html.allowed=There's no HTML allowed, so don't worry about about escaping &lt; and &gt;<br />URLs are automatically link-ified, so just reference those.
+.no.html.allowed2=There's no HTML allowed, so don't worry about escaping &lt; and &gt;<br />URLs are automatically link-ified, so just reference those.
 
 .none=None
 

--- a/views/support/request/form.tt
+++ b/views/support/request/form.tt
@@ -78,7 +78,7 @@ END -%]
 -%]
 </li>
 <li>
-<p style='padding-left: 12em'>[%- '.no.html.allowed' | ml -%]</p></li>
+<p style='padding-left: 12em'>[%- '.no.html.allowed2' | ml -%]</p></li>
 </ul>
 </fieldset>
 


### PR DESCRIPTION
Explanations about what happens to HTML entered in Support requests
does not need to have "about" repeated. This removes it from TT and
replaces all BML strings, just in case.