### PR TITLE
new function LJ::Talk::init_s2journal_js

### DIFF
--- a/cgi-bin/LJ/S2/DayPage.pm
+++ b/cgi-bin/LJ/S2/DayPage.pm
@@ -33,31 +33,12 @@ sub DayPage
         $p->{'head_content'} .= LJ::robot_meta_tags();
     }
 
-    # load for quick reply
-    LJ::need_res( { group => "jquery" }, qw(
-            js/jquery/jquery.ui.core.js
-            stc/jquery/jquery.ui.core.css
-            js/jquery/jquery.ui.widget.js
-            js/jquery.quickreply.js
-            stc/css/components/quick-reply.css
-            js/jquery.threadexpander.js
-        ) );
+    # include JS for quick reply, icon browser, and ajax cut tag
+    my $handle_with_siteviews = $opts->{handle_with_siteviews_ref} &&
+                              ${$opts->{handle_with_siteviews_ref}};
+    LJ::Talk::init_s2journal_js( iconbrowser => $remote && $remote->can_use_userpic_select,
+                                 siteskin => $handle_with_siteviews, lastn => 1 );
 
-    # libs for userpicselect
-    # if we're using the site skin, don't override the jquery-ui theme, as that's already included
-    my @iconbrowser_extra_stylesheet;
-    @iconbrowser_extra_stylesheet = ( 'stc/jquery/jquery.ui.theme.smoothness.css' )
-            unless $opts->{handle_with_siteviews_ref} && ${$opts->{handle_with_siteviews_ref}};
-
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( 1, @iconbrowser_extra_stylesheet ) )
-        if $remote && $remote->can_use_userpic_select;
-
-    # load for ajax cuttag
-    LJ::need_res( 'js/cuttag-ajax.js' );
-    LJ::need_res( { group => "jquery" }, qw(
-            js/jquery/jquery.ui.widget.js
-            js/jquery.cuttag-ajax.js
-        ) );
     my $collapsed = BML::ml( 'widget.cuttag.collapsed' );
     my $expanded = BML::ml( 'widget.cuttag.expanded' );
     my $collapseAll = BML::ml( 'widget.cuttag.collapseAll' );

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -75,22 +75,11 @@ sub EntryPage
     # canonical link to the entry or comment thread
     $p->{head_content} .= LJ::canonical_link( $permalink, $get->{thread} );
 
-    # quickreply js libs
-    # if we're using the site skin, don't override the jquery-ui theme, as that's already included
-    my @iconbrowser_extra_stylesheet;
-    @iconbrowser_extra_stylesheet = ( 'stc/jquery/jquery.ui.theme.smoothness.css' )
-        unless $opts->{handle_with_siteviews_ref} && ${$opts->{handle_with_siteviews_ref}};
-
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( 1, @iconbrowser_extra_stylesheet ) )
-        if $remote && $remote->can_use_userpic_select;
-
-    LJ::need_res( { group => "jquery" }, qw(
-            js/jquery/jquery.ui.core.js
-            stc/jquery/jquery.ui.core.css
-            js/jquery/jquery.ui.widget.js
-            js/jquery.quickreply.js
-            js/jquery.threadexpander.js
-        ) );
+    # include JS for quick reply, icon browser, and ajax cut tag
+    my $handle_with_siteviews = $opts->{handle_with_siteviews_ref} &&
+                              ${$opts->{handle_with_siteviews_ref}};
+    LJ::Talk::init_s2journal_js( iconbrowser => $remote && $remote->can_use_userpic_select,
+                                 siteskin => $handle_with_siteviews );
 
     $p->{'entry'} = $s2entry;
     LJ::Hooks::run_hook('notify_event_displayed', $entry);

--- a/cgi-bin/LJ/S2/FriendsPage.pm
+++ b/cgi-bin/LJ/S2/FriendsPage.pm
@@ -35,28 +35,11 @@ sub FriendsPage
 
     LJ::need_res( LJ::S2::tracking_popup_js() );
 
-    # load for icon browser
-    my @iconbrowser_extra_stylesheet;
-    @iconbrowser_extra_stylesheet = ( 'stc/jquery/jquery.ui.theme.smoothness.css' );
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( 1, @iconbrowser_extra_stylesheet ) )
-        if $remote && $remote->can_use_userpic_select;
+    # include JS for quick reply, icon browser, and ajax cut tag
+    my $handle_with_siteviews = 0;  # not an option for FriendsPage?
+    LJ::Talk::init_s2journal_js( iconbrowser => $remote && $remote->can_use_userpic_select,
+                                 siteskin => $handle_with_siteviews, lastn => 1 );
 
-    # load for quick reply
-    LJ::need_res( { group => "jquery" }, qw(
-            js/jquery/jquery.ui.core.js
-            stc/jquery/jquery.ui.core.css
-            js/jquery/jquery.ui.widget.js
-            js/jquery.quickreply.js
-            stc/css/components/quick-reply.css
-            js/jquery.threadexpander.js
-        ) );
-
-    # load for ajax cuttag
-    LJ::need_res( 'js/cuttag-ajax.js' );
-    LJ::need_res( { group => "jquery" }, qw(
-            js/jquery/jquery.ui.widget.js
-            js/jquery.cuttag-ajax.js
-        ) );
     my $collapsed = BML::ml( 'widget.cuttag.collapsed' );
     my $expanded = BML::ml( 'widget.cuttag.expanded' );
     my $collapseAll = BML::ml( 'widget.cuttag.collapseAll' );

--- a/cgi-bin/LJ/S2/RecentPage.pm
+++ b/cgi-bin/LJ/S2/RecentPage.pm
@@ -36,16 +36,6 @@ sub RecentPage
     $p->{filter_name} = "";
     $p->{filter_tags} = 0;
 
-    # load for quick reply
-    LJ::need_res( { group => "jquery" }, qw(
-            js/jquery/jquery.ui.core.js
-            stc/jquery/jquery.ui.core.css
-            js/jquery/jquery.ui.widget.js
-            js/jquery.quickreply.js
-            stc/css/components/quick-reply.css
-            js/jquery.threadexpander.js
-        ) );
-
     # Link to the friends page as a "group", for use with OpenID "Group Membership Protocol"
     {
         my $is_comm = $u->is_community;
@@ -96,15 +86,6 @@ sub RecentPage
         return 1;
     }
 
-    # libs for userpicselect
-    # if we're using the site skin, don't override the jquery-ui theme, as that's already included
-    my @iconbrowser_extra_stylesheet;
-    @iconbrowser_extra_stylesheet = ( 'stc/jquery/jquery.ui.theme.smoothness.css' )
-            unless $opts->{handle_with_siteviews_ref} && ${$opts->{handle_with_siteviews_ref}};
-
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( 1, @iconbrowser_extra_stylesheet ) )
-        if $remote && $remote->can_use_userpic_select;
-
     if ($u->should_block_robots || $get->{'skip'}) {
         $p->{'head_content'} .= LJ::robot_meta_tags();
     }
@@ -115,12 +96,12 @@ sub RecentPage
 
     LJ::need_res( LJ::S2::tracking_popup_js() );
 
-    # load for ajax cuttag
-    LJ::need_res( 'js/cuttag-ajax.js' );
-    LJ::need_res( { group => "jquery" }, qw(
-            js/jquery/jquery.ui.widget.js
-            js/jquery.cuttag-ajax.js
-        ) );
+    # include JS for quick reply, icon browser, and ajax cut tag
+    my $handle_with_siteviews = $opts->{handle_with_siteviews_ref} &&
+                              ${$opts->{handle_with_siteviews_ref}};
+    LJ::Talk::init_s2journal_js( iconbrowser => $remote && $remote->can_use_userpic_select,
+                                 siteskin => $handle_with_siteviews, lastn => 1 );
+
     my $collapsed = BML::ml( 'widget.cuttag.collapsed' );
     my $expanded = BML::ml( 'widget.cuttag.expanded' );
     my $collapseAll = BML::ml( 'widget.cuttag.collapseAll' );

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -63,14 +63,11 @@ sub ReplyPage
     LJ::need_res('stc/display_none.css');
     LJ::need_res( LJ::S2::tracking_popup_js() );
 
-    # libs for userpicselect
-    # if we're using the site skin, don't override the jquery-ui theme, as that's already included
-    my @iconbrowser_extra_stylesheet;
-    @iconbrowser_extra_stylesheet = ( 'stc/jquery/jquery.ui.theme.smoothness.css' )
-            unless $opts->{handle_with_siteviews_ref} && ${$opts->{handle_with_siteviews_ref}};
-
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( 1, @iconbrowser_extra_stylesheet ) )
-        if $remote && $remote->can_use_userpic_select;
+    # include JS for quick reply, icon browser, and ajax cut tag
+    my $handle_with_siteviews = $opts->{handle_with_siteviews_ref} &&
+                              ${$opts->{handle_with_siteviews_ref}};
+    LJ::Talk::init_s2journal_js( iconbrowser => $remote && $remote->can_use_userpic_select,
+                                 siteskin => $handle_with_siteviews, noqr => 1 );
 
     if ($u->should_block_robots || $entry->should_block_robots) {
         $p->{'head_content'} .= LJ::robot_meta_tags();

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2221,6 +2221,43 @@ sub init_iconbrowser_js {
     return @list;
 }
 
+# convenience/deduplication function for QR, cut tag, & icon browser JS loading
+# args: hash of opts to determine which JS files to load (iconbrowser, siteskin, lastn, noqr)
+# returns: nothing, just calls need_res
+sub init_s2journal_js {
+    my %opts = @_;
+
+    # load for quick reply (every view except ReplyPage)
+    LJ::need_res( { group => "jquery" }, qw(
+            js/jquery/jquery.ui.core.js
+            stc/jquery/jquery.ui.core.css
+            js/jquery/jquery.ui.widget.js
+            js/jquery.quickreply.js
+            js/jquery.threadexpander.js
+        ) ) unless $opts{noqr};
+
+    # this is only used on lastn-type pages (DayPage, RecentPage, FriendsPage)
+    LJ::need_res( { group => "jquery" }, qw(
+            stc/css/components/quick-reply.css
+        ) ) if $opts{lastn};
+
+    # load for userpicselect
+    LJ::need_res( init_iconbrowser_js( 1 ) ) if $opts{iconbrowser};
+
+    # if we're using the site skin, don't override the jquery-ui theme,
+    # as that's already included
+    LJ::need_res( { group => "jquery" }, qw(
+            stc/jquery/jquery.ui.theme.smoothness.css
+        ) ) unless $opts{siteskin};
+
+    # load for ajax cuttag - again, only needed on lastn-type pages
+    LJ::need_res( 'js/cuttag-ajax.js' ) if $opts{lastn};
+    LJ::need_res( { group => "jquery" }, qw(
+            js/jquery/jquery.ui.widget.js
+            js/jquery.cuttag-ajax.js
+        ) ) if $opts{lastn};
+}
+
 # generate the javascript code for the icon browser
 sub js_iconbrowser_button {
     my $remote = LJ::get_remote();


### PR DESCRIPTION
Do all inclusion of JS libraries for quick reply, icon browser,
and cut tag in one place, instead of duplicating similar code
on every S2 journal view.