### PR TITLE
[#1996] change expiration email for premium paid accounts

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3509,6 +3509,34 @@ Regards,
 The [[sitename]] Team
 .
 
+shop.expiration.comm.premium.14.body<<
+Dear [[touser]],
+
+We wanted to let you know that your paid [[sitename]] community,
+[[commname]], will be expiring in two weeks.
+
+If you'd like, you can add more paid time to your community account
+here:
+
+  [[shopurl]]
+
+You currently have a premium paid account. If you want to renew your
+account with regular paid time and not premium paid time, it's best to
+let your account expire completely before you renew. If you add
+regular paid time to a premium paid account that has not yet expired,
+the regular paid time will be converted to premium paid time at our
+standard conversion rate of 70% and your new expiration date won't be
+what you expect it to be.
+
+If you don't want to renew your community's paid account, don't worry -- it'll still be there for you to use. You and your community members just
+won't have access to all of the paid account features.
+
+Thank you for supporting [[sitename]].
+
+Regards,
+The [[sitename]] Team
+.
+
 shop.expiration.comm.14.subject=[[sitename]] Account Expiration
 
 shop.expiration.comm.3.body<<
@@ -3526,6 +3554,36 @@ Your community will automatically revert to a free account in
 another three days if you don't renew. If that happens, you'll still
 be able to use it; you just won't have access to our paid features
 anymore.
+
+Thank you for supporting [[sitename]].
+
+Regards,
+The [[sitename]] Team
+.
+
+shop.expiration.comm.premium.3.body<<
+Dear [[touser]],
+
+We just wanted to remind you that your paid [[sitename]] community,
+[[commname]], will be expiring in approximately three days.
+
+You can renew your paid account in our Shop:
+
+  [[shopurl]]
+
+This is the last reminder we'll send you -- we don't want to nag!
+Your community will automatically revert to a free account in
+another three days if you don't renew. If that happens, you'll still
+be able to use it; you just won't have access to our paid features
+anymore.
+
+You currently have a premium paid account. If you want to renew your
+account with regular paid time and not premium paid time, it's best to
+let your account expire completely before you renew. If you add
+regular paid time to a premium paid account that has not yet expired,
+the regular paid time will be converted to premium paid time at our
+standard conversion rate of 70% and your new expiration date won't be
+what you expect it to be.
 
 Thank you for supporting [[sitename]].
 
@@ -3578,6 +3636,34 @@ Regards,
 The [[sitename]] Team
 .
 
+shop.expiration.user.premium.14.body<<
+Dear [[touser]],
+
+We wanted to let you know that your paid [[sitename]] account will be
+expiring in two weeks.
+
+If you'd like, you can add more paid time to your account here:
+
+  [[shopurl]]
+
+You currently have a premium paid account. If you want to renew your
+account with regular paid time and not premium paid time, it's best to
+let your account expire completely before you renew. If you add
+regular paid time to a premium paid account that has not yet expired,
+the regular paid time will be converted to premium paid time at our
+standard conversion rate of 70% and your new expiration date won't be
+what you expect it to be.
+
+If you don't want to renew your paid account, don't worry -- you can
+still keep using the site. You just won't have access to all of the
+paid account features.
+
+Thank you so much for supporting [[sitename]].
+
+Regards,
+The [[sitename]] Team
+.
+
 shop.expiration.user.14.subject=[[sitename]] Account Expiration
 
 shop.expiration.user.3.body<<
@@ -3595,6 +3681,36 @@ Your account will automatically revert to a free account in
 another three days if you don't renew. If that happens, you'll still
 be able to use it; you just won't have access to our paid features
 anymore.
+
+Thank you for supporting [[sitename]].
+
+Regards,
+The [[sitename]] Team
+.
+
+shop.expiration.user.premium.3.body<<
+Dear [[touser]],
+
+We just wanted to remind you that your paid [[sitename]] account,
+[[touser]], will be expiring in approximately three days.
+
+You can renew your paid account in our Shop:
+
+  [[shopurl]]
+
+This is the last reminder we'll send you -- we don't want to nag!
+Your account will automatically revert to a free account in
+another three days if you don't renew. If that happens, you'll still
+be able to use it; you just won't have access to our paid features
+anymore.
+
+You currently have a premium paid account. If you want to renew your
+account with regular paid time and not premium paid time, it's best to
+let your account expire completely before you renew. If you add
+regular paid time to a premium paid account that has not yet expired,
+the regular paid time will be converted to premium paid time at our
+standard conversion rate of 70% and your new expiration date won't be
+what you expect it to be.
 
 Thank you for supporting [[sitename]].
 

--- a/bin/worker/paidstatus
+++ b/bin/worker/paidstatus
@@ -25,6 +25,7 @@ use LJ::Sendmail;
 use LJ::Lang;
 use DW::Shop;
 use DW::Shop::Cart;
+use DW::Pay;
 
 
 ################################################################################
@@ -240,6 +241,11 @@ sub warn_user {
 
     DW::Stats::increment( 'dw.shop.paid_account.warn_' . $mail, 1 );
 
+    # alter warning message body for premium paid accounts
+    my $bodytype = $mail;
+    my $status = DW::Pay::get_account_type( $u );
+    $bodytype = "$status.$mail" if $status eq "premium";
+
     if ( $u->is_community ) {
         # send an email to every maintainer
         my $maintus = LJ::load_userids( $u->maintainer_userids );
@@ -249,7 +255,7 @@ sub warn_user {
                 fromname => $LJ::SITENAME,
                 from => $LJ::ACCOUNTS_EMAIL,
                 subject => LJ::Lang::ml( "shop.expiration.comm.$mail.subject", { sitename => $LJ::SITENAME } ),
-                body => LJ::Lang::ml( "shop.expiration.comm.$mail.body", {
+                body => LJ::Lang::ml( "shop.expiration.comm.$bodytype.body", {
                     touser   => $maintu->display_name,
                     commname => $u->display_name,
                     shopurl  => "$LJ::SITEROOT/shop/account?for=gift&user=" . $u->user,
@@ -263,7 +269,7 @@ sub warn_user {
             fromname => $LJ::SITENAME,
             from => $LJ::ACCOUNTS_EMAIL,
             subject => LJ::Lang::ml( "shop.expiration.user.$mail.subject", { sitename => $LJ::SITENAME } ),
-            body => LJ::Lang::ml( "shop.expiration.user.$mail.body", {
+            body => LJ::Lang::ml( "shop.expiration.user.$bodytype.body", {
                 touser => $u->display_name,
                 shopurl => "$LJ::SITEROOT/shop/account?for=self",
                 sitename => $LJ::SITENAME,


### PR DESCRIPTION
Only tested for syntax errors, but it's a relatively small change apart from the additional translation text.

Fixes #1996.