### PR TITLE
merge get and post args for Net::OpenID::Server

### DIFF
--- a/cgi-bin/LJ/OpenID.pm
+++ b/cgi-bin/LJ/OpenID.pm
@@ -37,10 +37,11 @@ sub server_enabled {
 sub server {
     my ($get, $post) = @_;
 
+    my %args = ( %{ $get || {} }, %{ $post || {} } );
+
     return Net::OpenID::Server->new(
                                     compat       => $LJ::OPENID_COMPAT,
-                                    get_args     => $get  || {},
-                                    post_args    => $post || {},
+                                    args         => \%args,
 
                                     get_user     => \&LJ::get_remote,
                                     is_identity  => sub {


### PR DESCRIPTION
get_args and post_args are deprecated. If both are specified, as we do in htdocs/openid/server.bml, get_args is ignored, which can produce the "not a human-readable resource" error. Let's just merge them into one args hash.