### PR TITLE
don't add the bottom spacing for success links

### DIFF
--- a/htdocs/scss/skins/_page-layout-hacks.scss
+++ b/htdocs/scss/skins/_page-layout-hacks.scss
@@ -15,6 +15,11 @@
     margin-bottom: 0.75em;
 }
 
+// don't add the bottom spacing for success links
+#content ul.successlinks li {
+    margin-bottom: 0;
+}
+
 #content ul ul {
     margin-top: 0.75em;
 }

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -54,7 +54,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- IF links.size -%]
 <p>[%- links_header | ml -%]</p>
-<ul>
+<ul class="successlinks">
     [%- FOREACH link IN links -%]
         <li><a href="[% link.url %]">[% link.ml_string | ml %]</a></li>
     [%- END -%]

--- a/views/success-page.tt
+++ b/views/success-page.tt
@@ -26,7 +26,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <div class="row"><div class="large-12 columns">
     <div class="panel callout">
     <h3>[% 'success.next.header' | ml %]</h3>
-    <ul>[%- FOR link = links -%]
+    <ul class="successlinks">[%- FOR link = links -%]
         <li><a href="[% link.url %]">[% link.text_ml | ml %]</a></li>
     [%- END -%]</ul>
     </div>


### PR DESCRIPTION
After #1793 went live, a few people complained about
the additional spacing between elements of the list
of links shown when a form submission has succeeded.

This removes the extra spacing for that case by defining
a new target class "successlinks" for the affected pages,
views/entry/success.tt and views/success-page.tt.  I left
views/success.tt alone because it doesn't yet use the
SCSS/Foundation styling.