### PR TITLE
Add HTTPS Everywhere beta

### DIFF
--- a/cgi-bin/DW/Controller/Misc.pm
+++ b/cgi-bin/DW/Controller/Misc.pm
@@ -69,11 +69,14 @@ sub beta_handler {
     my $now = time();
     my @current_features;
     if ( keys %LJ::BETA_FEATURES ) {
-        my @all_features = sort { $LJ::BETA_FEATURES{$b}->{start_time} <=> $LJ::BETA_FEATURES{$a}->{start_time} } keys %LJ::BETA_FEATURES;
+        my @all_features = sort {
+                $LJ::BETA_FEATURES{$b}->{start_time} <=> $LJ::BETA_FEATURES{$a}->{start_time}
+            } keys %LJ::BETA_FEATURES;
         foreach my $feature ( @all_features ) {
             my $feature_handler = LJ::BetaFeatures->get_handler( $feature );
             push @current_features, $feature_handler
-                if $LJ::BETA_FEATURES{$feature}->{start_time} <= $now && $LJ::BETA_FEATURES{$feature}->{end_time} > $now
+                if $LJ::BETA_FEATURES{$feature}->{start_time} <= $now
+                    && $LJ::BETA_FEATURES{$feature}->{end_time} > $now
                     && ! $feature_handler->is_sitewide_beta;
         }
     }
@@ -82,7 +85,10 @@ sub beta_handler {
         remote => $rv->{remote},
         features => \@current_features,
         news_journal => LJ::load_user( $LJ::NEWS_JOURNAL ),
-        replace_ljuser_tag => sub { $_[0] =~ s/<\?ljuser (.+) ljuser\?>/LJ::ljuser($1)/mge; return $_[0] },
+        replace_ljuser_tag => sub {
+                $_[0] =~ s/<\?ljuser (.+) ljuser\?>/LJ::ljuser($1)/mge;
+                return $_[0];
+            },
     };
     return DW::Template->render_template( 'beta.tt', $vars );
 }

--- a/cgi-bin/LJ/BetaFeatures.pm
+++ b/cgi-bin/LJ/BetaFeatures.pm
@@ -108,8 +108,7 @@ sub remove_from_beta {
 }
 
 sub user_in_beta {
-    my $class = shift;
-    my ($u, $key) = @_;
+    my ( $class, $u, $key ) = @_;
 
     my $key_handler = $class->get_handler( $key );
     return 1 if $key_handler->is_sitewide_beta;

--- a/cgi-bin/LJ/User/Display.pm
+++ b/cgi-bin/LJ/User/Display.pm
@@ -37,8 +37,10 @@ sub format_time {
 }
 
 
+# return whether or not a user is in a given beta key (as defined by %LJ::BETA_FEATURES)
+# and enabled on the beta page
 sub is_in_beta {
-    my ($u, $key) = @_;
+    my ( $u, $key ) = @_;
     return LJ::BetaFeatures->user_in_beta( $u => $key );
 }
 

--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -3,21 +3,19 @@
 
 .betafeature.btn.on=Turn ON beta testing
 
-.betafeature.s2comments.cantadd=Sorry, your account is not eligible to test this feature.
+.betafeature.httpseverywhere.cantadd=Sorry, your account is not eligible to test this feature.
 
-.betafeature.s2comments.off<<
-<p>Activate the testing version of the sitescheme comments and reply pages. This is a complete rewrite of the existing pages into S2, the scripting language we use for journalstyles, which is more modern and flexible than the old code. It should be complete and a close match to old reply pages, but some bugs may still remain.</p>
-
-<p>To report bugs with the new comment and reply pages, leave a comment in <?ljuser dw_beta ljuser?>.</p>
+.betafeature.httpseverywhere.off<<
+<p>Activate HTTPS Everywhere. This will force your account to use a secure connection whenever
+you're logged in and browsing.</p>
 .
 
-.betafeature.s2comments.on<<
-<p>You are currently testing the the sitescheme comments and reply pages. This is a complete rewrite of the existing pages into S2, the scripting language we use for journalstyles, which is more modern and flexible than the old code. It should be complete and a close match to old reply pages, but some bugs may still remain.</p>
-
-<p>To report bugs with the new comment and reply pages, leave a comment in <?ljuser dw_beta ljuser?>.</p>
+.betafeature.httpseverywhere.on<<
+<p>You currently have HTTPS Everywhere enabled. Toggle off if you wish to resume browsing
+the site normally (unencrypted).</p>
 .
 
-.betafeature.s2comments.title=New S2 Comment Pages
+.betafeature.httpseverywhere.title=HTTPS Everywhere
 
 .betafeature.updatepage.cantadd=Sorry, your account is not eligible to test this feature.
 


### PR DESCRIPTION
This adds a beta option for testing use of HTTPS Everywhere. This will
allow us to ensure the site is fully working before turning it on for
everybody. When we do turn it on everywhere we'll have to do a little
cleanup to revert most of this.