### PR TITLE
free accounts can post entries and comments via email

### DIFF
--- a/etc/config.pl
+++ b/etc/config.pl
@@ -419,7 +419,7 @@
             'checkfriends_interval' => 0,
             'directory' => 1,
             'edit_comments' => 0,
-            'emailpost' => 0,
+            'emailpost' => 1,
             'findsim' => 0,
             'friendsfriendsview' => 0,
             'friendspage_per_day' => 0,


### PR DESCRIPTION
As pointed out in #1811, this is allowed in production, so let's turn it on in the default config.pl so that it works on dreamhacks as well.