### PR TITLE
allow etc/log4perl.conf to be superceded by ext/local

### DIFF
--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -70,7 +70,7 @@ log4perl.appender.DevNull.layout=Log::Log4perl::Layout::SimpleLayout
         };
         Log::Log4perl::init( \$conf );
     } else {
-        Log::Log4perl::init_and_watch($LJ::HOME . '/etc/log4perl.conf', 10);
+        Log::Log4perl::init_and_watch( LJ::resolve_file( 'etc/log4perl.conf' ), 10 );
     }
 }
 

--- a/etc/log4perl.conf
+++ b/etc/log4perl.conf
@@ -1,3 +1,13 @@
+# dev servers by default use log level DEBUG. other available levels:
+#
+# OFF   (prints nothing, ever)
+# FATAL (only prints the worst stuff)
+# ERROR (slightly more than FATAL)
+# WARN  (slightly more than ERROR)
+# INFO  (slightly more than WARN, less than DEBUG)
+# TRACE (even more than DEBUG)
+# ALL   (take a guess...)
+
 log4perl.rootLogger=DEBUG, STDERR
 
 log4perl.appender.STDERR=Log::Log4perl::Appender::Screen


### PR DESCRIPTION
Use LJ::resolve_file to prefer a version in ext/local
over the stock version in LJHOME, like we do for other
config files.