### PR TITLE
Display access filter name in journal page title

### DIFF
--- a/cgi-bin/LJ/S2/FriendsPage.pm
+++ b/cgi-bin/LJ/S2/FriendsPage.pm
@@ -151,8 +151,14 @@ sub FriendsPage
 
     my $filter;
     if ( $opts->{securityfilter} ) {
-            $p->{filter_active} = 1;
+        my $filter = $u->trust_groups( id => $opts->{securityfilter} );
+        $p->{filter_active} = 1;
+        if ( defined $filter ) {
+            $p->{filter_name} = $filter->{groupname};
+        } else {
+            # something went wrong; just use the group number
             $p->{filter_name} = $opts->{securityfilter};
+        }
     } else {
     # but we can't just use a filter, we have to make sure the person is allowed to
         if ( ( ! defined $get->{filter} || $get->{filter} ne "0" )

--- a/cgi-bin/LJ/S2/RecentPage.pm
+++ b/cgi-bin/LJ/S2/RecentPage.pm
@@ -79,8 +79,14 @@ sub RecentPage
     }
 
     if ( $opts->{securityfilter} ) {
+        my $filter = $u->trust_groups( id => $opts->{securityfilter} );
         $p->{filter_active} = 1;
-        $p->{filter_name} = $opts->{securityfilter};
+        if ( defined $filter ) {
+            $p->{filter_name} = $filter->{groupname};
+        } else {
+            # something went wrong; just use the group number
+            $p->{filter_name} = $opts->{securityfilter};
+        }
     } 
 
     my $get = $opts->{'getargs'};


### PR DESCRIPTION
Fixes #1669.

The Recent Entries page, when displaying posts to a specific access
filter, now has a title of the form "kaberett | (test)" rather than
"kaberett | (1)".