### PR TITLE
Fixes #1823 by removing KEY(moodthemeid)

### DIFF
--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -262,7 +262,6 @@ CREATE TABLE moodthemedata (
     width tinyint(3) unsigned NOT NULL default '0',
     height tinyint(3) unsigned NOT NULL default '0',
 
-    KEY (moodthemeid),
     PRIMARY KEY  (moodthemeid,moodid)
 )
 EOC


### PR DESCRIPTION
As suggested by @kareila and @Sophira I've made the suggested change to the initial SQL creation command for the table, which correctly avoids the error in this issue, allowing installation to proceed on an Ubuntu 16.04 image.

Fixes #1823 