### PR TITLE
[#2022] fix embed positioning on entry preview page

### DIFF
--- a/htdocs/preview/entry.bml
+++ b/htdocs/preview/entry.bml
@@ -322,6 +322,24 @@ _c?>
                 background-color: #ffd8d8;
                 color: #000;
             }
+            /* lj_embedcontent styling copied from lj_base.css */
+            .lj_embedcontent-wrapper {
+                overflow: hidden;
+            }
+            .lj_embedcontent-ratio {
+                position: relative;
+                height: 0;
+                /* this technique requires a padding top, but we
+                   calculate that dynamically and put it inline */
+            }
+            iframe.lj_embedcontent {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                border: 0;
+            }
             </style>
         };
 


### PR DESCRIPTION
This copies the styling for lj_embedcontent elements from lj_base.css to the inline CSS that was already being printed on the page, to minimize disruption to other page elements.

Fixes #2022.