### PR TITLE
Remove flip-flop warnings from test suite

### DIFF
--- a/t/esn-journalnewcomment.t
+++ b/t/esn-journalnewcomment.t
@@ -167,7 +167,7 @@ test_esn_flow(sub {
     ######## S3 (watching a thread)
 
     # make sure we can track threads
-    $LJ::CAP{0...15}->{track_thread} = 1;
+    $LJ::CAP{$_}->{track_thread} = 1 foreach (0..15);
 
     # subscribe to replies to a thread
     $subsc = $u1->subscribe(
@@ -205,7 +205,7 @@ test_esn_flow(sub {
     $email = $got_notified->($u1);
     ok(! $email, "didn't get notified");
 
-    $LJ::CAP{0...15}->{track_thread} = 0;
+    $LJ::CAP{$_}->{track_thread} = 0 foreach (0..15);
     $subsc->delete;
 
     if ( ( LJ::Event::JournalNewComment->zero_journalid_subs_means // "" ) eq "friends") {

--- a/t/notificationinbox.t
+++ b/t/notificationinbox.t
@@ -25,7 +25,7 @@ use Test::More;
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
 # Set more manageable limit for testing
-$LJ::CAP{0..15}->{inbox_max} = 10;
+$LJ::CAP{$_}->{inbox_max} = 10 foreach (0..15);
 
 use LJ::Test qw(temp_user memcache_stress);
 


### PR DESCRIPTION
`Use of uninitialized value $. in range (or flip) at t/esn-journalnewcomment.t line 170.`

`Use of uninitialized value $. in range (or flip) at t/esn-journalnewcomment.t line 208.`

`Use of uninitialized value $. in range (or flip) at t/notificationinbox.t line 28.`

`Use of uninitialized value $. in range (or flop) at t/notificationinbox.t line 28.`

I'm not sure why these suddenly manifested while testing on
the blobstore branch, but they appear to hinge on using
questionable syntax to assign to a hash slice.  Rewritten
as a postfix foreach to achieve more clarity/less shadiness.

A Google search on the error message turned up
http://www.perlmonks.org/?node_id=525392 which was
educational if not exactly enlightening.