### PR TITLE
[#1990] don't transform username tags in URLs

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1760,7 +1760,7 @@ sub clean_as_markdown {
             return qq|\@$user.$site|;
         }
     };
-    $$ref =~ s/(?<=\W)\@([\w\d_-]+)(?:\.([\w\d\.]+))?(?=$|\W)/$usertag->($1, $2)/mge;
+    $$ref =~ s!(?<=[^\w/])\@([\w\d_-]+)(?:\.([\w\d\.]+))?(?=$|\W)!$usertag->($1, $2)!mge;
 
     return 1;
 }

--- a/t/cleaner-markdown.t
+++ b/t/cleaner-markdown.t
@@ -1,0 +1,53 @@
+# t/cleaner-markdown.t
+#
+# Test LJ::CleanHTML with Markdown text.
+#
+# Authors:
+#      Jen Griffin <kareila@livejournal.com>
+#
+# Copyright (c) 2017 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+use LJ::CleanHTML;
+
+my $lju_sys = LJ::ljuser("system");
+my $url = 'https://medium.com/@username/title-of-page';
+
+my $as_markdown = sub { return "!markdown\n$_[0]" };
+
+my $clean = sub {
+    my ( $text ) = @_;
+    $text = $as_markdown->( $text );
+    LJ::CleanHTML::clean_event( \$text, { wordlength => 80 } );
+    chomp $text;
+    return $text;
+};
+
+# plain text user tag
+is( $clean->('@system'), "<p>$lju_sys</p>",
+    "user tag in plain text converted" );
+
+# plain URL containing user tag
+# (Markdown conversion sets preformatted flag, so this won't linkify)
+is( $clean->($url), "<p>$url</p>",
+    "user tag in URL not converted" );
+
+# linked URL containing user tag
+is( $clean->("[link from \@system]($url)"),
+    qq{<p><a href="$url">link from $lju_sys</a></p>},
+    "user tag in href not converted, but user tag in link text converted []" );
+
+# same as standard HTML
+is( $clean->(qq{<a href="$url">link from \@system</a>}),
+    qq{<p><a href="$url">link from $lju_sys</a></p>},
+    "user tag in href not converted, but user tag in link text converted <>" );


### PR DESCRIPTION
I thought about bringing out the heavy artillery (aka HTML::Parser) but realized that even if we just transformed on plain text, things that look like usernames in plain URLs would still be mangled.  So this just tweaks the existing regular expression to ignore `@username` if immediately preceded by a slash.

Fixes #1990.