### PR TITLE
Hide banned users on manage circle page

### DIFF
--- a/cgi-bin/LJ/User/Administration.pm
+++ b/cgi-bin/LJ/User/Administration.pm
@@ -217,6 +217,11 @@ sub rate_log {
 =head2 Banning-Related Functions
 =cut
 
+sub banned_userids {
+    my ( $u ) = @_;
+    return LJ::load_rel_user( $u, 'B' );
+}
+
 sub ban_note {
     my ( $u, $ban_u, $text ) = @_;
     my @banned;
@@ -297,7 +302,6 @@ sub ban_user_multi {
 
     return 1;
 }
-
 
 # return if $target is banned from $u's journal
 sub has_banned {

--- a/htdocs/manage/banusers.bml
+++ b/htdocs/manage/banusers.bml
@@ -154,7 +154,7 @@ body<=
 
     # unban users
     $ret .= "<h2 style='margin-top: 20px;'>$ML{'.header.unban'}</h2>";
-    my $banned = LJ::load_rel_user($u, 'B');
+    my $banned = $u->banned_userids;
     if ($banned && @$banned) {
         my $us = LJ::load_userids(@$banned);
         my $notes = $u->ban_note( $banned );

--- a/htdocs/manage/circle/edit.bml
+++ b/htdocs/manage/circle/edit.bml
@@ -29,6 +29,7 @@ body<=
 
     my $authas = $GET{'authas'} || $remote->user;
     my $getextra = $authas ne $remote->user ? "?authas=$authas" : '';
+    my $view_banned = $GET{view} eq 'banned';
 
     my $u = LJ::get_authas_user($authas);
     return LJ::bad_input($ML{'error.invalidauth'})
@@ -42,6 +43,9 @@ body<=
 
     # no post, show edit form
     unless ( LJ::did_post() ) {
+        my @banned_userids = @{$u->banned_userids || []};
+        my %is_banned = map { $_ => 1 } @banned_userids;
+
         my $trust_list = $u->trust_list;
         my $watch_list = $u->watch_list;
         my @trusted_by_userids = $u->trusted_by_userids;
@@ -58,6 +62,12 @@ body<=
         $ret .= LJ::form_auth();
         $ret .= "<p>" . BML::ml( '.circle.intro2', { aopts1 => "href='#editpeople'", aopts2 => "href='#editcomms'", aopts3 => "href='#editfeeds'", aopts4 => "href='$LJ::SITEROOT/manage/settings/?cat=notifications'", aopts5 => "href='$LJ::SITEROOT/manage/banusers'" }) . "</p>\n\n";
         $ret .= "<p>" . BML::ml( '.circle.intro.feeds', { sitename => "$LJ::SITENAMESHORT", aopts => "href='$LJ::SITEROOT/feeds'" }) . "</p>\n\n";
+        if ($view_banned) {
+            $ret .= "<p>" . BML::ml( '.circle.hide_banned', { aopts => "href='/manage/circle/edit'"} ) . "</p>\n";
+        } else {
+            $ret .= "<p>" . BML::ml( '.circle.show_banned', { aopts => "href='/manage/circle/edit?view=banned'" } ) . "</p>\n" if @banned_userids;
+        }
+
         $ret .= "<?h2 $ML{'.circle.header'} h2?>\n";
 
         # little standout box to repeat before each section:
@@ -69,6 +79,8 @@ body<=
 
             # get sorted arrays
             foreach my $uid ( sort { $us->{$a}->display_name cmp $us->{$b}->display_name } keys %$us ) {
+                next if $is_banned{$uid} && !$view_banned;
+
                 my $other_u = $us->{$uid};
                 next unless $other_u;
 

--- a/htdocs/manage/circle/edit.bml.text
+++ b/htdocs/manage/circle/edit.bml.text
@@ -29,6 +29,10 @@
 
 .circle.header=Current Relationships
 
+.circle.show_banned=<a [[aopts]]>Show accounts you have banned?</a>
+
+.circle.hide_banned=<a [[aopts]]>Hide accounts you have banned?</a>
+
 .circle.header.comms=Communities ([[num]])
 
 .circle.header.feeds=Feeds ([[num]])


### PR DESCRIPTION
Hides banned users on the manage circle page by default, with an optional link to show them.

<img width="356" alt="screen shot 2017-03-30 at 00 43 08" src="https://cloud.githubusercontent.com/assets/364169/24488008/e6953c40-14e1-11e7-89af-86d5caa17ddf.png">
