### PR TITLE
[#1709] warn for xmlrpc errors without faultcodes

### DIFF
--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -1643,6 +1643,10 @@ sub xmlrpc_method {
     }
     my $res = LJ::Protocol::do_request($method, $req, \$error);
     if ($error) {
+        # FIXME [#1709]: which errors don't start with numbers?
+        print STDERR "[#1709] xmlrpc error for $method needs faultcode: $error\n"
+            unless $error =~ /^\d{3}/;
+        # existing behavior
         die SOAP::Fault
             ->faultstring(LJ::Protocol::error_message($error))
             ->faultcode(substr($error, 0, 3));


### PR DESCRIPTION
Proposed logging to get more information on which XML-RPC error messages have the problem.