### PR TITLE
[#2074] update default value of MERCH_URL to use https

### DIFF
--- a/etc/config-local.pl
+++ b/etc/config-local.pl
@@ -110,7 +110,7 @@
     $EMBED_MODULE_DOMAIN = "embed.my-other-domain.net";
 
     # merchandise link
-    # $MERCH_URL = "http://www.zazzle.com/dreamwidth*";
+    # $MERCH_URL = "https://www.zazzle.com/dreamwidth*";
 
     # shop/pricing configuration
     # %SHOP = (


### PR DESCRIPTION
We will still need to make sure this gets updated in production.

Fixes #2074.