### PR TITLE
Clarify extradata options on entry success

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1044,17 +1044,38 @@ sub _do_post {
             security => $form_req->{security},
             security_ml => "",
             subject => $form_req->{subject},
+            visibility => "",
+            filters => ""
         };
         if ( $extradata->{security} eq "usemask" ) {
-            if ( $form_req -> {allowmask} == 1 ) {
-                $extradata->{security_ml} = ".extradata.sec.access";
-            } else {
-                $extradata->{security_ml} = ".extradata.sec.custom";
+            if ( $form_req->{allowmask} == 1 ) { # access list
+                if ( $ju->is_community ) {
+                    $extradata->{security_ml} = ".extradata.security";
+                    $extradata->{visibility} = "community members";
+                } else {
+                    $extradata->{security_ml} = ".extradata.security";
+                    $extradata->{visibility} = "your access list";
+                }
+            } elsif ( $form_req->{allowmask} > 1 ) { # custom group
+                my $filternames = $ju->security_group_display( $form_req->{allowmask} );
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "your custom access filter(s) ";
+                $extradata->{filters} = $filternames;
+            } else { # custom security with no group - essentially private
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "only you (private)";
             }
         } elsif ( $extradata->{security} eq "private" ) {
-            $extradata->{security_ml} = ".extradata.sec.private";
-        } else {
-            $extradata->{security_ml} = ".extradata.sec.public";
+            if ( $ju->is_community ) {
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "community administrators";
+            } else {
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "only you (private)";
+            }
+        } else { #public
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "everybody (public)";
         }
 
         # set sticky
@@ -1180,18 +1201,39 @@ sub _do_edit {
     my $extradata = {
         security => $form_req->{security},
         security_ml => "",
-        subject => LJ::ehtml( $form_req->{subject} ),
+        subject => $form_req->{subject},
+        visibility => "",
+        filters => ""
     };
     if ( $extradata->{security} eq "usemask" ) {
-        if ( $form_req -> {allowmask} == 1 ) {
-            $extradata->{security_ml} = ".extradata.sec.access";
-        } else {
-            $extradata->{security_ml} = ".extradata.sec.custom";
+        if ( $form_req->{allowmask} == 1 ) { # access list
+            if ( $journal->is_community ) {
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "community members";
+            } else {
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "your access list";
+            }
+        } elsif ( $form_req->{allowmask} > 1 ) { # custom group
+            my $filternames = $journal->security_group_display( $form_req->{allowmask} );
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "your custom access filter(s) ";
+            $extradata->{filters} = $filternames;
+        } else { # custom security with no group - essentially private
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "only you (private)";
         }
     } elsif ( $extradata->{security} eq "private" ) {
-        $extradata->{security_ml} = ".extradata.sec.private";
-    } else {
-        $extradata->{security_ml} = ".extradata.sec.public";
+        if ( $journal->is_community ) {
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "community administrators";
+        } else {
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "only you (private)";
+        }
+    } else { #public
+        $extradata->{security_ml} = ".extradata.security";
+        $extradata->{visibility} = "everybody (public)";
     }
 
     my $poststatus = { ml_string => $poststatus_ml };

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -350,20 +350,34 @@ body<=
 
                 if (!$deleted) {
                     if ($req{"security"} eq "private") {
-                        $result .="<p>$ML{'.extradata.sec.private'}</p>";
+                        if ( $journalu->is_community ) {
+                            $result .="<?p " . BML::ml('.extradata.security', {security => "community administrators", filters => "" }) . " p?>";
+                        } else {
+                            $result .="<?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" }) . " p?>";
+                        }
                     } elsif ($req{"security"} eq "usemask") {
                         if ($req{"allowmask"} == 0) { # custom security with no group -- essentially private
-                            $result .="<p>$ML{'.extradata.sec.private'}</p>";
+                            $result .="<?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" }) . " p?>";
                         } elsif ($req{"allowmask"} > 1) { # custom group
-                            $result .="<p>$ML{'.extradata.sec.custom'}</p>";
-                        } else { # friends only
-                            $result .="<p>$ML{'.extradata.sec.access'}</p>";
+                            my $filternames = $journalu->security_group_display( $req{allowmask} );
+                            $result .="<?p " . BML::ml('.extradata.security', {security=> "your custom access filter(s) ", filters => $filternames }) . " p?>";
+                        } else { # access list only
+                            if ( $journalu->is_community) {
+                                $result .="<?p " . BML::ml('.extradata.security', {security => "community members", filters => "" }) . " p?>";
+                            } else {
+                                $result .="<?p " . BML::ml('.extradata.security', {security => "your access list", filters => "" }) . " p?>";
+                            }
                         }
                     } else {
-                        $result .="<p>$ML{'.extradata.sec.public'}</p>";
+                        $result .="<?p " . BML::ml('.extradata.security', {security => "everyone (public)", filters => "" }) . " p?>";
                     }
 
-                    $result .="<?p " . BML::ml('.extradata.subject', { subject => LJ::ehtml( $req{"subject"} ) }) . " p?>";
+                    if ( length($req{"subject"}) > 0 ) {
+                        $result .="<?p " . $ML{'.extradata.subj'} . LJ::ehtml( $req{"subject"} ) . " p?>";
+                    } else {
+                            $result .="<?p " . $ML{'.extradata.subj'} . $ML{'.extradata.subject.no_subject'} . " p?>";
+                    }
+                     
                 }
 
                 $result .= "<div id='fromhere'>$ML{'.success.fromhere'}<ul>";

--- a/htdocs/editjournal.bml.text
+++ b/htdocs/editjournal.bml.text
@@ -66,5 +66,10 @@
 
 .extradata.sec.custom=The entry was posted with custom access.
 
+.extradata.security=The entry is visible to [[security]][[filters]].
+
 .extradata.subject=The entry was posted with the following subject: [[subject]]
 
+.extradata.subj=The entry was posted with the following subject: 
+
+.extradata.subject.no_subject=(no subject)

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -470,18 +470,27 @@ _c?>
                     my @after_entry_post_extra_options = LJ::Hooks::run_hooks('after_entry_post_extra_options', user => $ju, itemlink => $itemlink);
                     my $after_entry_post_extra_options = join('', map {$_->[0]} @after_entry_post_extra_options) || '';
                     
-                    if ($req{"security"} eq "private") {
-                        $$body .=" p?><?p $ML{'.extradata.sec.private'}";
-                    } elsif ($req{"security"} eq "usemask") {
-                        if ($req{"allowmask"} == 0) { # custom security with no group -- essentially private
-                            $$body .=" p?><?p $ML{'.extradata.sec.private'}";
-                        } elsif ($req{"allowmask"} > 1) { # custom group
-                            $$body .=" p?><?p $ML{'.extradata.sec.custom'}";
-                        } else { # friends only
-                            $$body .=" p?><?p $ML{'.extradata.sec.access'}";
+                    if ( $req{"security"} eq "private" ) {
+                        if ( $u->is_community ) {
+                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "community administrators", filters => "" });
+                        } else {
+                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" });
                         }
-                    } else {
-                        $$body .=" p?><?p $ML{'.extradata.sec.public'}";
+                    } elsif ( $req{"security"} eq "usemask" ) {
+                        if ( $req{"allowmask"} == 0 ) { # custom security with no group -- essentially private
+                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" });
+                        } elsif ( $req{"allowmask"} > 1 ) { # custom group
+                            my $filternames = $u->security_group_display( $req{"allowmask"} );   
+                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security=> "the access filter(s) ", filters => $filternames});
+                        } else { # access list
+                            if ( $u->is_community ) {
+                                $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "community members", filters => "" });
+                            } else {
+                                $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "your access list", filters => "" });
+                            }
+                        }
+                    } else { # public
+                        $$body .=" p?><? p " . BML::ml('.extradata.security', {security => "everyone (public)", filters => "" });
                     }
                 
                     if ( length($req{"subject"}) > 0 ) {

--- a/htdocs/update.bml.text
+++ b/htdocs/update.bml.text
@@ -147,6 +147,8 @@
 
 .extradata.sec.custom=The entry was posted with custom access.
 
+.extradata.security=The entry is visible to [[security]][[filters]].
+
 .extradata.subj=The entry was posted with the following subject: 
 
 .extradata.subject.no_subject=(no subject)

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -25,7 +25,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- IF poststatus.ml_string != ".edit.delete" -%]
 
-<p>[% extradata.security_ml | ml %]</p>
+<p>[% extradata.security_ml | ml( visibility => extradata.visibility, filters => extradata.filters ) %]</p>
 <p>[% ".extradata.subj" | ml %]
     [% IF extradata.subject.length > 0 %]
         [% extradata.subject | html %]

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -23,7 +23,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <p>[% poststatus.ml_string | ml( url => poststatus.url)%]</p>
 [%- END -%]
 
-[%- IF poststatus.ml_string != ".edit.delete" -%]
+    [%- IF poststatus.ml_string != ".edit.delete" -%]
 
     <p>[% extradata.security_ml | ml( visibility => extradata.visibility, filters => extradata.filters ) %]</p>
     <p>[% ".extradata.subj" | ml %]
@@ -33,6 +33,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [% ELSE %]
             [% ".extradata.subject.no_subject" | ml %]
         [% END %]</p>
+    [%- END -%]
 [%- END -%]
 
 [%- IF warnings.exist -%]

--- a/views/entry/success.tt.text
+++ b/views/entry/success.tt.text
@@ -48,6 +48,8 @@
 
 .extradata.sec.custom=The entry was posted with custom access.
 
+.extradata.security=The entry is visible to [[visibility]][[filters]].
+
 .extradata.subj=The entry was posted with the following subject: 
 
 .extradata.subject.no_subject=(no subject)


### PR DESCRIPTION
Related to #1641 and friends.

* Security information was misleading when posting to a community
rather than a personal account.
* When posting to custom filter(s), the names of the filter(s) in
question are now specified.
* Editing entries using the BML create entries page still provided
an empty string if no subject was provided - I overlooked this in
my earlier pull request #1641, sorry.
* This PR has conflicts with #1699 and #1658, which I am expecting
to resolve manually once they have been merged with develop.

(I note that there's a lot of duplicated code, and that how editjournal.bml and update.bml handle generating *exactly the same text* is unfortunately different -- not sure how best to go about fixing this, though, nor if I've been too verbose/could usefully rephrase how I choose whether to display filters.)