### PR TITLE
Fixes #1626 by storing the different plural phrases on the comment link

### DIFF
--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -119,8 +119,20 @@ jQuery(document).ready(function($) {
 
                                     $readLink
                                         .ajaxtip() // init
-                                        .ajaxtip("success", data.message) // success message
-                                        .text($readLink.text().replace(/\d+/, data.count)) // replace count
+                                        .ajaxtip("success", data.message); // success message
+
+                                    var commentText = '';
+                                    if ( data.count == 1 ) {
+                                        commentText = $readLink.data('sing');
+                                    }
+                                    else if ( data.count == 2 ) {
+                                        commentText = $readLink.data('dual');
+                                    }
+                                    else {
+                                        commentText = $readLink.data('plur').replace(/\d+/, data.count);
+                                    }
+
+                                    $readLink.text(commentText); // replace count
                                 });
 
                         }

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -6120,11 +6120,14 @@ function CommentInfo::print_readlink {
     var string text_screened = get_plural_phrase($.screened_count, "text_read_comments_screened");
     var string text_both = $text_visible + $*text_default_separator + $text_screened;
     var string text_total = get_plural_phrase($.count, $p.view == "read" ? "text_read_comments_friends" : "text_read_comments");
+    var string text_sing = get_plural_phrase(1, $p.view == "read" ? "text_read_comments_friends" : "text_read_comments");
+    var string text_dual = get_plural_phrase(2, $p.view == "read" ? "text_read_comments_friends" : "text_read_comments");
+    var string text_plur = get_plural_phrase(3, $p.view == "read" ? "text_read_comments_friends" : "text_read_comments");
 
     if ($.screened) { # show visible count and screened count
-        print safe """<a href="$.read_url#comments">"""+ $text_both + """</a>""";
+        print safe """<a href="$.read_url#comments" data-sing="$text_sing" data-dual="$text_dual" data-plur="$text_plur">"""+ $text_both + """</a>""";
     } else {
-        print safe """<a href="$.read_url#comments">"""+ $text_total + """</a>""";
+        print safe """<a href="$.read_url#comments" data-sing="$text_sing" data-dual="$text_dual" data-plur="$text_plur">"""+ $text_total + """</a>""";
     }
 }
 

--- a/styles/database/layout.s2
+++ b/styles/database/layout.s2
@@ -472,10 +472,13 @@ function CommentInfo::print_readlink {
     var string text_screened = get_plural_phrase($.screened_count, "text_read_comments_screened");
     var string text_both = $text_visible + $*text_default_separator + $text_screened;
     var string text_total = get_plural_phrase($.count, $p.view == "read" ? "text_read_comments_friends" : "text_read_comments");
+    var string text_sing = get_plural_phrase(1, $p.view == "read" ? "text_read_comments_friends" : "text_read_comments");
+    var string text_dual = get_plural_phrase(2, $p.view == "read" ? "text_read_comments_friends" : "text_read_comments");
+    var string text_plur = get_plural_phrase(3, $p.view == "read" ? "text_read_comments_friends" : "text_read_comments");
 
     if ($.screened) {
         if ($*entry_interaction_links == "text") {
-            print safe """<a href="$.read_url#comments">"""+ $text_visible + $*text_default_separator + $text_screened + """</a>""";
+            print safe """<a href="$.read_url#comments" data-sing="$text_sing" data-dual="$text_dual" data-plur="$text_plur">"""+ $text_visible + $*text_default_separator + $text_screened + """</a>""";
         } else {
             print safe """<a href="$.read_url#comments" alt="$text_both" title="$text_both">$.count <img src="$*image_comments" />"""
                 + """ + $.screened_count <img src="$*image_screen" />"""
@@ -483,7 +486,7 @@ function CommentInfo::print_readlink {
         }
     } else {
         if ($*entry_interaction_links == "text") {
-            print safe """<a href="$.read_url#comments">"""+ $text_total + """</a>""";
+            print safe """<a href="$.read_url#comments" data-sing="$text_sing" data-dual="$text_dual" data-plur="$text_plur">"""+ $text_total + """</a>""";
         } else {
             print safe """<a href="$.read_url#comments" alt="$text_total" title="$text_total">$.count <img src="$*image_comments" /></a>""";
         }


### PR DESCRIPTION
Fixes #1626 

Both core and database use print_readlink, thus changes to both S2 styles.

I would have liked to have use get_plural_phrase() in DW::Controller::RPC::Misc::addcomment_handler - but I couldn't figure that one out, so it seemed easiest to just store the plural phrases on the link.