### PR TITLE
[#1643] remove HTML entities from default comment reply subjects

### DIFF
--- a/cgi-bin/DW/CleanEmail.pm
+++ b/cgi-bin/DW/CleanEmail.pm
@@ -13,6 +13,9 @@ package DW::CleanEmail;
 
 use strict;
 
+use HTML::Entities;
+
+
 =head1 NAME
 
 DW::CleanEmail - Clean up text from email
@@ -80,7 +83,7 @@ sub nonquoted_text {
 
 =head2 C<< $class->reply_subject( $text ) >>
 
-Clean out "Re:" from the subject
+Clean out "Re:" from the subject and decode HTML entities
 
 =cut
 sub reply_subject {
@@ -89,7 +92,7 @@ sub reply_subject {
     $subject =~ s/^(Re:\s*)*//i;
     $subject = "Re: $subject" if $subject;
 
-    return $subject;
+    return HTML::Entities::decode( $subject );
 }
 
 1;

--- a/cgi-bin/DW/EmailPost/Comment.pm
+++ b/cgi-bin/DW/EmailPost/Comment.pm
@@ -220,7 +220,6 @@ sub determine_subject {
         # we always have a parent comment, because that's the only way we can get an auth hash
         # if that changes, we'll have to add checking here
         my $parent_obj = LJ::Comment->new( $ju, dtalkid => $parent );
-        #$subject = DW::CleanEmail->reply_subject( $parent_obj->subject_text );
         $subject = DW::CleanEmail->reply_subject( $parent_obj->subject_text );
     }
 

--- a/t/emailpost-comment.t
+++ b/t/emailpost-comment.t
@@ -1,6 +1,6 @@
 # t/emailpost-comment.t
 #
-# Test TODO
+# Test replying to comments via email.
 #
 # Authors:
 #      Afuna <coder.dw@afunamatata.com>
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More tests => 6;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -54,16 +54,29 @@ $subject = DW::EmailPost::Comment->determine_subject(
 );
 is( $subject, "Re: Some custom subject", "custom parent subject, default email subject" );
 
+$c_parent->set_subject( "Make sure punctuation isn't escaped" );
+$subject = DW::EmailPost::Comment->determine_subject(
+    "Re: Make sure punctuation isn't escaped $generated",
+    $u, $ditemid, $c_parent->dtalkid
+);
+is( $subject, "Re: Make sure punctuation isn't escaped", "punctuated parent subject, default email subject" );
+
 $c_parent->set_subject( "" );
 $subject = DW::EmailPost::Comment->determine_subject(
     "Change of topic mid-thread",
     $u, $ditemid, $c_parent->dtalkid
 );
-is( $subject, "Change of topic mid-thread", "default parent subjct, custom email subject" );
+is( $subject, "Change of topic mid-thread", "default parent subject, custom email subject" );
 
 $c_parent->set_subject( "Some custom subject" );
 $subject = DW::EmailPost::Comment->determine_subject(
     "Change of topic mid-thread",
     $u, $ditemid, $c_parent->dtalkid
 );
-is( $subject, "Change of topic mid-thread", "custom parent subjct, custom email subject" );
+is( $subject, "Change of topic mid-thread", "custom parent subject, custom email subject" );
+
+$subject = DW::EmailPost::Comment->determine_subject(
+    "Make sure punctuation isn't escaped",
+    $u, $ditemid, $c_parent->dtalkid
+);
+is( $subject, "Make sure punctuation isn't escaped", "custom parent subject, punctuated email subject" );


### PR DESCRIPTION
Using the subject_text method on the parent comment returns
HTML-escaped text, so the reply_subject method should remove
the HTML escaping. Otherwise the resulting text will end up
double-escaped on the site.

Custom reply subjects did not have the escaping problem, but
this adds test cases for both scenarios just to be sure.

Fixes #1643.