### PR TITLE
List "Other Services" in neatly formatted columns

### DIFF
--- a/htdocs/profile.bml
+++ b/htdocs/profile.bml
@@ -601,16 +601,16 @@ body<=
     my $imlist;
     foreach my $service ( $profile->external_services ) {
         my $title = $ML{$service->{title_ml}};
-        $imlist .= "<tr class='im_$service->{type}'>";
-        $imlist .= "<td class='im_icon'><img src='$LJ::IMGPREFIX/profile_icons/$service->{image}' alt=\"$title\" title=\"$title\" /></td>";
+        $imlist .= "<li class=\"im_$service->{type}\">";
+        $imlist .= "<div class=\"im_icon\"><img src=\"$LJ::IMGPREFIX/profile_icons/$service->{image}\" alt=\"$title\" title=\"$title\" /></div>";
         if ( $service->{status_image} ) {
             my $status_title = $ML{$service->{status_title_ml}};
-            $imlist .= "<td>" . $linkify->( $service ) . "</td>";
-            $imlist .= "<td class='im_status'><img src='$service->{status_image}' alt=\"$status_title\" title=\"$status_title\" width='$service->{status_width}' height='$service->{status_height}' /></td>";
+            $imlist .= " " . $linkify->( $service );
+            $imlist .= "<div class=\"im_status\"><img src=\"$service->{status_image}\" alt=\"$status_title\" title=\"$status_title\" width='$service->{status_width}' height='$service->{status_height}' /></div>";
         } else {
-            $imlist .= "<td colspan='2'>" . $linkify->( $service ) . "</td>";
+            $imlist .= " " . $linkify->( $service );
         }
-        $imlist .= "</tr>";
+        $imlist .= "</li>";
     }
     if ( $imlist ) {
         my $secimg = $profile->security_image( $u->opt_showcontact );
@@ -625,7 +625,7 @@ body<=
             section_name_postfix => $secimg,
             section_link    => 'services',
             extra_attrs     => $new_im_margin,
-            body            => "<table summary=''>$imlist</table>",
+            body            => "<ul>$imlist</ul>",
             links           => $links,
             collapsible     => 0,
         );

--- a/htdocs/profile.bml
+++ b/htdocs/profile.bml
@@ -605,7 +605,7 @@ body<=
         $imlist .= "<div class=\"im_icon\"><img src=\"$LJ::IMGPREFIX/profile_icons/$service->{image}\" alt=\"$title\" title=\"$title\" /></div>";
         if ( $service->{status_image} ) {
             my $status_title = $ML{$service->{status_title_ml}};
-            $imlist .= " " . $linkify->( $service );
+            $imlist .= " " . $linkify->( $service ) . " ";
             $imlist .= "<div class=\"im_status\"><img src=\"$service->{status_image}\" alt=\"$status_title\" title=\"$status_title\" width='$service->{status_width}' height='$service->{status_height}' /></div>";
         } else {
             $imlist .= " " . $linkify->( $service );

--- a/htdocs/stc/profile.css
+++ b/htdocs/stc/profile.css
@@ -211,9 +211,17 @@ span.expandcollapse {
     padding-right: 3px;
     max-width: 19px;
 }
+.external_services ul {
+    -webkit-column-width: 15em;
+    -moz-column-width: 15em;
+    column-width: 15em;
+    list-style-type: none;
+}
 .external_services div.im_icon,
 .external_services div.im_status {
     text-align: center;
+    display: inline;
+    width: 19px;
 }
 .external_services div.im_icon img,
 .external_services div.im_status img {

--- a/htdocs/stc/profile.css
+++ b/htdocs/stc/profile.css
@@ -211,11 +211,11 @@ span.expandcollapse {
     padding-right: 3px;
     max-width: 19px;
 }
-.external_services table td.im_icon,
-.external_services table td.im_status {
+.external_services div.im_icon,
+.external_services div.im_status {
     text-align: center;
 }
-.external_services table td.im_icon img,
-.external_services table td.im_status img {
+.external_services div.im_icon img,
+.external_services div.im_status img {
     border: 0;
 }

--- a/htdocs/stc/profile.css
+++ b/htdocs/stc/profile.css
@@ -216,6 +216,11 @@ span.expandcollapse {
     column-width: 15em;
     list-style-type: none;
 }
+.external_services ul li {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .external_services div.im_icon,
 .external_services div.im_status {
     text-align: center;

--- a/htdocs/stc/profile.css
+++ b/htdocs/stc/profile.css
@@ -204,7 +204,6 @@ span.expandcollapse {
 }
 
 .external_services {
-    float: left;
     margin: 10px 70px 0 0;
 }
 .external_services img {

--- a/htdocs/stc/profile.css
+++ b/htdocs/stc/profile.css
@@ -207,15 +207,15 @@ span.expandcollapse {
     float: left;
     margin: 10px 70px 0 0;
 }
-    .external_services img {
-        padding-right: 3px;
-        max-width: 19px;
-    }
-    .external_services table td.im_icon,
-    .external_services table td.im_status {
-        text-align: center;
-    }
-        .external_services table td.im_icon img,
-        .external_services table td.im_status img {
-            border: 0;
-        }
+.external_services img {
+    padding-right: 3px;
+    max-width: 19px;
+}
+.external_services table td.im_icon,
+.external_services table td.im_status {
+    text-align: center;
+}
+.external_services table td.im_icon img,
+.external_services table td.im_status img {
+    border: 0;
+}


### PR DESCRIPTION
Fixes #1702.

Rather than using tables to render the list of "Other Services" on profile pages, use a `ul`. While we're at it, format the list into columns on devices that support it.

AIUI, this will:

* Render columns on any vaguely recent version of most browsers, with the exception of IE9 and earlier, which don't have support for columns.
* Render a list that looks very similar to the current table display on graphical browsers that don't support columns (looking at you, IE)
* Be considerably more accessible than the old table-based layout for users with screen readers or text-only browsers.

I've picked a width of 15em as something that looks vaguely reasonable to me, and I've made sure the behaviour is reasonable for over-sized usernames. You can currently see what it looks like on my Dreamhack at http://system.meandering.hack.dreamwidth.net/profile.