### PR TITLE
Cleanup 2016q4

### DIFF
--- a/cgi-bin/LJ/Capabilities.pm
+++ b/cgi-bin/LJ/Capabilities.pm
@@ -119,7 +119,7 @@ sub caps_string {
     foreach my $bit (0..15) {
         my $class = class_of_bit( $bit );
         next unless $class && caps_in_group( $caps, $class );
-        my $name = $LJ::CAP{$bit}->{$name_value};
+        my $name = $LJ::CAP{$bit}->{$name_value} // "";
         push @classes, $name if $name ne "";
     }
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -296,6 +296,7 @@ sub s2_run
     };
     my $out_clean = sub {
         my $text = shift;
+        $text = '' unless defined $text;
 
         $cleaner->parse($text);
 


### PR DESCRIPTION
Two minor undefined warning fixes:

* Use of uninitialized value $name in string ne ... cgi-bin/LJ/Capabilities.pm line 123.

* Use of uninitialized value in subroutine entry ... cgi-bin/LJ/S2.pm line 300.