### PR TITLE
Add url and url_full methods to LJ::Faq

### DIFF
--- a/cgi-bin/LJ/Faq.pm
+++ b/cgi-bin/LJ/Faq.pm
@@ -231,6 +231,18 @@ sub sortorder {
     return $self->{sortorder};
 }
 
+sub url {
+    my ($class, $faqid) = @_;
+    $faqid = $class->{faqid} if ref $class;
+    return "$LJ::SITEROOT/support/faqbrowse?faqid=$faqid";
+}
+
+sub url_full {
+    my ($class, $faqid) = @_;
+    $faqid = $class->{faqid} if ref $class;
+    return "$LJ::SITEROOT/support/faqbrowse?faqid=$faqid&view=full";
+}
+
 # <LJFUNC>
 # name: LJ::Faq::has_summary
 # class: general

--- a/cgi-bin/LJ/Support.pm
+++ b/cgi-bin/LJ/Support.pm
@@ -1012,7 +1012,7 @@ sub mail_response_to_user
         if ( $faq ) {
             $faq->render_in_place;
             $body .= LJ::Lang::ml( "support.email.update.faqref") . " " . $faq->question_raw . "\n";
-            $body .= "$LJ::SITEROOT/support/faqbrowse?faqid=$faqid&view=full";
+            $body .= $faq->url_full;
             $body .= "\n\n";
         }
     }
@@ -1177,7 +1177,7 @@ sub work {
             my $faq = LJ::Faq->load( $faqid, lang => $lang );
             if ( $faq ) {
                 $faq->render_in_place;
-                my $faqref = $faq->question_raw . " " . "$LJ::SITEROOT/support/faqbrowse?faqid=$faqid&view=full";
+                my $faqref = $faq->question_raw . " " . $faq->url_full;
 
                 # now add it to the e-mail!
                 $body .= "\n" . LJ::Lang::ml( "support.email.notif.update.body.faqref", {

--- a/t/faq.t
+++ b/t/faq.t
@@ -18,7 +18,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 60;
+use Test::More tests => 72;
 
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
@@ -45,6 +45,10 @@ sub run_tests {
         {
             my $f = eval { LJ::Faq->new(%skel, lang => 'xx') };
             is($f->lang, $LJ::DEFAULT_LANG, "unknown language code falls back to default");
+
+            # URLs should provide something sane
+            like($f->url, qr#/support/faqbrowse#, "Support URL matches expected");
+            like($f->url_full, qr#view=full#, "Full support URL matches expected");
         }
 
         foreach my $lang (qw(en)) {
@@ -113,6 +117,9 @@ sub run_tests {
             ok($f->has_summary, "${sum}: summary present");
         }
     }
+
+    like(LJ::Faq->url(123), qr#/support/faqbrowse#, "Support URL matches expected");
+    like(LJ::Faq->url_full(123), qr#view=full#, "Full support URL matches expected");
 
     # TODO: render_in_place (needs FAQs in the database)
     # FIXME: more robust tests


### PR DESCRIPTION
These are callable both on FAQ instances ($faq->url), and directly
(LJ::Faq->url 123), so you can easily produce a FAQ URL regardless
of whether you have a Faq object, or just the id.

Closes #1722.