### PR TITLE
Encode plaintext e-mails with quoted-printable

### DIFF
--- a/cgi-bin/LJ/Sendmail.pm
+++ b/cgi-bin/LJ/Sendmail.pm
@@ -147,7 +147,8 @@ sub send_mail
                                    'Bcc'     => $opt->{bcc} || '',
                                    'Subject' => $subject,
                                    'Type'    => 'text/plain',
-                                   'Data'    => $body);
+                                   'Data'    => $body,
+                                   'Encoding' => 'quoted-printable');
 
             $msg->attr("content-type.charset" => $charset);
         }


### PR DESCRIPTION
HTML e-mails apparently work okay, but plaintext e-mails are full of
mojibake, but only in production, which runs through SES (that is,
sending e-mails via my local SMTP server works fine!).  The primary
difference between the two is that the HTML e-mails encode their
contents via quoted-printable, and the plaintext e-mails send raw,
unencoded 8-bit data.  SMTP and 8-bit data do not get along, and I
strongly suspect SES is re-encoding the data into 7-bit, poorly.

If what I surmise is correct, this should fix #1501.