### PR TITLE
Issue 1733 / 1735 - Eliminate special casing for PMs to minor accounts

### DIFF
--- a/cgi-bin/LJ/Setting/UserMessaging.pm
+++ b/cgi-bin/LJ/Setting/UserMessaging.pm
@@ -32,7 +32,7 @@ sub option {
     my ($class, $u, $errs, $args) = @_;
     my $key = $class->pkgkey;
 
-    my $usermsg = $class->get_arg($args, "usermsg") || $u->prop("opt_usermsg");
+    my $usermsg = $class->get_arg($args, "usermsg") || $u->opt_usermsg;
 
     my @options = (
         "Y" => $class->ml( 'setting.usermessaging.opt.y' ),

--- a/cgi-bin/LJ/User/Message.pm
+++ b/cgi-bin/LJ/User/Message.pm
@@ -424,7 +424,6 @@ sub opt_usermsg {
     if ( defined $prop && $prop =~ /^(Y|F|M|N)$/ ) {
         return $prop;
     } else {
-        return 'M' if $u->is_minor;
         return 'Y';
     }
 }


### PR DESCRIPTION
Changed minor accounts to receive PMs from all registered users.
Fixed call when checking whether a PM can be sent.

Fixes issue #1733. Fixes issue #1735.