### PR TITLE
Safer payments

### DIFF
--- a/cgi-bin/DW/Pay.pm
+++ b/cgi-bin/DW/Pay.pm
@@ -405,11 +405,14 @@ sub expire_user {
     DW::Pay::update_paid_status( $u, _expire => 1 );
     DW::Pay::sync_caps( $u );
 
-    # inactivate userpics (yes, this method does inactivation too)
-    $u->activate_userpics;
-
-    # disable email alias
-    $u->delete_email_alias;
+    my $rv = eval {
+        # activate also does inactivations
+        $u->activate_userpics;
+        $u->delete_email_alias;
+        1;
+    };
+    warn "Failed to perform one or more payment postflight tasks!\n"
+        unless $rv;
 
     # happy times
     DW::Stats::increment( 'dw.shop.paid_account.expired', 1 );
@@ -525,11 +528,15 @@ sub add_paid_time {
     DW::Pay::sync_caps( $u )
         if $rv;
 
-    # activate userpics
-    $u->activate_userpics;
-
-    # enable email alias
-    $u->update_email_alias;
+    # the following updates can error, and if they do then we don't want to break the
+    # whole payment flow
+    my $rv = eval {
+        $u->activate_userpics;
+        $u->update_email_alias;
+        1;
+    };
+    warn "Failed to perform one or more payment postflight tasks!\n"
+        unless $rv;
 
     # all good, we hope :-)
     return $rv;

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -822,6 +822,8 @@ sub preload_props {
                 LJ::get_db_reader();
             $used_slave = 1;
         }
+        die "No db\n" unless $db;
+
         $sql = "SELECT upropid, value FROM $table WHERE userid=$uid";
         if (ref $loadfrom{$table}) {
             $sql .= " AND upropid IN (" . join(",", @{$loadfrom{$table}}) . ")";

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -15,7 +15,7 @@ package LJ::User;
 use strict;
 no warnings 'uninitialized';
 
-use Carp;
+use Carp qw/ confess /;
 use LJ::Identity;
 
 use DW::Pay;
@@ -822,7 +822,7 @@ sub preload_props {
                 LJ::get_db_reader();
             $used_slave = 1;
         }
-        die "No db\n" unless $db;
+        confess "No database handle available" unless $db;
 
         $sql = "SELECT upropid, value FROM $table WHERE userid=$uid";
         if (ref $loadfrom{$table}) {


### PR DESCRIPTION
Fix an issue where preload_props could get no database handle and
wouldn't fail immediately (but would instead fail two lines later).
Also, make the payment system catch failures in the post-payment tasks
and not fail hard.