### PR TITLE
Embed triage

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -136,6 +136,10 @@ LJ::Hooks::register_hook( 'allow_iframe_embeds', sub {
         return ( 1, 1 ) if $uri_path =~ m!^/wiki/File:! && $parsed_uri->query =~ m/embedplayer=yes/;
     }
 
+    if ( $uri_host eq "i.cdn.turner.com" ) {
+        return ( 1, 1 ) if $uri_path =~ '/cnn_\d+x\d+_embed.swf$' && $parsed_uri->query =~ m/^context=embed&videoId=/;
+    }
+
     if ( $uri_host eq "www.facebook.com" ) {
         return ( 1, 1 ) if $uri_path eq '/plugins/video.php' && $parsed_uri->query =~ m/^href=https%3A%2F%2Fwww.facebook.com%2F[^%]+%2Fvideos%2F/;
     }

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -49,11 +49,21 @@ sub match_full_path {
 my %host_path_match = (
                                 # regex, whether this supports https or not
     "8tracks.com"           => [ qr!^/mixes/!, 0 ],
+
+    "archive.org"           => [ qr!^/embed/!, 1 ],
+
     "bandcamp.com"          => [ qr!^/EmbeddedPlayer/!, 1 ],
     "blip.tv"               => [ qr!^/play/!, 1 ],
 
+    "codepen.io"            => [ qr!^/enxaneta/embed/!, 1 ],
+    "www.criticalcommons.org" => [ qr!/embed_view$!, 0 ],
+
     "www.dailymotion.com"   => [ qr!^/embed/video/!, 1 ],
     "dotsub.com"            => [ qr!^/media/!, 1 ],
+
+    "episodecalendar.com"   => [ qr!^/icalendar/!, 0 ],
+
+    "www.flickr.com"        => [ qr!/player/$!, 1 ],
 
     "www.goodreads.com"     => [ qr!^/widgets/!, 1 ],
 
@@ -63,12 +73,17 @@ my %host_path_match = (
     # drawings do not need to be whitelisted as they are images.
     # forms arent being allowed for security concerns.
     "docs.google.com"       => [ qr!^/(document|spreadsheets?|presentation)/!, 1 ],
-    
     "books.google.com"      => [ qr!^/ngrams/!, 1 ],
+
+    "imgur.com"             => [ qr!^/a/.+?/embed!, 1 ],
+    "instagram.com"         => [ qr!^/p/.*/embed/$!, 1 ],
 
     "www.kickstarter.com"   => [ qr!/widget/[a-zA-Z]+\.html$!, 1 ],
 
     "ext.nicovideo.jp"      => [ qr!^/thumb/!, 0 ],
+    "www.npr.org"           => [ qr!^/templates/event/embeddedVideo\.php!, 1 ],
+
+    "www.plurk.com"         => [ qr!^/getWidget$!, 1 ],
 
     "www.sbs.com.au"        => [ qr!/player/embed/!, 0 ],  # best guess; language parameter before /player may vary
     "www.scribd.com"        => [ qr!^/embeds/!, 1 ],
@@ -76,36 +91,16 @@ my %host_path_match = (
     "w.soundcloud.com"      => [ qr!^/player/!, 1 ],
     "embed.spotify.com"     => [ qr!^/$!, 1 ],
 
-    "player.vimeo.com"      => [ qr!^/video/\d+$!, 1 ],
-
-    "www.plurk.com"         => [ qr!^/getWidget$!, 1 ],
-
-    "instagram.com"         => [ qr!^/p/.*/embed/$!, 1 ],
-
-    "www.criticalcommons.org" => [ qr!/embed_view$!, 0 ],
-
     "embed.ted.com"         => [ qr!^/talks/!, 1 ],
 
-    "archive.org"           => [ qr!^/embed/!, 1 ],
-
-    "video.yandex.ru"       => [ qr!^/iframe/[\-\w]+/[a-z0-9]+\.\d{4}/?$!, 1 ], #don't think the last part can include caps; amend if necessary
-
-    "episodecalendar.com"   => [ qr!^/icalendar/!, 0 ],
-
-    "www.flickr.com"        => [ qr!/player/$!, 1 ],
-
-    "www.npr.org"           => [ qr!^/templates/event/embeddedVideo\.php!, 1 ],
-
-    "imgur.com"             => [ qr!^/a/.+?/embed!, 1 ],
-
+    "vid.me"                => [ qr!^/e/!, 1 ],
+    "player.vimeo.com"      => [ qr!^/video/\d+$!, 1 ],
     "vine.co"               => [ qr!^/v/[a-zA-Z0-9]{11}/embed/simple$!, 1 ],
     # Videos seemed to use an 11-character identification; may need to be changed
 
+    "video.yandex.ru"       => [ qr!^/iframe/[\-\w]+/[a-z0-9]+\.\d{4}/?$!, 1 ], #don't think the last part can include caps; amend if necessary
+
     "www.zippcast.com"      => [ qr!^/videoview\.php$!, 0 ],
-
-    "codepen.io"            => [ qr!^/enxaneta/embed/!, 1 ],
-
-    "vid.me"                => [ qr!^/e/!, 1 ],
 
 );
 
@@ -140,7 +135,7 @@ LJ::Hooks::register_hook( 'allow_iframe_embeds', sub {
     if ( $uri_host eq "commons.wikimedia.org" ) {
         return ( 1, 1 ) if $uri_path =~ m!^/wiki/File:! && $parsed_uri->query =~ m/embedplayer=yes/;
     }
-    
+
     if ( $uri_host eq "www.jigsawplanet.com" ) {
         return ( 1, 1 ) if $parsed_uri->query =~ m/rc=play/;
     }

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -84,6 +84,7 @@ my %host_path_match = (
     "ext.nicovideo.jp"      => [ qr!^/thumb/!, 0 ],
     "www.npr.org"           => [ qr!^/templates/event/embeddedVideo\.php!, 1 ],
 
+    "playmoss.com"          => [ qr!^/embed/!, 1 ],
     "www.plurk.com"         => [ qr!^/getWidget$!, 1 ],
 
     "www.sbs.com.au"        => [ qr!/player/embed/!, 0 ],  # best guess; language parameter before /player may vary

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -84,6 +84,8 @@ my %host_path_match = (
     "ext.nicovideo.jp"      => [ qr!^/thumb/!, 0 ],
     "www.npr.org"           => [ qr!^/templates/event/embeddedVideo\.php!, 1 ],
 
+    "onedrive.live.com"     => [ qr!^/embed$!, 1 ],
+
     "playmoss.com"          => [ qr!^/embed/!, 1 ],
     "www.plurk.com"         => [ qr!^/getWidget$!, 1 ],
 

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -48,6 +48,7 @@ sub match_full_path {
 
 my %host_path_match = (
                                 # regex, whether this supports https or not
+    "www.4shared.com"       => [ qr!^/web/embed/file/!, 1 ],
     "8tracks.com"           => [ qr!^/mixes/!, 0 ],
 
     "archive.org"           => [ qr!^/embed/!, 1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -136,6 +136,10 @@ LJ::Hooks::register_hook( 'allow_iframe_embeds', sub {
         return ( 1, 1 ) if $uri_path =~ m!^/wiki/File:! && $parsed_uri->query =~ m/embedplayer=yes/;
     }
 
+    if ( $uri_host eq "www.facebook.com" ) {
+        return ( 1, 1 ) if $uri_path eq '/plugins/video.php' && $parsed_uri->query =~ m/^href=https%3A%2F%2Fwww.facebook.com%2F[^%]+%2Fvideos%2F/;
+    }
+
     if ( $uri_host eq "www.jigsawplanet.com" ) {
         return ( 1, 1 ) if $parsed_uri->query =~ m/rc=play/;
     }

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 59;
+use Test::More tests => 60;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -93,6 +93,7 @@ note( "misc" );
     test_good_url( "http://episodecalendar.com/icalendar/sampleuser\@example.com/abcde/", "Will 404, but correctly-formed" );
 
     # F
+    test_good_url( "https://www.facebook.com/plugins/video.php?href=https%3A%2F%2Fwww.facebook.com%2FSenegocom%2Fvideos%2F775953559125595%2F&width=500&show_text=false&height=283&appId" );
     test_good_url( "https://www.flickr.com/photos/cards_by_krisso/13983859958/player/" );
 
     # G

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 63;
+use Test::More tests => 64;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -124,6 +124,9 @@ note( "misc" );
     test_good_url( "http://ext.nicovideo.jp/thumb/123123123" );
 
     test_good_url( "http://www.npr.org/templates/event/embeddedVideo.php?storyId=326182003&mediaId=327658636" );
+
+    # O
+    test_good_url( "https://onedrive.live.com/embed?cid=9B3AE57006984006&resid=9B3AE57006984006%21172&authkey=ACnVTXqwCqi3zpo" );
 
     # P
     test_good_url( "https://playmoss.com/embed/wingedbeastie/the-swamp-witch-nix-s-playlist" );

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 62;
+use Test::More tests => 63;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -126,6 +126,7 @@ note( "misc" );
     test_good_url( "http://www.npr.org/templates/event/embeddedVideo.php?storyId=326182003&mediaId=327658636" );
 
     # P
+    test_good_url( "https://playmoss.com/embed/wingedbeastie/the-swamp-witch-nix-s-playlist" );
     test_good_url( "http://www.plurk.com/getWidget?uid=123123123&h=375&w=200&u_info=2&bg=cf682f&tl=cae7fd" );
 
     # S

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 60;
+use Test::More tests => 61;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -136,6 +136,7 @@ note( "misc" );
 
     # T
     test_good_url( "http://embed.ted.com/talks/handpring_puppet_co_the_genius_puppetry_behind_war_horse.html" );
+    test_good_url( "http://i.cdn.turner.com/cnn/.element/apps/cvp/3.0/swf/cnn_416x234_embed.swf?context=embed&videoId=bestoftv/2012/09/05/exp-tsr-dem-platform-voice-vote.cnn" );
 
     # V
     test_good_url( "https://vid.me/e/v63?stats=1&amp;tools=1" );

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 61;
+use Test::More tests => 62;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -70,6 +70,7 @@ note( "youtube" );
 note( "misc" );
 {
     # 0-9
+    test_good_url( "http://www.4shared.com/web/embed/file/VtBG91EOba" );
     test_good_url( "http://8tracks.com/mixes/878698/player_v3_universal" );
 
     # A

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -69,18 +69,33 @@ note( "youtube" );
 
 note( "misc" );
 {
+    # 0-9
     test_good_url( "http://8tracks.com/mixes/878698/player_v3_universal" );
+
+    # A
+    test_good_url( "https://archive.org/embed/LeonardNimoy15Oct2013YiddishBookCenter" );
+
+    # B
     test_good_url( "http://bandcamp.com/EmbeddedPlayer/v=2/track=123123123/size=venti/bgcol=FFFFFF/linkcol=4285BB/" );
     test_good_url( "http://bandcamp.com/EmbeddedPlayer/v=2/track=123123123" );
 
     test_good_url( "http://blip.tv/play/x11Xx11Xx.html" );
 
-    test_good_url( "http://www.dailymotion.com/embed/video/x1xx11x" );
+    # C
+    test_good_url( "//codepen.io/enxaneta/embed/gPeZdP/?height=268&theme-id=0&default-tab=result" );
+    test_good_url( "http://www.criticalcommons.org/Members/china_shop/clips/handle-with-care-white-collar-fanvid/embed_view" );
 
+    # D
+    test_good_url( "http://www.dailymotion.com/embed/video/x1xx11x" );
     test_good_url( "http://dotsub.com/media/9db493c6-6168-44b0-89ea-e33a31db48db/e/m" );
 
-    test_good_url( "//instagram.com/p/cA1pRXKGBT/embed/" );
+    # E
+    test_good_url( "http://episodecalendar.com/icalendar/sampleuser\@example.com/abcde/", "Will 404, but correctly-formed" );
 
+    # F
+    test_good_url( "https://www.flickr.com/photos/cards_by_krisso/13983859958/player/" );
+
+    # G
     test_good_url( "http://www.goodreads.com/widgets/user_update_widget?height=400&num_updates=3&user=12345&width=250" );
 
     test_good_url( "http://maps.google.com/maps?f=q&source=s_q&hl=en&geocode=&q=somethingsomething&aq=0&sll=00.000,-00.0000&sspn=0.00,0.0&vpsrc=0&ie=UTF8&hq=&hnear=somethingsomething&z=0&ll=0,-00&output=embed" );
@@ -90,62 +105,57 @@ note( "misc" );
     test_good_url( "https://docs.google.com/document/d/1Bo38jRzUWrEAHT6oaNyeGLlluscRY6TS2lE2E1T94dQ/pub?embedded=true" );
     test_good_url( "https://docs.google.com/presentation/d/1AxZkO9k4ISxku0__jRD8Im6mJC9xv5i4MgETEJ_MnA8/embed?start=false&loop=false&delayms=3000" );
 
+    # I
+    test_good_url( "//imgur.com/a/J4OKE/embed" );
+    test_good_url( "//instagram.com/p/cA1pRXKGBT/embed/" );
+
+    # J
+    test_good_url( "//www.jigsawplanet.com/?rc=play&amp;pid=35458f1355c4&amp;view=iframe" );
+
+    # K
     test_good_url( "http://www.kickstarter.com/projects/25352323/arrival-a-short-film-by-alex-myung/widget/video.html" );
     test_good_url( "http://www.kickstarter.com/projects/25352323/arrival-a-short-film-by-alex-myung/widget/card.html" );
 
+    # N
     test_good_url( "http://ext.nicovideo.jp/thumb/sm123123123" );
     test_good_url( "http://ext.nicovideo.jp/thumb/nm123123123" );
     test_good_url( "http://ext.nicovideo.jp/thumb/123123123" );
 
+    test_good_url( "http://www.npr.org/templates/event/embeddedVideo.php?storyId=326182003&mediaId=327658636" );
+
+    # P
+    test_good_url( "http://www.plurk.com/getWidget?uid=123123123&h=375&w=200&u_info=2&bg=cf682f&tl=cae7fd" );
+
+    # S
     test_good_url( "http://www.sbs.com.au/yourlanguage//player/embed/id/163111" );
-
     test_good_url( "http://www.scribd.com/embeds/123123/content?start_page=1&view_mode=list&access_key=" );
-
     test_good_url( "http://www.slideshare.net/slideshow/embed_code/12312312" );
-
     test_good_url( "http://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F23318382&show_artwork=true" );
-
     test_good_url( "https://embed.spotify.com/?uri=spotify:track:1DeuZgn99eUC1hreXTWBvY" );
+
+    # T
+    test_good_url( "http://embed.ted.com/talks/handpring_puppet_co_the_genius_puppetry_behind_war_horse.html" );
+
+    # V
+    test_good_url( "https://vid.me/e/v63?stats=1&amp;tools=1" );
 
     test_good_url( "http://player.vimeo.com/video/123123123?title=0&byline=0&portrait=0" );
     test_bad_url( "http://player.vimeo.com/video/123abc?title=0&byline=0&portrait=0" );
-
-    test_good_url( "http://commons.wikimedia.org/wiki/File:somethingsomethingsomething.ogv?withJS=MediaWiki:MwEmbed.js&embedplayer=yes" );
-    test_bad_url( "http://commons.wikimedia.org/wiki/File:1903_Burnley_Ironworks_company_steam_engine_in_use.ogv?withJS=MediaWiki:MwEmbed.js" );
-
-    test_good_url( "http://www.plurk.com/getWidget?uid=123123123&h=375&w=200&u_info=2&bg=cf682f&tl=cae7fd" );
-
-    test_good_url( "http://www.criticalcommons.org/Members/china_shop/clips/handle-with-care-white-collar-fanvid/embed_view" );
-
-    test_good_url( "http://embed.ted.com/talks/handpring_puppet_co_the_genius_puppetry_behind_war_horse.html" );
-
-    test_good_url( "https://archive.org/embed/LeonardNimoy15Oct2013YiddishBookCenter" );
-
-    test_good_url( "http://video.yandex.ru/iframe/v-rednaia7/9hvgcmpgkd.5440/" );
-
-    test_good_url( "http://episodecalendar.com/icalendar/sampleuser\@example.com/abcde/", "Will 404, but correctly-formed" );
-
-    test_good_url( "https://www.flickr.com/photos/cards_by_krisso/13983859958/player/" );
-
-    test_good_url( "http://www.npr.org/templates/event/embeddedVideo.php?storyId=326182003&mediaId=327658636" );
-
-    test_good_url( "//imgur.com/a/J4OKE/embed" );
 
     test_good_url( "https://vine.co/v/bjHh0zHdgZT/embed/simple" );
     test_bad_url( "https://vine.co/v/bjHh0zHdgZT/embed/postcard" );
     test_bad_url( "https://vine.co/v/bjHh0zHdgZT/embed" );
     test_bad_url( "https://vine.co/v/abc/embed/simple" );
 
-    test_good_url( "//www.jigsawplanet.com/?rc=play&amp;pid=35458f1355c4&amp;view=iframe" );
+    # W
+    test_good_url( "http://commons.wikimedia.org/wiki/File:somethingsomethingsomething.ogv?withJS=MediaWiki:MwEmbed.js&embedplayer=yes" );
+    test_bad_url( "http://commons.wikimedia.org/wiki/File:1903_Burnley_Ironworks_company_steam_engine_in_use.ogv?withJS=MediaWiki:MwEmbed.js" );
 
+    # Y
     test_good_url( "https://screen.yahoo.com/fashion-photographer-life-changed-chance-193621376.html?format=embed" );
+    test_good_url( "http://video.yandex.ru/iframe/v-rednaia7/9hvgcmpgkd.5440/" );
 
+    # Z
     test_good_url( "//www.zippcast.com/videoview.php?vplay=6c91dae3fc1bc909db0&auto=no" );
 
-    test_good_url( "//codepen.io/enxaneta/embed/gPeZdP/?height=268&theme-id=0&default-tab=result" );
-
-    test_good_url( "https://vid.me/e/v63?stats=1&amp;tools=1" );
-
 }
-
-


### PR DESCRIPTION
Whitelist embeds from onedrive.com, playmoss.com, 4shared.com, cnn.com, & facebook.com.

Fixes #1860, #1906, #1908, #1920, #1946.

NB I was not able to add support for Wired as referenced in #1920 because the necessary data was encoded in the "flashVars" parameter, not in the URL.