### PR TITLE
[#2030] do check before trying to create feed account

### DIFF
--- a/cgi-bin/DW/Controller/Feeds.pm
+++ b/cgi-bin/DW/Controller/Feeds.pm
@@ -172,16 +172,21 @@ sub index_handler {
                 return error_ml( '/feeds/index.tt.invalid.notrss.text' )
                     unless $content =~ m/<(\w+:)?(?:rss|feed|RDF)/;
 
+                # before we try to create the account, make
+                # sure that the name is not already in use
+                if ( my $u = LJ::load_user( $acct ) ) {
+                    return error_ml( '/feeds/index.tt.invalid.inuse.text2',
+                                     { user => $u->ljuser_display } );
+                }
+
                 # create the feed account
                 my $synfeed =
                     LJ::User->create_syndicated(    user => $acct,
                                                  feedurl => $syn_url );
-                unless ( $synfeed ) {
-                    # if creation failed, we assume the name is already in use
-                    my $u = LJ::load_user( $acct );
-                    return error_ml( '/feeds/index.tt.invalid.inuse.text2',
-                                     { user => $u->ljuser_display } );
-                }
+
+                # we made sure the name was OK, not sure why we failed
+                return error_ml( '/feeds/index.tt.error.unknown' )
+                    unless $synfeed;
 
                 $su = LJ::Feed::synrow_select( userid => $synfeed->id );
             }


### PR DESCRIPTION
The error condition was already there; we just needed to change the order of operations so that the existence check was tested before the account creation attempt.

Fixes #2030.