### PR TITLE
[#2089] calculate correct URL for entry import metadata

### DIFF
--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -56,9 +56,9 @@ $domaintosite{"pinboard.in"} = DW::External::Site->new("20", "www.pinboard.in", 
 $domaintosite{"fanfiction.net"} = DW::External::Site->new("21", "www.fanfiction.net", "fanfiction.net", "FanFiction", "FanFiction");
 $domaintosite{"pinterest.com"} = DW::External::Site->new("22", "www.pinterest.com", "pinterest.com", "Pinterest", "pinterest");
 $domaintosite{"youtube.com"} = DW::External::Site->new("23", "www.youtube.com", "youtube.com", "YouTube", "yt");
-$domaintosite{"github.com"} = DW::External::Site->new("24", "www.github.com", "github.com", "GitHub", "gh"); 
+$domaintosite{"github.com"} = DW::External::Site->new("24", "www.github.com", "github.com", "GitHub", "gh");
 # three-part domain name
-$domaintosite{"lj.rossia.org"} = DW::External::Site->new("25", "lj.rossia.org", "lj.rossia.org", "LJRossia", "lj"); 
+$domaintosite{"lj.rossia.org"} = DW::External::Site->new("25", "lj.rossia.org", "lj.rossia.org", "LJRossia", "lj");
 
 
 @all_sites_without_alias = values %domaintosite;
@@ -146,7 +146,7 @@ sub get_site {
                     split( /\./, $site );
 
         $mapped = $domaintosite{"$parts[-2].$parts[-1]"};
-        # if two-part domain not matched, try three-part (for e.g. lj.rossia.org) 
+        # if two-part domain not matched, try three-part (for e.g. lj.rossia.org)
         $mapped ||= $domaintosite{"$parts[-3].$parts[-2].$parts[-1]"};
         $mapped ||= DW::External::Site::Unknown->accepts( \@parts );
     }

--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -206,6 +206,24 @@ sub journal_url {
     return "http://$self->{hostname}/users/" . $u->user . '/';
 }
 
+# returns an entry link for this user on this site.
+sub entry_url {
+    my ( $self, $u, %opts ) = @_;
+    croak 'need a DW::External::User'
+        unless $u && ref $u eq 'DW::External::User';
+
+    # override this on a site-by-site basis if needed
+    my $base = $self->journal_url( $u );
+
+    # several possible options for specifying an entry;
+    # for now we just support itemid + anum
+    return unless exists $opts{itemid} && exists $opts{anum};
+
+    my $pagenum = $opts{itemid} * 256 + $opts{anum};
+
+    return $base . $pagenum . ".html";
+}
+
 # returns the profile_url for this user on this site.
 sub profile_url {
     my ( $self, $u ) = @_;


### PR DESCRIPTION
Using a new method, `DW::External::Site->entry_url`, which uses itemid and anum to calculate the page link using the journal_url method, which can differ between sites.

There is an assumption here that every import source will have a definition in DW::External::Site, but that seems safe enough.

Fixes #2089.