### PR TITLE
Updates to the image uploader and management system

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1701,3 +1701,11 @@ contentflag.viewingexplicit.byposter
 
 general /customize/options.bml.widget.navstripchooser.option.color.control_strip_borderc
 general /customize/options.bml.widget.navstripchooser.option.color.control_strip_linkcol
+
+general /views/media/edit.tt.title
+general /views/media/edit.tt.intro
+general /views/media/home.tt.title
+general /views/media/home.tt.edit
+general /views/media/index.tt.title
+general /views/media/index.tt.intro
+general /views/media/index.tt.intro.edit

--- a/cgi-bin/DW/Controller/Media.pm
+++ b/cgi-bin/DW/Controller/Media.pm
@@ -85,7 +85,7 @@ sub media_bulkedit_handler {
 
             my %props;
             while ( my ($key, $val) = each %post ) {
-                next if $key =~ m/delete/;
+                next if $key eq "delete";
                 next unless $key =~ m/^(\w+)-(\d+)/;
                 my $mediaid = $2 >> 8;
                 if ( exists $props{$mediaid} ) {

--- a/cgi-bin/DW/Controller/Media.pm
+++ b/cgi-bin/DW/Controller/Media.pm
@@ -85,6 +85,7 @@ sub media_bulkedit_handler {
 
             my %props;
             while ( my ($key, $val) = each %post ) {
+                next if $key =~ m/delete/;
                 next unless $key =~ m/^(\w+)-(\d+)/;
                 my $mediaid = $2 >> 8;
                 if ( exists $props{$mediaid} ) {

--- a/cgi-bin/DW/Controller/Media.pm
+++ b/cgi-bin/DW/Controller/Media.pm
@@ -25,7 +25,7 @@ use DW::BlobStore;
 use DW::Routing;
 use DW::Request;
 use DW::Controller;
-use POSXIX;
+use POSIX;
 
 my %VALID_SIZES = ( map { $_ => $_ } ( 100, 320, 200, 640, 480, 1024, 768, 1280,
             800, 600, 720, 1600, 1200 ) );

--- a/cgi-bin/DW/Media/Base.pm
+++ b/cgi-bin/DW/Media/Base.pm
@@ -113,6 +113,16 @@ sub url {
         '.' . $self->{ext};
 }
 
+# construct a URL for the fullsize version of this url. This is the same as
+# url if the object is the orignal, fullsize version, but returns the url of
+# the original if we're using version of it.
+sub full_url {
+    my $self = $_[0];
+
+    return $self->u->journal_base . '/file/' . $self->{displayid} .
+        '.' . $self->{ext};
+}
+
 # if user can see this
 sub visible_to {
     my ( $self, $other_u ) = @_;

--- a/cgi-bin/DW/Media/Photo.pm
+++ b/cgi-bin/DW/Media/Photo.pm
@@ -44,6 +44,11 @@ sub new_from_row {
         if ( $vid == $self->id ) {
             $self->{width} = $self->{versions}->{$vid}->{width};
             $self->{height} = $self->{versions}->{$vid}->{height};
+
+            # save the original values of these for reference in case we resize later
+            $self->{orig_width} = $self->{width};
+            $self->{orig_height} = $self->{height};
+            $self->{orig_filesize} = $self->{filesize};
             last;
         }
     }

--- a/htdocs/js/jquery.fileupload.js
+++ b/htdocs/js/jquery.fileupload.js
@@ -132,7 +132,8 @@ $(function() {
                     return file_id;
                 }).end()
                 .find(".progress").toggleClass( "secondary success" ).end()
-                .find("input[name=generated-code]").trigger("imagecodeupdate", [ response.result ]).end();
+                .find("input[name=generated-code]").trigger("imagecodeupdate", [ response.result ]).end()
+                .find(".success").attr("style", "").end();
         } else {
             $(data.context).trigger( "uploaderror", [ { error : data.error } ] );
         }
@@ -209,12 +210,10 @@ $(function() {
         $field.data( "image-attributes", image );
 
         var text = [];
-        text.push( "<figure>", "<a href='" + image.url + "'><img src='" + image.thumbnail_url + "'" );
-        if ( image.title ) text.push( " alt='" + image.title + "' " );
+        text.push( "<a href='" + image.url + "'><img src='" + image.thumbnail_url + "'" );
+        if ( image.title ) text.push( " title='" + image.title + "' " );
+        if ( image.alttext ) text.push(" alt='" + image.alttext + "' ");
         text.push( " /></a>" );
-        if ( image.description ) text.push("<figcaption>" + image.description + "</figcaption>");
-        text.push( "</figure>" );
-
         $field.val(text.join(""));
     });
 

--- a/htdocs/scss/components/foundation-custom/_pagination.scss
+++ b/htdocs/scss/components/foundation-custom/_pagination.scss
@@ -1,3 +1,12 @@
 .pagination a {
     text-decoration: none;
 }
+
+.pagination-wrapper { 
+	margin: 1em auto;
+    text-align: center;
+}
+
+ul.pagination {
+    display: inline-block;
+}

--- a/htdocs/scss/pages/media/new.scss
+++ b/htdocs/scss/pages/media/new.scss
@@ -40,7 +40,7 @@
   margin-bottom: 1em;
 }
 
-@media #{$small} {
+@media #{$large} {
   .drop_zone {
     font-size: 6em;
   }

--- a/htdocs/scss/skins/_skin-colors.scss
+++ b/htdocs/scss/skins/_skin-colors.scss
@@ -227,3 +227,12 @@ div.disabled, div.disabled * { color: scale-color($text-color, $lightness: 50%);
 
 // replacement colors for jquery-ui elements
 @import "skins/jquery-ui-theme";
+
+// alternating row colors
+.odd, tr.odd th, tr.odd td {
+    background-color: $background_color;
+}
+
+.even, tr.even th, tr.even td {
+    background-color: darken($background_color, 5%);
+}

--- a/htdocs/stc/media.css
+++ b/htdocs/stc/media.css
@@ -1,5 +1,4 @@
 #media-grid {
-    pasdding:0;
     margin: 0;
 }
 
@@ -54,10 +53,6 @@
     padding: 1em 0;
 }
 
-/*#media-list .media-item div, #media-list .media-item select, #media-list .media-item img {
-    display: inline-block;
-    margin: 0 1em;
-}*/
 
 #media-list .media-item .media {
     padding: 0 1em 1em 1em

--- a/htdocs/stc/media.css
+++ b/htdocs/stc/media.css
@@ -69,7 +69,7 @@
 
 .embed {padding: 0 1em;}
 
-@media screen and (min-width: 64.01em) {
+@media screen and (min-width: 64.036em) {
 .edit label, .embed label {
     text-align: right;
 }

--- a/htdocs/stc/media.css
+++ b/htdocs/stc/media.css
@@ -69,7 +69,7 @@
 
 .embed {padding: 0 1em;}
 
-@media screen and (min-width: 64em) {
+@media screen and (min-width: 64.01em) {
 .edit label, .embed label {
     text-align: right;
 }

--- a/htdocs/stc/media.css
+++ b/htdocs/stc/media.css
@@ -69,7 +69,9 @@
 
 .embed {padding: 0 1em;}
 
+@media screen and (min-width: 64em) {
 .edit label, .embed label {
     text-align: right;
 }
 
+}

--- a/htdocs/stc/media.css
+++ b/htdocs/stc/media.css
@@ -1,8 +1,21 @@
+#media-grid {
+    pasdding:0;
+    margin: 0;
+}
+
 #media-grid .media-item {
     list-style-type: none;
     display: inline-block;
     vertical-align: top;
-    margin: 2em 1em;
+    padding: 0;
+    margin: 0;
+    min-width: 50px;
+    width:32%;
+}
+
+#media-grid .media-item .inner {
+    vertical-align: top;
+    margin: 1em;
     outline: 1px #666 solid;
     padding: 1em;
     min-width: 50px;
@@ -10,11 +23,12 @@
     box-shadow: 1px 2px 3px 1px rgba(200, 200, 200, 1);
 }
 
-#media-grid .media-item img {
-    max-height: 300px;
-    outline: 1px #eee solid;
-    margin: 0 auto 1em auto;
-    display: block;
+#media-grid .media-item .media {
+    height: 200px;
+    width: 200px;
+    line-height: 200px;
+    margin: auto;
+
 }
 
 #media-grid .media-item div {
@@ -22,13 +36,13 @@
     text-align: center;
 }
 
-#media-grid .media-item .name {
-    font-weight: bold;
+#media-grid .name {
+    height: 3.4em;
 }
 
-#media-grid .media-item .filesize {
-    font-size: smaller;
-    font-style: italic;
+
+.media-item .name {
+    font-weight: bold;
 }
 
 #media-list .media-item {
@@ -40,59 +54,27 @@
     padding: 1em 0;
 }
 
-#media-list .media-item div, #media-list .media-item select, #media-list .media-item img {
+/*#media-list .media-item div, #media-list .media-item select, #media-list .media-item img {
     display: inline-block;
     margin: 0 1em;
-}
+}*/
 
 #media-list .media-item .media {
-    width: 200px;
-    padding: 0 1em 0 0;
+    padding: 0 1em 1em 1em
 }
 
-#media-list .details {
-    width: 10em;
+.media-item .details, .media-item .description {
+    padding-bottom: 0.5em;
 }
 
-#media-list .filesize {
+.media-item .dimensions, .media-item .time {
     font-size: smaller;
     font-style: italic;
-    display: none;
-}
+    }
 
-#media-list .name {
-    display: none;
-}
+.embed {padding: 0 1em;}
 
-fieldset.submit {
+.edit label, .embed label {
     text-align: right;
 }
 
-fieldset.submit input {
-  margin-top: 2em;
-  border-width: 1px;
-  border-style: solid;
-  -webkit-border-radius: 3px;
-  -moz-border-radius: 3px;
-  border-radius: 3px;
-  font-weight: bold;
-  line-height: 1;
-  padding: 3px 8px 4px;
-  text-align: center;
-
-  font-size: 1.2em;
-  line-height: 1.5em;
-}
-
-fieldset.destructive input {
-  border: 0;
-  background: transparent;
-  -moz-box-shadow: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
-
-  font-size: 0.9em;
-  text-decoration: underline;
-  margin-right: 2em;
-  float: left;
-}

--- a/views/media/edit.tt
+++ b/views/media/edit.tt
@@ -9,43 +9,107 @@ This program is free software; you may redistribute it and/or modify it under
 the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
-[% sections.title = '.title' | ml %]
+[% sections.title = '.title2' | ml %]
 
 [% CALL dw.active_resource_group( "jquery") %]
 [% CALL dw.need_res( { group => "jquery" },
     "js/media/bulkedit.js"
+) %]
+
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[% dw.need_res( { group => "foundation" },
     "stc/media.css"
 ) %]
 
-<p>[% ".intro" | ml %]</p>
+[% IF media.size %]
+    <p>[% dw.ml(".intro2", { aopts1 => '/file/list',
+                             aopts2 => '/file/new',
+                                 } ) %] 
+[% ELSE %]
+    <p>[% ".intro.empty" | ml %]</p>
+    <ul>
+        <li class='subnav'><a href="[%site.root%]/file/new">[% '.new' | ml %]</a></li>
+    </ul>
+[% END %]
 
 [% IF media.size %]
+[% IF maxpage > 1 %]
+    <div class="action-box">
+    [%- INCLUDE components/pagination.tt
+        current => page,
+        total_pages => maxpage, -%]
+    </div>
+[% END %]
 <form id="media-manage" method="POST" action="[%site.root%]/file/edit">
 [%- dw.form_auth -%]
-<fieldset id="media-list">
-<ul>
-    [%- FOREACH obj IN media -%]
-        <li class='media-item [% loop.count % 2 ? 'even' : 'odd' %]'>
+<div id="media-list">
+    [% first_index = (page - 1) * 20 %]
+    [% last_index = page * 20 - 1 < media.size ? page * 20 - 1 : media.max %]
+    [%- FOREACH obj IN media.slice(first_index, last_index) -%]
+        
+        <div class='media-item [% loop.count % 2 ? 'even' : 'odd' %] row'>
         <div class='inner'>
-            <div class='media'><img src="[% obj.url %]" /></div>
-            <div class='details'><span class='name '>[%obj.displayid%]</span>
-                <br /><span class='filesize'>[% obj.size / 1000 %] kb</span></div>
-            [%- form.select( name="security-$obj.displayid"
-                items = security
-                selected = obj.security ) -%]
-            <div><label for="delete_[% obj.displayid %]">Delete?</label>
-                <input type="checkbox" name="delete" id="delete_[% obj.displayid %]" value="[% obj.displayid %]" />
+            <div class='media large-3 column'><img src="[% obj.url %]" /></div>
+            <div class='edit large-9 column'>
+            <div class="row">
+                    <div class="large-8 columns">
+                        [%- INCLUDE 'media/field-row.tt' 
+                            label = dw.ml(".edit.title")
+                            type = "text" 
+                            id = "edit-title-$obj.displayid" 
+                            value = obj.prop('title') 
+                            name = "title-$obj.displayid" 
+                            maxlength = '125'
+                            labelSize = 3 
+                        -%]
+                    </div>
+                    <div class="large-4 columns">
+                        [%- INCLUDE 'media/field-row.tt' 
+                            label = dw.ml(".edit.security")
+                            type = "select"
+                            name="security-$obj.displayid"
+                            items = security
+                            selected = obj.security 
+                            labelSize = 4
+                        -%]
+                    </div>
+                </div>
+            [% INCLUDE 'media/field-row.tt'  
+                label = dw.ml(".edit.alt")
+                type = "text" 
+                id = "edit-alttext-$obj.displayid" 
+                value = obj.prop('alttext') 
+                name = "alttext-$obj.displayid" 
+                maxlength = '125'
+            %]
+            [% INCLUDE 'media/field-row.tt' 
+                label = dw.ml(".edit.desc") 
+                type = "textarea"
+                id = "edit-description-$obj.displayid" 
+                value = obj.prop('description') 
+                name = "description-$obj.displayid"
+            %]
+            [% INCLUDE 'media/field-row.tt' 
+                type = "checkbox"
+                label = dw.ml(".edit.delete") 
+                id = "delete_$obj.displayid" 
+                name = "delete-$obj.displayid"
+            %]
             </div>
         </div>
-        </li>
+        </div>
     [%- END -%]
-</ul>
-</fieldset>
-<fieldset class="submit">
-    <input type="submit" value="Change Security" name="action:edit" />
-</fieldset>
-<fieldset class="submit destructive">
-    <input type="submit" value="Delete Selected" name="action:delete" />
-</fieldset>
+</div>
+
+[% form.submit( name = "action:edit", value = dw.ml( '.submit.save' ) ) %]
+[% form.submit( name = "action:delete", value = dw.ml( '.submit.delete' ) ) %]
 </form>
+[% IF maxpage > 1 %]
+    <div class="action-box">
+    [%- INCLUDE components/pagination.tt
+        current => page,
+        total_pages => maxpage, -%]
+    </div>
+[% END %]
 [% END %]

--- a/views/media/edit.tt
+++ b/views/media/edit.tt
@@ -94,7 +94,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
                 type = "checkbox"
                 label = dw.ml(".edit.delete") 
                 id = "delete_$obj.displayid" 
-                name = "delete-$obj.displayid"
+                name = "delete"
+                value = "$obj.displayid"
             %]
             </div>
         </div>

--- a/views/media/edit.tt.text
+++ b/views/media/edit.tt.text
@@ -1,4 +1,21 @@
-.intro=Here are all the files you've uploaded from mobile.
+.intro2=Here are all the images you've uploaded. <a href="[[aopts1]]">View all your images</a> or <a href="[[aopts2]]">upload new images</a>.
 
-.title=Bulk Edit Files
+.title2=Bulk Edit Images
 
+.intro.empty=You haven't uploaded anything.
+
+.new=Upload Images
+
+.edit.title=Title
+
+.edit.alt=Short Description
+
+.edit.desc=Full Description
+
+.edit.security=Security
+
+.edit.delete=Delete?
+
+.submit.save=Save Changes
+
+.submit.delete=Delete Selected

--- a/views/media/field-row.tt
+++ b/views/media/field-row.tt
@@ -1,0 +1,32 @@
+[% DEFAULT
+    labelSize = 2
+    fieldSize = 12 - labelSize
+    type      = "text"
+%]
+<div class="row">
+    <div class="large-[% labelSize %] columns">
+        <label for="[% name %]">[% label %]</label>
+    </div>
+    <div class="large-[% fieldSize %] columns">
+        [% IF type == "text" %]
+            [%- form.textbox( "name" = name, "id" = id, "value" = value ) -%]
+        [% ELSIF type == "textarea" %]
+            [%- form.textarea( "name" = name 
+                                rows = 3
+                                "id" = id
+                                "value" = value
+                                "maxlength" = maxlength) 
+            -%]
+        [% ELSIF type == "select" %]
+            [%- form.select( "items"   = items
+                             "name"    = name
+                             "id" = id
+                             "selected" = selected
+                           )
+            -%]
+        [% ELSIF type == "checkbox" %]
+            [%- form.checkbox( "name" = name, "id" = id) -%]
+        [% END %]
+
+    </div>
+</div>

--- a/views/media/field-row.tt
+++ b/views/media/field-row.tt
@@ -25,7 +25,7 @@
                            )
             -%]
         [% ELSIF type == "checkbox" %]
-            [%- form.checkbox( "name" = name, "id" = id) -%]
+            [%- form.checkbox( "name" = name, "id" = id, "value" = value) -%]
         [% END %]
 
     </div>

--- a/views/media/home.tt
+++ b/views/media/home.tt
@@ -10,11 +10,11 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
 
-[% sections.title = '.title' | ml %]
+[% sections.title = '.title2' | ml %]
 
 [%- CALL dw.active_resource_group( "foundation" ) -%]
 
 <ul>
     <li class='subnav'><a href="[%site.root%]/file/new">[% '.new' | ml %]</a></li>
-    <li class='subnav'><a href="[%site.root%]/file/edit">[% '.edit' | ml %]</a></li>
+    <li class='subnav'><a href="[%site.root%]/file/edit">[% '.edit2' | ml %]</a></li>
 </ul>

--- a/views/media/home.tt.text
+++ b/views/media/home.tt.text
@@ -1,7 +1,7 @@
 ;; -*- coding: utf-8 -*-
 
-.edit=Manage Your Files
+.edit2=Manage Your Images
 
 .new=Upload Images
 
-.title=Your Files
+.title2=Your Images

--- a/views/media/index.tt
+++ b/views/media/index.tt
@@ -9,24 +9,134 @@ This program is free software; you may redistribute it and/or modify it under
 the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
-[% sections.title = '.title' | ml %]
+[% sections.title = '.title2' | ml %]
 
-[% dw.need_res(
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[% dw.need_res( { group => "foundation" }
     "stc/media.css"
 ) %]
 
-<p>[% ".intro" | ml %] <a href="[%site.root%]/file/edit">[% '.intro.edit' | ml %]</a></p>
+[% sections.head = BLOCK %]
+<script>
+function updateEmbed ( evt ) {
+    var thumbnail_value = evt.target.value;
+    var name = evt.target.id.replace(/thumbnail_sizes/, 'embed-thumb');
+    var url = document.getElementById(name).value;
+    document.getElementById(name).value = url.replace(/\d{3,4}x\d{3,4}/, thumbnail_value + 'x' + thumbnail_value);
+}
+
+window.onload = function() {
+  var dropdowns = document.getElementsByClassName('embed-select');
+  for (elem of dropdowns) {
+    elem.style = '';
+    elem.classList = "columns large-2 embed-select"
+}
+
+  var textboxes = document.getElementsByClassName('embed-thumb');
+  for (elem of textboxes) {
+    elem.classList.remove('large-9')
+    elem.classList.add('large-7')
+}
+};
+</script>
+[% END  # sections.head %]
+
+<p>[% dw.ml(".intro2" {aopts1 => '/file/edit', aopts2 => '/file/new'}) %]</p>
+
+[% getextra = page == 1 ? '' : "?page=$page" %]
+[% getsep = getextra == '' ? "?" : "&" %]
 
 [% IF media.size %]
+<p>
+[% IF view_type == 'grid' %]
+    <a href="[% "$site.root/file/list$getextra${getsep}view=list" %]">[% '.view.list' | ml %]</a> | [% '.view.grid' | ml %]
+[% ELSE %]
+    [% '.view.list' | ml %] | <a href="[% "$site.root/file/list$getextra${getsep}view=grid" %]">[% '.view.grid' | ml %]</a>
+[% END %]
+</p>
+[% IF maxpage > 1 %]
+    <div class="action-box">
+    [%- INCLUDE components/pagination.tt
+        current => page,
+        total_pages => maxpage, -%]
+    </div>
+[% END %]
+
+[% first_index = (page - 1) * 20 %]
+[% last_index = page * 20 - 1 < media.size ? page * 20 - 1 : media.max %]
+[% media_page = media.slice(first_index, last_index) %]
+
+[% IF view_type == 'grid' %]
 <ul id="media-grid">
-    [%- FOREACH obj IN media -%]
+    [%- FOREACH obj IN media_page -%]
         <li class='media-item'>
         <div class='inner'>
-            <p class='media'><img src="[% obj.url %]" /></p>
-            <p class='details'><span class='name'>[% obj.displayid %]. [% obj.ext %]</span><br /><span class='filesize'>[% obj.size / 1000 %] kb</span></p>
+            <div class='media'><img src="[% obj.url %]" alt='[% obj.prop('alttext') %]'/></div>
+            <div class='details'><div class='name'>[% obj.prop('title') != '' ? obj.prop('title') : obj.displayid _ "." _ obj.ext %]</div>
+            <span class='dimensions'>[% obj.orig_filesize / 1000 | format('%d') %] kb | [% obj.orig_width %] x [% obj.orig_height %] px</span></div>
+            <div class='embed row'>
+            <div class="columns large-3"><label for="embed-thumb-[% obj.displayid %]">[% dw.ml(".embed.short") %]</label></div>
+            <div class="columns large-9 embed-thumb">[%- form.textbox( id = "embed-thumb-$obj.displayid" value = make_embed_url(obj, 'type', 'thumbnail', 'size', 100)) -%]</div>
+            <div class="embed-select" style = 'display:none;'>
+            [%- form.select( "items"   = valid_sizes.nsort
+                             "id"    = "thumbnail_sizes-$obj.displayid"
+                             "class" = "select"
+                             "onChange" = "return updateEmbed(event);"
+                           )
+            -%]
+            </div>
+            </div>
         </div>
         </li>
     [%- END -%]
 </ul>
-
+[% ELSE %]
+<div id="media-list">
+    [%- FOREACH obj IN media_page -%]
+        <div class='media-item [% loop.count % 2 ? 'even' : 'odd' %] row'>
+        <div class='inner'>
+            <div class='media large-3 column'>
+            <img src="[% obj.url %]" alt='[% obj.prop('alttext') %]' />
+            </div>
+            <div class='large-9 column'>
+            <div class='details'><span class='name'>[% obj.prop('title') != '' ? obj.prop('title') : obj.displayid _ "." _ obj.ext %]</span><br />
+                        <span class='time'>[% convert_time(obj.logtime, "1") %] UTC<span><br />
+                <span class='dimensions'>[% obj.orig_filesize / 1000 | format('%d') %] kb | [% obj.orig_width %] x [% obj.orig_height %] px</span></div>
+            [% IF obj.prop('description') != '' %]
+            <div class='description'>[% obj.prop('description') %]</div>
+            [% END %]
+            <div class='embed'>
+            [%- INCLUDE 'media/field-row.tt' label = dw.ml(".embed.full") id = "embed-full-$obj.displayid" value = make_embed_url(obj) type="text" labelSize=3 %]
+            </div>
+            <div class='embed row'>
+                <div class="large-3 columns">
+                    <label for="embed-thumb-[% obj.displayid %]">[% dw.ml(".embed.thumbnail") %]</label>
+                </div>
+                <div class="large-9 columns embed-thumb">
+                        [%- form.textbox( id = "embed-thumb-$obj.displayid" value = make_embed_url(obj, 'type', 'thumbnail', 'size', 100)) -%]
+                </div>
+            <div class="embed-select" style = 'display:none;'>
+            [%- form.select( "items"   = valid_sizes.nsort
+                             "id"    = "thumbnail_sizes-$obj.displayid"
+                             "class" = "select"
+                             "onChange" = "return updateEmbed(event);"
+                           )
+            -%]
+            </div>
+            </div>
+            </div>
+            
+        </div>
+        </div>
+    [%- END -%]
+</div>
+[% END %]
+[% IF maxpage > 1 %]
+    <div class="action-box">
+    [%- INCLUDE components/pagination.tt
+        current => page,
+        total_pages => maxpage, -%]
+    </div>
+[% END %]
 [% END %]

--- a/views/media/index.tt
+++ b/views/media/index.tt
@@ -28,15 +28,15 @@ function updateEmbed ( evt ) {
 
 window.onload = function() {
   var dropdowns = document.getElementsByClassName('embed-select');
-  for (elem of dropdowns) {
-    elem.style = '';
-    elem.classList = "columns large-2 embed-select"
+  for (var i = 0; i < dropdowns.length; i++) {
+    dropdowns[i].style = '';
+    dropdowns[i] = "columns large-2 embed-select"
 }
 
   var textboxes = document.getElementsByClassName('embed-thumb');
-  for (elem of textboxes) {
-    elem.classList.remove('large-9')
-    elem.classList.add('large-7')
+  for (var i = 0; i < textboxes.length; i++) {
+    textboxes[i].classList.remove('large-9')
+    textboxes[i].classList.add('large-7')
 }
 };
 </script>

--- a/views/media/index.tt
+++ b/views/media/index.tt
@@ -30,7 +30,7 @@ window.onload = function() {
   var dropdowns = document.getElementsByClassName('embed-select');
   for (var i = 0; i < dropdowns.length; i++) {
     dropdowns[i].style = '';
-    dropdowns[i] = "columns large-2 embed-select"
+    dropdowns[i].classList = "columns large-2 embed-select"
 }
 
   var textboxes = document.getElementsByClassName('embed-thumb');

--- a/views/media/index.tt.text
+++ b/views/media/index.tt.text
@@ -1,7 +1,16 @@
 ;; -*- coding: utf-8 -*-
 
-.intro=Below are the files you have uploaded to the site.
+.intro2=Below are the images you have uploaded to the site. <a href="[[aopts1]]">Manage your images</a> or <a href="[[aopts2]]">upload new images</a>.
 
-.intro.edit=Manage your files
+.title2=Your Images
 
-.title=Your Files
+.embed.full=Image Embed:
+
+.embed.thumbnail=Thumbnail Embed:
+
+.embed.short=Embed:
+
+.view.list=List View
+
+.view.grid=Grid View
+

--- a/views/media/new.tt
+++ b/views/media/new.tt
@@ -29,6 +29,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     "stc/css/pages/media/new.css"
 ) -%]
 
+<p>[% dw.ml(".intro" {aopts1 => '/file/edit', aopts2 => '/file/new'}) %]</p>
 
 <div class="row">
     <div class="large-12 columns">
@@ -95,6 +96,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         <div class="progress secondary"><span class="meter" style="width:0"></span></div>
     </div>
     <div class="large-9 columns">
+        <div class="alert-box success" style="display:none;">[% dw.ml(".success") %]</div>
         <div class="row">
             <div class="large-8 columns">
                 [%- INCLUDE row_with_field(
@@ -116,7 +118,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
                 ) -%]
             </div>
         </div>
-
+        [%- INCLUDE row_with_field( label = dw.ml( ".label.alttext" ), name = "alttext", type = "text" ) %]
         [%- INCLUDE row_with_field( label = dw.ml( ".label.description" ), name = "description", type = "textarea" ) %]
         [%- INCLUDE row_with_field( label = "Image Code", name="generated-code" ) -%]
     </div>

--- a/views/media/new.tt
+++ b/views/media/new.tt
@@ -29,7 +29,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     "stc/css/pages/media/new.css"
 ) -%]
 
-<p>[% dw.ml(".intro" {aopts1 => '/file/edit', aopts2 => '/file/new'}) %]</p>
+<p>[% dw.ml(".intro" {aopts1 => '/file/list', aopts2 => '/file/edit'}) %]</p>
 
 <div class="row">
     <div class="large-12 columns">

--- a/views/media/new.tt.text
+++ b/views/media/new.tt.text
@@ -4,8 +4,14 @@
 
 .label.title=Title
 
+.label.alttext=Short Description
+
 .title=Upload Images
 
 .upload.legend=Upload
 
 .upload.submit=Upload
+
+.success=Image uploaded successfully.
+
+.intro=Upload new images to the site below. <a href="[[aopts1]]">View all your images</a> or <a href="[[aopts2]]">manage your images</a>.


### PR DESCRIPTION
-adds an index page with links to all subpages
-adds editable textfields for title, description and alt-text
-adds two views for showing all files, with pagination
-list view shows all info about the original file with embed code
for fullsized and selectable thumbnail sized versions of the image
-grid view shows title, file size and dimensions, and thumbnail embed code
-pload date and time is now shown in list view
-file list now displays correct text when no files have been uploaded
-all subpaes are now crosslinked with other subpages
-uploader page now has alt-text field, and displays message on successful upload
-language across pages has been standardized to say 'images' instead of a mix
of 'files' and 'images'.
-edit page has been converted to Foundation
-backend changes make original file's url, size, and dimensions available to
resized versions of that image

Fixes #1936