### PR TITLE
Remove customview from codebase

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1032,6 +1032,7 @@ general error.interest.bytes.chars.words
 general error.interest.chars.words
 general error.interest.excessive
 general error.interest.words
+general error.vhost.nostyle
 general esn.add_friend
 general esn.befriended.email_text
 general esn.befriended.openid_email_text

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -853,8 +853,6 @@ error.vhost.nocomm=This account isn't a community journal.
 
 error.vhost.nodomain1=URLs like <nobr><b>https://<i>username</i>.[[user_domain]]/</b></nobr> are not available for this user's account type.
 
-error.vhost.nostyle=This user's account type is not permitted to create and embed styles.
-
 esn.addedtocircle.trusted.email_text<<
 Hi [[user]],
 

--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -187,12 +187,6 @@ sub totally_down_content
         return OK;
     }
 
-    if ($uri =~ m!^/customview.cgi!) {
-        $apache_r->content_type("text/html");
-        $apache_r->print("<!-- $LJ::SERVER_DOWN_MESSAGE -->");
-        return OK;
-    }
-
     # set to 500 so people don't cache this error message
     my $body = "<h1>$LJ::SERVER_DOWN_SUBJECT</h1>$LJ::SERVER_DOWN_MESSAGE<!-- " . ("x" x 1024) . " -->";
     $apache_r->status( 503 );
@@ -632,11 +626,6 @@ sub trans
 
             my ($mode, $path) = ($1, $2);
 
-            if ($mode eq "customview") {
-                $apache_r->handler("perl-script");
-                $apache_r->push_handlers(PerlResponseHandler => \&customview_content);
-                return OK;
-            }
             if (my $handler = LJ::Hooks::run_hook("data_handler:$mode", $RQ{'user'}, $path)) {
                 $apache_r->handler("perl-script");
                 $apache_r->push_handlers(PerlResponseHandler => $handler);
@@ -1023,13 +1012,6 @@ sub trans
 
         my $view = $determine_view->($user, $vhost, $rest);
         return $view if defined $view;
-    }
-
-    # customview (get an S1 journal by number)
-    if ($uri =~ m!^/customview\.cgi!) {
-        $apache_r->handler("perl-script");
-        $apache_r->push_handlers(PerlResponseHandler => \&customview_content);
-        return OK;
     }
 
     if ($uri =~ m!^/palimg/!) {
@@ -1473,83 +1455,6 @@ sub journal_content
     $apache_r->headers_out->{"Content-length"} = $length;
     $apache_r->print($html) unless $apache_r->header_only;
 
-    return OK;
-}
-
-sub customview_content
-{
-    my $apache_r = shift;
-    my %FORM = $apache_r->args;
-
-    my $charset = "utf-8";
-
-    if ($LJ::UNICODE && $FORM{'charset'}) {
-        $charset = $FORM{'charset'};
-        if ($charset ne "utf-8" && ! Unicode::MapUTF8::utf8_supported_charset($charset)) {
-            $apache_r->content_type("text/html");
-            $apache_r->print("<b>Error:</b> requested charset not supported.");
-            return OK;
-        }
-    }
-
-    my $ctype = "text/html";
-    if ($FORM{'type'} eq "xml") {
-        $ctype = "text/xml";
-    }
-
-    if ($LJ::UNICODE) {
-        $ctype .= "; charset=$charset";
-    }
-
-    $apache_r->content_type($ctype);
-
-    my $cur_journal = LJ::Session->domain_journal;
-    my $user = LJ::canonical_username($FORM{'username'} || $FORM{'user'} || $cur_journal);
-    my $styleid = $FORM{'styleid'} + 0;
-    my $nooverride = $FORM{'nooverride'} ? 1 : 0;
-
-    if ($LJ::ONLY_USER_VHOSTS && $cur_journal ne $user) {
-        my $u = LJ::load_user($user)
-            or return 404;
-        my $safeurl = $u->journal_base . "/data/customview?";
-        my %get_args = %FORM;
-        delete $get_args{'user'};
-        delete $get_args{'username'};
-        $safeurl .= join("&", map { LJ::eurl($_) . "=" . LJ::eurl($get_args{$_}) } keys %get_args);
-        return redir($apache_r, $safeurl);
-    }
-
-    my $remote;
-    if ($FORM{'checkcookies'}) {
-        $remote = LJ::get_remote();
-    }
-
-    my $data = (LJ::make_journal($user, "", $remote,
-                 { "nocache" => $FORM{'nocache'},
-                   "vhost" => "customview",
-                   "nooverride" => $nooverride,
-                   "styleid" => $styleid,
-                   "saycharset" => $charset,
-                   "args" => scalar $apache_r->args,
-                   "r" => $apache_r,
-               })
-          || "<b>[$LJ::SITENAME: Bad username, styleid, or style definition]</b>");
-
-    if ($FORM{'enc'} eq "js") {
-        $data =~ s/\\/\\\\/g;
-        $data =~ s/\"/\\\"/g;
-        $data =~ s/\n/\\n/g;
-        $data =~ s/\r//g;
-        $data = "document.write(\"$data\")";
-    }
-
-    if ($LJ::UNICODE && $charset ne 'utf-8') {
-        $data = Unicode::MapUTF8::from_utf8({-string=>$data, -charset=>$charset});
-    }
-
-    $apache_r->headers_out->{"Cache-Control"} = "must-revalidate";
-    $apache_r->headers_out->{"Content-Length"} = length($data);
-    $apache_r->print($data) unless $apache_r->header_only;
     return OK;
 }
 

--- a/cgi-bin/DW/FeedCanonicalizer.pm
+++ b/cgi-bin/DW/FeedCanonicalizer.pm
@@ -29,7 +29,7 @@ my %LJISH_SITES = map { $_ => 1 } (
 );
 
 my $LJISH_URL_PART = "(data/(?:rss|atom)(?:_friends|\.xml|\.html)?|"
-    . "data/customview|rss(?:/friends|/data|\.xml|\.html)?)(/.+?)?(.+?)?";
+    . "rss(?:/friends|/data|\.xml|\.html)?)(/.+?)?(.+?)?";
 
 sub canonicalize {
     my $uri_string = $_[0];
@@ -319,25 +319,15 @@ sub make_ljish {
     $username =~ s/-/_/g;
 
     my $extra = "";
-    if ( $feed =~ m/customview$/i ) {
-        $extra = $extra_raw if $extra_raw =~ m!^/!;
-        return LJ::create_url("/$username/customview$extra",
-            proto => "ljish",
-            host => $domain,
-            cur_args => { $uri->query_form },
-            keep_args => [ qw/ styleid show filter / ] );
-    } else {
-        my $extra;
-        $extra = "/friends" if $feed =~ /friends$/;
+    $extra = "/friends" if $feed =~ /friends$/;
 
-        my %query = $uri->query_form;
+    my %query = $uri->query_form;
 
-        if ( $query{tag} ) {
-            return "ljish://$domain/$username$extra?tag=" . uri_escape( $query{tag} );
-        }
-
-        return "ljish://$domain/$username$extra";
+    if ( $query{tag} ) {
+        $extra .= "?tag=" . uri_escape( $query{tag} );
     }
+
+    return "ljish://$domain/$username$extra";
 }
 
 1;

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -861,6 +861,8 @@ sub clean
                 # in S1 with a page that embeds scripting as well.  An example being an AJAX
                 # six degrees tool, while cool it should not be allowed.
                 #
+                # FIXME Dreamwidth does not support S1 and customview has been removed.
+                #
                 # Example syntax:
                 # <xsl:element name="script">
                 # <xsl:attribute name="type">text/javascript</xsl:attribute>

--- a/cgi-bin/LJ/User/Styles.pm
+++ b/cgi-bin/LJ/User/Styles.pm
@@ -616,9 +616,6 @@ sub make_journal {
     if ($opts->{'vhost'} =~ /^other:/ && ! LJ::get_cap($u, "domainmap")) {
         return $notice->( BML::ml( 'error.vhost.noalias' ) );
     }
-    if ($opts->{'vhost'} eq "customview" && ! LJ::get_cap($u, "styles")) {
-        return $notice->( BML::ml( 'error.vhost.nostyle' ) );
-    }
     if ($opts->{'vhost'} eq "community" && $u->journaltype !~ /[CR]/) {
         $opts->{'badargs'} = 1; # Output a generic 'bad URL' message if available
         return $notice->( BML::ml( 'error.vhost.nocomm' ) );

--- a/t/feed-canonicalizer.t
+++ b/t/feed-canonicalizer.t
@@ -42,8 +42,6 @@ my @pairs = map {
     [ "http://username.fakejournal.com/data/rss?tag=cupcakes", "ljish://fakejournal.com/username?tag=cupcakes"],
     [ "http://username.fakejournal.com/data/atom?tag=cupcakes", "ljish://fakejournal.com/username?tag=cupcakes"],
 
-    [ "http://username.fakejournal.com/data/customview?styleid=1&show=2&filter=3", "ljish://fakejournal.com/username/customview?filter=3&show=2&styleid=1"],
-
     # These only work on lj-ish sites    
     [ "http://username.livejournal.com/rss", "ljish://livejournal.com/username"],
     [ "http://username.livejournal.com/rss/friends", "ljish://livejournal.com/username/friends"],    


### PR DESCRIPTION
Fixes Bugzilla bug 2324.

customview has always been a hack (to allow users to use their own
domains?) and has never been supported on Dreamwidth; as of 2011 no
reports had been received of customview being used or needed, and
the decision was taken to remove the feature rather than begin
supporting it. This commit applies the code machete; visiting URLs of
the form e.g.
http://kaberett.kaberett.hack.dreamwidth.net/data/customview/?s2id=148
now produces a site-skinned 404 instead of a black-on-white error
message about account permissions.