### PR TITLE
[#1998] make print_global_title a hyperlink to Recent Entries

### DIFF
--- a/styles/boxesandborders/layout.s2
+++ b/styles/boxesandborders/layout.s2
@@ -145,7 +145,7 @@ function Page::print_global_title() {
     }
 
     if ($.global_title) {
-        """<h1 id="title"><span>""" + $.global_title + """</span></h1>""";
+        """<h1 id="title"><span><a href='""" + $.base_url + """'>""" + $.global_title + """</a></span></h1>""";
     }
 }
 

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -3826,7 +3826,7 @@ function Page::print_head_title()
 }
 function Page::print_global_title() {
     if ($.global_title) {
-        """<h1 id="title"><span>""" + $.global_title + """</span></h1>""";
+        """<h1 id="title"><span><a href='""" + $.base_url + """'>""" + $.global_title + """</a></span></h1>""";
     }
 }
 function FriendsPage::print_global_title() {
@@ -3834,7 +3834,7 @@ function FriendsPage::print_global_title() {
         """<h1 id="title"><span>""" + $.friends_title + """</span></h1>""";
     }
     else {
-        """<h1 id="title"><span>""" + $.global_title + """</span></h1>""";
+        """<h1 id="title"><span><a href='""" + $.base_url + """'>""" + $.global_title + """</a></span></h1>""";
     }
 }
 function Page::print_global_subtitle() {


### PR DESCRIPTION
This should modify the behavior for every page except for reading pages that use a custom title.

The Boxes and Borders layout had a customized print_global_title function that required updating as well.

Fixes #1998.