### PR TITLE
Remove reproxying

### DIFF
--- a/cgi-bin/DW/Controller/Media.pm
+++ b/cgi-bin/DW/Controller/Media.pm
@@ -159,7 +159,6 @@ sub media_handler {
         unless $obj->visible_to( LJ::get_remote() );
 
     # load the data for this object
-# FIXME: support X-REPROXY headers here
     my $dataref = LJ::mogclient()->get_file_data( $obj->mogkey );
     return $error_out->( 500, 'Unexpected internal error locating file' )
         unless defined $dataref && ref $dataref eq 'SCALAR';

--- a/cgi-bin/LJ/ConfCheck/General.pm
+++ b/cgi-bin/LJ/ConfCheck/General.pm
@@ -430,10 +430,6 @@ add_conf('$MEMCACHE_CB_CONNECT_FAIL',
          des => "Callback when a connection to a memcached instance fails.  Subref gets the IP address that was being connected to, but without the port number."
          );
 
-add_conf('%REPROXY_DISABLE',
-         des => "Set of file classes that shouldn't be internally redirected to mogstored nodes.  Values are true, keys are one of 'userpics', or site-local file types like 'phoneposts' for ljcom.  Seee also \%USERPIC_REPROXY_DISABLE"
-         );
-
 add_conf('$SQUAT_URL',
          des => "For anti-squatter checking in Apache/LiveJournal.pm."
          );

--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -195,10 +195,6 @@ no strict "vars";
     $MOGILEFS_CONFIG{classes}->{vgifts}      ||= 3;
     $MOGILEFS_CONFIG{classes}->{media}       ||= 3;
 
-    # Default to allow all reproxying.
-    %REPROXY_DISABLE = () unless %REPROXY_DISABLE;
-
-
     # detect whether we are running on 32-bit architecture
     my $arch = ( length(pack "L!", 0) == 4 ) ? 1 : 0;
     if ( defined $ARCH32 ) {
@@ -207,7 +203,6 @@ no strict "vars";
     } else {
         $ARCH32 = $arch;
     }
-
 
     # setup default minimal style information
     $MINIMAL_USERAGENT{$_} ||= 1 foreach qw(Links Lynx w BlackBerry WebTV); # w is for w3m

--- a/cgi-bin/LJ/User/Icons.pm
+++ b/cgi-bin/LJ/User/Icons.pm
@@ -746,7 +746,8 @@ sub get_userpic_kw_map {
     foreach my $keyword ( keys %{$picinfo->{kw}} ) {
         my $picid = $picinfo->{kw}->{$keyword}->{picid};
         $keywords->{$picid} = [] unless $keywords->{$picid};
-        push @{$keywords->{$picid}}, $keyword if ( defined( $keyword ) && $picid && $keyword !~ m/^pic\#(\d+)$/ );
+        push @{$keywords->{$picid}}, $keyword
+            if defined $keyword && $picid && $keyword !~ m/^pic\#(\d+)$/;
     }
 
     return $u->{picid_kw_map} = $keywords;


### PR DESCRIPTION
This is part of a series, but this simplifies some later things. This
removes "reproxying" from the codebase. Since we're recommending people
use Varnish, Cloudflare, or some other caching system, there's not a lot
of performance gain by reproxying. Particularly with how fast computers
are these days.