### PR TITLE
Widen userpic2 column 'description' to allow longer descriptions

### DIFF
--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -599,7 +599,7 @@ CREATE TABLE userpic2 (
     picdate datetime default NULL,
     md5base64 char(22) NOT NULL default '',
     comment varchar(255) BINARY NOT NULL default '',
-    description varchar(255) BINARY NOT NULL default '',
+    description varchar(600) BINARY NOT NULL default '',
     flags tinyint(1) unsigned NOT NULL default 0,
     location enum('blob','disk','mogile','blobstore') default NULL,
 
@@ -4091,6 +4091,12 @@ EOF
             MODIFY COLUMN location ENUM('blob', 'disk', 'mogile', 'blobstore')
             DEFAULT NULL}
         );
+    }
+
+    # widen the description field for userpics
+    if ( column_type( 'userpic2', 'description' ) eq "varchar(255)" ) {
+        do_alter( 'userpic2',
+            "ALTER TABLE userpic2 MODIFY COLUMN description VARCHAR(600) DEFAULT NULL");
     }
 
 });

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -4096,7 +4096,7 @@ EOF
     # widen the description field for userpics
     if ( column_type( 'userpic2', 'description' ) eq "varchar(255)" ) {
         do_alter( 'userpic2',
-            "ALTER TABLE userpic2 MODIFY COLUMN description VARCHAR(600) DEFAULT NULL");
+            "ALTER TABLE userpic2 MODIFY COLUMN description VARCHAR(600) BINARY NOT NULL default ''");
     }
 
 });

--- a/cgi-bin/LJ/Global/Constants.pm
+++ b/cgi-bin/LJ/Global/Constants.pm
@@ -53,8 +53,8 @@ use constant BMAX_SITEKEYWORD => 100;
 use constant CMAX_SITEKEYWORD => 50;
 use constant BMAX_UPIC_COMMENT => 255;
 use constant CMAX_UPIC_COMMENT => 120;
-use constant BMAX_UPIC_DESCRIPTION => 255;
-use constant CMAX_UPIC_DESCRIPTION => 120;
+use constant BMAX_UPIC_DESCRIPTION => 600;
+use constant CMAX_UPIC_DESCRIPTION => 300;
 
 # user.dversion values:
 #    0: unclustered  (unsupported)


### PR DESCRIPTION
Fixes #2055.

Converts the description column of the userpic2 table from varchar(255) (which lets descriptions be 120 characters long to account for bytes, yadda) to varchar(600), which allows for 300 characters.