### PR TITLE
[#2065] only show UK/GB once in shop CC country selector

### DIFF
--- a/htdocs/shop/entercc.bml
+++ b/htdocs/shop/entercc.bml
@@ -77,6 +77,7 @@ body<=
         # load country codes, and US states
         my ( %countries, %usstates );
         DW::Countries->load( \%countries );
+        delete $countries{UK}; # UK is also GB; don't display both
         LJ::load_codes( { state => \%usstates } );
 
         # accepted credit card list.  this should be populated by the hooks.


### PR DESCRIPTION
Same approach that @kaberett used in #1684.

Fixes #2065.