### PR TITLE
[#2016] look for both possible saved orderings

### DIFF
--- a/cgi-bin/LJ/User/Administration.pm
+++ b/cgi-bin/LJ/User/Administration.pm
@@ -88,7 +88,7 @@ sub log_event {
     }
     my $remote = delete($info->{remote}) || LJ::get_remote() || undef;
     my $targetid = (delete($info->{actiontarget})+0) || undef;
-    my $extra = %$info ? join('&', map { LJ::eurl($_) . '=' . LJ::eurl($info->{$_}) } keys %$info) : undef;
+    my $extra = %$info ? join('&', map { LJ::eurl($_) . '=' . LJ::eurl($info->{$_}) } sort keys %$info) : undef;
 
     # now insert the data we have
     $u->do("INSERT INTO userlog (userid, logtime, action, actiontarget, remoteid, ip, uniq, extra) " .


### PR DESCRIPTION
I can confirm that this lookup works in testing with unsorted data. I'm also adding a sort to log_event so prevent similar problems in the future, but that won't correct previously logged events.

Fixes #2016.