### PR TITLE
[#1338] display different payment error for duplicate transactions

### DIFF
--- a/htdocs/shop/cart.bml
+++ b/htdocs/shop/cart.bml
@@ -39,7 +39,14 @@ body<=
     $ret .= qq{
         <div class='warning-box message-box'>
             <div class='title'>$ML{'.payment.failed.title'}</div>
-            <p>$ML{'.payment.failed'}</p>
+            <p>$ML{'.payment.failed.duplicate'}</p>
+        </div>\n}
+        if $GET{duplicate};
+
+    $ret .= qq{
+        <div class='warning-box message-box'>
+            <div class='title'>$ML{'.payment.failed.title'}</div>
+            <p>$ML{'.payment.failed.other'}</p>
         </div>\n}
         if $GET{failed};
 

--- a/htdocs/shop/cart.bml.text
+++ b/htdocs/shop/cart.bml.text
@@ -3,7 +3,9 @@
 
 .gift=Give a Gift
 
-.payment.failed=Unfortunately, your method of payment was declined by our merchant processor.  If you would like to choose an alternate form of payment, or make sure you entered everything correctly, you will need to initiate the checkout process again.
+.payment.failed.duplicate=Your card was declined by our payment processor for trying to process a duplicate transaction. Usually, this happens because you just made a payment, and are trying to make another payment for the same amount on the same credit card: our payment processor tries to prevent consecutive identical charges on the same card. If that's what happened, please wait an hour and try again, or add or remove something from your cart so the amount you're charging is different. If you think you received this message in error, <a href="/support/submit">submit a support request</a> in the Account Payments category and we'll help you figure out what the problem is.
+
+.payment.failed.other=Unfortunately, your card was declined by our payment processor. Please try checking out again, making sure that you've entered your address and security code (CVN) correctly. You can also check with your credit card company to make sure they don't think the charge is suspicious. If none of that helps and you still get an error, <a href="/support/submit">submit a support request</a> in the Account Payments category and we'll help you figure out what the problem is.
 
 .payment.failed.title=Payment Failed
 

--- a/htdocs/shop/creditcard_wait.bml
+++ b/htdocs/shop/creditcard_wait.bml
@@ -51,9 +51,13 @@ body<=
         unless $row && $row->{cctransid} == $cctransid &&
                $row->{cartid} == $cart->id;
 
-    # if it failed, redirect back to the cart
-    return BML::redirect( "$LJ::SITEROOT/shop/cart?failed=1" )
-        if $row->{jobstate} eq 'failed';
+    # if it failed, redirect back to the cart, but print
+    # a different error message if it was flagged as a duplicate
+    if ( $row->{jobstate} eq 'failed' ) {
+        my $errtype = $row->{responsetext} =~ /^Duplicate transaction /
+                      ? 'duplicate' : 'failed';
+        return BML::redirect( "$LJ::SITEROOT/shop/cart?$errtype=1" );
+    }
 
     # if we're still queued, set the refresh
     $head = q{<meta http-equiv="refresh" content="3" />}


### PR DESCRIPTION
I haven't tested this because figuring out how to fake a credit card transaction on my dreamhack is a deeper rabbit hole than I care to explore today, but this seems like a straightforward change, as long as I didn't make any typos.  😬 

Fixes #1338.