### PR TITLE
Alway show Beta info, even when the user is not presently involved in a beta

### DIFF
--- a/htdocs/support/see_request.bml
+++ b/htdocs/support/see_request.bml
@@ -295,10 +295,11 @@ body<=
                 if $view_userlog;
         }
 
-        if ( $u->in_class( LJ::BetaFeatures->cap_name )
+        if ( %LJ::BETA_FEATURES
             && LJ::Support::has_any_support_priv( $remote ) ) {
             $ret .= "<br />$ML{'.betatesting'}: ";
-            $ret .= join ", ", $u->prop( LJ::BetaFeatures->prop_name );
+            my $betafeatures = join ", ", $u->prop( LJ::BetaFeatures->prop_name );
+            $ret .= $betafeatures || $ML{'.no-beta'};
         }
 
         $ret .= "</td></tr>\n";

--- a/htdocs/support/see_request.bml.text
+++ b/htdocs/support/see_request.bml.text
@@ -13,6 +13,8 @@
 
 .betatesting=Beta testing
 
+.no-beta=(none)
+
 .birthday=birthday
 
 .change.cat=Change Category


### PR DESCRIPTION
Because the absense of information is very different from an explicitly indicated negative.

Fixes #1835, assuming I'm understanding what $u->in_class() does, anyway.