### PR TITLE
re-enable stats graph printing

### DIFF
--- a/htdocs/stats.bml
+++ b/htdocs/stats.bml
@@ -376,10 +376,6 @@ body<=
  }
 
 
- # return early, since the graphs below are pretty much broken now
- # with index changes.  FIXME: make alternate means to generate stats
- return $ret;
-
  ### graphs!
  $ret .= "<?h1 Pretty Graphs! h1?><?p These are the most fun, aren't they? p?>";
  

--- a/htdocs/stats.bml
+++ b/htdocs/stats.bml
@@ -375,12 +375,22 @@ body<=
      }
  }
 
+my %graphs = ( newbyday => 'stats/newbyday.png',
+             );
 
- ### graphs!
- $ret .= "<?h1 Pretty Graphs! h1?><?p These are the most fun, aren't they? p?>";
- 
- $ret .= "<?h2 New accounts -- last 60 days h2?><?p How fast are we growing? p?>";
- $ret .= "<p align='center'><img src=\"stats/newbyday.png\" width='520' height='350' /></p>";
+foreach ( keys %graphs ) {
+    delete $graphs{$_} unless -f "$LJ::HOME/htdocs/$graphs{$_}";
+}
+
+if ( %graphs ) {
+    $ret .= "<?h1 $ML{'.graphs.header'} h1?><?p $ML{'.graphs.desc'} p?>";
+
+    if ( $graphs{newbyday} ) {
+        $ret .= "<?h2 $ML{'.graphs.newbyday.header'} h2?>";
+        $ret .= "<?p $ML{'.graphs.newbyday.desc'} p?>";
+        $ret .= "<p align='center'><img src=\"$graphs{newbyday}\" width='520' height='350' /></p>";
+    }
+}
 
  return $ret;
 

--- a/htdocs/stats.bml.text
+++ b/htdocs/stats.bml.text
@@ -27,6 +27,14 @@
 
 .gender.unspecified=Rather not say
 
+.graphs.desc=Pretty graphs are the most fun, aren't they?
+
+.graphs.header=Data Visualization
+
+.graphs.newbyday.desc=How fast are we growing?
+
+.graphs.newbyday.header=New accounts &mdash; last 60 days
+
 .new.desc.community=These are the 10 most recently created community accounts.  Their creators probably haven't made many entries in them yet.
 
 .new.desc.feeds=These are the 10 most recently created feeds.


### PR DESCRIPTION
This early return prevented the "pretty graphs" from being printed, with a comment saying they were broken.  @alierak says they are not broken - looks like newbyday.png is generated by bin/maint/statspics.pl.  The early return dates from the original LJ import.

While we're here, only try to display the image if the image file exists, and English-strip the text.