### PR TITLE
more code machete in poll code

### DIFF
--- a/bin/dumpsql.pl
+++ b/bin/dumpsql.pl
@@ -144,7 +144,7 @@ foreach my $k (keys %output) {
 print "Dumping proplists.dat\n";
 open (my $plg, ">$ENV{LJHOME}/bin/upgrading/proplists.dat") or die;
 open (my $pll, ">$ENV{LJHOME}/bin/upgrading/proplists-local.dat") or die;
-foreach my $table ('userproplist', 'talkproplist', 'logproplist', 'usermsgproplist', 'pollproplist2') {
+foreach my $table ('userproplist', 'talkproplist', 'logproplist', 'usermsgproplist') {
     my $sth = $dbh->prepare("DESCRIBE $table");
     $sth->execute;
     my @cols = ();

--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -1654,12 +1654,6 @@ logproplist.xpostdetail:
 usermsgproplist.userpic:
   des: Userpic chosen by the user who created the message
 
-pollproplist2.unique:
-  des: If set to 1, then a person with a given email address can only vote once in the poll
-
-pollproplist2.createdate:
-  des: The voter must have created their account by the date specified (Pacific time) in order to vote.  Must be in format YYYY-MM-DD, otherwise there will be no restriction.
-
 media_prop_list.title:
   des: Title of this object
   prettyname: Title

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -957,6 +957,8 @@ register_tabledrop("jabpresence");
 register_tabledrop("jabcluster");
 register_tabledrop("jablastseen");
 register_tabledrop("domains");
+register_tabledrop("pollprop2");
+register_tabledrop("pollproplist2");
 
 
 register_tablecreate("infohistory", <<'EOC');
@@ -2386,28 +2388,6 @@ CREATE TABLE pollsubmission2 (
 EOC
 
 # clustered
-register_tablecreate("pollprop2", <<'EOC');
-CREATE TABLE pollprop2 (
-    journalid INT UNSIGNED NOT NULL,
-    pollid INT UNSIGNED NOT NULL,
-    propid SMALLINT UNSIGNED NOT NULL,
-    propval VARCHAR(255) NOT NULL,
-
-    PRIMARY KEY (journalid,pollid,propid)
-)
-EOC
-
-register_tablecreate("pollproplist2", <<'EOC');
-CREATE TABLE pollproplist2 (
-    propid SMALLINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
-    name VARCHAR(255) DEFAULT NULL,
-    des VARCHAR(255) DEFAULT NULL,
-    scope ENUM('general', 'local') DEFAULT 'general' NOT NULL,
-
-    UNIQUE KEY (name)
-)
-EOC
-
 # clustered
 register_tablecreate("embedcontent", <<'EOC');
 CREATE TABLE embedcontent (

--- a/bin/upgrading/update-db.pl
+++ b/bin/upgrading/update-db.pl
@@ -530,7 +530,6 @@ sub populate_proplist_file {
         'media_prop_list' => 'name',
         'talkproplist' => 'name',
         'usermsgproplist' => 'name',
-        'pollproplist2'   => 'name',
         );
     my %id = (
         'userproplist' => 'upropid',
@@ -538,7 +537,6 @@ sub populate_proplist_file {
         'media_prop_list' => 'propid',
         'talkproplist' => 'tpropid',
         'usermsgproplist' => 'propid',
-        'pollproplist2'   => 'propid',
     );
 
     my $table;  # table

--- a/cgi-bin/LJ/DB.pm
+++ b/cgi-bin/LJ/DB.pm
@@ -57,7 +57,7 @@ $LJ::DBIRole = new DBI::Role {
                     "poll2", "pollquestion2", "pollitem2",
                     "pollresult2", "pollsubmission2", "vgift_trans",
                     "embedcontent", "usermsg", "usermsgtext", "usermsgprop",
-                    "notifyarchive", "notifybookmarks", "pollprop2", "embedcontent_preview",
+                    "notifyarchive", "notifybookmarks", "embedcontent_preview",
                     "logprop_history", "import_status", "externalaccount",
                     "content_filters", "content_filter_data", "userpicmap3",
                     "media", "collections", "collection_items", "logslugs",

--- a/cgi-bin/LJ/Poll.pm
+++ b/cgi-bin/LJ/Poll.pm
@@ -17,7 +17,6 @@ use Carp qw (croak);
 use LJ::Entry;
 use LJ::Poll::Question;
 use LJ::Event::PollVote;
-use LJ::Typemap;
 
 ##
 ## Memcache routines
@@ -30,7 +29,7 @@ sub _memcache_stored_props          {
     # next - allowed object properties
     return qw/ 2
                ditemid itemid
-               pollid journalid posterid isanon whovote whoview name status questions props
+               pollid journalid posterid isanon whovote whoview name status questions
                /;
 }
     *_memcache_hashref_to_object    = \*absorb_row;
@@ -137,17 +136,11 @@ sub create {
 
     if (ref $classref eq 'LJ::Poll') {
         $classref->{pollid} = $pollid;
-        foreach my $prop (keys %{$opts{props}}) {
-            $classref->set_prop($prop, $opts{props}->{$prop});
-        }
 
         return $classref;
     }
 
     my $pollobj = LJ::Poll->new($pollid);
-    foreach my $prop (keys %{$opts{props}}) {
-        $pollobj->set_prop($prop, $opts{props}->{$prop});
-    }
 
     return $pollobj;
 }
@@ -525,9 +518,8 @@ sub save_to_db {
 
     my %createopts;
 
-    # name and props are optional fields
+    # name is optional field
     $createopts{name} = $opts{name} || $self->{name};
-    $createopts{props} = $opts{props} || $self->{props};
 
     foreach my $f (qw(ditemid journalid posterid questions isanon whovote whoview)) {
         $createopts{$f} = $opts{$f} || $self->{$f} or croak "Field $f required for save_to_db";
@@ -590,7 +582,7 @@ sub absorb_row {
 
     # questions is an optional field for creating a fake poll object for previewing
     $self->{ditemid} = $row->{ditemid} || $row->{itemid}; # renamed to ditemid in poll2
-    $self->{$_} = $row->{$_} foreach qw(pollid journalid posterid isanon whovote whoview name status questions props);
+    $self->{$_} = $row->{$_} foreach qw(pollid journalid posterid isanon whovote whoview name status questions);
     $self->{_loaded} = 1;
     return $self;
 }
@@ -1354,50 +1346,6 @@ sub respondents_as_html {
             "<span class='polluser' id='LJ_PollUserAnswerRes_${pollid}_$userid'>" . $u->ljuser_display . "</span></div>\n";
     }
     return $ret;
-}
-
-########## Props
-# get the typemap for pollprop2
-sub typemap {
-    return LJ::Typemap->new(
-        table       => 'pollproplist2',
-        classfield  => 'name',
-        idfield     => 'propid',
-    );
-}
-
-sub prop {
-    my ($self, $propname) = @_;
-
-    my $tm = $self->typemap;
-    my $propid = $tm->class_to_typeid($propname);
-    my $u = $self->journal;
-
-    my $sth = $u->prepare("SELECT * FROM pollprop2 WHERE journalid = ? AND pollid = ? AND propid = ?");
-    $sth->execute($u->id, $self->pollid, $propid);
-    die $sth->errstr if $sth->err;
-
-    if (my $row = $sth->fetchrow_hashref) {
-        return $row->{propval};
-    }
-
-    return undef;
-}
-
-sub set_prop {
-    my ($self, $propname, $propval) = @_;
-
-    if (defined $propval) {
-        my $tm = $self->typemap;
-        my $propid = $tm->class_to_typeid($propname);
-        my $u = $self->journal;
-
-        $u->do("INSERT INTO pollprop2 (journalid, pollid, propid, propval) " .
-               "VALUES (?,?,?,?)", undef, $u->id, $self->pollid, $propid, $propval);
-        die $u->errstr if $u->err;
-    }
-
-    return 1;
 }
 
 ########## Class methods

--- a/htdocs/poll/create.bml
+++ b/htdocs/poll/create.bml
@@ -104,7 +104,7 @@ _c?>
         return;
     }
 
-    # first pageview, show authas and pregeneration hook
+    # first pageview, show authas
     if (! LJ::did_post() || $POST{'start_over'}) {
 
         # postto switcher form
@@ -122,9 +122,6 @@ _c?>
                     }) . "\n";
         }
         $body .= "</form>\n\n";
-
-        # show pregenerate options
-        $body .= LJ::Hooks::run_hook('poll_pregeneration_html', $u, $authas);
     }
 
     # does the remote or selected user have the 'makepoll' cap?
@@ -801,11 +798,6 @@ _c?>
     # variables to pass around
     my $poll = {};
     my $err  = {};
-
-    # should we pregenerate something?
-    if (my $pgid = $GET{'pregen'}+0) {
-        $poll = LJ::Hooks::run_hook('pregenerate_poll', $u, $pgid);
-    }
 
     # process post input
     if (LJ::did_post() && ! $POST{'start_over'}) {


### PR DESCRIPTION
Followup to #1789.

Removes more unused poll-related hooks, which has the side effect of removing everything related to the "createdate" poll property.

Now that "unique" and "createdate" have both been excised, we can also completely drop the pollprop tables and related code.  I verified that "SELECT COUNT(*) FROM pollprop2" returned zero rows in production; pollproplist2 was populated from proplists.dat.