### PR TITLE
[#1778] add prev/next day links to /read?date=YYYY-MM-DD

### DIFF
--- a/cgi-bin/LJ/S2/FriendsPage.pm
+++ b/cgi-bin/LJ/S2/FriendsPage.pm
@@ -276,7 +276,7 @@ sub FriendsPage
     # these are the same for both previous and next links
     my %linkvars;
     $linkvars{show} = $get->{show} if defined $get->{show} && $get->{show} =~ /^\w+$/;
-    $linkvars{date} = $get->{date} if $get->{date};
+    $linkvars{date} = $get->{date} if $get->{date} && $u->can_use_daily_readpage;
     $linkvars{filter} = $get->{filter} + 0 if defined $get->{filter};
 
     # if we've skipped down, then we can skip back up
@@ -288,6 +288,15 @@ sub FriendsPage
         $nav->{'forward_skip'} = $newskip;
         $nav->{'forward_count'} = $itemshow;
         $p->{head_content} .= qq#<link rel="next" href="$nav->{forward_url}" />\n#;
+    } elsif ( $linkvars{date} ) {
+        # next day when viewing by date
+        my %nextvars = %linkvars;
+        my $nexttime = LJ::mysqldate_to_time( $linkvars{date} ) + 86400;
+        unless ( $nexttime > time ) {
+            $nextvars{date} = LJ::mysql_date( $nexttime );
+            $nav->{'forward_url'} = LJ::S2::make_link( $base, \%nextvars );
+            $p->{head_content} .= qq#<link rel="next" href="$nav->{forward_url}" />\n#;
+        }
     }
 
     ## unless we didn't even load as many as we were expecting on this
@@ -300,6 +309,14 @@ sub FriendsPage
         $nav->{'backward_url'} = LJ::S2::make_link( $base, \%linkvars );
         $nav->{'backward_skip'} = $newskip;
         $nav->{'backward_count'} = $itemshow;
+        $p->{head_content} .= qq#<link rel="prev" href="$nav->{backward_url}" />\n#;
+    } elsif ( $linkvars{date} ) {
+        # prev day when viewing by date
+        my %prevvars = %linkvars;
+        my $prevtime = LJ::mysqldate_to_time( $linkvars{date} ) - 86400;
+        $prevvars{date} = LJ::mysql_date( $prevtime );
+        delete $prevvars{skip};  # from forward case; not used here
+        $nav->{'backward_url'} = LJ::S2::make_link( $base, \%prevvars );
         $p->{head_content} .= qq#<link rel="prev" href="$nav->{backward_url}" />\n#;
     }
 

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -5562,18 +5562,22 @@ function RecentPage::print_body {
     <div id="entries" class="hfeed">
         <div class="inner">
             """;
-        $this->print_navigation( { "class" => "topnav" } );
+            $this->print_navigation( { "class" => "topnav" } );
 
-    foreach var Entry e ($.entries) {
-        # Print the entry
-        if ( $e isa StickyEntry ) {
-            var StickyEntry s = $e as StickyEntry;
-            $this->print_sticky_entry($s);
-        }
-        else {
-            $this->print_entry($e);
-        }
-    }
+            if (size $.entries) {
+                foreach var Entry e ($.entries) {
+                    # Print the entry
+                    if ( $e isa StickyEntry ) {
+                        var StickyEntry s = $e as StickyEntry;
+                        $this->print_sticky_entry($s);
+                    }
+                    else {
+                        $this->print_entry($e);
+                    }
+                }
+            } elseif ( $this isa FriendsPage and $.nav.backward_url != "" ) {
+                print safe "<div class=\"text_noentries text_noentries_day\">$*text_noentries_day</div>";
+            }
 
             $this->print_navigation( { "class" => "bottomnav" } );
             """
@@ -5598,13 +5602,21 @@ function RecentPage::print_navigation( string{} opts ) [fixed] {
         if ( $.nav.backward_url != "" or $.nav.forward_url != "" ) {
             "<ul>";
             if ( $.nav.backward_url != "" ) {
-                print safe """<li class="page-back"><a href="$.nav.backward_url">""" + get_plural_phrase( $.nav.backward_count, "text_skiplinks_back" ) + "</a></li>\n";
+                if ( $.nav.backward_count ) {
+                    print safe """<li class="page-back"><a href="$.nav.backward_url">""" + get_plural_phrase( $.nav.backward_count, "text_skiplinks_back" ) + "</a></li>\n";
+                } else {
+                    print safe """<li class="page-back"><a href="$.nav.backward_url">$*text_day_prev</a></li>\n""";
+                }
             }
             if ( $.nav.backward_url != "" and $.nav.forward_url != "" ) {
                 print safe """<li class="page-separator">$*text_default_separator</li>""";
             }
             if ( $.nav.forward_url != "" ) {
-                print safe """<li class="page-forward"><a href="$.nav.forward_url">""" + get_plural_phrase( $.nav.forward_count, "text_skiplinks_forward" ) + "</a></li>\n";
+                if ( $.nav.forward_count ) {
+                    print safe """<li class="page-forward"><a href="$.nav.forward_url">""" + get_plural_phrase( $.nav.forward_count, "text_skiplinks_forward" ) + "</a></li>\n";
+                } else {
+                    print safe """<li class="page-forward"><a href="$.nav.forward_url">$*text_day_next</a></li>\n""";
+                }
             }
             "</ul>";
         }


### PR DESCRIPTION
This changes the existing behavior of the Reading Page View By Date feature as follows:

- Add navigation links to Previous Day and Next Day, unless the next day would be in the future (according to GMT), or if there are more entries to view for the given day (normal skip behavior constrained by date, as before).

- Don't propagate ?date page arguments in skiplinks if the user can't use the feature (page renders normally, argument is ignored).

- Print text_noentries_day on an empty reading page if viewing by date and no entries were found for that day (according to server logtime, which again is in GMT).  We infer whether we are viewing by date by checking for usage of a backward skip link on an empty reading page.

This does NOT:

- Transition automatically from normal viewing mode at the end of the 14 day / 1000 entry limit if the user can use the feature (that's a different bug);

- Take the user's timezone into account (that's outside of scope).

Fixes #1778.