### PR TITLE
[#2096] don't include FAQs with no category in LJ::Faq->load_matching

### DIFF
--- a/cgi-bin/LJ/Faq.pm
+++ b/cgi-bin/LJ/Faq.pm
@@ -123,7 +123,7 @@ sub load_all {
     my $lang = delete $opts{lang} || $LJ::DEFAULT_LANG;
     my $faqcat = delete $opts{cat};
     my $allow_no_cat = delete $opts{allow_no_cat} || 0;
-    
+
     my $wherecat = "";
     if ( $allow_no_cat ) {
         $wherecat = "WHERE faqcat = " . $dbr->quote($faqcat) if defined $faqcat;
@@ -493,34 +493,22 @@ sub load_matching {
         or die "initial FAQ rendering failed";
 
     foreach my $f (@faqs) {
-	my $score = 0;
+        my $score = 0;
 
-	if ($f->question_raw =~ /\Q$term\E/i) {
-	    $score += 3;
-	}
-	if ($f->question_raw =~ /\b\Q$term\E\b/i) {
-	    $score += 5;
-	}
+        $score += 3 if $f->question_raw =~ /\Q$term\E/i;
+        $score += 5 if $f->question_raw =~ /\b\Q$term\E\b/i;
 
-	if ($f->summary_raw =~ /\Q$term\E/i) {
-	    $score += 2;
-	}
-	if ($f->summary_raw =~ /\b\Q$term\E\b/i) {
-	    $score += 4;
-	}
+        $score += 2 if $f->summary_raw =~ /\Q$term\E/i;
+        $score += 4 if $f->summary_raw =~ /\b\Q$term\E\b/i;
 
-	if ($f->answer_raw =~ /\Q$term\E/i) {
-	    $score += 1;
-	}
-	if ($f->answer_raw =~ /\b\Q$term\E\b/i) {
-	    $score += 3;
-	}
+        $score += 1 if $f->answer_raw =~ /\Q$term\E/i;
+        $score += 3 if $f->answer_raw =~ /\b\Q$term\E\b/i;
 
-	next unless $score;
+        next unless $score;
 
-	$scores{$f->{faqid}} = $score;
+        $scores{$f->{faqid}} = $score;
 
-	push @results, $f;
+        push @results, $f;
     }
 
     return sort { $scores{$b->{faqid}} <=> $scores{$a->{faqid}} } @results;

--- a/cgi-bin/LJ/Faq.pm
+++ b/cgi-bin/LJ/Faq.pm
@@ -479,7 +479,7 @@ sub load_matching {
     croak("unknown parameters: " . join(", ", keys %opts))
         if %opts;
 
-    my @faqs = $class->load_all( lang => $lang, allow_no_cat => 1 );
+    my @faqs = $class->load_all( lang => $lang, allow_no_cat => 0 );
     die "unable to load faqs" unless @faqs;
 
     my %scores  = (); # faqid => score


### PR DESCRIPTION
This page has the only use of this method, so changing its behavior here won't affect anything else.

Fixes #2096.