### PR TITLE
Get rid of %S2_TRUSTED and associated checks

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -1389,7 +1389,7 @@ sub layer_compile
     }
 
     my $is_system = $layer->{userid} == LJ::get_userid( "system" );
-    my $untrusted = ! $LJ::S2_TRUSTED{$layer->{userid}} && ! $is_system;
+    my $untrusted = ! $is_system;
 
     # system writes go to global.  otherwise to user clusters.
     my $dbcm;

--- a/etc/config.pl
+++ b/etc/config.pl
@@ -541,11 +541,6 @@
     # kept in memcache and the database by doing:
     # %FILEEDIT_VIA_DB = ( 'support_links' => 1, );
 
-    ### S2 Style Options
-
-    # which users' s2 layers should always run trusted un-cleaned?
-    #%S2_TRUSTED = ( '2' => 'whitaker' ); # userid => username
-
 
     # Setup support email address to not accept new emails.  Basically if an
     # address is specified below, any user who emails it out of the blue will


### PR DESCRIPTION
Fixes #2047.

Removes %S2_TRUSTED from config.pl and change the check in S2.pm to only
look for whether the owner is the system account, eliminating the check
to S2_TRUSTED.