### PR TITLE
[#1900] remove any additional cachebuster arguments

### DIFF
--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -208,8 +208,9 @@ sub send_concat_res_response {
     return 404
         unless -d $dir;
 
-    # Might contain cache buster "?v=3234234234" at the end
-    $args =~ s/\?v=\d+$//;
+    # Might contain cache buster "?v=3234234234" at the end;
+    # plus possibly other unique args (caught by the .*)
+    $args =~ s/\?v=\d+.*$//;
 
     # Collect each file
     my ( $body, $size, $mtime, $mime ) = ( '', 0, 0, undef );


### PR DESCRIPTION
Fixes #1900.

(If we don't think the "v=" will always be first maybe we should just remove everything? But I decided to try the more conservative approach first.)