### PR TITLE
fixes for failed uploads breaking /file/edit page

### DIFF
--- a/cgi-bin/DW/Media.pm
+++ b/cgi-bin/DW/Media.pm
@@ -126,6 +126,19 @@ sub upload_media {
     # now we can cook -- allocate an id and upload
     my $id = LJ::alloc_user_counter( $opts{user}, 'A' )
         or croak 'Unable to allocate user counter for uploaded file.';
+
+    # to avoid having database rows for an image that failed to upload,
+    # do the upload first - we can create a fake object to get the mogkey
+
+    # FIXME: have different MogileFS classes for different media types
+
+    my $fakeobj = bless { userid => $opts{user}->id, versionid => $id }, 'DW::Media::Photo';
+    my $fh = $mog->new_file( $fakeobj->mogkey, 'media' )
+        or croak 'Unable to instantiate file in MogileFS.';
+    $fh->print( $opts{data} );
+    $fh->close or croak 'Unable to save file to MogileFS.';
+
+    # now update the database tables
     $opts{user}->do(
         q{INSERT INTO media (userid, mediaid, anum, ext, state, mediatype, security, allowmask,
             logtime, mimetype, filesize) VALUES (?, ?, ?, ?, 'A', ?, ?, ?, UNIX_TIMESTAMP(), ?, ?)},
@@ -143,19 +156,8 @@ sub upload_media {
     croak "Failed to insert version row: " . $opts{user}->errstr . "."
         if $opts{user}->err;
 
-    # now get this back as an object
-    my $obj = DW::Media->new( user => $opts{user}, mediaid => $id );
-
-    # now we have to stick this in MogileFS
-    # FIXME: have different MogileFS classes for different media types
-    my $fh = $mog->new_file( $obj->mogkey, 'media' )
-        or croak 'Unable to instantiate file in MogileFS.'; # FIXME: nuke the row!
-    $fh->print( $opts{data} );
-    $fh->close
-        or croak 'Unable to save file to MogileFS.'; # FIXME: nuke the row!
-
     # uploaded, so return an object for this item
-    return $obj;
+    return DW::Media->new( user => $opts{user}, mediaid => $id );
 }
 
 sub preprocess {

--- a/cgi-bin/DW/Media.pm
+++ b/cgi-bin/DW/Media.pm
@@ -202,8 +202,17 @@ sub get_active_for_user {
     return () unless $rows && ref $rows eq 'ARRAY';
 
     # construct media objects for each of the items and return that
-    return sort { $b->logtime <=> $a->logtime }
-           map { DW::Media->new( user => $u, mediaid => $_, %opts ) } @$rows;
+    my @media;
+    foreach ( @$rows ) {
+        # use eval to catch croaks
+        my $obj = eval { DW::Media->new( user => $u, mediaid => $_, %opts ) };
+        if ( $obj ) {
+            push @media, $obj;
+        } else {
+            warn "Failed to load media: $@";
+        }
+    }
+    return sort { $b->logtime <=> $a->logtime } @media;
 }
 
 

--- a/cgi-bin/DW/Media/Photo.pm
+++ b/cgi-bin/DW/Media/Photo.pm
@@ -96,7 +96,9 @@ sub _resize {
         int($height * $ratio + 0.5) );
 
     # Load the image data, then scale it.
-    my $dataref = LJ::mogclient()->get_file_data( $self->mogkey );
+    my ( $username, $mediaid ) = ( $self->u->user, $self->{mediaid} );
+    my $dataref = LJ::mogclient()->get_file_data( $self->mogkey )
+        or croak "Failed to load image file $mediaid for $username.";
     my $timage = Image::Magick->new()
         or croak 'Failed to instantiate Image::Magick object.';
     $timage->BlobToImage( $$dataref );


### PR DESCRIPTION
This fix is in three stages as detailed in each individual commit:

- Provide a more informative error if get_file_data fails in the _resize method.

- Print the error to the log instead, and hide any problematic images from the user.

- Reorder operations in upload_media to prevent the problem from happening again.

Fixes #1928.