### PR TITLE
define support box colors and classes for Foundation/SCSS

### DIFF
--- a/htdocs/scss/skins/_skin-colors.scss
+++ b/htdocs/scss/skins/_skin-colors.scss
@@ -215,5 +215,15 @@ div.disabled, div.disabled * { color: scale-color($text-color, $lightness: 50%);
     }
 }
 
+// support boxes
+.bluebox {
+    background-color: $_support-bg-blue;
+    border-color: $_support-fg-blue;
+}
+.greenbox {
+    background-color: $_support-bg-green;
+    border-color: $_support-fg-green;
+}
+
 // replacement colors for jquery-ui elements
 @import "skins/jquery-ui-theme";

--- a/htdocs/scss/skins/celerity.scss
+++ b/htdocs/scss/skins/celerity.scss
@@ -24,6 +24,11 @@ $_dark-gray:         #636363;
 $_low-contrast-gray: #ddd;
 $_off-black:         #222211;
 
+$_support-bg-blue:  #c5dff9;
+$_support-fg-blue:  darken( $_support-bg-blue, 15% );
+$_support-bg-green: #d0fbca;
+$_support-fg-green: darken( $_support-bg-green, 15% );
+
 // color assignment
 $background-color:   $_white;
 $text-color:         $_off-black;

--- a/htdocs/scss/skins/gradation/_gradation-base.scss
+++ b/htdocs/scss/skins/gradation/_gradation-base.scss
@@ -9,6 +9,11 @@ $_very-light-green: #e9e9e0;
 $_light-green:      #cccc99;
 $_dark-green:       #999966;
 
+$_support-fg-blue:  #6DB5C2;
+$_support-bg-blue:  #3D606B;
+$_support-fg-green: #53914D;
+$_support-bg-green: #2B5229;
+
 // color assignment
 $background-color:    $_black;
 $text-color:          $_very-light-green;

--- a/htdocs/scss/skins/lynx.scss
+++ b/htdocs/scss/skins/lynx.scss
@@ -3,6 +3,11 @@ $_black:     #000;
 $_white:     #FFF;
 $_dark-gray: #636363;
 
+$_support-bg-blue:  #c5dff9;
+$_support-fg-blue:  darken( $_support-bg-blue, 15% );
+$_support-bg-green: #d0fbca;
+$_support-fg-green: darken( $_support-bg-green, 15% );
+
 // color assignment
 $text-color: $_black;
 $primary-text-color: $_white;


### PR DESCRIPTION
For use with #1666.  See also dreamwidth/dw-nonfree#116.

I copied the Gradation colors from the older gradation.css file.  For the other site schemes, I used the given color from #1666 and calculated a corresponding border color using the SCSS "darken" function.