### PR TITLE
There is only one United Kingdom

### DIFF
--- a/cgi-bin/LJ/Widget/Location.pm
+++ b/cgi-bin/LJ/Widget/Location.pm
@@ -265,6 +265,7 @@ sub country_options {
     my %countries;
     # load country codes
     DW::Countries->load( \%countries );
+    delete $countries{UK};
 
     my $options = ['' => $class->ml('widget.location.country.choose'), 'US' => 'United States',
                    map { $_, $countries{$_} } sort { $countries{$a} cmp $countries{$b} } keys %countries];

--- a/cgi-bin/LJ/Widget/Location.pm
+++ b/cgi-bin/LJ/Widget/Location.pm
@@ -265,7 +265,9 @@ sub country_options {
     my %countries;
     # load country codes
     DW::Countries->load( \%countries );
-    delete $countries{UK};
+    delete $countries{UK}; # we need to include UK in the hash for legacy reasons -- some users still have
+                           # their country set as UK -- but UK is mapped to GB, so there's no need to confuse
+                           # users by offering them expansions of both "UK" and "GB" in the drop-down.
 
     my $options = ['' => $class->ml('widget.location.country.choose'), 'US' => 'United States',
                    map { $_, $countries{$_} } sort { $countries{$a} cmp $countries{$b} } keys %countries];


### PR DESCRIPTION
Fixes #1623.

We don't need to offer users two United Kingdoms for location. The
superfluous one is removed from the presented list of options. (I...
*think* it's the correct one I'm removing, at any time.)