### PR TITLE
[#1747] verify https OpenID URLs

### DIFF
--- a/cgi-bin/LJ/OpenID.pm
+++ b/cgi-bin/LJ/OpenID.pm
@@ -132,7 +132,8 @@ sub is_identity {
         # legacy:
         $ident eq "$LJ::SITEROOT/users/$user/" ||
         $ident eq "$LJ::SITEROOT/~$user/" ||
-        $ident eq "http://$user.$LJ::USER_DOMAIN/";
+        $ident eq "http://$user.$LJ::USER_DOMAIN/" ||
+        $ident eq "https://$user.$LJ::USER_DOMAIN/";
 
     return 0;
 }


### PR DESCRIPTION
I think this is only an issue when the verification request
is insecure, but at any rate, this should fix #1747.

I haven't tested this, though.