### PR TITLE
remove references to unused comm_promo_list

### DIFF
--- a/bin/maint/taskinfo.txt
+++ b/bin/maint/taskinfo.txt
@@ -17,9 +17,6 @@ generic.pl:
   joinmail - Generates daily email digests for community join requests
   clean_spamreports - Clean out data from the spamreports table older than 90 days.
 
-comm_promo_list.pl:
-  comm_promo_list - Generates data needed for community promos
-
 captcha.pl:
   cache_textcaptcha - Generates textcaptcha instances
   clean_captchas - Clean out captchas that have been used

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -914,6 +914,7 @@ register_tabledrop("pollprop2");
 register_tabledrop("pollproplist2");
 register_tabledrop("dirsearchres2");
 register_tabledrop("txtmsg");
+register_tabledrop("comm_promo_list");
 
 
 register_tablecreate("infohistory", <<'EOC');
@@ -2192,16 +2193,6 @@ CREATE TABLE sch_exitstatus (
     delete_after    INTEGER UNSIGNED,
 
     INDEX (delete_after)
-)
-EOC
-
-register_tablecreate("comm_promo_list", <<'EOC');
-CREATE TABLE comm_promo_list (
-    journalid INT UNSIGNED NOT NULL,
-    r_start INT UNSIGNED NOT NULL,
-    r_end INT UNSIGNED NOT NULL,
-
-    INDEX (r_start)
 )
 EOC
 


### PR DESCRIPTION
Found this when investigating the bin/maint directory.  Probably an ljcom thing.