### PR TITLE
Cleanup 2016q2

### DIFF
--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -758,14 +758,6 @@ userproplist.opt_embedplaceholders:
   multihomed: 0
   prettyname: Use Placeholders for lj-template embedded objects
 
-userproplist.opt_exclude_stats:
-  cldversion: 4
-  datatype: bool
-  des: 1: don't include user when using offsite hit tracker
-  indexed: 0
-  multihomed: 0
-  prettyname: Exclude From Offsite Stats Tracking
-
 userproplist.opt_findbyemail:
   cldversion: 4
   datatype: char

--- a/cgi-bin/DW/Controller/Admin/Props.pm
+++ b/cgi-bin/DW/Controller/Admin/Props.pm
@@ -60,7 +60,8 @@ sub entryprops_handler {
         my $entry = LJ::Entry->new_from_url( $post->{url} );
 
         my $url = LJ::ehtml( $post->{url} );
-        $errors->add_string( "$url is not a valid entry URL." ) unless $entry && $entry->valid;
+        $errors->add_string( 'url', "$url is not a valid entry URL." )
+            unless $entry && $entry->valid;
 
         unless ( $errors->exist ) {
             # WE HAEV ENTRY!!
@@ -172,7 +173,7 @@ sub propedit_handler {
 
         $u = LJ::load_user( $post->{username} );
         my $username = LJ::ehtml( $post->{username} );
-        $errors->add_string( "$username is not a valid username" ) unless $u;
+        $errors->add_string( 'username', "$username is not a valid username" ) unless $u;
 
         if ( ! $errors->exist && $can_save && $post->{_save} ) {
             foreach my $key ( $post->keys ) {

--- a/cgi-bin/DW/Controller/Misc.pm
+++ b/cgi-bin/DW/Controller/Misc.pm
@@ -52,10 +52,10 @@ sub beta_handler {
         my $post = $r->post_args;
 
         my $feature = $post->{feature};
-        $errors->add_string( "No feature defined." ) unless $feature;
+        $errors->add_string( 'feature', "No feature defined." ) unless $feature;
 
         my $u = LJ::load_user( $post->{user} );
-        $errors->add_string( "Invalid user." ) unless $u;
+        $errors->add_string( 'user', "Invalid user." ) unless $u;
 
         unless ( $errors->exist ) {
             if ( $post->{on} ) {

--- a/cgi-bin/DW/Controller/Search/Directory.pm
+++ b/cgi-bin/DW/Controller/Search/Directory.pm
@@ -55,7 +55,7 @@ sub directory_handler {
             return DW::Template->render_template( 'directory/searchdots.tt', $rv );
         }
 
-        my $journaltype = $rv->{journaltype} = uc $args->{journaltype} || '';
+        my $journaltype = $rv->{journaltype} = uc( $args->{journaltype} || '' );
         $rv->{searchurl} = $journaltype eq 'C' ?
                            "community/search" : "directorysearch";
 

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1718,7 +1718,15 @@ sub clean_as_markdown {
     # second, convert @-style addressing to user tags
     my $usertag = sub {
         my ($user, $site) = ($1, $2 || $LJ::DOMAIN);
-        if (my $siteobj = DW::External::Site->get_site( site => $site )) {
+        my $siteobj = DW::External::Site->get_site( site => $site );
+
+        if ( $site eq $LJ::DOMAIN ) {
+            # just use a plain usertag in the most common case, which
+            # also avoids problems with other sites (dreamhacks etc.)
+            # that aren't found in DW::External::Site
+            return qq|<user name="$user" />|;
+        } elsif ( $siteobj && ref $siteobj ne 'DW::External::Site::Unknown' ) {
+            # only do site tags for known site formats
             return qq|<user name="$user" site="$siteobj->{domain}" />|;
         } else {
             return qq|\@$user.$site|;

--- a/cgi-bin/LJ/Emailpost/Web.pm
+++ b/cgi-bin/LJ/Emailpost/Web.pm
@@ -25,7 +25,7 @@ sub get_allowed_senders {
     return undef unless LJ::isu( $u );
     my (%addr, @address);
 
-    @address = split( /\s*,\s*/, $u->prop( 'emailpost_allowfrom' ) );
+    @address = split( /\s*,\s*/, $u->prop( 'emailpost_allowfrom' ) || '' );
 
     # add their personal email, and assume we want to receive errors here
     unshift @address, $u->email_raw . "(E)" if $include_user_email;

--- a/cgi-bin/LJ/PageStats.pm
+++ b/cgi-bin/LJ/PageStats.pm
@@ -93,9 +93,6 @@ sub should_do_pagestats {
     my $self = shift;
 
     my $u = $self->get_user;
-
-    return 0 if $u && $u->prop('opt_exclude_stats');
-
     my $ctx = $self->get_context;
 
     if ( $ctx && $ctx eq 'journal' ) {

--- a/cgi-bin/LJ/Time.pm
+++ b/cgi-bin/LJ/Time.pm
@@ -29,6 +29,8 @@ use Time::Local ();
 sub days_in_month
 {
     my ($month, $year) = @_;
+    return unless $month;  # not a mind reader
+
     if ($month == 2)
     {
         return 29 unless $year;  # assume largest

--- a/cgi-bin/LJ/Widget/NavStripChooser.pm
+++ b/cgi-bin/LJ/Widget/NavStripChooser.pm
@@ -36,9 +36,8 @@ sub render_body {
     $ret .= "<p>" . $class->ml('widget.navstripchooser.colors') . "</p>";
 
     # choose colors
-    my $color_selected = $u->prop( 'control_strip_color' ) ne ''
-        ? $u->prop( 'control_strip_color' )
-        : "dark";
+    my $chosen_color = $u->prop( 'control_strip_color' ) // '';
+    my $color_selected = $chosen_color ne '' ? $chosen_color : "dark";
 
     my ($theme, @props, %prop_is_used, %colors_values, %bgcolor_values, %fgcolor_values, %bordercolor_values, %linkcolor_values, $color_custom);
     if ($u->prop('stylesys') == 2) {

--- a/htdocs/manage/profile/index.bml
+++ b/htdocs/manage/profile/index.bml
@@ -591,7 +591,7 @@ body<=
             push @errors, $ML{'.error.day.outofrange'};
         }
 
-        if (@errors == 0 && $POST{'day'} > LJ::days_in_month($POST{'month'}, $POST{'year'})) {
+        if ( @errors == 0 && $POST{'day'} && $POST{'day'} > LJ::days_in_month($POST{'month'}, $POST{'year'}) ) {
             push @errors, $ML{'.error.day.notinmonth'};
         }
 
@@ -627,10 +627,17 @@ body<=
 
         my $newbio = defined($POST{'bio_absent'}) ? $saved{'bio'} : $POST{'bio'};
         my $has_bio = ($newbio =~ /\S/) ? "Y" : "N";
+        my $new_bdate = sprintf( "%04d-%02d-%02d",
+                                 $POST{'year'}  || 0,
+                                 $POST{'month'} || 0,
+                                 $POST{'day'}   || 0
+                               );
+        my $new_bday = sprintf( "%02d-%02d", $POST{'month'} || 0, $POST{'day'} || 0 );
+
         # setup what we're gonna update in the user table:
         my %update = (
                       'name' => $newname,
-                      'bdate' => sprintf("%04d-%02d-%02d", $POST{'year'}, $POST{'month'}, $POST{'day'}),
+                      'bdate' => $new_bdate,
                       'has_bio' => $has_bio,
                       'allow_getljnews' => $POST{'allow_getljnews'} ? "Y" : "N",
                       );
@@ -670,15 +677,15 @@ body<=
             # if they share their birthdate publically
             if ($POST{'opt_sharebday'} =~ /^[AR]$/) {
                 # and actually provided a birthday
-                if ($POST{'month'} > 0 && $POST{'day'} > 0) {
+                if ( $POST{'month'} && $POST{'month'} > 0 && $POST{'day'} > 0 ) {
                     # and allow the entire thing to be displayed
                     if ($POST{'opt_showbday'} eq "F" && $POST{'year'}) {
-                        $POST{'sidx_bdate'} = sprintf("%04d-%02d-%02d", map { $POST{$_} } qw(year month day));
+                        $POST{'sidx_bdate'} = $new_bdate;
                     }
 
                     # or allow the date portion to be displayed
                     if ($POST{'opt_showbday'} =~ /^[FD]$/) {
-                        $POST{'sidx_bday'} = sprintf("%02d-%02d", map { $POST{$_} } qw(month day));
+                        $POST{'sidx_bday'} = $new_bday;
                     }
                 }
             }


### PR DESCRIPTION
Details in individual commit messages.  The usual, plus removing an unused userprop, rewriting a faulty conditional in CleanHTML.pm, and fixing some calls to DW::FormErrors->add_string that had one argument instead of two.