### PR TITLE
don't test $LJ::HTTPS_UPGRADE_REGEX unless it is defined

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1673,7 +1673,8 @@ sub https_url {
     return $url if $url =~ m!^(?:https://|//)!;
 
     # if this link is on our site, let's just switch it to https
-    if ( $url =~ $LJ::DOMAIN || $url =~ $LJ::HTTPS_UPGRADE_REGEX ) {
+    if ( $url =~ $LJ::DOMAIN || defined $LJ::HTTPS_UPGRADE_REGEX
+                             && $url =~ $LJ::HTTPS_UPGRADE_REGEX ) {
         $url =~ s!^http:!https:!;
         return $url;
     }


### PR DESCRIPTION
Otherwise the conditional will always be true.

This made t/post.t start failing.  Yay tests!