### PR TITLE
Fix redirect for query strings

### DIFF
--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -488,7 +488,7 @@ sub trans {
             ( $apache_r->method eq 'GET' || $apache_r->method eq 'HEAD' ) &&
             $remote->is_in_beta( 'httpseverywhere' ) ) {
 
-        my $url = LJ::create_url( $uri, keep_args => 1, ssl => 1 );
+        my $url = LJ::create_url( $uri, keep_query_string => 1, ssl => 1 );
         return redir( $apache_r, $url );
     }
 


### PR DESCRIPTION
Certain codepaths use querystrings that do not contain arguments and
instead are just plaintext. This codepath was only passing through valid
looking arguments. This updates it to always use the raw query string.