### PR TITLE
Fix #1528: failure to untag shouldn't fail rest of edit but should fail a tag-add

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3983,7 +3983,7 @@ taglib.error.access=You are not allowed to tag entries in this journal.
 
 taglib.error.add=You are not allowed to create new tags for this journal; the entry was not tagged with [[tags]].
 
-taglib.error.delete=You are not allowed to delete tags from entries for this journal; the entry is still tagged with [[tags]].
+taglib.error.delete2=You are not allowed to delete tags from entries for this journal; the entry is still tagged with [[tags]].  Any tags you tried to add have not been added.
 
 taglib.error.exists=The tag name '[[tagname]]' is already in use and cannot be renamed to. You can merge the tags instead.
 

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3983,7 +3983,11 @@ taglib.error.access=You are not allowed to tag entries in this journal.
 
 taglib.error.add=You are not allowed to create new tags for this journal; the entry was not tagged with [[tags]].
 
-taglib.error.delete2=You are not allowed to delete tags from entries for this journal; any tags you tried to add have not been added.  The entry is still tagged with [[tags]].
+taglib.error.delete2<<
+You are not allowed to delete tags from entries for this journal; any tags you tried to add have not been added.
+
+The entry is still tagged with: [[tags]].
+.
 
 taglib.error.exists=The tag name '[[tagname]]' is already in use and cannot be renamed to. You can merge the tags instead.
 

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3983,7 +3983,7 @@ taglib.error.access=You are not allowed to tag entries in this journal.
 
 taglib.error.add=You are not allowed to create new tags for this journal; the entry was not tagged with [[tags]].
 
-taglib.error.delete2=You are not allowed to delete tags from entries for this journal; the entry is still tagged with [[tags]].  Any tags you tried to add have not been added.
+taglib.error.delete2=You are not allowed to delete tags from entries for this journal; any tags you tried to add have not been added.  The entry is still tagged with [[tags]].
 
 taglib.error.exists=The tag name '[[tagname]]' is already in use and cannot be renamed to. You can merge the tags instead.
 

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1138,7 +1138,7 @@ sub _do_edit {
     my $warnings = $opts{warnings} || DW::FormErrors->new;
 
     # e.g., bad HTML in the entry
-    $warnings->add_string( undef, LJ::auto_linkify( LJ::ehtml( $res->{message} ) ) )
+    $warnings->add_string( undef, LJ::auto_linkify( LJ::html_newlines( LJ::ehtml( $res->{message} ) ) ) )
         if $res->{message};
 
     # bunch of helpful links:

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1763,7 +1763,7 @@ sub editevent
     my $add_message = sub {
         my $new_message = shift;
         if ( $res->{message} ) {
-            $res->{message} .= ' ' . $new_message;
+            $res->{message} .= "\n\n" . $new_message;
         } else {
             $res->{message} = $new_message;
         }

--- a/cgi-bin/LJ/Tags.pm
+++ b/cgi-bin/LJ/Tags.pm
@@ -820,7 +820,7 @@ sub update_logtags {
 
     my @add_delete_errors;
     push @add_delete_errors, LJ::Lang::ml( "taglib.error.add", { tags => join( ", ", @unauthorized_add ) } ) if @unauthorized_add;
-    push @add_delete_errors, LJ::Lang::ml( "taglib.error.delete", { tags => join( ", ", map { $utags->{$_}->{name} } keys %delete ) } ) if %delete && ! $can_control && ! $opts->{force};
+    push @add_delete_errors, LJ::Lang::ml( "taglib.error.delete2", { tags => join( ", ", map { $utags->{$_}->{name} } keys %delete ) } ) if %delete && ! $can_control && ! $opts->{force};
     return $err->( join " ", @add_delete_errors ) if @add_delete_errors;
 
     # bail out if nothing needs to be done

--- a/cgi-bin/LJ/Tags.pm
+++ b/cgi-bin/LJ/Tags.pm
@@ -821,7 +821,7 @@ sub update_logtags {
     my @add_delete_errors;
     push @add_delete_errors, LJ::Lang::ml( "taglib.error.add", { tags => join( ", ", @unauthorized_add ) } ) if @unauthorized_add;
     push @add_delete_errors, LJ::Lang::ml( "taglib.error.delete2", { tags => join( ", ", map { $utags->{$_}->{name} } keys %{$tags} ) } ) if %delete && ! $can_control && ! $opts->{force};
-    return $err->( join " ", @add_delete_errors ) if @add_delete_errors;
+    return $err->( join "\n\n", @add_delete_errors ) if @add_delete_errors;
 
     # bail out if nothing needs to be done
     return 1 unless %add || %delete;

--- a/cgi-bin/LJ/Tags.pm
+++ b/cgi-bin/LJ/Tags.pm
@@ -750,8 +750,6 @@ sub update_logtags {
     my $utags = LJ::Tags::get_usertags($u);
     return undef unless $utags;
 
-    # for errors that we want to skip over silently instead of failing, but still report at the end
-    my @skippable_errors;
     my @unauthorized_add;
 
     # take arrayrefs of tag strings and stringify them for validation
@@ -820,13 +818,10 @@ sub update_logtags {
     # now don't readd things we already have
     delete $add{$_} foreach keys %{$tags};
 
-    # populate the errref, but don't actually return.
-    push @skippable_errors, LJ::Lang::ml( "taglib.error.add", { tags => join( ", ", @unauthorized_add ) } ) if @unauthorized_add;
-    push @skippable_errors, LJ::Lang::ml( "taglib.error.delete", { tags => join( ", ", map { $utags->{$_}->{name} } keys %delete ) } ) if %delete && ! $can_control ;
-    $err->( join " ", @skippable_errors ) if @skippable_errors;
-
-    # but delete nothing if we're not a controller
-    %delete = () unless $can_control || $opts->{force};
+    my @add_delete_errors;
+    push @add_delete_errors, LJ::Lang::ml( "taglib.error.add", { tags => join( ", ", @unauthorized_add ) } ) if @unauthorized_add;
+    push @add_delete_errors, LJ::Lang::ml( "taglib.error.delete", { tags => join( ", ", map { $utags->{$_}->{name} } keys %delete ) } ) if %delete && ! $can_control && ! $opts->{force};
+    return $err->( join " ", @add_delete_errors ) if @add_delete_errors;
 
     # bail out if nothing needs to be done
     return 1 unless %add || %delete;

--- a/cgi-bin/LJ/Tags.pm
+++ b/cgi-bin/LJ/Tags.pm
@@ -820,7 +820,7 @@ sub update_logtags {
 
     my @add_delete_errors;
     push @add_delete_errors, LJ::Lang::ml( "taglib.error.add", { tags => join( ", ", @unauthorized_add ) } ) if @unauthorized_add;
-    push @add_delete_errors, LJ::Lang::ml( "taglib.error.delete2", { tags => join( ", ", map { $utags->{$_}->{name} } keys %delete ) } ) if %delete && ! $can_control && ! $opts->{force};
+    push @add_delete_errors, LJ::Lang::ml( "taglib.error.delete2", { tags => join( ", ", map { $utags->{$_}->{name} } keys %{$tags} ) } ) if %delete && ! $can_control && ! $opts->{force};
     return $err->( join " ", @add_delete_errors ) if @add_delete_errors;
 
     # bail out if nothing needs to be done

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -322,7 +322,7 @@ body<=
                     $result .= ($journalu->is_community) ?
                         "<?p $ML{'.success.edited.comm'} p?>" :
                         "<?p $ML{'.success.edited'} p?>";
-                    $result .= "<?p $message p?>" if $message;
+                    $result .= "<div class='alert-box'>$message</div>" if $message;
                     $result .= $xpost_result;
                     # open a request about the unsuspension if one doesn't already exist
                     if ($POST{'action:saveunsuspend'} && !$entry_obj->prop("unsuspend_supportid") && $LJ::UNSUSPENSION_REQUEST_SPCATID) {

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -318,7 +318,7 @@ body<=
                     my $deleted_extras = LJ::Hooks::run_hook('entry_deleted_page_extras');
                     $result .= $deleted_extras if defined $deleted_extras;
                 } else {
-                    $message = LJ::auto_linkify( LJ::ehtml( $res{message} ) );
+                    $message = LJ::auto_linkify( LJ::html_newlines( LJ::ehtml( $res{message} ) ) );
                     $result .= ($journalu->is_community) ?
                         "<?p $ML{'.success.edited.comm'} p?>" :
                         "<?p $ML{'.success.edited'} p?>";

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -259,7 +259,7 @@ body<=
 
                 # check response
                 unless ($res{'success'} eq "OK") {
-                    return "<?h1 $ML{'Error'} h1?><?p $ML{'.error.modify'} <ul><li><b>$res{'errmsg'}</b></li></ul> p?>";
+                    return "<?h1 $ML{'Error'} h1?><?p <ul><li><b>$res{'errmsg'}</b></li></ul> p?>";
                 }
 
                 my $deleted = $req{event} ? 0 : 1;

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -23,6 +23,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <p>[% poststatus.ml_string | ml( url => poststatus.url)%]</p>
 [%- END -%]
 
+[%- IF warnings.exist -%]
+    [%- FOREACH warning IN warnings.get_all -%]
+        <div class="alert-box">[%- warning.message -%]</div>
+    [%- END -%]
+[%- END -%]
+
 [%- IF poststatus.ml_string != ".edit.delete" -%]
 
     <p>[% extradata.security_ml | ml( filters => extradata.filters ) %]</p>
@@ -33,12 +39,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [% ELSE %]
             [% ".extradata.subject.no_subject" | ml %]
         [% END %]</p>
-    [%- END -%]
-[%- END -%]
-
-[%- IF warnings.exist -%]
-    [%- FOREACH warning IN warnings.get_all -%]
-        <div class="alert-box">[%- warning.message -%]</div>
     [%- END -%]
 [%- END -%]
 


### PR DESCRIPTION
See commit messages; I've gone with @kaberett's suggested behaviour. Here's what it looks like from the beta editor:

![from-new](https://cloud.githubusercontent.com/assets/127305/14412189/9e4b1eb2-ff54-11e5-9605-73652b4f1056.png)

...and from editjournal.bml:

![from-old](https://cloud.githubusercontent.com/assets/127305/14412190/9e618c74-ff54-11e5-8159-177ed601c75d.png)

Fixes: #1528
