### PR TITLE
Blobstore-related cleanup

### DIFF
--- a/bin/checkconfig.pl
+++ b/bin/checkconfig.pl
@@ -241,6 +241,7 @@ my %modules = (
         },
     "MogileFS::Client" => {
         ver => '1.12',
+        opt => 'Used for legacy MogileFS support',
     },
     "TheSchwartz" => {
         deb => 'libtheschwartz-perl',
@@ -293,6 +294,9 @@ my %modules = (
     "Paws::S3" => {
         opt => "Used for BlobStore support of S3",
     },
+    "Text::Wrap" => {
+        ver => '2013.0523', # issue #1447
+    },
 );
 
 
@@ -303,7 +307,7 @@ sub check_modules {
     my (@debs, @mods);
 
     foreach my $mod (sort keys %modules) {
-        my $rv = eval "use $mod;";
+        my $rv = eval "use $mod ();";
         if ($@) {
             my $dt = $modules{$mod};
             unless ($debs_only) {

--- a/cgi-bin/DW/Media.pm
+++ b/cgi-bin/DW/Media.pm
@@ -127,7 +127,7 @@ sub upload_media {
     # to avoid having database rows for an image that failed to upload,
     # do the upload first - we can create a fake object to get the mogkey
 
-    # FIXME: have different MogileFS classes for different media types
+    # FIXME: have different storage classes for different media types
 
     my $fakeobj = bless { userid => $opts{user}->id, versionid => $id }, 'DW::Media::Photo';
     DW::BlobStore->store( media => $fakeobj->mogkey, \$opts{data} )

--- a/cgi-bin/DW/Media/Photo.pm
+++ b/cgi-bin/DW/Media/Photo.pm
@@ -113,7 +113,7 @@ sub _resize {
     $self->{height} = $timage->Get( 'height' );
     $self->{filesize} = length $blob;
 
-    # Now save to MogileFS first, before adding it to the database.
+    # Now save to file storage first, before adding it to the database.
     DW::BlobStore->store( media => $self->mogkey, \$blob )
         or croak 'Unable to save resized file to storage.';
 

--- a/cgi-bin/DW/VirtualGift.pm
+++ b/cgi-bin/DW/VirtualGift.pm
@@ -89,7 +89,7 @@ sub create {
     # opts are values for object properties as defined in PROPLIST.
     # also allowed: 'error' which should be a scalar reference;
     # 'img_small' & 'img_large' which should contain raw
-    # image data to be stored in MogileFS.
+    # image data to be stored in media storage (blobstore).
     my ( $class, %opts ) = @_;
     my %vg;  # hash for storing row data
     foreach ( PROPLIST ) {
@@ -204,7 +204,7 @@ sub edit {
     # opts are values for object properties as defined in PROPLIST.
     # also allowed: 'error' which should be a scalar reference;
     # 'img_small' & 'img_large' which should contain raw
-    # image data to be stored in MogileFS.
+    # image data to be stored in media storage (blobstore).
     my ( $self, %opts ) = @_;
     return undef unless $self->id;
 

--- a/cgi-bin/modperl_subs.pl
+++ b/cgi-bin/modperl_subs.pl
@@ -59,7 +59,6 @@ use LJ::Location;
 use LJ::SpellCheck;
 use LJ::ModuleCheck;
 use LJ::Widget;
-use MogileFS::Client;
 use DDLockClient;
 use LJ::BetaFeatures;
 use DW::InviteCodes;

--- a/htdocs/admin/vgifts/index.bml.text
+++ b/htdocs/admin/vgifts/index.bml.text
@@ -27,8 +27,6 @@
 
 .error.upload.noheader=No content-length header: can't upload
 
-.error.upload.nomogilefs=Couldn't load MogileFS: can't upload
-
 .error.upload.nourl=You must enter the URL of an image
 
 .error.upload.urlerror=An error ocurred while trying to fetch your image.

--- a/t/blobstore.t
+++ b/t/blobstore.t
@@ -1,4 +1,4 @@
-# t/media-security.t
+# t/blobstore.t
 #
 # Test some BlobStore functionality.
 #

--- a/t/console-expungeuserpic.t
+++ b/t/console-expungeuserpic.t
@@ -46,7 +46,7 @@ die "No such file $upfile" unless -e $upfile;
 my $up;
 eval { $up = LJ::Userpic->create($u, data => $file_contents->($upfile)) };
 if ( $@ ) {
-    plan skip_all => "MogileFS failure: $@";
+    plan skip_all => "Storage failure: $@";
     exit 0;
 } else {
     plan tests => 3;

--- a/t/directorysearch.t
+++ b/t/directorysearch.t
@@ -211,7 +211,7 @@ memcache_stress(sub {
 }
 });
 
-# search with a shitload of ids (force it to use Mogile for set handles)
+# search with a huge number of ids (force it to use blobstore for set handles)
 SKIP: {
     my ($search, $res);
 


### PR DESCRIPTION
* Indicate in checkconfig.pl that MogileFS::Client is now optional, and remove it from modperl_subs.pl.

* A couple of other minor checkconfig.pl issues.

* Fix incorrect file name in header of blobstore.t.

* Update various other textual MogileFS references, mostly code comments.