### PR TITLE
[#1742] don't lowercase all get_args keys in LJ::create_url

### DIFF
--- a/cgi-bin/DW/Request/Base.pm
+++ b/cgi-bin/DW/Request/Base.pm
@@ -164,13 +164,19 @@ sub post_args {
 
 # returns a Hash::MultiValue of query string arguments
 sub get_args {
-    my DW::Request $self = $_[0];
+    my DW::Request $self = shift;
     return $self->{get_args} if defined $self->{get_args};
 
+    my %opts = @_;
+
     # We lowercase GET arguments because these are often typed by users, and
-    # that's nicer on them.
+    # that's nicer on them.  This isn't always desired behavior, though.
+    # In particular, it confuses post_fields_by_widget in LJ::Widget.
+
+    my $lc = $opts{preserve_case} ? 0 : 1;
+
     return $self->{get_args} =
-        $self->_string_to_multivalue( $self->query_string, lowercase => 1 );
+        $self->_string_to_multivalue( $self->query_string, lowercase => $lc );
 }
 
 # Returns a JSON object contained in the body of this request if and only if

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -1096,7 +1096,13 @@ sub create_url {
         foreach my $k ( keys %$orig_args ) {
             next if $k eq lc $k;
             next if $k =~ /^Widget\b/;
-            warn "[#1742] lowercasing $k, url: $url\n";
+            # already found another unintended side effect in /endpoints/draft
+            next if $k eq 'getProperties';
+
+            # don't complain about hand-typed arguments, but do convert them (for now)
+            my $referer = DW::Request->get->header_in("Referer");
+            warn "[#1742] lowercasing $k, url: $url (referer: $referer)\n"
+                if $referer;
             $orig_args->{lc $k} = $orig_args->{$k};
             delete $orig_args->{$k};
         }

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -1088,7 +1088,19 @@ sub create_url {
     my $proto = $opts{proto} // ( $opts{ssl} ? "https" : "http" );
     my $url = $proto . "://$host$path";
 
-    my $orig_args = $opts{cur_args} || DW::Request->get->get_args;
+    my $orig_args = $opts{cur_args} || DW::Request->get->get_args( preserve_case => 1 );
+
+    # Mimic previous behavior of lowercasing keys unless they start with Widget
+    # FIXME: this should eventually go away - see #1742
+    unless ( $opts{cur_args} ) {
+        foreach my $k ( keys %$orig_args ) {
+            next if $k eq lc $k;
+            next if $k =~ /^Widget\b/;
+            warn "[#1742] lowercasing $k, url: $url\n";
+            $orig_args->{lc $k} = $orig_args->{$k};
+            delete $orig_args->{$k};
+        }
+    }
 
     # Move over viewing style arguments
     if( $opts{viewing_style} ) {


### PR DESCRIPTION
This is the conservative version that only preserves case sensitivity for known case-sensitive arguments, and logs a warning if any other case changes are requested from clicked links. Hand-typed requests are still silently converted to lowercase as originally intended, for now.

I'd like to gather some data from the production logs and add any other needed exceptions before going on to the next step, which would be to hopefully eliminate lowercasing in create_url, and move the logging up a level into get_args.