### PR TITLE
Embiggen ml_items.itcode

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1676,3 +1676,6 @@ contentflag.viewingconcepts.byposter
 contentflag.viewingexplicit.bycommunity
 contentflag.viewingexplicit.byjournal
 contentflag.viewingexplicit.byposter
+
+general /customize/options.bml.widget.navstripchooser.option.color.control_strip_borderc
+general /customize/options.bml.widget.navstripchooser.option.color.control_strip_linkcol

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -1203,7 +1203,7 @@ CREATE TABLE ml_items (
     dmid    TINYINT UNSIGNED NOT NULL,
     itid    MEDIUMINT UNSIGNED AUTO_INCREMENT NOT NULL,
     PRIMARY KEY (dmid, itid),
-    itcode  VARCHAR(80) NOT NULL,
+    itcode  VARCHAR(120) CHARACTER SET ascii NOT NULL,
     UNIQUE  (dmid, itcode),
     proofed TINYINT NOT NULL DEFAULT 0, -- boolean, really
     INDEX   (proofed),
@@ -4151,6 +4151,12 @@ EOF
                   "ALTER TABLE spamreports ".
                   "MODIFY ip VARCHAR(45)" );
     }
+
+    unless ( column_type( 'ml_items', 'itcode' ) =~ /120/ ) {
+        do_alter( 'ml_items',
+                  "ALTER TABLE ml_items MODIFY COLUMN itcode VARCHAR(120) CHARACTER SET ascii NOT NULL" );
+    }
+
 });
 
 

--- a/cgi-bin/LJ/Lang.pm
+++ b/cgi-bin/LJ/Lang.pm
@@ -16,7 +16,7 @@ use strict;
 use LJ::LangDatFile;
 
 
-use constant MAXIMUM_ITCODE_LENGTH => 80;
+use constant MAXIMUM_ITCODE_LENGTH => 120;
 
 my @day_short   = (qw[Sun Mon Tue Wed Thu Fri Sat]);
 my @day_long    = (qw[Sunday Monday Tuesday Wednesday Thursday Friday Saturday]);


### PR DESCRIPTION
And deadphrase the truncated codes, of course.

Possibly controversial: I've marked ml_items.itcode as being ASCII-only, under the theory that it's intended as an internal name and has not had due consideration for the prospect of containing anything other than ASCII.  It felt appropriate, but I'd be happy to yank it out if preferred.

Fixes #1787.