### PR TITLE
delete associated thumbnails when a media image is deleted

### DIFF
--- a/cgi-bin/DW/Media.pm
+++ b/cgi-bin/DW/Media.pm
@@ -227,7 +227,10 @@ sub get_usage_for_user {
     confess 'Invalid user' unless LJ::isu( $u );
 
     my ( $usage ) = $u->selectrow_array(
-        q{SELECT SUM(filesize) FROM media_versions WHERE userid = ?},
+        q{SELECT SUM(mv.filesize) FROM media_versions AS mv, media AS m
+          WHERE mv.userid=? AND m.userid=mv.userid AND m.mediaid=mv.mediaid
+          AND m.state = 'A';
+         },
         undef, $u->id
     );
     croak 'Failed to get file sizes: ' . $u->errstr . '.' if $u->err;

--- a/cgi-bin/DW/Media.pm
+++ b/cgi-bin/DW/Media.pm
@@ -229,7 +229,7 @@ sub get_usage_for_user {
     my ( $usage ) = $u->selectrow_array(
         q{SELECT SUM(mv.filesize) FROM media_versions AS mv, media AS m
           WHERE mv.userid=? AND m.userid=mv.userid AND m.mediaid=mv.mediaid
-          AND m.state = 'A';
+          AND m.state = 'A'
          },
         undef, $u->id
     );

--- a/cgi-bin/DW/Media/Base.pm
+++ b/cgi-bin/DW/Media/Base.pm
@@ -149,7 +149,6 @@ sub delete {
     my $self = $_[0];
     return 0 if $self->is_deleted;
 
-    # we need a mogilefs client or we can't edit media
     my $u = $self->u
         or croak 'Sorry, unable to load the user.';
 

--- a/cgi-bin/DW/Media/Photo.pm
+++ b/cgi-bin/DW/Media/Photo.pm
@@ -177,41 +177,27 @@ sub _select_version {
 # this adds on to the base method by also deleting any associated thumbnails
 sub delete {
     my $self = $_[0];
-    my $deleted = $self->SUPER::delete;
+    my $deleted = $self->SUPER::delete;  # this deletes the original as before
     return 0 unless $deleted;  # was already deleted
 
     # at this point the image has just been deleted - look for thumbnails
-    my $u = $self->u
-        or croak 'Sorry, unable to load the user.';
-    my @mv = $u->selectrow_array( "SELECT mediaid FROM media_versions" .
-                                  " WHERE userid=? AND versionid=?", undef,
-                                  $u->id, $self->versionid );
-    # this shouldn't happen unless something was saved in an incomplete state
-    # or the database has taken an unexpected vacation
+    my $u = $self->u or croak 'Sorry, unable to load the user.';
+    my @mv = $u->selectrow_array(
+        "SELECT versionid FROM media_versions WHERE userid=? AND mediaid=?" .
+        " AND versionid != ?", undef, $u->id, $self->versionid, $self->versionid );
+
     return $deleted unless @mv;
-    my ( $mediaid ) = @mv;
 
-    if ( $mediaid == $self->versionid ) {
-        # find any resized versions and queue them for deletion as well
-        @mv = $u->selectrow_array(
-            "SELECT versionid FROM media_versions WHERE userid=? AND mediaid=?" .
-            " AND mediaid != versionid", undef, $u->id, $mediaid );
-        return $deleted unless @mv;  # no other versions found
-
-        foreach my $id ( @mv ) {
-            # create a fake object to get the mogkey
-            my $fakeobj = bless { userid => $u->id, versionid => $id },
-                                'DW::Media::Photo';
-            # we aren't concerned whether the file existed or not
-            DW::BlobStore->delete( media => $fakeobj->mogkey );
-        }
-
-        return 1;  # done
-
-    } else {
-        # this wasn't the original, don't do anything else
-        return $deleted;
+    foreach my $id ( @mv ) {
+        # create a fake object to get the mogkey
+        my $fakeobj = bless { userid => $u->id, versionid => $id },
+                            'DW::Media::Photo';
+        # we aren't concerned whether the file existed or not,
+        # and the associated media row is already in a deleted state
+        DW::BlobStore->delete( media => $fakeobj->mogkey );
     }
+
+    return 1;  # done
 }
 
 


### PR DESCRIPTION
This calls the parent method to do the deletion as before, then looks for other versions of the same image to also delete from storage once the original is gone.

While testing this, I realized that the relevant rows in media_versions are preserved, so we need to crosscheck against the 'state' column of the media table and make sure we aren't counting the sizes of deleted files against the user's quota.

Fixes #1931.