### PR TITLE
Add referenced FAQ to volunteer support notifs

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3907,7 +3907,7 @@ You are receiving this email because you've requested notifications of new suppo
 
 .
 
-support.email.notif.update.body3<<
+support.email.notif.update.body4<<
 A follow-up to the following [[sitename]] support request has been submitted:
 
 Category: [[category]]
@@ -3916,6 +3916,12 @@ User: [[username]]
 URL: [[url]]
 Type: [[type]]
 Text:
+
+.
+
+support.email.notif.update.body.faqref=FAQ REFERENCE: [[faqref]]
+
+support.email.notif.update.body.text<<
 
 [[text]]
 


### PR DESCRIPTION
Fixes #1715.

If a FAQ was referenced in a Support answer, the ticket update
notification e-mail will now include the FAQ title and link.