### PR TITLE
Fixes #1651 - show hidden readlink on all pages

### DIFF
--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -718,6 +718,7 @@ sub comment_info {
         screened => $has_screened,
         screened_count => $screenedcount,
         show_readlink => $comments_enabled && ( $replycount || $has_screened ),
+        show_readlink_hidden => $comments_enabled,
         show_postlink => $comments_enabled,
     };
 }

--- a/cgi-bin/LJ/S2/FriendsPage.pm
+++ b/cgi-bin/LJ/S2/FriendsPage.pm
@@ -248,7 +248,6 @@ sub FriendsPage
         my $entry = Entry_from_entryobj( $u, $entry_obj, $opts );
 
         $entry->{_ymd} = join('-', map { $entry->{'time'}->{$_} } qw(year month day));
-        $entry->{comments}->{show_readlink_hidden} = 1;
 
         push @{$p->{'entries'}}, $entry;
         $eventnum++;


### PR DESCRIPTION
Fixes #1651 - as all pages have quickenedinger reply all pages should show the hidden readlink so that it can be updated by the JS.

Removed the specific setter from the FriendsPage as it'll already be set now.