### PR TITLE
additional headers for media file requests

### DIFF
--- a/cgi-bin/DW/Controller/Media.pm
+++ b/cgi-bin/DW/Controller/Media.pm
@@ -233,6 +233,7 @@ sub media_handler {
         unless defined $dataref && ref $dataref eq 'SCALAR';
 
     # now we're done!
+    $r->set_last_modified( $obj->{logtime} ) if $obj->{logtime};
     $r->content_type( $obj->mimetype );
     $r->print( $$dataref );
     return $r->OK;

--- a/cgi-bin/DW/Routing.pm
+++ b/cgi-bin/DW/Routing.pm
@@ -218,6 +218,13 @@ sub _call_hash {
     $r->content_type( $default_content_types->{$format} )
         if $default_content_types->{$format};
 
+    # apply default cache-avoidant settings to "journal" content
+    # (similar to the behavior of our Apache server modules)
+    # so that proxies (e.g. Cloudflare) must revalidate the response
+    if ( $opts->role eq 'user' && ! $opts->no_cache ) {
+        $r->header_out( "Cache-Control" => "private, proxy-revalidate" );
+    }
+
     # apply no-cache if needed
     $r->no_cache if $opts->no_cache;
 


### PR DESCRIPTION
Discussion with @alierak led to the conclusion that media files should use the Cache-Control and Last-Modified headers.

Inspection of Apache/LiveJournal.pm and Apache/BML.pm indicates that Cache-Control should be applied to all user content responses, so we make that the new default behavior for user content in DW/Routing.pm.

The Last-Modified header is set in the media file controller as the upload date of the file, which will never change.

Without the Last-Modified header, the image may be redownloaded unnecessarily.  Without the Cache-Control header, Cloudflare caching may interfere with the ability to load the image correctly.