### PR TITLE
add margins for Foundation list elements

### DIFF
--- a/htdocs/scss/skins/_page-layout-hacks.scss
+++ b/htdocs/scss/skins/_page-layout-hacks.scss
@@ -10,6 +10,19 @@
     padding-top: 1px;  /*to ensure margin*/
 }
 
+#content ul li {
+    margin-left: 2em;
+    margin-bottom: 0.75em;
+}
+
+#content ul ul {
+    margin-top: 0.75em;
+}
+
+#content dl dd {
+    margin-left: 1.5em;
+}
+
 /**
  * Temporary hack to hide account links / userpics on small screens
  */


### PR DESCRIPTION
When working on dreamwidth/dw-nonfree#113, I discovered the lack
of marginal padding around various list elements made the pages
hard to read.  These are my suggested changes for improvements.

If this isn't the best place to put these definitions, let me
know of a preferable alternative.