### PR TITLE
[#1981] anchor regexp in break_word subroutine

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1696,7 +1696,7 @@ sub break_word {
     # the last punctuation point; otherwise it will be placed at the maximum
     # length of the unbroken word as defined by $at.
 
-    while ( $word =~ s/((?:$onechar){$at})// ) {
+    while ( $word =~ s/^((?:$onechar){$at})// ) {
         $chunk = $1;
 
         # Edge case: if the next character would be whitespace, we

--- a/t/clean-event.t
+++ b/t/clean-event.t
@@ -17,7 +17,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 48;
+use Test::More tests => 49;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::CleanHTML;
@@ -325,5 +325,10 @@ $orig_post  = qq{"This_is_a_test_of_the_emergency_word_break_system."};
 $clean_post = qq{"This_is_a_test_of_the_emergency_word_br<wbr />eak_system."};
 $clean->({ wordlength => 40 });
 is( $orig_post, $clean_post, "Don't choose first character in string" );
+
+$orig_post  = qq{"Auto-linkify: http://www.dreamwidth.org/file/edit"};
+$clean_post = qq{"Auto-linkify: <a href="http://www.dreamwidth.org/file/edit">http://www.dreamwidth.org/file/edit</a>"};
+$clean->({ wordlength => 40 });
+is( $orig_post, $clean_post, "Don't mutilate URL entity markers" );
 
 1;


### PR DESCRIPTION
I committed the cardinal sin of not anchoring my regexp.  In my defense, the nearly-identical regexp in the original code wasn't exactly anchored either.

Fixes #1981.