### PR TITLE
Add LJ::dhtml to mirror LJ::ehtml

### DIFF
--- a/cgi-bin/DW/CleanEmail.pm
+++ b/cgi-bin/DW/CleanEmail.pm
@@ -13,9 +13,6 @@ package DW::CleanEmail;
 
 use strict;
 
-use HTML::Entities;
-
-
 =head1 NAME
 
 DW::CleanEmail - Clean up text from email
@@ -92,7 +89,7 @@ sub reply_subject {
     $subject =~ s/^(Re:\s*)*//i;
     $subject = "Re: $subject" if $subject;
 
-    return HTML::Entities::decode( $subject );
+    return LJ::dhtml( $subject );
 }
 
 1;

--- a/cgi-bin/DW/EmailPost/Entry.pm
+++ b/cgi-bin/DW/EmailPost/Entry.pm
@@ -30,7 +30,6 @@ use strict;
 use LJ::Protocol;
 
 use Date::Parse;
-use HTML::Entities;
 use IO::Handle;
 use XML::Simple;
 
@@ -513,7 +512,7 @@ sub _cleanup_mobile_carriers {
         return $self->err( "Unable to find XML content in PictureMail message." )
             unless $xml_string;
 
-        HTML::Entities::decode_entities( $xml_string );
+        LJ::dhtml( $xml_string );
         my $xml = eval { XML::Simple::XMLin( $xml_string ); };
         return $self->err( "Unable to parse XML content in PictureMail message." )
             if ! $xml || $@;
@@ -522,8 +521,7 @@ sub _cleanup_mobile_carriers {
             unless $xml->{messageContents}->{type} eq 'PICTURE';
 
         my $url =
-          HTML::Entities::decode_entities(
-            $xml->{messageContents}->{mediaItems}->{mediaItem}->{url} );
+          LJ::dhtml( $xml->{messageContents}->{mediaItems}->{mediaItem}->{url} );
         $url = LJ::trim($url);
         $url =~ s#</?url>##g;
 
@@ -550,7 +548,7 @@ sub _cleanup_mobile_carriers {
         my $ua_rv = $ua->get( $url, ':content_file' => $tempfile );
 
         $self->{body} = $xml->{messageContents}->{messageText};
-        $self->{body} = ref $self->{body} ? "" : HTML::Entities::decode( $self->{body} );
+        $self->{body} = ref $self->{body} ? "" : LJ::dhtml( $self->{body} );
 
         if ($ua_rv->is_success) {
             # (re)create a basic mime entity, so the rest of the

--- a/cgi-bin/DW/EmailPost/Entry.pm
+++ b/cgi-bin/DW/EmailPost/Entry.pm
@@ -512,7 +512,8 @@ sub _cleanup_mobile_carriers {
         return $self->err( "Unable to find XML content in PictureMail message." )
             unless $xml_string;
 
-        LJ::dhtml( $xml_string );
+        LJ::dhtml( $xml_string ); # $xml_string is being modified by this function call
+                                  # special characters are replaced with equivalent HTML entities
         my $xml = eval { XML::Simple::XMLin( $xml_string ); };
         return $self->err( "Unable to parse XML content in PictureMail message." )
             if ! $xml || $@;

--- a/cgi-bin/DW/External/XPostProtocol/LJXMLRPC.pm
+++ b/cgi-bin/DW/External/XPostProtocol/LJXMLRPC.pm
@@ -20,7 +20,6 @@ use warnings;
 
 use Digest::MD5 qw(md5_hex);
 use XMLRPC::Lite;
-use HTML::Entities ();
 
 # create a new instance of LJXMLRPC
 sub instance {

--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Userpics.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Userpics.pm
@@ -154,7 +154,7 @@ sub get_lj_userpic_data {
     my ( @upics, $upic, $default_upic, $text_tag );
 
     my $cleanup_string = sub {
-        # FIXME: If LJ ever fixes their /data/userpics feed to double-escepe, this will cause issues.
+        # FIXME: If LJ ever fixes their /data/userpics feed to double-escape, this will cause issues.
         # Probably need to figure out a way to detect that a double-escape happened and only fix in that case.
         return LJ::dhtml( encode_utf8( $_[0] || "" ) );
     };

--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Userpics.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Userpics.pm
@@ -20,7 +20,6 @@ use strict;
 use base 'DW::Worker::ContentImporter::LiveJournal';
 
 use DW::XML::Parser;
-use HTML::Entities;
 use Storable qw/ freeze /;
 use Carp qw/ croak confess /;
 use Encode qw/ encode_utf8 /;
@@ -157,7 +156,7 @@ sub get_lj_userpic_data {
     my $cleanup_string = sub {
         # FIXME: If LJ ever fixes their /data/userpics feed to double-escepe, this will cause issues.
         # Probably need to figure out a way to detect that a double-escape happened and only fix in that case.
-        return HTML::Entities::decode_entities( encode_utf8( $_[0] || "" ) );
+        return LJ::dhtml( encode_utf8( $_[0] || "" ) );
     };
 
     my $upic_handler = sub {
@@ -172,7 +171,7 @@ sub get_lj_userpic_data {
         } elsif ( $tag eq 'category' ) {
             # keywords get triple-escaped
             # DW::XML::Parser handles unescaping it once, $cleanup_string second, and then we have to unescape it a third time.
-            push @{$upic->{keywords}}, HTML::Entities::decode_entities( $cleanup_string->( $temp{term} ) );
+            push @{$upic->{keywords}}, LJ::dhtml( $cleanup_string->( $temp{term} ) );
         } else {
             $text_tag = $tag;
         }

--- a/cgi-bin/LJ/TextUtil.pm
+++ b/cgi-bin/LJ/TextUtil.pm
@@ -16,6 +16,7 @@ use strict;
 
 use LJ::ConvUTF8;
 use HTML::TokeParser;
+use HTML::Entities;
 
 # <LJFUNC>
 # name: LJ::trim
@@ -212,6 +213,21 @@ sub ehtml {
     return $a;
 }
 *eall = \&ehtml;  # old BML syntax required eall to also escape BML.  not anymore.
+
+# <LJFUNC>
+# name: LJ::dhtml
+# class: text
+# des: Decodes a value that's HTML-escaped.  See also [func[LJ::ehtml]].
+# args: string
+# des-string: string to be decoded
+# returns: string decoded
+# </LJFUNC>
+sub dhtml {
+    my $a = $_[0];
+    return '' unless defined $a;
+
+    return HTML::Entities::decode_entities( $a );
+}
 
 # <LJFUNC>
 # name: LJ::etags


### PR DESCRIPTION
Fixes #1737.

Adds LJ::dhtml for symmetry with LJ::ehtml, which applies
HTML::Entities::decode (or equivalently HTML::Entities::decode_entities)
to an input string. Replaces HTML::Entities::decode(_entities) with
LJ::dhtml in the codebase.

---

I have a couple of questions about preferred implementation...

Based on http://search.cpan.org/dist/HTML-Parser/lib/HTML/Entities.pmv I think using decode_entities() rather than decode() is Better Practice, so that's what I've done.

Comparing with LJ::ehtml, would it be preferable to add in
`return $a unless $a =~ /[&]/;`
... (or regex that actually definitely works as opposed to Alex being sort of perplexed and suspicious) for the common case of "contains no HTML entities"? Because any HTML entity will be of the form `&entity;`?

ETA: replying to comments by e-mail requires a paid/seed account on Dreamhacks (but not in production) -- is this intentional?

Behaviour is appropriate for comments that are e-mailed in (http://kaberett.kaberett.hack.dreamwidth.net/20617.html#comments). Ditto posts that are e-mailed in (http://kaberett.kaberett.hack.dreamwidth.net/20746.html).