### PR TITLE
better automatic word-break behavior

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1493,7 +1493,8 @@ sub preview_handler {
         if ( $u->should_block_robots ) {
             $p->{head_content} .= LJ::robot_meta_tags();
         }
-        $p->{head_content} .= '<meta http-equiv="Content-Type" content="text/html; charset=' . $opts->{'saycharset'} . "\" />\n";
+        my $charset = $opts->{saycharset} // '';
+        $p->{head_content} .= '<meta http-equiv="Content-Type" content="text/html; charset=' . $charset . "\" />\n";
         # Don't show the navigation strip or invisible content
         $p->{head_content} .= qq{
             <style type="text/css">

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1687,8 +1687,28 @@ sub break_word {
     my ($word, $at) = @_;
     return $word unless $at;
 
-    $word =~ s/((?:$onechar){$at})\B/$1<wbr \/>/g;
-    return $word;
+    my $ret = '';
+    my $chunk;
+
+    # This while loop splits up $word into chunks that are each $at characters
+    # long.  The \B ensures that the match fails if the word/chunk is EXACTLY
+    # $at characters long.  If the chunk contains punctuation (here defined as
+    # anything that isn't a word character or digit), the word break tag will
+    # be placed at the last punctuation point; otherwise it will be placed at
+    # the maximum length of the unbroken word as defined by $at.
+
+    while ( $word =~ s/((?:$onechar){$at})\B// ) {
+        $chunk = $1;
+
+        if ( $chunk =~ /([^\d\w])(.+?)$/p ) {
+            $ret .= "${^PREMATCH}$1<wbr />";
+            $word = "$2$word";
+        } else {
+            $ret .= "$chunk<wbr />";
+        }
+    }
+
+    return "$ret$word";
 }
 
 sub quote_html {

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -91,7 +91,7 @@ my %tag_substitute = (
 # slash and get the proper behavior from a browser.
 #
 # In HTML5 these are called "void elements".
-my $slashclose_tags = qr/^(?:area|base|basefont|br|col|embed|frame|hr|img|input|isindex|link|meta|param|lj-embed|site-embed)$/i;
+my $slashclose_tags = qr/^(?:area|base|basefont|br|col|embed|frame|hr|img|input|isindex|link|meta|param|wbr|lj-embed|site-embed)$/i;
 
 # <LJFUNC>
 # name: LJ::CleanHTML::clean

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1416,7 +1416,7 @@ my $subject_remove = [qw[bgsound embed object caption link font noscript]];
 sub clean_subject
 {
     my $ref = shift;
-    return unless $$ref =~ /[\<\>]/;
+    return unless defined $$ref and $$ref =~ /[\<\>]/;
     clean($ref, {
         'wordlength' => 40,
         'addbreaks' => 0,

--- a/t/clean-event.t
+++ b/t/clean-event.t
@@ -17,7 +17,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 42;
+use Test::More tests => 45;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::CleanHTML;
@@ -293,4 +293,22 @@ note( "mismatched and misnested tags" );
     $clean->();
     is ( $orig_post, $clean_post, "Full text of entry, with mismatched HTML tags within and with-out the cut" );
 }
+
+note("expected wordbreak behavior");
+
+$orig_post  = qq{wordbreak};
+$clean_post = qq{word<wbr />brea<wbr />k};
+$clean->({ wordlength => 4 });
+is( $orig_post, $clean_post, "Word break tags inserted where requested" );
+
+$orig_post  = qq{insert a word<wbr>break};
+$clean_post = qq{insert a word<wbr>break};
+$clean->();
+is( $orig_post, $clean_post, "Existing word break tags unchanged" );
+
+$orig_post  = qq{word-break};
+$clean_post = qq{word-<wbr />break};
+$clean->({ wordlength => 8 });
+is( $orig_post, $clean_post, "Word break tag prefers punctuation points" );
+
 1;

--- a/t/clean-event.t
+++ b/t/clean-event.t
@@ -17,7 +17,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 45;
+use Test::More tests => 48;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::CleanHTML;
@@ -310,5 +310,20 @@ $orig_post  = qq{word-break};
 $clean_post = qq{word-<wbr />break};
 $clean->({ wordlength => 8 });
 is( $orig_post, $clean_post, "Word break tag prefers punctuation points" );
+
+$orig_post  = qq{&quot;entity&quot; test};
+$clean_post = qq{&quot;entity&quot; test};
+$clean->({ wordlength => 8 });
+is( $orig_post, $clean_post, "Word break handling of HTML entities OK" );
+
+$orig_post  = qq{multi-character-string test};
+$clean_post = qq{multi-character-<wbr />string test};
+$clean->({ wordlength => 20 });
+is( $orig_post, $clean_post, "Choose last punctuation in string" );
+
+$orig_post  = qq{"This_is_a_test_of_the_emergency_word_break_system."};
+$clean_post = qq{"This_is_a_test_of_the_emergency_word_br<wbr />eak_system."};
+$clean->({ wordlength => 40 });
+is( $orig_post, $clean_post, "Don't choose first character in string" );
 
 1;


### PR DESCRIPTION
Now the HTML cleaner will prefer punctuation marks for word breaks, if available, and has been told that &lt;/wbr> is not a thing.  Includes many tests for the new behavior.

Fixes #1948.