### PR TITLE
enforce limits for media (photo) usage

### DIFF
--- a/cgi-bin/DW/Controller/API/Media.pm
+++ b/cgi-bin/DW/Controller/API/Media.pm
@@ -59,6 +59,9 @@ sub file_new_handler {
     LJ::isu( $rv->{u} )
         or return api_error( $r->HTTP_UNAUTHORIZED, 'Not logged in' );
 
+    return api_error( $r->HTTP_BAD_REQUEST, 'Quota exceeded' )
+        unless $u->can_upload_media;
+
     my $uploads = $r->uploads;
     return api_error( $r->HTTP_BAD_REQUEST, 'No uploads found' )
         unless ref $uploads eq 'ARRAY' && scalar @$uploads;

--- a/cgi-bin/DW/Controller/Media.pm
+++ b/cgi-bin/DW/Controller/Media.pm
@@ -157,6 +157,8 @@ sub media_handler {
 # FIXME: support viewall
     return $error_out->( 403, 'Not authorized' )
         unless $obj->visible_to( LJ::get_remote() );
+    return $error_out->( 403, 'Not authorized' )
+        unless LJ::check_referer();  # no offsite loading
 
     # load the data for this object
     my $dataref = LJ::mogclient()->get_file_data( $obj->mogkey );

--- a/cgi-bin/DW/EmailPost/Entry.pm
+++ b/cgi-bin/DW/EmailPost/Entry.pm
@@ -297,6 +297,8 @@ sub _upload_images {
     my @imgs = $self->get_entity( $self->{_entity}, 'image' );
     return 1 unless scalar @imgs;
 
+    return 1401 unless $u->can_upload_media;  # error code from insert_images
+
     my @images;
     foreach my $img_entity ( @imgs ) {
         my $obj = DW::Media->upload_media(

--- a/etc/config.pl
+++ b/etc/config.pl
@@ -309,6 +309,7 @@
             'makepoll' => 0,
             'maxcomments' => 10000,
             'maxfriends' => 500,
+            'media_file_quota' => 500, # megabytes
             'mod_queue' => 50,
             'mod_queue_per_poster' => 5,
             'moodthemecreate' => 0,


### PR DESCRIPTION
Don't allow offsite loading of images, and enforce storage quotas.

Fixes #1940.