### PR TITLE
Adjust things to avoid Perl 5.20's precedence warnings

### DIFF
--- a/cgi-bin/DW/Hooks/SiteSearch.pm
+++ b/cgi-bin/DW/Hooks/SiteSearch.pm
@@ -21,8 +21,9 @@ use LJ::Hooks;
 
 sub _sphinx_db {
     # ensure we can talk to our system
-    return LJ::get_dbh( 'sphinx_search' )
+    my $dbh = LJ::get_dbh( 'sphinx_search' )
         or die "Unable to get sphinx_search database handle.\n";
+    return $dbh;
 }
 
 LJ::Hooks::register_hook( 'setprop', sub {

--- a/cgi-bin/DW/Shop.pm
+++ b/cgi-bin/DW/Shop.pm
@@ -187,8 +187,9 @@ use Carp qw/ confess /;
 
 # returns the shop on a user
 sub shop {
-    return $_[0]->{_shop}
+    my $shop = $_[0]->{_shop}
         or confess 'tried to get shop without calling DW::Shop->initialize()';
+    return $shop;
 }
 
 1;

--- a/cgi-bin/LJ/Stats.pm
+++ b/cgi-bin/LJ/Stats.pm
@@ -62,8 +62,9 @@ sub LJ::Stats::run_stats {
             # rather than passing an actual db handle to the stat handler,
             # just pass a getter subef so it can be revalidated as necessary
             my $dbr_getter = sub {
-                return LJ::Stats::get_db("dbr")
+                my $dbr = LJ::Stats::get_db("dbr")
                     or die "Can't get db reader handle.";
+                return $dbr;
             };
 
             print "-I- Running: $jobname\n";
@@ -109,8 +110,9 @@ sub LJ::Stats::run_stats {
                 # pass a dbcr getter subref so the stat handler knows how
                 # to revalidate its database handles, by invoking this closure
                 my $dbcr_getter = sub {
-                    return LJ::Stats::get_db("dbcr", $cid)
+                    my $dbcr = LJ::Stats::get_db("dbcr", $cid)
                         or die "Can't get cluster $cid db handle.";
+                    return $dbcr;
                 };
 
                 print "-I- Running: $jobname, cluster $cid\n";


### PR DESCRIPTION
Due to Perl's precedence rules, `return x or thing` is always
interpreted as `return x`, so the `or thing` never happens.
That's not really ideal when you're trying to error out (`or die`),
so adjust these calls to ensure the dieing is not dead code.

Fixes #1772