### PR TITLE
Move concatenating resources to DW

### DIFF
--- a/cgi-bin/LJ/ConfCheck/General.pm
+++ b/cgi-bin/LJ/ConfCheck/General.pm
@@ -760,8 +760,6 @@ my %bools = (
              "OPENID_STATELESS" => "Speak stateless OpenID.  Slower, but no local state needs to be kept.",
              "ONLY_USER_VHOSTS" => "Don't allow www.* journals at /users/ and /~ and /community/.  Only allow them on their own user virtual host domains.",
              "USERPIC_MOGILEFS" => "Store userpics on MogileFS.",
-             "CONCAT_RES" => "Instruct Perlbal to concatenate static files on non-SSL pages",
-             "CONCAT_RES_SSL" => "Instruct Perlbal to concatenate static files on SSL pages",
              );
 
 foreach my $k (keys %bools) {

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -2340,7 +2340,6 @@ sub res_includes {
     # TODO: automatic dependencies from external map and/or content of files,
     # currently it's limited to dependencies on the order you call LJ::need_res();
     my $ret = "";
-    my $do_concat = $LJ::IS_SSL ? $LJ::CONCAT_RES_SSL : $LJ::CONCAT_RES;
 
     # use correct root and prefixes for SSL pages
     my ($siteroot, $imgprefix, $statprefix, $jsprefix, $wstatprefix, $iconprefix);
@@ -2440,7 +2439,6 @@ sub res_includes {
             # the modtime, but rather do one global max modtime at the
             # end, which is done later in the tags function.
             $modtime = '' unless defined $modtime;
-            $what .= "?v=$modtime" unless $do_concat;
 
             $list{$type} ||= [];
             push @{$list{$type}[$order] ||= []}, $what;
@@ -2499,18 +2497,10 @@ sub res_includes {
                 my $template_order = $template;
                 next unless $list = $list{$type}[$o];
 
-                if ($do_concat) {
-                    my $csep = join(',', @$list);
-                    $csep .= "?v=" . $oldest{$type}[$o];
-                    $template_order =~ s/__+/??$csep/;
-                    $ret .= $template_order;
-                } else {
-                    foreach my $item (@$list) {
-                        my $inc = $template;
-                        $inc =~ s/__+/$item/;
-                        $ret .= $inc;
-                    }
-                }
+                my $csep = join(',', @$list);
+                $csep .= "?v=" . $oldest{$type}[$o];
+                $template_order =~ s/__+/??$csep/;
+                $ret .= $template_order;
             }
         };
 


### PR DESCRIPTION
This functionality was previously handled by Perlbal. As part of the
question to get rid of Perlbal in production, we can now do this all in
the Apache layer.