### PR TITLE
convert URL space to %20 in get_proxy_url subroutine

### DIFF
--- a/cgi-bin/DW/Proxy.pm
+++ b/cgi-bin/DW/Proxy.pm
@@ -41,6 +41,9 @@ sub get_proxy_url {
     my ( $url, %opts ) = @_;
     return undef unless $LJ::PROXY_URL && substr($url, 0, 7) eq 'http://';
 
+    # replace any space characters with %20 before calculating checksum
+    $url =~ s/ /%20/g;
+
     my $signature = DW::Proxy::get_url_signature($url);
     return undef unless $signature;
 

--- a/t/https-url.t
+++ b/t/https-url.t
@@ -43,6 +43,9 @@ my @urls = (
     # links that can be upgraded via KNOWN_HTTPS_SITES
     [ "http://xkcd.com/file/foo",  "https://xkcd.com/file/foo" ],
     [ "http://username.blogspot.com/a.png",  "https://username.blogspot.com/a.png" ],
+
+    # link that includes a space - will be transformed into %20 by the browser
+    [ "http://example.com/a%20b.png", DW::Proxy::get_proxy_url( "http://example.com/a b.png" ) ],
 );
 
 local %LJ::KNOWN_HTTPS_SITES = qw( xkcd.com 1 blogspot.com 1 );


### PR DESCRIPTION
This will change the link returned by the proxy to use %20 if the
original URL included a space, which is what most browsers will
expect.  Without this transformation, requests that changed
spaces to %20 would fail because the checksums wouldn't match.

Fixes #2134.