### PR TITLE
[#1660] improve error message when uploading multiple icons fails

### DIFF
--- a/cgi-bin/Apache/BML.pm
+++ b/cgi-bin/Apache/BML.pm
@@ -1562,7 +1562,7 @@ sub parse_multipart_interactive {
             return $err->($@);
         }
         unless ($ret) {
-            return $err->("Hook: '$name' returned false");
+            return $err->( $$errref ? $$errref : "Hook: '$name' returned false" );
         }
         return 1;
     };

--- a/htdocs/editicons.bml
+++ b/htdocs/editicons.bml
@@ -1051,9 +1051,12 @@ sub parse_large_upload
         }
 
         if (index(lc($$errorref), 'unknown format') == 0) {
-            return $err->(BML::ml(".error.unknowntype"));
+            $$errorref = BML::ml(".error.unknowntype");
+        } else {
+            $$errorref = "couldn't parse upload: $$errorref";
         }
-        return $err->("couldn't parse upload: $$errorref");
+        # the error page is printed in the caller
+        return 0;
     }
 
     return $retval;


### PR DESCRIPTION
Some bits of code were expecting errorrefs that weren't being set.
Others were ignoring errorrefs that were being set.  Both cases
should be fixed now, such that the intended error messages will
actually be shown to the user.

The error message shown when one of many icons is an unsupported
image type is now "You can only upload GIF, PNG, or JPG files."
instead of "Hook: 'enddata' returned false" - it's in the
translation system if we want to make it more verbose.

Fixes #1660.