### PR TITLE
OpenID fixes

### DIFF
--- a/cgi-bin/DW/Controller/OpenID.pm
+++ b/cgi-bin/DW/Controller/OpenID.pm
@@ -112,6 +112,13 @@ sub openid_claimed_handler {
 
     my $ou = LJ::User::load_identity_user( 'O', $url, $vident );
     return $err->( '.error.failed_vivification' ) unless $ou;
+    return $err->( LJ::Lang::ml( '/openid/claim.tt.error.account_deleted',
+                                 { sitename => $LJ::SITENAMESHORT,
+                                   aopts1 => '/openid',
+                                   aopts2 => '/accountstatus',
+                                 }
+                               )
+                 ) if $ou->is_deleted;
 
     # generate the authaction
     my $aa = LJ::register_authaction( $u->id, 'claimopenid', $ou->id )
@@ -167,11 +174,20 @@ sub openid_claim_confirm_handler {
     my $ou = LJ::load_userid( $aa->{arg1}+0 );
     return $err->( '.error.invalid_account' )
         unless $ou && $ou->is_identity;
+
     if ( my $cbu = $ou->claimed_by ) {
         return $err->( '.error.already_claimed_self' )
             if $cbu->equals( $u );
         return $err->( '.error.already_claimed_other' );
     }
+
+    return $err->( LJ::Lang::ml( '/openid/claim.tt.error.account_deleted',
+                                 { sitename => $LJ::SITENAMESHORT,
+                                   aopts1 => '/openid',
+                                   aopts2 => '/accountstatus',
+                                 }
+                               )
+                 ) if $ou->is_deleted;
 
     # now start the claim process
     $u->claim_identity( $ou );

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -1501,16 +1501,12 @@ sub load_user_or_identity {
         return _set_u_req_cache( $u ) if $u;
     }
 
-    my $dbh = LJ::get_db_writer();
-    my $uid = $dbh->selectrow_array("SELECT userid FROM identitymap WHERE idtype=? AND identity=?",
-                                    undef, 'O', $url);
-
-    my $u = $uid ? LJ::load_userid($uid) : undef;
+    my $u = LJ::User::load_existing_identity_user( 'O', $url );
 
     # set user in memcache
     if ( $u ) {
         # memcache URL-to-userid for identity users
-        LJ::MemCache::set( "uidof:$url", $uid, 1800 );
+        LJ::MemCache::set( "uidof:$url", $u->id, 1800 );
         LJ::memcache_set_u( $u );
         return _set_u_req_cache( $u );
     }

--- a/htdocs/inbox/compose.bml
+++ b/htdocs/inbox/compose.bml
@@ -249,7 +249,7 @@ body<=
         $body .= $reply_u->ljuser_display;
         $body .= LJ::html_hidden({
                     name      => 'msg_to',
-                    value     => "$reply_to",
+                    value     => $reply_u->username,
                  });
     } else {
         $body .= LJ::html_text({

--- a/views/openid/claim.tt.text
+++ b/views/openid/claim.tt.text
@@ -27,6 +27,8 @@ Regards,
 
 .email.subject=Your [[sitename]] Request
 
+.error.account_deleted=The specified account has been deleted. You must first <a href="[[aopts1]]">log in</a> to the OpenID account on [[sitename]] and <a href="[[aopts2]]">undelete it</a> before you can claim the account.
+
 .error.cantuseownsite=You can't claim a [[sitename]] account!
 
 .error.failed_vivification=We failed to load a user account for that OpenID. Please try again and if it continues to fail, report this error.


### PR DESCRIPTION
* Fixes #1744 - failure when replying to PMs from OpenID users.
* Fixes #1939 - don't allow a user to claim a deleted OpenID account.
* Fixes #1907 - using https when http was used previously when logging in with OpenID.