### PR TITLE
[#1367] make rename acct reusable when using rename_opts cmd

### DIFF
--- a/cgi-bin/DW/Console/Command/RenameOpts.pm
+++ b/cgi-bin/DW/Console/Command/RenameOpts.pm
@@ -1,7 +1,8 @@
 #!/usr/bin/perl
 #
 # DW::Console::Command::RenameOpts
-# This module 
+#
+# Console command for tweaking options on renamed users.
 #
 # Authors:
 #      Afuna <coder.dw@afunamatata.com>
@@ -24,7 +25,7 @@ sub desc { 'Manage options attached to a rename. Requires priv: siteadmin:rename
 
 sub args_desc {
     [
-        'command' => 'Subcommand: redirect, break_redirect, break_redirect_email, del_trusted_by, del_watched_by, del_trusted, del_watched, del_communities.',
+        'command' => 'Subcommand: redirect, break_redirect, break_email_redirect, del_trusted_by, del_watched_by, del_trusted, del_watched, del_communities.',
         'username' => 'Username to act on.',
     ]
 }
@@ -57,7 +58,7 @@ sub execute {
 
         return $self->error( 'Unable to break the email redirect. Note that from_user must redirect to to_user' )
             unless DW::User::Rename->break_email_redirection( $user, $tousername );
-            
+
     } else {
         my $u = LJ::load_user( $user );
         return $self->error( 'Invalid user.' )
@@ -65,7 +66,7 @@ sub execute {
 
         if ( $cmd eq 'break_redirect' )  {
             if ( $u->break_redirects ) {
-                $u->set_deleted;
+                $u->set_expunged;
             } else {
                 $self->error( "Unable to break redirection" );
             }


### PR DESCRIPTION
Updates the rename_opts console command to expunge a broken
redirect account instead of merely deleting it, so that its
username can be renamed to by someone else.

Also some minor housekeeping: whitespace cleanup, module
header cleanup, and fixing a typo in the reference.

Fixes #1367.