### PR TITLE
QuickReply box appears in appropriate location in Drifting

### DIFF
--- a/styles/drifting/layout.s2
+++ b/styles/drifting/layout.s2
@@ -1203,11 +1203,14 @@ function Page::print_entry (Entry e)
         $e->print_text();
         if ($*entry_metadata_position == "bottom") { $e->print_metadata(); }
         $e->print_tags();
-        $e->print_management_links();
-        $e->print_interaction_links("topcomment");
-        $this->print_reply_container({ "target" => "topcomment" });
-
+        $this->print_entry_footer($e);
     $e->print_wrapper_end();
+}
+
+function Page::print_entry_footer(Entry e) {
+    $e->print_management_links();
+    $e->print_interaction_links();
+    $e->print_reply_container({ "target" => $e.dom_id + "-reply" });
 }
 
 ## Entry Page
@@ -1254,6 +1257,12 @@ function EntryPage::print_comment (Comment c)
         println "</div>";
 
     $c->print_wrapper_end();
+}
+
+function EntryPage::print_entry_footer(Entry e) {
+    $e->print_management_links();
+    $e->print_interaction_links("topcomment");
+    $this->print_reply_container({ "target" => "topcomment" });
 }
 
 ## Reply Page


### PR DESCRIPTION
Adds the print_entry_footer code form core2 into Drifting to
give proper targets for the QuickReply box to anchor to.

Fixes #1509