### PR TITLE
[#1854] improve detection of metadata headers in emailposts

### DIFF
--- a/cgi-bin/DW/EmailPost/Base.pm
+++ b/cgi-bin/DW/EmailPost/Base.pm
@@ -227,13 +227,13 @@ sub _extract_post_headers {
     my ( %post_headers, $amask );
 
     # first look for old style lj headers
-    while ( $self->{body} =~ s/^lj-(.+?):\s*(.+?)\n//is ) {
+    while ( $self->{body} =~ s/(?:^|\n)lj-(.+?):\s*(.+?)(?:$|\n)//is ) {
         $post_headers{lc($1)} = LJ::trim($2);
     }
 
     # next look for new style post headers
     # so if both are specified, this value will be retained
-    while ($self->{body} =~ s/^post-(.+?):\s*(.+?)\n//is) {
+    while ($self->{body} =~ s/(?:^|\n)post-(.+?):\s*(.+?)(?:$|\n)//is) {
         $post_headers{lc($1)} = LJ::trim($2);
     }
 

--- a/t/data/emailpost/parse-props.txt
+++ b/t/data/emailpost/parse-props.txt
@@ -1,0 +1,18 @@
+Return-Path: <${FROM_EMAIL}>
+Delivered-To: bradfitz@danga.com
+To: LJ LJ <${TEMPUSER}+${EMAILPIN}@${POSTDOMAIN}>
+Mime-Version: 1.0 (Apple Message framework v752.2)
+Message-Id: <0DA4840B-93E7-4B3C-A278-4D4D10A3EA1A@tangent.org>
+Content-Transfer-Encoding: 7bit
+From: ${FROM_EMAIL}
+Date: Mon, 1 Jan 2007 12:28:00 -0800
+X-Mailer: Apple Mail (2.752.2)
+Subject: Testing emailpost entry settings
+
+post-mood: curious
+
+post-music: Jonathan Coulton -- Code Monkey
+
+This is a test post.
+
+post-security: private

--- a/t/emailpost.t
+++ b/t/emailpost.t
@@ -16,7 +16,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 19;
+use Test::More tests => 24;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -97,6 +97,17 @@ ok($text =~ qr!http://krow\.livejournal\.com/434338\.html!, "got correct URL in 
     ok( $ok, "posted entry with long subject" );
     my $entry = LJ::Entry->new( $u, jitemid => 2 );
     is( $entry->subject_raw, "Here's an entry emailed-in with a long subject (>100 characters) which will end up being truncated s", "Entry subject truncated" );
+}
+
+{
+    my $email_post = DW::EmailPost->get_handler(get_mime("parse-props", $user_email_info));
+    my ( $ok, $msg ) = $email_post->process;
+    ok( $ok, "posted entry with custom settings" );
+    my $entry = LJ::Entry->new( $u, jitemid => 3 );
+    is ( $entry->event_raw, "This is a test post.", "Settings removed from body text" );
+    is ( $entry->security, 'private', "Entry security is correct" );
+    is ( $entry->prop( 'current_moodid' ), 56, "Entry mood is correct" );
+    is ( $entry->prop( 'current_music' ), "Jonathan Coulton -- Code Monkey", "Entry music is correct" );
 }
 
 sub get_mime {


### PR DESCRIPTION
You still can't post an entry with a blank body because the
protocol won't allow it, but you can put metadata headers
in places other than the very beginning of the body text
and have them be properly detected.

Fixes #1854.