### PR TITLE
[#2095] temporarily disable LJRossia crossposts

### DIFF
--- a/cgi-bin/DW/Worker/XPostWorker.pm
+++ b/cgi-bin/DW/Worker/XPostWorker.pm
@@ -62,6 +62,10 @@ sub work {
     my $acct = DW::External::Account->get_external_account( $u, $acctid )
         or return $job->failed("Unable to load account $acctid for uid $uid");
 
+    # LJRossia is temporarily broken, so skip
+    return $job->permanent_failure( "Crossposts to LJRossia are disabled until the remote site fixes their XMLRPC protocol handler." )
+        if $acct->externalsite && $acct->externalsite->{sitename} eq 'LJRossia';
+
     my $domain = $acct->externalsite ? $acct->externalsite->{domain} : 'unknown';
 
     my $entry = LJ::Entry->new( $u, ditemid => $ditemid );

--- a/cgi-bin/DW/Worker/XPostWorker.pm
+++ b/cgi-bin/DW/Worker/XPostWorker.pm
@@ -62,9 +62,21 @@ sub work {
     my $acct = DW::External::Account->get_external_account( $u, $acctid )
         or return $job->failed("Unable to load account $acctid for uid $uid");
 
-    # LJRossia is temporarily broken, so skip
-    return $job->permanent_failure( "Crossposts to LJRossia are disabled until the remote site fixes their XMLRPC protocol handler." )
-        if $acct->externalsite && $acct->externalsite->{sitename} eq 'LJRossia';
+    my $sclient = LJ::theschwartz();
+    my $notify_fail = sub {
+        $sclient->insert_jobs(
+            LJ::Event::XPostFailure->new(
+                $u, $acctid, $ditemid, ( $_[0] || 'Unknown error message.' )
+            )->fire_job
+        );
+    };
+
+    # LJRossia is temporarily broken, so skip - but we do want to notify
+    if ( $acct->externalsite && $acct->externalsite->{sitename} eq 'LJRossia' ) {
+        my $ljr_msg = "Crossposts to LJRossia are disabled until the remote site fixes their XMLRPC protocol handler.";
+        $notify_fail->( $ljr_msg );
+        return $job->permanent_failure( $ljr_msg );
+    }
 
     my $domain = $acct->externalsite ? $acct->externalsite->{domain} : 'unknown';
 
@@ -82,7 +94,6 @@ sub work {
     my $start = [ gettimeofday ];
     my $result = $delete ? $acct->delete_entry(\%auth, $entry) : $acct->crosspost(\%auth, $entry);
 
-    my $sclient = LJ::theschwartz();
     if ($result->{success}) {
         $sclient->insert_jobs(LJ::Event::XPostSuccess->new($u, $acctid, $ditemid)->fire_job );
         DW::Stats::increment( 'dw.worker.crosspost.success', 1, [ "domain:$domain" ] );
@@ -101,11 +112,7 @@ sub work {
         }
 
         # Some other failure, so let's just let it go through.
-        $sclient->insert_jobs(
-            LJ::Event::XPostFailure->new(
-                $u, $acctid, $ditemid, ( $result->{error} || 'Unknown error message.' )
-            )->fire_job
-        );
+        $notify_fail->( $result->{error} );
         DW::Stats::increment( 'dw.worker.crosspost.failure', 1, [ "domain:$domain" ] );
         # FIXME: subroutine not implemented
         # DW::Stats::timing( 'dw.worker.crosspost.failure_time', $start, [ "domain:$domain" ] );

--- a/htdocs/manage/externalaccount.bml
+++ b/htdocs/manage/externalaccount.bml
@@ -18,7 +18,7 @@ body<=
 use strict;
 {
     use vars qw(%GET %POST $title $windowtitle $headextra @errors @warnings);
-    
+
     if ($LJ::USE_SSL && ! $LJ::IS_SSL && $FORM{ssl} ne "no") {
         my $getextra = $GET{acctid} ? "?acctid=" . LJ::eurl($GET{acctid}) : "";
         return BML::redirect("$LJ::SSLROOT/manage/externalaccount$getextra");
@@ -61,7 +61,7 @@ use strict;
             $editpage = 1;
         }
     }
-    
+
     $title = $editpage ? $ML{'.title.edit'} : $ML{'.title.new'};
 
     my $body .= qq {
@@ -86,7 +86,7 @@ use strict;
     } else {
         my @sitevalues;
         my @sites = DW::External::Site->get_xpost_sites;
-        
+
         # sort the sites for the site dropdown, but also add in the protocol
         # map for the options hide/show
         $body .= "<script type='text/javascript'>\n";
@@ -95,19 +95,19 @@ use strict;
             $body .= "siteProtocolMap[" . $site->{siteid} . "] = '" . $site->servicetype . "';\n";
         }
         $body .= "</script>\n";
-        
+
         # add the custom site option
         push @sitevalues, '-1';
         push @sitevalues, $ML{'.setting.xpost.option.site.custom'};
-        
+
         # the values for the protocol selection dropdown for custom sites
         my %protocolselectmap;
         foreach my $protocol (keys %protocols) {
             $protocolselectmap{$protocol} = $protocol;
         }
-        
+
         $body .= "<td>" . LJ::html_select({
-            name => "site", 
+            name => "site",
             onchange => "updateSiteSelection()",
             selected => $POST{site} || '2'
                                           }, @sitevalues);
@@ -116,7 +116,7 @@ use strict;
         $body .= "<br />$servicetype_errdiv\n" if $servicetype_errdiv;
 
         $body .= "<table summary='' id='customsite'>";
-    
+
         $body .= "<tr><td class='setting_label'><label for='servicetype'>" . $ML{'.setting.xpost.option.servicetype'} . "</label></td>";
         $body .= "<td>" . LJ::html_select({
             name => "servicetype",
@@ -137,7 +137,7 @@ use strict;
 
         # servicename
         $body .= "<tr class='customsite_all'><td class='setting_label'><label for='servicename'>" . $ML{'.setting.xpost.option.servicename'} . "</label></td>";
-        $body .= "<td>" . LJ::html_text({ 
+        $body .= "<td>" . LJ::html_text({
             name => "servicename",
             id => "servicename",
             value => $POST{servicename},
@@ -149,7 +149,7 @@ use strict;
         my $servicename_errdiv = errdiv(\%errs, "servicename");
         $body .= "<br />$servicename_errdiv" if $servicename_errdiv;
         $body .= "</td></tr>\n";
-        
+
         # serviceurl
         $body .= "<tr class='customsite_all'><td class='setting_label'><label for='serviceurl'>" . $ML{'.setting.xpost.option.serviceurl'} . "</label></td>";
         $body .= "<td>" . LJ::html_text({
@@ -165,7 +165,7 @@ use strict;
         $body .= "</td></tr>\n";
 
         $body .= "</table>"; # end customsite table
-        $body .= "</td></tr>\n"; # end 
+        $body .= "</td></tr>\n"; # end
     }
 
     $body .= "<tr><td class='setting_label'><label for='username'>" . $ML{'.setting.xpost.option.username'} . "</label></td>";
@@ -231,14 +231,14 @@ use strict;
         name     => "savepassword",
         value    => 1,
         id       => "savepassword",
-        selected => LJ::did_post() ? 
+        selected => LJ::did_post() ?
                       $POST{savepassword} :
                       $editpage ? $editacct->password ne "" : 1,
     });
     my $savepassword_errdiv = errdiv(\%errs, "savepassword");
     $body .= "<br />$savepassword_errdiv" if $savepassword_errdiv;
     $body .= "</td></tr>\n";
-    
+
     # put in the protocol option section for each protocol
     foreach my $protocol_id ( keys %protocols ) {
         my $protocol = $protocols{$protocol_id};
@@ -246,7 +246,7 @@ use strict;
         if ( @protocol_options ) {
             $body .= "<tbody class='protocol_options' id='" . $protocol_id . "_options'><tr><td>" . BML::ml( '.protocol.options', { protocol => $protocol->protocolid } ) . "</td>\n";
             $body .="<td>";
-            foreach my $option ( @protocol_options ) { 
+            foreach my $option ( @protocol_options ) {
                 if ( $option->{type} eq 'select' ) {
                     $body .= "<label for=" . $option->{opts}->{propid} . ">" . LJ::ehtml( $option->{description} ) . "</label>" . LJ::html_select( $option->{opts}, @{$option->{options}} ) . "</td>\n";
                 }
@@ -373,7 +373,7 @@ sub create_external_account {
         if ( $opts{siteid} ) {
             my $site = DW::External::Site->get_site_by_id( $opts{siteid} );
             $protocol = DW::External::XPostProtocol->get_protocol( $site->servicetype );
-        } else { 
+        } else {
             $protocol = DW::External::XPostProtocol->get_protocol( $opts{servicetype} );
         }
         my $options = parse_options( $protocol, $extacct_info );
@@ -391,7 +391,7 @@ sub create_external_account {
             return 0;
         }
     }
-    
+
     return $ok;
 }
 
@@ -409,7 +409,7 @@ sub account_isvalid {
         $proxyurl = "http://" . $externalsite->{domain} . "/interface/xmlrpc";
         $protocol_id = $externalsite->servicetype;
     } else {
-        $proxyurl = $extacct->{serviceurl}; 
+        $proxyurl = $extacct->{serviceurl};
         $protocol_id = $extacct->{servicetype};
     }
 

--- a/htdocs/manage/externalaccount.bml
+++ b/htdocs/manage/externalaccount.bml
@@ -91,6 +91,8 @@ use strict;
         # map for the options hide/show
         $body .= "<script type='text/javascript'>\n";
         foreach my $site (sort { $a->{sitename} cmp $b->{sitename} } @sites) {
+            # LJRossia is temporarily broken, so remove from list
+            next if $site->{sitename} eq 'LJRossia';
             push @sitevalues, $site->{siteid},  $site->{sitename};
             $body .= "siteProtocolMap[" . $site->{siteid} . "] = '" . $site->servicetype . "';\n";
         }


### PR DESCRIPTION
This removes LJRossia from the "Add External Account" form and preemptively fails any attempts to crosspost there.

It turns out that failing the job doesn't automatically notify the user, so we also make sure to send a notification to inform the user of the current situation.

Fixes #2095.