### PR TITLE
Update $JSPREFIX to use $RELATIVE_SITEROOT

### DIFF
--- a/cgi-bin/DW/Hooks/SSL.pm
+++ b/cgi-bin/DW/Hooks/SSL.pm
@@ -21,8 +21,12 @@ LJ::Hooks::register_hook( 'ssl_check', sub {
     my $apache_r = $_[0]->{r}
         or return 0;
 
+    # SSL_HEADER would be set by caching proxy
     return 1 if $LJ::SSL_HEADER &&
                 $apache_r->headers_in->{$LJ::SSL_HEADER} == 1;
+    # fallback: true if using port defined in config
+    return 1 if $LJ::SSL_PORT &&
+                $apache_r->get_server_port == $LJ::SSL_PORT;
     return 0;
 } );
 

--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -66,11 +66,11 @@ no strict "vars";
     $IMGPREFIX ||= "$SITEROOT/img";
     $STATPREFIX ||= "$SITEROOT/stc";
     $WSTATPREFIX ||= "$SITEROOT/stc";
-    $JSPREFIX ||= "$SITEROOT/js";
     $USERPIC_ROOT ||= "$LJ::SITEROOT/userpic";
 
     $RELATIVE_SITEROOT ||= "//$DOMAIN_WEB";
     $PALIMGROOT ||= "$RELATIVE_SITEROOT/palimg";
+    $JSPREFIX ||= "$RELATIVE_SITEROOT/js";
 
     # SSL prefix defaults
     $SSLIMGPREFIX   ||= "$SSLROOT/img";

--- a/etc/config-private.pl
+++ b/etc/config-private.pl
@@ -113,6 +113,9 @@
     # Set this to the IP address of your main site.  This is used for Tor exit checking.
     #$EXTERNAL_IP = '127.0.0.1';
 
+    # Set this to the port number used for incoming SSL connections
+    #$SSL_PORT = 443;
+
     # configuration/ID for statistics tracker modules which apply to
     # site pages (www, non-journal)
     %SITE_PAGESTAT_CONFIG = (


### PR DESCRIPTION
Fixes issue #1711 in global defaults; configs with custom JSPREFIX will need updating.

Also adds support for a new config variable SSL_PORT without which I could not have tested this.