### PR TITLE
[#2097] raise feed size limit for initial fetch

### DIFF
--- a/cgi-bin/DW/Controller/Feeds.pm
+++ b/cgi-bin/DW/Controller/Feeds.pm
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 
 use LJ::Feed;
+use LJ::SynSuck;
 use HTTP::Message;
 use URI;
 
@@ -110,8 +111,9 @@ sub index_handler {
                 }
 
                 # create a safeagent to fetch the feed for validation purposes
+                my $max_size = LJ::SynSuck::max_size();
                 my $ua = LJ::get_useragent( role     => 'syn_new',
-                                            max_size => (1024 * 300) );
+                                            max_size => $max_size );
                 $ua->agent( "$LJ::SITENAME ($LJ::ADMIN_EMAIL; Initial check)" );
 
                 my $can_accept = HTTP::Message::decodable;
@@ -121,6 +123,9 @@ sub index_handler {
                             : undef;
 
                 unless ( $content ) {
+                    return error_ml( '/feeds/index.tt.invalid.toolarge',
+                                     { max => ( $max_size / 1024 ) } )
+                        if $res && $res->is_success;
                     return DW::Template->render_template( 'error.tt',
                             { message => $res->status_line } )
                         if $remote->show_raw_errors;

--- a/cgi-bin/DW/Logic/ProfilePage.pm
+++ b/cgi-bin/DW/Logic/ProfilePage.pm
@@ -581,10 +581,10 @@ sub _basic_info_syn_status {
         posterror => "Posting error",
         ok => "",     # no status line necessary
         nonew => "",  # no status line necessary
-    }->{ $synd->{laststatus} };
+    }->{ $synd->{laststatus} // 'ok' };
     $syn_status .= " ($status)" if $status;
 
-    if ($synd->{laststatus} eq 'parseerror') {
+    if ( $synd->{laststatus} && $synd->{laststatus} eq 'parseerror' ) {
        $syn_status .= "<br />" . LJ::Lang::ml( '.syn.parseerror' ) . " " . LJ::ehtml( $u->prop( 'rssparseerror' ) );
     }
 

--- a/views/feeds/index.tt.text
+++ b/views/feeds/index.tt.text
@@ -35,6 +35,8 @@
 
 .invalid.reserved=This account name is reserved. Please choose a different one.
 
+.invalid.toolarge=The feed data exceeds the maximum allowable size of [[max]] KB.
+
 .invalid.url=The URL you've entered is invalid. Please make sure you've entered it correctly and try again.
 
 .remove=Remove Selected


### PR DESCRIPTION
Uses the same limit as the synsuck process.

Also prints a more informative error message if the feed was still too large when fetched.

Fixes #2097.