### PR TITLE
fix variable reuse warning in DW::Pay

### DIFF
--- a/cgi-bin/DW/Pay.pm
+++ b/cgi-bin/DW/Pay.pm
@@ -530,13 +530,13 @@ sub add_paid_time {
 
     # the following updates can error, and if they do then we don't want to break the
     # whole payment flow
-    my $rv = eval {
+    my $do_postflight = eval {
         $u->activate_userpics;
         $u->update_email_alias;
         1;
     };
     warn "Failed to perform one or more payment postflight tasks!\n"
-        unless $rv;
+        unless $do_postflight;
 
     # all good, we hope :-)
     return $rv;


### PR DESCRIPTION
`"my" variable $rv masks earlier declaration in same scope .. cgi-bin/DW/Pay.pm line 533.`

Traced this back to bd33881 - eval code added in two spots, but one of
the spots was already using $rv.

Changed the new $rv to use a different variable name, which means the
function will return the earlier $rv as before.