### PR TITLE
return suffix-neutral URIs from BML::get_uri

### DIFF
--- a/cgi-bin/Apache/BML.pm
+++ b/cgi-bin/Apache/BML.pm
@@ -264,7 +264,7 @@ sub handler
 
     # parse in data
     parse_inputs( $apache_r );
-    
+
     %BMLCodeBlock::GET_POTENTIAL_XSS = ();
     if ($env->{MildXSSProtection}) {
         foreach my $k (keys %BMLCodeBlock::GET) {
@@ -315,7 +315,7 @@ sub handler
     # now we've made the decision about what scheme to use
     # -- does a hook want to translate this into another scheme?
     if ($env->{'HOOK-scheme_translation'}) {
-        my $newscheme = eval { 
+        my $newscheme = eval {
             $env->{'HOOK-scheme_translation'}->($scheme);
         };
         $scheme = $newscheme if $newscheme;
@@ -1892,7 +1892,9 @@ sub get_query_string
 sub get_uri
 {
     my $apache_r = BML::get_request();
-    return $apache_r->uri;
+    my $uri = $apache_r->uri;
+    $uri =~ s/\.bml$//;
+    return $uri;
 }
 
 sub get_hostname


### PR DESCRIPTION
@kaberett pointed out that when visiting /tools/importer without
being logged in, the returnto pointed to /tools/importer.bml.

This changes the behavior of BML::get_uri to strip the .bml suffix
from the return value.  I checked all 3 places the function is
called and I believe this is the desired behavior in each case.