### PR TITLE
[#1957] add request text search to /support/history

### DIFF
--- a/cgi-bin/DW/Controller/Support/History.pm
+++ b/cgi-bin/DW/Controller/Support/History.pm
@@ -154,6 +154,11 @@ sub history_handler {
         } else {
             $vars->{noresults} = 1;
         }
+    } elsif ( $get->{fulltext} ) {
+        $rv = DW::Controller::Support::Search::do_search(
+                remoteid => $remote->id, query => $get->{fulltext} );
+        return DW::Template->render_template( 'support/search.tt', $rv );
+
     } elsif ( ! $fullsearch ) {
         my $redirect_user = $remote->user;
         $r->header_out( Location => "$LJ::SITEROOT/support/history?user=$redirect_user" );

--- a/cgi-bin/DW/Controller/Support/History.pm
+++ b/cgi-bin/DW/Controller/Support/History.pm
@@ -33,23 +33,23 @@ sub history_handler {
 
     my ( $ok, $rv ) = controller( anonymous => 0, form_auth => 1 );
     return $rv unless $ok;
-    
-    my $vars = {};    
+
+    my $vars = {};
 
     my $remote = $rv->{remote};
     my $fullsearch = $remote->has_priv( 'supporthelp' );
 
     $vars->{fullsearch} = $fullsearch;
-    
+
     if ( $get->{user} || $get->{email} || $get->{userid} ) {
         my $dbr = LJ::get_db_reader();
         return error_ml( '/support/history.tt.error.nodatabase' ) unless $dbr;
-        
+
         $vars->{get_user} = ( $get->{user} ) ? 1 : 0;
         $vars->{get_userid} = ( $get->{userid} ) ? 1 : 0;
         $vars->{get_email} = ( $get->{email} ) ? 1 : 0;
         $vars->{user} = $remote->user;
-                
+
         my $reqlist;
         if ( $get->{user} || $get->{userid} ) {
             # get requests by a user, regardless of email (only gets user requests)
@@ -57,7 +57,7 @@ sub history_handler {
             return error_ml( '/support/history.tt.error.invaliduser' ) unless $userid
                 && ( $fullsearch || $remote->id == $userid );
             $vars->{username} = LJ::ljuser( LJ::get_username( $userid ) );
-            $reqlist = $dbr->selectall_arrayref( 
+            $reqlist = $dbr->selectall_arrayref(
                 'SELECT spid, subject, state, spcatid, requserid, ' .
                        'timecreate, timetouched, timelasthelp, reqemail ' .
                 'FROM support WHERE reqtype = \'user\' AND requserid = ?',
@@ -80,13 +80,13 @@ sub history_handler {
 
             return error_ml( '/support/history.tt.error.invalidemail' ) unless $email =~ /^.+\@.+$/
                 && ( $fullsearch || $user_emails{$email} );
-            $reqlist = $dbr->selectall_arrayref( 
+            $reqlist = $dbr->selectall_arrayref(
                 'SELECT spid, subject, state, spcatid, requserid, ' .
                        'timecreate, timetouched, timelasthelp, reqemail ' .
                 'FROM support WHERE reqemail = ?',
                 undef, $email );
-        } 
-        
+        }
+
         if ( @{$reqlist || []} ) {
             # construct a list of people who have answered these requests
             my @ids;
@@ -159,9 +159,9 @@ sub history_handler {
         $r->header_out( Location => "$LJ::SITEROOT/support/history?user=$redirect_user" );
         return $r->REDIRECT;
     }
-    
+
     return DW::Template->render_template( 'support/history.tt', $vars );
-    
+
 }
-    
+
 1;

--- a/cgi-bin/DW/Controller/Support/Search.pm
+++ b/cgi-bin/DW/Controller/Support/Search.pm
@@ -38,15 +38,14 @@ sub search_handler {
     die "Invalid form auth.\n"
         unless LJ::check_form_auth( $args->{lj_form_auth} );
 
-    ( $ok, $rv ) = do_search( remoteid => $remote->id,
-                                 query => $args->{query},
-                                offset => $args->{offset} );
+    $rv = do_search( remoteid => $remote->id,
+                        query => $args->{query},
+                       offset => $args->{offset} );
 
     return DW::Template->render_template( 'support/search.tt', $rv );
 }
 
 # helper subroutine that can be called from other contexts
-# returns ( $ok, $rv ) like a controller
 
 sub do_search {
     my %args = @_;
@@ -60,9 +59,9 @@ sub do_search {
     die "Sorry, content searching is not configured on this server.\n"
         unless $gc && @LJ::SPHINX_SEARCHD;
 
-    my $error = sub { return ( 0, { query => $q, error => $_[0] } ); };
-    my $ok    = sub { return ( 1, { query => $q, offset => $offset,
-                                   result => $_[0] } ); };
+    my $error = sub { return { query => $q, error => $_[0] } };
+    my $ok    = sub { return { query => $q, offset => $offset,
+                               result => $_[0] } };
 
     return $error->( "Please specify a shorter search string." )
         if length $q > 255;

--- a/cgi-bin/DW/Controller/Support/Search.pm
+++ b/cgi-bin/DW/Controller/Support/Search.pm
@@ -27,16 +27,7 @@ DW::Routing->register_string( "/support/search", \&search_handler, app => 1 );
 sub search_handler {
     my ( $ok, $rv ) = controller( authas => 1, form_auth => 0 );
     return $rv unless $ok;
-
-    my $q = '';
-    my $error = sub {
-        return DW::Template->render_template( 'support/search.tt',
-            { error => $_[0], query => $q } );
-    };
-
-    my $gc = LJ::gearman_client();
-    die "Sorry, content searching is not configured on this server.\n"
-        unless $gc && @LJ::SPHINX_SEARCHD;
+    my $remote = $rv->{remote};
 
     my $r = DW::Request->get;
     return DW::Template->render_template( 'support/search.tt' )
@@ -47,18 +38,41 @@ sub search_handler {
     die "Invalid form auth.\n"
         unless LJ::check_form_auth( $args->{lj_form_auth} );
 
-    $q = LJ::strip_html( LJ::trim( $args->{query} ) );
+    ( $ok, $rv ) = do_search( remoteid => $remote->id,
+                                 query => $args->{query},
+                                offset => $args->{offset} );
+
+    return DW::Template->render_template( 'support/search.tt', $rv );
+}
+
+# helper subroutine that can be called from other contexts
+# returns ( $ok, $rv ) like a controller
+
+sub do_search {
+    my %args = @_;
+
+    my $remoteid = delete $args{remoteid} or die "No remoteid";
+    my $q = LJ::strip_html( LJ::trim( delete $args{query} ) );
+    my $offset = ( delete $args{offset} // 0 ) + 0;
+    die "Unknown opts to do_search" if %args;
+
+    my $gc = LJ::gearman_client();
+    die "Sorry, content searching is not configured on this server.\n"
+        unless $gc && @LJ::SPHINX_SEARCHD;
+
+    my $error = sub { return ( 0, { query => $q, error => $_[0] } ); };
+    my $ok    = sub { return ( 1, { query => $q, offset => $offset,
+                                   result => $_[0] } ); };
+
     return $error->( "Please specify a shorter search string." )
         if length $q > 255;
     return $error->( "Please specify a search string." )
         unless length $q > 0;
-
-    my $offset = ( $args->{offset} // 0 ) + 0;
     return $error->( "Offset must be between 0 and 1000." )
         unless $offset >= 0 && $offset <= 1000;
 
     # Gearman worker takes a blob, we send it a frozen hash.
-    my $search_args = { remoteid => $rv->{remote}->id, query => $q,
+    my $search_args = { remoteid => $remoteid, query => $q,
         offset => $offset, support => 1 };
     my $arg = Storable::nfreeze( $search_args );
 
@@ -85,9 +99,7 @@ sub search_handler {
     return $error->( "Sorry, there were no results found for that search." )
         if $result->{total} <= 0;
 
-    # Okay, render the results with the matches.
-    return DW::Template->render_template( 'support/search.tt',
-        { query => $q, result => $result, offset => $offset } );
+    return $ok->( $result );
 }
 
 1;

--- a/cgi-bin/DW/Controller/Support/Search.pm
+++ b/cgi-bin/DW/Controller/Support/Search.pm
@@ -85,11 +85,9 @@ sub search_handler {
     return $error->( "Sorry, there were no results found for that search." )
         if $result->{total} <= 0;
 
-    use Data::Dumper;
-
     # Okay, render the results with the matches.
     return DW::Template->render_template( 'support/search.tt',
-        { query => $q, result => $result, offset => $offset, tmp => Dumper( $result ) } );
+        { query => $q, result => $result, offset => $offset } );
 }
 
 1;

--- a/views/support/history.tt
+++ b/views/support/history.tt
@@ -88,6 +88,18 @@ the same terms as Perl itself. For a copy of the license, please reference
             </div>
         </div>
         <div class="row">
+            <div class="large-6 columns">
+                <div class="row">
+                    <div class="small-3 columns">
+                        <label for="fulltext" class="right inline">[% '.search.fulltext' | ml %]</label>
+                    </div>
+                    <div class="small-9 columns">
+                        <input type="text" id="fulltext" name="fulltext" placeholder="[% '.search.fulltext.text' | ml %]">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
       <div class="small-2 columns">
         <input type='submit' class="button" value='[% '.search.btn' | ml %]'>
         </div>

--- a/views/support/history.tt
+++ b/views/support/history.tt
@@ -48,7 +48,7 @@ the same terms as Perl itself. For a copy of the license, please reference
     </table>
 [% END %]
 [% IF fullsearch %]
-    <form method='get' action='history'>
+    <form method='post' action='history'>
         <fieldset>
             <legend>[% '.search.text' | ml %]</legend>
         <div class="row">
@@ -108,6 +108,7 @@ the same terms as Perl itself. For a copy of the license, please reference
             <div data-alert class="alert-box radius">[% '.search.onefield' | ml %]</div>
         </div>
         </fieldset>
+    [% dw.form_auth %]
     </form>
 [% ELSE %]
     [% IF get_user %]

--- a/views/support/history.tt.text
+++ b/views/support/history.tt.text
@@ -16,6 +16,10 @@
 
 .search.email.text=Email Address
 
+.search.fulltext=Containing Text:
+
+.search.fulltext.text=Search Text
+
 .search.onefield=Please fill out only one of the search fields.
 
 .search.otheremails=You may also search for requests from email addresses associated with your account.


### PR DESCRIPTION
Engaged in a bit of sleight of hand to work around the fact that you can't redirect POST requests, but this seems to work fine in my limited test environment.

Fixes #1957.