### PR TITLE
Make alttext and titletext on /icons consistent with other uses of icons

### DIFF
--- a/cgi-bin/LJ/S2/IconsPage.pm
+++ b/cgi-bin/LJ/S2/IconsPage.pm
@@ -116,10 +116,12 @@ sub IconsPage {
             });
         }
 
+        my $kwstr = join( ', ', @{$keywords} );
+
         push @pics_out, {
             '_type' => 'Icon',
             id => $pic->picid,
-            image => Image( $pic->url, $pic->width, $pic->height, LJ::ehtml( $pic->alttext ), title => LJ::ehtml( $pic->keywords ) ),
+            image => Image( $pic->url, $pic->width, $pic->height, LJ::ehtml( $pic->alttext( $kwstr, $pic->is_default ) ), title => LJ::ehtml( $pic->titletext( $kwstr, $pic->is_default ) ) ),
             keywords => [ map { LJ::ehtml($_) } sort { lc($a) cmp lc($b) } ( @$keywords ) ],
             comment => $eh_comment,
             description => $eh_description,

--- a/cgi-bin/LJ/S2/IconsPage.pm
+++ b/cgi-bin/LJ/S2/IconsPage.pm
@@ -121,7 +121,7 @@ sub IconsPage {
         push @pics_out, {
             '_type' => 'Icon',
             id => $pic->picid,
-            image => Image( $pic->url, $pic->width, $pic->height, LJ::ehtml( $pic->alttext( $kwstr, $pic->is_default ) ), title => LJ::ehtml( $pic->titletext( $kwstr, $pic->is_default ) ) ),
+            image => Image( $pic->url, $pic->width, $pic->height, $pic->alttext( $kwstr, $pic->is_default ), title => $pic->titletext( $kwstr, $pic->is_default ) ),
             keywords => [ map { LJ::ehtml($_) } sort { lc($a) cmp lc($b) } ( @$keywords ) ],
             comment => $eh_comment,
             description => $eh_description,

--- a/cgi-bin/LJ/Userpic.pm
+++ b/cgi-bin/LJ/Userpic.pm
@@ -360,10 +360,9 @@ sub fullurl {
     return $self->{url};
 }
 
-
 # given a userpic and a keyword, return the alt text
 sub alttext {
-    my ( $self, $kw ) = @_;
+    my ( $self, $kw, $mark_default ) = @_;
 
     # load the alttext.  
     # "username: description (keyword)"
@@ -379,10 +378,11 @@ sub alttext {
     }
 
     # 1. If there is a keyword associated with the icon, use it.
-    # 2. If it was chosen via the default icon, show "(Default)".
     if ( defined $kw ) {
         $alt .= " (" . $kw . ")";
-    } else {
+    }
+    # 2. If it was chosen via the default icon, show "(Default)".
+    if ( $mark_default // !defined $kw ) {
         $alt .= " (Default)";
     }
 
@@ -392,7 +392,7 @@ sub alttext {
 
 # given a userpic and a keyword, return the title text
 sub titletext {
-    my ( $self, $kw ) = @_;
+    my ( $self, $kw, $mark_default ) = @_;
 
     # load the titletext.  
     # "username: keyword (description)"
@@ -404,10 +404,11 @@ sub titletext {
     my $title = $u->username . ":";
 
     # 1. If there is a keyword associated with the icon, use it.
-    # 2. If it was chosen via the default icon, show "(Default)".
     if ( defined $kw ) {
         $title .= " " . $kw;
-    } else {
+    }
+    # 2. If it was chosen via the default icon, show "(Default)".
+    if ( $mark_default // !defined $kw ) {
         $title .= " (Default)";
     }
 


### PR DESCRIPTION
lightgetsin in dw-accessibility made an excellent point that it's useful to have icons use the same format on the /icons page as everywhere else, so the redundant information can help guide people to understand how the alt and title texts are formatted elsewhere.

So... this makes it use largely the same format, and practically by accident fixes #1703.  Unlike comment/entry icons, the default marker is included alongside a userpic's keywords.  Also unlike comment/entry icons, the "Upload Order" view includes all of an icon's keywords rather than only one.

As a bonus commit, fixes double-encoding of alt and title attributes.