### PR TITLE
[#1734] always set opt_preformatted to a defined value when crossposting

### DIFF
--- a/cgi-bin/DW/External/XPostProtocol/LJXMLRPC.pm
+++ b/cgi-bin/DW/External/XPostProtocol/LJXMLRPC.pm
@@ -337,9 +337,12 @@ sub entry_to_req {
     my $entryprops = $entry->props;
     $req->{props} = {};
     # only bring over these properties
-    for my $entrykey (qw ( adult_content current_coords current_location current_music opt_backdated opt_nocomments opt_noemail opt_preformatted opt_screening used_rte pingback )) {
+    for my $entrykey (qw ( adult_content current_coords current_location current_music opt_backdated opt_nocomments opt_noemail opt_screening used_rte pingback )) {
         $req->{props}->{$entrykey} = $entryprops->{$entrykey} if defined $entryprops->{$entrykey};
     }
+
+    # always carry over opt_preformatted, otherwise we can't request to clear it
+    $req->{props}->{opt_preformatted} = $entryprops->{opt_preformatted} ? 1 : 0;
 
     # determine if we used Markdown by examining the raw entry text (not
     # the cleaned text) and advertise the opt_preformatted flag if so


### PR DESCRIPTION
When the checkbox was cleared, the entry property was undefined,
so the effective value wasn't being passed along when editing a
crosspost, and the preformatting on the remote site could never
be undone.

Fixes #1734.