### PR TITLE
Fixes #1671. Needs max and interval set at time of creation

### DIFF
--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -548,6 +548,8 @@ var postForm = (function($) {
         $("#js-entrytime-time").pickatime({
             editable: true,
             format: "HH:i",
+            interval: 1,
+            max: 1439,
 
             trigger: document.getElementById("js-entrytime-time-button"),
             container: '.displaydate-component .picker-output'


### PR DESCRIPTION
Does not stop interval working correctly when selecting time through menu

(Fixes #1671 - adding this everywhere because I can never remember where it needs to actually be)