### PR TITLE
[#1742] remove lowercasing of unknown getargs in LJ::create_url

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -1090,24 +1090,6 @@ sub create_url {
 
     my $orig_args = $opts{cur_args} || DW::Request->get->get_args( preserve_case => 1 );
 
-    # Mimic previous behavior of lowercasing keys unless they start with Widget
-    # FIXME: this should eventually go away - see #1742
-    unless ( $opts{cur_args} ) {
-        foreach my $k ( keys %$orig_args ) {
-            next if $k eq lc $k;
-            next if $k =~ /^Widget\b/;
-            # already found another unintended side effect in /endpoints/draft
-            next if $k eq 'getProperties';
-
-            # don't complain about hand-typed arguments, but do convert them (for now)
-            my $referer = DW::Request->get->header_in("Referer");
-            warn "[#1742] lowercasing $k, url: $url (referer: $referer)\n"
-                if $referer;
-            $orig_args->{lc $k} = $orig_args->{$k};
-            delete $orig_args->{$k};
-        }
-    }
-
     # Move over viewing style arguments
     if( $opts{viewing_style} ) {
         my $vs_args = LJ::viewing_style_opts( %$orig_args );


### PR DESCRIPTION
DW::Request->get->get_args still does automatic lowercasing in other contexts, and we should continue to investigate that at a later date.

In the meantime, I've checked the logs and determined there aren't any active code paths on the site that rely on the lowercasing behavior in this context.