### PR TITLE
better/more helpful text on "not authorized for this filter" 403 error

### DIFF
--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -1405,7 +1405,8 @@ sub journal_content
 
         # otherwise be vague with a 403
         } else {
-            return 403;
+            $status = "403 Forbidden";
+            $html = "<h1>Invalid Filter</h1><p>Either this reading filter doesn't exist or you are not authorized to view it. Try <a href='$LJ::SITEROOT/login'>checking that you are logged in</a> if you're sure you have the name right.</p>";
         }
 
         $generate_iejunk = 1;


### PR DESCRIPTION
Fixes #2061.

Alters cgi-bin/Apache/LiveJournal.pm to change the Apache-default bare-unstyled 403 in the event of a non-public or non-existant reading page filter to a still-bare-unstyled page that at least has a link to the login page so people don't get stranded.

This has specifically been checked for enumeration attacks in the following situations:

* Specified filter does exist but logged-in user isn't authorized to see it;
* Specified filter does not exist, user is logged in;
* Specified filter does exist but is not public/remote not logged in;
* Specified filter does not exist user is not logged in

The error message is the same in all four scenarios, so people won't be able to use this to fish for filters that do exist but that they don't have access to.