### PR TITLE
change LF to CRLF in graph labels to display properly

### DIFF
--- a/cgi-bin/DW/Controller/Graphs.pm
+++ b/cgi-bin/DW/Controller/Graphs.pm
@@ -76,10 +76,10 @@ sub accounts_by_type {
 
     # Package the input for the DW::Graphs
     my $hashref = {
-                "$personal_label\n   $personal" => $personal,
-                "$identity_label\n   $identity" => $identity,
-                "$community_label\n   $community" => $community,
-                "$syndicated_label\n   $syndicated" => $syndicated,
+                "$personal_label\r\n   $personal" => $personal,
+                "$identity_label\r\n   $identity" => $identity,
+                "$community_label\r\n   $community" => $community,
+                "$syndicated_label\r\n   $syndicated" => $syndicated,
     };
 
     # create an image
@@ -252,10 +252,10 @@ sub paid_accounts {
 
     # Package the input for DW::Graphs
     my $input = {
-                "$paid_label\n   $paid" => $paid,
-                "$premium_label\n   $premium" => $premium,
-                "$seed_label\n   $seed" => $seed,
-                "$active_free_label\n   $active_30d_free" => $active_30d_free,
+                "$paid_label\r\n   $paid" => $paid,
+                "$premium_label\r\n   $premium" => $premium,
+                "$seed_label\r\n   $seed" => $seed,
+                "$active_free_label\r\n   $active_30d_free" => $active_30d_free,
     };
     # create an image
     my $gd = DW::Graphs::pie( $input );

--- a/cgi-bin/DW/Graphs.pm
+++ b/cgi-bin/DW/Graphs.pm
@@ -161,7 +161,7 @@ sub bar {
 
     # Default settings (can be over-ridden by config file)
     my %settings = (
-        x_label      => "\n$xlabel",
+        x_label      => "\r\n$xlabel",
         y_label      => $ylabel,
         show_values  => 1,
         values_space => 1,   # Pixels between top of bar and value above
@@ -243,7 +243,7 @@ sub bar2 {
 
     #Default settings (can be over-ridden by config file)
     my %settings = (
-        x_label         => "\n$xlabel",
+        x_label         => "\r\n$xlabel",
         y_label         => $ylabel,
         show_values    => 1,
         values_space   => 1,  # Pixels between top of bar and value above


### PR DESCRIPTION
GD interprets LF as a vertical tab, which it displays as a little V over T glyph.
That's weird. It wants CRLF instead.