### PR TITLE
[#1983] fix one more occurrence of reference mismatch errors

### DIFF
--- a/cgi-bin/DW/Controller/EditIcons.pm
+++ b/cgi-bin/DW/Controller/EditIcons.pm
@@ -214,7 +214,7 @@ sub parse_post_uploads {
                         # to get files between the N different web processes you might talk to
                         my $rv = DW::BlobStore->store(
                             temp => "upf_${counter}:$u->{userid}",
-                            \$POST->{$userpic_key}
+                            $current_upload{image}
                         );
                         unless ( $rv ) {
                             $current_upload{error} = 'Failed to upload file to storage system.';
@@ -234,8 +234,8 @@ sub parse_post_uploads {
                             $current_upload{image} = $picinfo->[0];
                         };
 
-                        if ( $@ || length $POST->{$userpic_key} > $MAX_UPLOAD ) {
-                            $current_upload{error} = ML::ml( '.error.filetoolarge',
+                        if ( $@ || length ${$current_upload{image}} > $MAX_UPLOAD ) {
+                            $current_upload{error} = LJ::Lang::ml( '.error.filetoolarge',
                                 { maxsize => int($MAX_UPLOAD / 1024) } );
                         }
 


### PR DESCRIPTION
Found 4 paths before; 5th path is obscure edge case where icon is 100x100 or less, but file size is > $MAX_UPLOAD.  I think this edit removes the last direct references to $POST->{$userpic_key} from parse_post_uploads.  This is the error in the logs:

`FATAL> BlobStore.pm:100 DW::BlobStore::store | Store requires data be a scalar reference. at /home/dw/production/cgi-bin/DW/Controller/EditIcons.pm line 215.`