### PR TITLE
Tidy up CSS credit for Leftovers and Patsy

### DIFF
--- a/styles/leftovers/layout.s2
+++ b/styles/leftovers/layout.s2
@@ -77,11 +77,10 @@ function print_stylesheet () {
 /*-------------------------------------
 
 
-	layout name: leftovers
-	latout type: tabularasa
+    layout name: leftovers
+    layout type: tabularasa
 
-	renoir.dreamwidth.org / vaisselle.livejournal.com
-	please do not redistribute
+    renoir.dreamwidth.org / vaisselle.livejournal.com
 
 
 -------------------------------------*/

--- a/styles/patsy/layout.s2
+++ b/styles/patsy/layout.s2
@@ -219,12 +219,10 @@ if ( ($*comment_userpic_style == "" and $*entry_userpic_style == "small") or ($*
 /*-------------------------------------
 
 
-	layout name: patsy
-	latout type: tabularasa
-	tiny icon credits: pinvoke.com
+    layout name: patsy
+    layout type: tabularasa
 
-	renoir.dreamwidth.org / vaisselle.livejournal.com
-	please do not redistribute
+    renoir.dreamwidth.org / vaisselle.livejournal.com
 
 
 -------------------------------------*/


### PR DESCRIPTION
Fixes Bugzilla bug 5223.

Replaces tab characters with spaces, and removes "please do not
redistribute" note and credit to pinvoke (not used), per @ninetyd's
comments on the original bug.