### PR TITLE
Make light/lynx mode render better on mobile devices

### DIFF
--- a/schemes/lynx.tt
+++ b/schemes/lynx.tt
@@ -14,6 +14,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <!DOCTYPE html>
 <html>
 <head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="home" title="[% 'lynx.nav.home' | ml %]" href="[% site.root %]/" />
 <link rel="contents" title="[% 'lynx.nav.sitemap' | ml %]" href="[% site.root %]/site/" />
 <link rel="help" title="[% 'lynx.nav.help' | ml %]" href="[% site.root %]/support/" />


### PR DESCRIPTION
This commit adds a meta viewport tag. Here's a nice overview for the meta viewport tag; https://developers.google.com/speed/docs/insights/ConfigureViewport

> When a page does not specify a viewport, mobile browsers will render that page at a _fallback width_ ranging from 800 to 1024 CSS pixels. The page scale factor is adjusted so that the page fits on the display, forcing users to zoom before they can interact with the page.

> [...]

> Using the meta viewport value `width=device-width` instructs the page to match the screen's width in device independent pixels. This allows the page to reflow content to match different screen sizes.

> Some browsers, including iOS and Windows Phone, will keep the page's width constant when rotating to landscape mode, and zoom rather than reflow to fill the screen. Adding the attribute `initial-scale=1` instructs browsers to establish a 1:1 relationship between CSS pixels and device independent pixels regardless of device orientation, and allows the page to take advantage of the full landscape width.