### PR TITLE
Use of $# considered harmful

### DIFF
--- a/cgi-bin/DW/BlobStore/MogileFS.pm
+++ b/cgi-bin/DW/BlobStore/MogileFS.pm
@@ -62,8 +62,8 @@ sub exists {
 	# retrieving files since keys are globally unique.
 	# Just check if any paths exist to see if the file exists
 	my @paths = $self->{mogclient}->get_paths( $key );
-	$log->debug( "Found $#paths paths from MogileFS for key: $key" );
-	return $#paths > 0 ? 1 : 0;
+	$log->debug( "Found ", scalar( @paths ), " paths from MogileFS for key: ", $key );
+	return scalar @paths > 0 ? 1 : 0;
 }
 
 sub retrieve {


### PR DESCRIPTION
This construction returns the index of the last item rather than the
count which means this was only returning true once the file had
replicated, which while often successful is definitely not what we want.