### PR TITLE
[#1896] only populate notifyarchive if esn_archive enabled

### DIFF
--- a/cgi-bin/LJ/NotificationInbox.pm
+++ b/cgi-bin/LJ/NotificationInbox.pm
@@ -417,7 +417,7 @@ sub enqueue {
     my ($self, %opts) = @_;
 
     my $evt = delete $opts{event};
-    my $archive = delete $opts{archive} || 1;
+    my $archive = delete $opts{archive} || LJ::is_enabled( 'esn_archive' );
     croak "No event" unless $evt;
     croak "Extra args passed to enqueue" if %opts;
 


### PR DESCRIPTION
Metadata for every notification is saved in this table,
but if the feature is disabled, it's never used anywhere.

Perhaps this "feature" could be entirely removed in the
future, but I think that decision should be delayed until
we have a spec for the requested inbox redesign.  It might
be useful when trying to implement a trash folder, for example.

Fixes #1896.