### PR TITLE
Make entry moderation message box auto-scale.

### DIFF
--- a/htdocs/js/jquery.autogrow-textarea.js
+++ b/htdocs/js/jquery.autogrow-textarea.js
@@ -1,0 +1,68 @@
+/**
+*  Auto-growing textareas; technique ripped from Facebook
+*  (c) 2008 Jason Frame (jason@onehackoranother.com)
+*  Released under The MIT License.
+*  http://github.com/jaz303/jquery-grab-bag/tree/master/javascripts/jquery.autogrow-textarea.js
+*/
+
+(function($)
+{
+    $.fn.autogrow = function(options)
+    {
+        return this.filter('textarea').each(function()
+        {
+            var self = this;
+            var $self = $(self);
+			var minHeight = $self.height();
+            var noFlickerPad = $self.hasClass('autogrow-short') ? 0 : parseInt($self.css('lineHeight')) || 0;
+
+            var shadow = $('<div></div>').css({
+                position: 'absolute',
+                top: -10000,
+                left: -10000,
+                width: $self.width(),
+                fontSize: $self.css('fontSize'),
+                fontFamily: $self.css('fontFamily'),
+                fontWeight: $self.css('fontWeight'),
+                lineHeight: $self.css('lineHeight'),
+                resize: 'none',
+				'word-wrap': 'break-word'
+            }).appendTo(document.body);
+
+            var update = function(event)
+            {
+                var times = function(string, number)
+                {
+                    for (var i=0, r=''; i<number; i++) r += string;
+                    return r;
+                };
+
+                var val = self.value.replace(/</g, '&lt;')
+                                    .replace(/>/g, '&gt;')
+                                    .replace(/&/g, '&amp;')
+                                    .replace(/\n$/, '<br/>&nbsp;')
+                                    .replace(/\n/g, '<br/>')
+                                    .replace(/ {2,}/g, function(space){ return times('&nbsp;', space.length - 1) + ' ' });
+
+// Did enter get pressed? Resize in this keydown event so that the flicker doesn't occur.
+if (event && event.data && event.data.event === 'keydown' && event.keyCode === 13) {
+val += '<br />';
+}
+
+                shadow.css('width', $self.width());
+                shadow.html(val + (noFlickerPad === 0 ? '...' : '')); // Append '...' to resize pre-emptively.
+                $self.height(Math.max(shadow.height() + noFlickerPad, minHeight));
+            }
+
+            $self.change(update).keyup(update).keydown({event:'keydown'},update);
+            $(window).resize(update);
+
+            update();
+        });
+    };
+})(jQuery);
+
+// initialize all expanding textareas
+jQuery(document).ready(function() {
+	jQuery("textarea[class*=expand]").autogrow();
+});

--- a/views/communities/queue/entries/edit.tt
+++ b/views/communities/queue/entries/edit.tt
@@ -18,6 +18,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- dw.need_res( { group => "foundation" }
     "stc/entrypage.css"
     "stc/css/pages/communities/queue/entries/edit.css"
+    "js/jquery.autogrow-textarea.js"
 ) -%]
 
 [%- linkbar -%]
@@ -68,6 +69,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [% form.textarea(
             name  = "message"
             label = dw.ml( ".form.label.message" )
+            class = "expand"
         ) %]
         [%- END -%]
 


### PR DESCRIPTION
Moves autogrow plugin in from non-free (MIT licensed, only in non-free
because only /site/suggest was using it; separate PR to follow to clean
up the other end of this move).

Fixes: #1287