### PR TITLE
Fixes #1672 whitelist embed for codepen.io

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -101,7 +101,9 @@ my %host_path_match = (
     "vine.co"               => [ qr!^/v/[a-zA-Z0-9]{11}/embed/simple$!, 1 ],
     # Videos seemed to use an 11-character identification; may need to be changed
 
-    "www.zippcast.com"      => [ qr!^/videoview\.php$!, 0 ]
+    "www.zippcast.com"      => [ qr!^/videoview\.php$!, 0 ],
+
+    "codepen.io"            => [ qr!^/enxaneta/embed/!, 1 ]
 
 );
 

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 57;
+use Test::More tests => 58;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -141,6 +141,8 @@ note( "misc" );
     test_good_url( "https://screen.yahoo.com/fashion-photographer-life-changed-chance-193621376.html?format=embed" );
 
     test_good_url( "//www.zippcast.com/videoview.php?vplay=6c91dae3fc1bc909db0&auto=no" );
+
+    test_good_url( "//codepen.io/enxaneta/embed/gPeZdP/?height=268&theme-id=0&default-tab=result" );
 
 }
 


### PR DESCRIPTION
Fixes #1672 by adding embedding whitelist for codepen.io. The count of tests will clash with #1680 when merging, but should be easy to fix, or I can do so once that is merged.