### PR TITLE
[#2034] use %LJ::KNOWN_HTTPS_SITES for simple whitelist

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1670,9 +1670,11 @@ sub https_url {
     # https:// and the relative // protocol don't need proxying
     return $url if $url =~ m!^(?:https://|//)!;
 
-    # if this link is on our site, let's just switch it to https
-    if ( $url =~ $LJ::DOMAIN || defined $LJ::HTTPS_UPGRADE_REGEX
-                             && $url =~ $LJ::HTTPS_UPGRADE_REGEX ) {
+    # if this link is on a site that supports HTTPS, upgrade the protocol
+    my $https_ok = %LJ::KNOWN_HTTPS_SITES ? \%LJ::KNOWN_HTTPS_SITES : {};
+    my ( $domain ) = ( $url =~ m!://[^/]*?([^.]+\.\w{2,3})/! );
+
+    if ( $domain && ( $domain eq $LJ::DOMAIN || $https_ok->{$domain} ) ) {
         $url =~ s!^http:!https:!;
         return $url;
     }

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1672,7 +1672,7 @@ sub https_url {
 
     # if this link is on a site that supports HTTPS, upgrade the protocol
     my $https_ok = %LJ::KNOWN_HTTPS_SITES ? \%LJ::KNOWN_HTTPS_SITES : {};
-    my ( $domain ) = ( $url =~ m!://[^/]*?([^.]+\.\w{2,3})/! );
+    my ( $domain ) = ( $url =~ m!^http://[^/]*?([^.]+\.\w{2,3})/! );
 
     if ( $domain && ( $domain eq $LJ::DOMAIN || $https_ok->{$domain} ) ) {
         $url =~ s!^http:!https:!;

--- a/etc/config-local.pl
+++ b/etc/config-local.pl
@@ -174,7 +174,12 @@
 
     # Domains that are known to support HTTPS. This is an optimization to
     # reduce traffic to our proxy and improve the user experience.
-    $HTTPS_UPGRADE_REGEX = qr!\.(?:photobucket\.com|imgur\.com|yandex\.ru|xkcd\.com)/!;
+    %KNOWN_HTTPS_SITES = map { $_ => 1 }
+                         qw/ imgur.com yandex.ru xkcd.com abload.de tumblr.com
+                             flickr.com staticflickr.com blogspot.com feedburner.com
+                             imageshack.us levkonoe.com wikimedia.org plurk.com
+                           /;
+
 }
 
 1;

--- a/t/https-url.t
+++ b/t/https-url.t
@@ -4,8 +4,9 @@
 #
 # Authors:
 #      Afuna <coder.dw@afunamatata.com>
+#      Jen Griffin <kareila@livejournal.com>
 #
-# Copyright (c) 2015 by Dreamwidth Studios, LLC.
+# Copyright (c) 2015-2017 by Dreamwidth Studios, LLC.
 #
 # This program is free software; you may redistribute it and/or modify it under
 # the same terms as Perl itself.  For a copy of the license, please reference
@@ -20,6 +21,13 @@ use Test::More;
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::CleanHTML;
 
+# make sure we have a working proxy subroutine for testing
+local $LJ::PROXY_URL = "https://proxy.myhost.net";
+unless ( $LJ::PROXY_SALT_FILE && -e $LJ::PROXY_SALT_FILE ) {
+    no warnings 'redefine';
+    *DW::Proxy::get_url_signature = sub { return 'testfoo' };
+}
+
 my @urls = (
     # internal links
     [ "https://example.$LJ::DOMAIN/file/foo", "https://example.$LJ::DOMAIN/file/foo" ],
@@ -27,10 +35,17 @@ my @urls = (
 
     # external links
     [ "https://example.com/a.png", "https://example.com/a.png" ],
+    [ "http://example.com/a.png", DW::Proxy::get_proxy_url( "http://example.com/a.png" ) ],
 
     # protocol relative links
     [ "//example.com/a.png", "//example.com/a.png" ],
+
+    # links that can be upgraded via KNOWN_HTTPS_SITES
+    [ "http://xkcd.com/file/foo",  "https://xkcd.com/file/foo" ],
+    [ "http://username.blogspot.com/a.png",  "https://username.blogspot.com/a.png" ],
 );
+
+local %LJ::KNOWN_HTTPS_SITES = qw( xkcd.com 1 blogspot.com 1 );
 
 if ( $LJ::USE_SSL ) {
     plan tests => scalar @urls;


### PR DESCRIPTION
Replaces regular expression in config with a list of domains that support HTTPS connections, and tests the domain of the given URL against that whitelist.

Also updates https-url.t with a working dummy proxy config.

Fixes #2034.