### PR TITLE
[#1942] add file/new, file/edit to menunav

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -769,6 +769,8 @@ error.noschwartz=TheSchwartz not installed or not configured properly.
 
 error.notloggedin=You have to <a [[aopts]]>log in</a> in order to use this page.
 
+error.openid=This page is not available to OpenID users. <a href="[[aopts]]">Create a [[sitename]] account?</a>
+
 error.pay.cmo.engbadstate=Payment engine is in a bad state.  Please try your order again.
 
 error.pay.dberr=Database error: [[errstr]].  Please try again later.

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -1980,6 +1980,8 @@ menunav.organize.managecommunities=Manage Communities
 
 menunav.organize.managefilters=Manage Filters
 
+menunav.organize.manageimages=Manage Images
+
 menunav.organize.managerelationships=Manage Circle
 
 menunav.organize.managetags=Manage Tags

--- a/cgi-bin/DW/Controller/API/Media.pm
+++ b/cgi-bin/DW/Controller/API/Media.pm
@@ -59,6 +59,9 @@ sub file_new_handler {
     LJ::isu( $rv->{u} )
         or return api_error( $r->HTTP_UNAUTHORIZED, 'Not logged in' );
 
+    return api_error( $r->HTTP_UNAUTHORIZED, 'Invalid account type' )
+        if $rv->{u}->is_identity;
+
     return api_error( $r->HTTP_BAD_REQUEST, 'Quota exceeded' )
         unless $rv->{u}->can_upload_media;
 

--- a/cgi-bin/DW/Controller/Media.pm
+++ b/cgi-bin/DW/Controller/Media.pm
@@ -41,6 +41,9 @@ DW::Routing->register_string( '/file', \&media_index_handler, app => 1 );
 sub media_manage_handler {
     my ( $ok, $rv ) = controller();
     return $rv unless $ok;
+    return error_ml( 'error.openid', { sitename => $LJ::SITENAMESHORT,
+                                       aopts => '/create' } )
+        if $rv->{remote}->is_identity;
 
     # load all of a user's media.  this is inefficient and won't be like this forever,
     # but it's simple for now...
@@ -52,6 +55,9 @@ sub media_manage_handler {
 sub media_bulkedit_handler {
     my ( $ok, $rv ) = controller();
     return $rv unless $ok;
+    return error_ml( 'error.openid', { sitename => $LJ::SITENAMESHORT,
+                                       aopts => '/create' } )
+        if $rv->{remote}->is_identity;
 
     my @security = (
             { value => "public",  text => LJ::Lang::ml( 'label.security.public2' ) },
@@ -179,6 +185,9 @@ sub media_handler {
 sub media_new_handler {
     my ( $ok, $rv ) = controller();
     return $rv unless $ok;
+    return error_ml( 'error.openid', { sitename => $LJ::SITENAMESHORT,
+                                       aopts => '/create' } )
+        if $rv->{remote}->is_identity;
 
     $rv->{security} = [
         { value => "public",  text => LJ::Lang::ml( 'label.security.public2' ) },

--- a/cgi-bin/DW/Logic/MenuNav.pm
+++ b/cgi-bin/DW/Logic/MenuNav.pm
@@ -97,11 +97,11 @@ sub get_menu_navigation {
                     text_opts => { num => $userpic_count, max => $userpic_max },
                     display => $loggedin,
                 },
-#                {
-#                    url => "$LJ::SITEROOT/file/new",
-#                    text => "menunav.create.uploadimages",
-#                    display => $loggedin,
-#                },
+                {
+                    url => "$LJ::SITEROOT/file/new",
+                    text => "menunav.create.uploadimages",
+                    display => $loggedin_hasjournal,
+                },
                 {
                     url => "$LJ::SITEROOT/communities/new",
                     text => "menunav.create.createcommunity",
@@ -136,6 +136,11 @@ sub get_menu_navigation {
                     url => "$LJ::SITEROOT/communities/list",
                     text => "menunav.organize.managecommunities",
                     display => $loggedin_canjoincomms,
+                },
+                {
+                    url => "$LJ::SITEROOT/file/edit",
+                    text => "menunav.organize.manageimages",
+                    display => $loggedin_hasjournal,
                 },
                 {
                     url => "$LJ::SITEROOT/tools/importer",

--- a/cgi-bin/DW/Media.pm
+++ b/cgi-bin/DW/Media.pm
@@ -240,6 +240,7 @@ package LJ::User;
 
 sub can_upload_media {
     my ( $u ) = @_;
+    return 0 if $u->is_identity;
 
     my $quota = DW::Media->get_quota_for_user( $u );
     my $usage = DW::Media->get_usage_for_user( $u );


### PR DESCRIPTION
This adds links for the file management area to the core navigation menu, and restricts the feature so that OpenID users can't use it (since they don't have journals).

Fixes #1942.