### PR TITLE
Provide useful error messages for get_maintainer

### DIFF
--- a/cgi-bin/LJ/Console/Command/GetMaintainer.pm
+++ b/cgi-bin/LJ/Console/Command/GetMaintainer.pm
@@ -40,7 +40,16 @@ sub execute {
 
     my $relation = LJ::Console::Command::GetRelation->new( command => 'get_maintainer', args => [ $user, 'A' ] );
     $relation->execute($relation->args);
-    $self->add_responses($relation->responses);
+    if ( $relation->responses ) {
+        $self->add_responses($relation->responses);
+    } else {
+        my $u = LJ::load_user_or_identity($user);
+        if ( $u->is_community ) {
+            return $self->error("No admins");
+        } else {
+            return $self->error("No communities adminned");
+        }
+    }
 
     return 1;
 }


### PR DESCRIPTION
Fixes #1762.

Adds error messages for the case where get_maintainer is given an
argument consisting of either a user who doesn't admin any communities,
or a community that has no admins (though I've not, in testing, managed
to remove myself as the admin of a deleted comm).