### PR TITLE
remove "ban community" from hover menu for comms

### DIFF
--- a/htdocs/js/contextualhover.js
+++ b/htdocs/js/contextualhover.js
@@ -505,7 +505,7 @@ ContextualPopup.renderPopup = function (ctxPopupId) {
         // ban / unban
 
         var ban;
-        if (data.is_logged_in && ! data.is_requester && ! data.is_syndicated) {
+        if (data.is_logged_in && ! data.is_requester && ! data.is_syndicated && ! data.is_comm ) {
             ban = document.createElement("span");
 
             if(!data.is_banned) {

--- a/htdocs/js/jquery.contextualhover.js
+++ b/htdocs/js/jquery.contextualhover.js
@@ -316,13 +316,13 @@ _renderPopup: function() {
         }
     }
 
-    if ( data.is_logged_in && ! data.is_requester && ! data.is_syndicated ) {
+    if ( data.is_logged_in && ! data.is_requester && ! data.is_syndicated && ! data.is_comm ) {
         if ( data.is_banned ) {
             this._addAction( Site.siteroot + "/manage/banusers",
-                data.is_comm ? "Unban community" : "Unban user", "setUnban" );
+                "Unban user", "setUnban" );
         } else {
             this._addAction( Site.siteroot + "/manage/banusers",
-                data.is_comm ? "Ban community" : "Ban user", "setBan" );
+                "Ban user", "setBan" );
             var $banlink = $("<a></a>", { href: Site.siteroot + "/manage/banusers" });
         }
     }


### PR DESCRIPTION
Fixes #2010.

Removes the "ban community" message from the hover menu for communities.