### PR TITLE
Clarify extradata options on entry success

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2268,6 +2268,18 @@ portal.update.portaltitle=Update Your Journal
 
 portal.update.subject=Subject:
 
+post.security.access.c=The entry is visible to community members.
+
+post.security.access.p=The entry is visible to your access list.
+
+post.security.custom=The entry is visible to your custom access filter(s) [[filters]].
+
+post.security.private.c=The entry is only visible to community administrators.
+
+post.security.private.p=The entry is only visible to you (private).
+
+post.security.public=The entry is visible to everyone (public).
+
 protocol.bad_password=Your password is too easy to guess.  We strongly recommend you change it, otherwise you risk having your journal hijacked.  Visit [[siteroot]]/changepassword to change your password.
 
 protocol.mail_bouncing=You are currently using a bad email address.  All mail we try to send you is bouncing.  We require a valid email address for continued use.  Visit the support area for more information.

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1048,17 +1048,38 @@ sub _do_post {
             security => $form_req->{security},
             security_ml => "",
             subject => $subject,
+            visibility => "",
+            filters => ""
         };
         if ( $extradata->{security} eq "usemask" ) {
-            if ( $form_req -> {allowmask} == 1 ) {
-                $extradata->{security_ml} = ".extradata.sec.access";
-            } else {
-                $extradata->{security_ml} = ".extradata.sec.custom";
+            if ( $form_req->{allowmask} == 1 ) { # access list
+                if ( $ju->is_community ) {
+                    $extradata->{security_ml} = ".extradata.security";
+                    $extradata->{visibility} = "community members";
+                } else {
+                    $extradata->{security_ml} = ".extradata.security";
+                    $extradata->{visibility} = "your access list";
+                }
+            } elsif ( $form_req->{allowmask} > 1 ) { # custom group
+                my $filternames = $ju->security_group_display( $form_req->{allowmask} );
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "your custom access filter(s) ";
+                $extradata->{filters} = $filternames;
+            } else { # custom security with no group - essentially private
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "only you (private)";
             }
         } elsif ( $extradata->{security} eq "private" ) {
-            $extradata->{security_ml} = ".extradata.sec.private";
-        } else {
-            $extradata->{security_ml} = ".extradata.sec.public";
+            if ( $ju->is_community ) {
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "community administrators";
+            } else {
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "only you (private)";
+            }
+        } else { #public
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "everybody (public)";
         }
 
         # set sticky
@@ -1189,17 +1210,38 @@ sub _do_edit {
         security => $form_req->{security},
         security_ml => "",
         subject => $subject,
+        visibility => "",
+        filters => ""
     };
     if ( $extradata->{security} eq "usemask" ) {
-        if ( $form_req -> {allowmask} == 1 ) {
-            $extradata->{security_ml} = ".extradata.sec.access";
-        } else {
-            $extradata->{security_ml} = ".extradata.sec.custom";
+        if ( $form_req->{allowmask} == 1 ) { # access list
+            if ( $journal->is_community ) {
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "community members";
+            } else {
+                $extradata->{security_ml} = ".extradata.security";
+                $extradata->{visibility} = "your access list";
+            }
+        } elsif ( $form_req->{allowmask} > 1 ) { # custom group
+            my $filternames = $journal->security_group_display( $form_req->{allowmask} );
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "your custom access filter(s) ";
+            $extradata->{filters} = $filternames;
+        } else { # custom security with no group - essentially private
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "only you (private)";
         }
     } elsif ( $extradata->{security} eq "private" ) {
-        $extradata->{security_ml} = ".extradata.sec.private";
-    } else {
-        $extradata->{security_ml} = ".extradata.sec.public";
+        if ( $journal->is_community ) {
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "community administrators";
+        } else {
+            $extradata->{security_ml} = ".extradata.security";
+            $extradata->{visibility} = "only you (private)";
+        }
+    } else { #public
+        $extradata->{security_ml} = ".extradata.security";
+        $extradata->{visibility} = "everybody (public)";
     }
 
     my $poststatus = { ml_string => $poststatus_ml };

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -350,17 +350,26 @@ body<=
 
                 if (!$deleted) {
                     if ($req{"security"} eq "private") {
-                        $result .="<p>$ML{'.extradata.sec.private'}</p>";
+                        if ( $journalu->is_community ) {
+                            $result .="<?p " . BML::ml('.extradata.security', {security => "community administrators", filters => "" }) . " p?>";
+                        } else {
+                            $result .="<?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" }) . " p?>";
+                        }
                     } elsif ($req{"security"} eq "usemask") {
                         if ($req{"allowmask"} == 0) { # custom security with no group -- essentially private
-                            $result .="<p>$ML{'.extradata.sec.private'}</p>";
+                            $result .="<?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" }) . " p?>";
                         } elsif ($req{"allowmask"} > 1) { # custom group
-                            $result .="<p>$ML{'.extradata.sec.custom'}</p>";
-                        } else { # friends only
-                            $result .="<p>$ML{'.extradata.sec.access'}</p>";
+                            my $filternames = $journalu->security_group_display( $req{allowmask} );
+                            $result .="<?p " . BML::ml('.extradata.security', {security=> "your custom access filter(s) ", filters => $filternames }) . " p?>";
+                        } else { # access list only
+                            if ( $journalu->is_community) {
+                                $result .="<?p " . BML::ml('.extradata.security', {security => "community members", filters => "" }) . " p?>";
+                            } else {
+                                $result .="<?p " . BML::ml('.extradata.security', {security => "your access list", filters => "" }) . " p?>";
+                            }
                         }
                     } else {
-                        $result .="<p>$ML{'.extradata.sec.public'}</p>";
+                        $result .="<?p " . BML::ml('.extradata.security', {security => "everyone (public)", filters => "" }) . " p?>";
                     }
 
                     my $subject = $req{subject};

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -349,28 +349,26 @@ body<=
                 }
 
                 if (!$deleted) {
+                    my $security_ml;
+                    my $filternames = '';
+                    my $c_or_p = $journalu->is_community ? 'c' : 'p';
+
                     if ($req{"security"} eq "private") {
-                        if ( $journalu->is_community ) {
-                            $result .="<?p " . BML::ml('.extradata.security', {security => "community administrators", filters => "" }) . " p?>";
-                        } else {
-                            $result .="<?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" }) . " p?>";
-                        }
+                        $security_ml = "post.security.private.$c_or_p";
                     } elsif ($req{"security"} eq "usemask") {
                         if ($req{"allowmask"} == 0) { # custom security with no group -- essentially private
-                            $result .="<?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" }) . " p?>";
+                            $security_ml = "post.security.private.$c_or_p";
                         } elsif ($req{"allowmask"} > 1) { # custom group
-                            my $filternames = $journalu->security_group_display( $req{allowmask} );
-                            $result .="<?p " . BML::ml('.extradata.security', {security=> "your custom access filter(s) ", filters => $filternames }) . " p?>";
+                            $filternames = $journalu->security_group_display( $req{allowmask} );
+                            $security_ml = "post.security.custom";
                         } else { # access list only
-                            if ( $journalu->is_community) {
-                                $result .="<?p " . BML::ml('.extradata.security', {security => "community members", filters => "" }) . " p?>";
-                            } else {
-                                $result .="<?p " . BML::ml('.extradata.security', {security => "your access list", filters => "" }) . " p?>";
-                            }
+                            $security_ml = "post.security.access.$c_or_p";
                         }
                     } else {
-                        $result .="<?p " . BML::ml('.extradata.security', {security => "everyone (public)", filters => "" }) . " p?>";
+                        $security_ml = "post.security.public";
                     }
+
+                    $result .= "<?p " . BML::ml( $security_ml, { filters => $filternames } ) . " p?>";
 
                     my $subject = $req{subject};
 

--- a/htdocs/editjournal.bml.text
+++ b/htdocs/editjournal.bml.text
@@ -13,14 +13,6 @@
 
 .error.nofind=Could not find selected journal entry.
 
-.extradata.sec.access=The entry was posted with circle access.
-
-.extradata.sec.custom=The entry was posted with custom access.
-
-.extradata.sec.private=The entry was posted privately.
-
-.extradata.sec.public=The entry was posted publicly.
-
 .extradata.subj=The entry was posted with the following subject:
 
 .extradata.subj.no_subject=(no subject)

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -469,29 +469,27 @@ _c?>
 
                     my @after_entry_post_extra_options = LJ::Hooks::run_hooks('after_entry_post_extra_options', user => $ju, itemlink => $itemlink);
                     my $after_entry_post_extra_options = join('', map {$_->[0]} @after_entry_post_extra_options) || '';
-                    
+
+                    my $security_ml;
+                    my $filternames = '';
+                    my $c_or_p = $ju->is_community ? 'c' : 'p';
+
                     if ( $req{"security"} eq "private" ) {
-                        if ( $u->is_community ) {
-                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "community administrators", filters => "" });
-                        } else {
-                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" });
-                        }
+                        $security_ml = "post.security.private.$c_or_p";
                     } elsif ( $req{"security"} eq "usemask" ) {
                         if ( $req{"allowmask"} == 0 ) { # custom security with no group -- essentially private
-                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" });
+                            $security_ml = "post.security.private.$c_or_p";
                         } elsif ( $req{"allowmask"} > 1 ) { # custom group
-                            my $filternames = $u->security_group_display( $req{"allowmask"} );   
-                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security=> "the access filter(s) ", filters => $filternames});
+                            $filternames = $ju->security_group_display( $req{"allowmask"} );
+                            $security_ml = "post.security.custom";
                         } else { # access list
-                            if ( $u->is_community ) {
-                                $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "community members", filters => "" });
-                            } else {
-                                $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "your access list", filters => "" });
-                            }
+                            $security_ml = "post.security.access.$c_or_p";
                         }
                     } else { # public
-                        $$body .=" p?><? p " . BML::ml('.extradata.security', {security => "everyone (public)", filters => "" });
+                        $security_ml = "post.security.public";
                     }
+
+                    $$body .= " p?><?p " . BML::ml( $security_ml, { filters => $filternames } );
 
                     my $subject = $req{subject};
 
@@ -499,10 +497,11 @@ _c?>
                         # use the HTML cleaner on the entry subject,
                         # then display it without escaping
                         LJ::CleanHTML::clean_subject( \$subject );
-                        $$body .=" p?><?p " . $ML{'.extradata.subj'} . $subject;
                     } else {
-                        $$body .=" p?><?p " . $ML{'.extradata.subj'} . $ML{'.extradata.subject.no_subject'};
+                        $subject = $ML{'.extradata.subject.no_subject'};
                     }
+
+                    $$body .= sprintf( " p?><?p %s %s", $ML{'.extradata.subj'}, $subject );
 
                     my $backdatedlink = '';
                     if ( $POST{prop_opt_backdated} or $GET{prop_opt_backdated} ) {

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -469,19 +469,28 @@ _c?>
 
                     my @after_entry_post_extra_options = LJ::Hooks::run_hooks('after_entry_post_extra_options', user => $ju, itemlink => $itemlink);
                     my $after_entry_post_extra_options = join('', map {$_->[0]} @after_entry_post_extra_options) || '';
-
-                    if ($req{"security"} eq "private") {
-                        $$body .=" p?><?p $ML{'.extradata.sec.private'}";
-                    } elsif ($req{"security"} eq "usemask") {
-                        if ($req{"allowmask"} == 0) { # custom security with no group -- essentially private
-                            $$body .=" p?><?p $ML{'.extradata.sec.private'}";
-                        } elsif ($req{"allowmask"} > 1) { # custom group
-                            $$body .=" p?><?p $ML{'.extradata.sec.custom'}";
-                        } else { # friends only
-                            $$body .=" p?><?p $ML{'.extradata.sec.access'}";
+                    
+                    if ( $req{"security"} eq "private" ) {
+                        if ( $u->is_community ) {
+                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "community administrators", filters => "" });
+                        } else {
+                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" });
                         }
-                    } else {
-                        $$body .=" p?><?p $ML{'.extradata.sec.public'}";
+                    } elsif ( $req{"security"} eq "usemask" ) {
+                        if ( $req{"allowmask"} == 0 ) { # custom security with no group -- essentially private
+                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "only you (private)", filters => "" });
+                        } elsif ( $req{"allowmask"} > 1 ) { # custom group
+                            my $filternames = $u->security_group_display( $req{"allowmask"} );   
+                            $$body .=" p?><?p " . BML::ml('.extradata.security', {security=> "the access filter(s) ", filters => $filternames});
+                        } else { # access list
+                            if ( $u->is_community ) {
+                                $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "community members", filters => "" });
+                            } else {
+                                $$body .=" p?><?p " . BML::ml('.extradata.security', {security => "your access list", filters => "" });
+                            }
+                        }
+                    } else { # public
+                        $$body .=" p?><? p " . BML::ml('.extradata.security', {security => "everyone (public)", filters => "" });
                     }
 
                     my $subject = $req{subject};

--- a/htdocs/update.bml.text
+++ b/htdocs/update.bml.text
@@ -147,6 +147,8 @@
 
 .extradata.sec.custom=The entry was posted with custom access.
 
+.extradata.security=The entry is visible to [[security]][[filters]].
+
 .extradata.subj=The entry was posted with the following subject: 
 
 .extradata.subject.no_subject=(no subject)

--- a/htdocs/update.bml.text
+++ b/htdocs/update.bml.text
@@ -45,6 +45,10 @@
 
 .event=Event:
 
+.extradata.subj=The entry was posted with the following subject:
+
+.extradata.subject.no_subject=(no subject)
+
 .full=Full Update Page
 
 .htmlokay.norich=(HTML okay; by default, newlines will be auto-formatted to <tt>&lt;br&gt;</tt>)
@@ -138,17 +142,3 @@
 .update.success2.community=Your update was successful. <a [[aopts]]>View your updated community</a>.
 
 .username=Account name:
-
-.extradata.sec.public=The entry was posted publicly.
-
-.extradata.sec.access=The entry was posted with circle access.
-
-.extradata.sec.private=The entry was posted privately.
-
-.extradata.sec.custom=The entry was posted with custom access.
-
-.extradata.security=The entry is visible to [[security]][[filters]].
-
-.extradata.subj=The entry was posted with the following subject: 
-
-.extradata.subject.no_subject=(no subject)

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -23,9 +23,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <p>[% poststatus.ml_string | ml( url => poststatus.url)%]</p>
 [%- END -%]
 
-    [%- IF poststatus.ml_string != ".edit.delete" -%]
+[%- IF poststatus.ml_string != ".edit.delete" -%]
 
-    <p>[% extradata.security_ml | ml %]</p>
+    <p>[% extradata.security_ml | ml( visibility => extradata.visibility, filters => extradata.filters ) %]</p>
     <p>[% ".extradata.subj" | ml %]
         [% IF extradata.subject.length > 0 %]
             [%# cleaned subject should render HTML #%]

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -25,7 +25,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- IF poststatus.ml_string != ".edit.delete" -%]
 
-    <p>[% extradata.security_ml | ml( visibility => extradata.visibility, filters => extradata.filters ) %]</p>
+    <p>[% extradata.security_ml | ml( filters => extradata.filters ) %]</p>
     <p>[% ".extradata.subj" | ml %]
         [% IF extradata.subject.length > 0 %]
             [%# cleaned subject should render HTML #%]

--- a/views/entry/success.tt.text
+++ b/views/entry/success.tt.text
@@ -20,6 +20,10 @@
 
 .edit.links.viewentry=View this entry
 
+.extradata.subj=The entry was posted with the following subject: 
+
+.extradata.subject.no_subject=(no subject)
+
 .new.community=Your update was successful. <a href="[[url]]">View your updated community</a>.
 
 .new.journal=Your update was successful. <a href="[[url]]">View your updated journal</a>.
@@ -39,17 +43,3 @@
 .new.links.view=View the entry
 
 .sticky.max=This entry was not made sticky because you've reached your limit of [[limit]] for sticky entries.
-
-.extradata.sec.public=The entry was posted publicly.
-
-.extradata.sec.access=The entry was posted with circle access.
-
-.extradata.sec.private=The entry was posted privately.
-
-.extradata.sec.custom=The entry was posted with custom access.
-
-.extradata.security=The entry is visible to [[visibility]][[filters]].
-
-.extradata.subj=The entry was posted with the following subject: 
-
-.extradata.subject.no_subject=(no subject)

--- a/views/entry/success.tt.text
+++ b/views/entry/success.tt.text
@@ -48,6 +48,8 @@
 
 .extradata.sec.custom=The entry was posted with custom access.
 
+.extradata.security=The entry is visible to [[visibility]][[filters]].
+
 .extradata.subj=The entry was posted with the following subject: 
 
 .extradata.subject.no_subject=(no subject)


### PR DESCRIPTION
Refactor and simplify @kaberett's code from #1701 for displaying different success text depending on the security status of the entry, and whether it was posted to a personal journal vs. a community.