### PR TITLE
handle not using active-active clusters in prod

### DIFF
--- a/cgi-bin/LJ/DB.pm
+++ b/cgi-bin/LJ/DB.pm
@@ -263,7 +263,7 @@ sub foreach_cluster {
     die $@ if $@;
 
     foreach my $cluster_id (@LJ::CLUSTERS) {
-        my $dbr = ($LJ::IS_DEV_SERVER) ?
+        my $dbr = (defined %LJ::CLUSTER_PAIR_ACTIVE) ?
             LJ::get_cluster_reader($cluster_id) : LJ::DBUtil->get_inactive_db($cluster_id, $opts->{verbose});
         $coderef->($cluster_id, $dbr);
     }

--- a/cgi-bin/LJ/DB.pm
+++ b/cgi-bin/LJ/DB.pm
@@ -263,7 +263,7 @@ sub foreach_cluster {
     die $@ if $@;
 
     foreach my $cluster_id (@LJ::CLUSTERS) {
-        my $dbr = (defined %LJ::CLUSTER_PAIR_ACTIVE) ?
+        my $dbr = %LJ::CLUSTER_PAIR_ACTIVE ?
             LJ::get_cluster_reader($cluster_id) : LJ::DBUtil->get_inactive_db($cluster_id, $opts->{verbose});
         $coderef->($cluster_id, $dbr);
     }

--- a/cgi-bin/LJ/DB.pm
+++ b/cgi-bin/LJ/DB.pm
@@ -256,15 +256,8 @@ sub foreach_cluster {
     my $coderef = shift;
     my $opts = shift || {};
 
-    # have to include this via an eval so it doesn't actually get included
-    # until someone calls foreach cluster.  at which point, if they're in web
-    # context, it will fail.
-    eval "use LJ::DBUtil; 1;";
-    die $@ if $@;
-
     foreach my $cluster_id (@LJ::CLUSTERS) {
-        my $dbr = %LJ::CLUSTER_PAIR_ACTIVE ?
-            LJ::get_cluster_reader($cluster_id) : LJ::DBUtil->get_inactive_db($cluster_id, $opts->{verbose});
+        my $dbr = LJ::get_cluster_reader( $cluster_id );
         $coderef->($cluster_id, $dbr);
     }
 }


### PR DESCRIPTION
Probably fixes #1909 since we switched to writer/reader clusters in prod. Code should check whether active-active clusters are defined, not whether this is a dev server.