### PR TITLE
add stats collection for resolve-extacct

### DIFF
--- a/cgi-bin/DW/External/Userinfo.pm
+++ b/cgi-bin/DW/External/Userinfo.pm
@@ -18,6 +18,9 @@ use strict;
 use Carp qw/ croak /;
 use Storable qw/ nfreeze /;
 
+use DW::External::Site;
+use DW::Stats;
+
 # timeout interval - to avoid hammering the remote site,
 # wait 30 minutes before trying again for this user
 sub wait { return 1800; }
@@ -110,6 +113,9 @@ sub save {
     my $user = $u->user;
     my $site = $u->site->{siteid};
 
+    my $stat_tags = [ "username:$user",
+                      "site:" . DW::External::Site->get_site_by_id( $site ) ];
+
     my $memkey = "ext_userinfo:$site:$user";
     my $dbh = LJ::get_db_writer() or return undef;
 
@@ -118,6 +124,7 @@ sub save {
                   " VALUES (?,?,?)", undef, $user, $site, $opts{timeout} );
         die $dbh->errstr if $dbh->err;
         LJ::MemCache::set( $memkey, '', $class->wait );
+        DW::Stats::increment( 'dw.worker.extacct.failure', 1, $stat_tags );
 
     } elsif ( $opts{type} && $opts{type} =~ /^[PYC]$/ ) {
     # save as journaltype and clear any timeout
@@ -125,6 +132,7 @@ sub save {
                   " VALUES (?,?,?,?)", undef, $user, $site, $opts{type}, undef );
         die $dbh->errstr if $dbh->err;
         LJ::MemCache::set( $memkey, $opts{type} );
+        DW::Stats::increment( 'dw.worker.extacct.success', 1, $stat_tags );
 
     } else {
         my $opterr = join ', ', map { "$_ => $opts{$_}" } keys %opts;


### PR DESCRIPTION
If my understanding of DW::Stats is correct, this should report `resolve-extacct` successes and failures to Datadog or similar.

I haven't actually tested this and don't know if any further setup in Datadog is needed.