### PR TITLE
Move the inbox's expando activation event to the link

### DIFF
--- a/htdocs/js/esn_inbox.js
+++ b/htdocs/js/esn_inbox.js
@@ -87,7 +87,8 @@ ESN_Inbox.initContentExpandButtons = function (folder) {
     var buttons = DOM.filterElementsByClassName(domElements, "InboxItem_Expand") || [];
 
     Array.prototype.forEach.call(buttons, function (button) {
-        DOM.addEventListener(button, "click", function (evt) {
+        var link = DOM.getFirstAncestorByTagName(button, "a");
+        DOM.addEventListener(link, "click", function (evt) {
             if (evt.shiftKey) {
                 // if shift key, make all like inverse of current button
                 var expand = button.src == Site.imgprefix + "/collapse.gif" ? 'collapse' : 'expand';


### PR DESCRIPTION
The link is what makes the expando button selectable from the keyboard, but the event was on the img tag.  That works fine for clicking, but results in keyboard-activation following the link instead of firing the desired event.

This is a partial fix for bug #1808.  It fixes keyboard activation if JS is enabled, but does not attempt to deal with the no-JS case.