### PR TITLE
[#2159] adjust journal header styling to accommodate title links

### DIFF
--- a/styles/abstractia/layout.s2
+++ b/styles/abstractia/layout.s2
@@ -904,18 +904,19 @@ q {
 * #Header *
 ************************************************/
 
-#title, #subtitle {
+#title, #title a, #subtitle {
     $page_title_colors
-    line-height: 150%;
 }
 
 #title {
     $page_title_font
+    line-height: 150%;
     opacity: .5;
 }
 
 #subtitle {
     $page_subtitle_font
+    line-height: 150%;
     opacity: .2;
 }
 

--- a/styles/bannering/layout.s2
+++ b/styles/bannering/layout.s2
@@ -348,6 +348,8 @@ $header_spacing_css
     padding-right: 1em; }
 
 #title { font-size: large; }
+#title a { color: $*color_page_text;
+    text-decoration: none; }
 #subtitle { font-size: medium;
     font-style: italic; }
 #pagetitle { font-weight: normal;

--- a/styles/bases/layout.s2
+++ b/styles/bases/layout.s2
@@ -594,9 +594,11 @@ ul ul {list-style: circle;}
         }
 }
 
-#title { $page_title_font font-weight: bold; padding: 2em 0 0 0.65em; color: $*color_page_title; margin: 0; }
+#title, #title a, #subtitle { color: $*color_page_title; }
 
-#subtitle { $page_subtitle_font padding-left: 1.5em; color: $*color_page_title; }
+#title { $page_title_font font-weight: bold; padding: 2em 0 0 0.65em; margin: 0; }
+
+#subtitle { $page_subtitle_font padding-left: 1.5em; }
 
 #pagetitle { border-bottom: 0.083em solid $*color_page_border; font-size: 1em; padding: 0 0 1em 2.2em; margin: 0.5em 0 0 0; }
 

--- a/styles/boxesandborders/layout.s2
+++ b/styles/boxesandborders/layout.s2
@@ -265,6 +265,10 @@ body {
     padding-top: 1em;
     }
 
+#title a {
+    color: $*color_page_title;
+    }
+
 #subtitle {
     font-size: large;
     font-weight: normal;

--- a/styles/brittle/layout.s2
+++ b/styles/brittle/layout.s2
@@ -488,8 +488,8 @@ q { font-style: italic; }
     text-transform: lowercase;
 }
 
-#header {
-  color: $*color_page_title;
+#header, #header #title a {
+  color: $*color_page_text;
 }
 #header h1 {
   $journal_title_font

--- a/styles/colorside/layout.s2
+++ b/styles/colorside/layout.s2
@@ -142,6 +142,7 @@ width: 96% !important; }
     margin-bottom: 1em; }
 
 #title { font-size: x-large; }
+#title a { color: $*color_page_text; }
 #subtitle { font-size: large; }
 #pagetitle { font-size:  medium;
     font-weight: bold; }

--- a/styles/corinthian/layout.s2
+++ b/styles/corinthian/layout.s2
@@ -288,6 +288,10 @@ h1#title {
     text-transform: uppercase;
     }
 
+h1#title a {
+    color: $*color_page_title;
+    }
+
 h2#subtitle,
 h2#pagetitle {
     color: $*color_page_subtitle;

--- a/styles/crossroads/layout.s2
+++ b/styles/crossroads/layout.s2
@@ -283,6 +283,11 @@ h1, h2, h3, h4 {
     padding-right: .25em;
     }
 
+h1#title a {
+    color: $*color_page_title;
+    text-decoration: none;
+    }
+
 .tags-container h2,
 .page-archive h3,
 .page-day h3.day-date {

--- a/styles/database/layout.s2
+++ b/styles/database/layout.s2
@@ -1389,6 +1389,14 @@ h1#title {
     text-shadow: 2px 2px 2px $*color_page_title_shadow;
     }
 
+h1#title a {
+    color: $*color_page_link;
+    }
+
+h1#title a:hover {
+    text-decoration: none;
+    }
+
 h2#subtitle,
 h2#pagetitle {
     font-weight: normal;

--- a/styles/drifting/layout.s2
+++ b/styles/drifting/layout.s2
@@ -478,11 +478,15 @@ function Page::print_default_stylesheet()
         min-height: 4.7em;
     }
 
+    #header h1#title, #header h1#title a {
+        color: $*color_page_title;
+        text-decoration: none;
+    }
+
     #header h1#title {
         $page_title_font
         font-weight: bold;
         font-style: italic;
-        color: $*color_page_title;
         line-height: 0.9em;
         width: 100%;
         margin: 0;

--- a/styles/dustyfoot/layout.s2
+++ b/styles/dustyfoot/layout.s2
@@ -406,10 +406,13 @@ h2#pagetitle {
     padding: 10px;
     }
 
+#header h1#title a { color: $*color_page_title; }
 #header .module-navlinks li a { color: $*color_header_link; }
 #header .module-navlinks li a:visited { color: $*color_header_link_visited ; }
-#header .module-navlinks li a:hover { color: $*color_header_link_hover; }
-#header .module-navlinks li a:active { color: $*color_header_link_active ; }
+#header h1#title a:hover, #header .module-navlinks li a:hover {
+    color: $*color_header_link_hover; }
+#header h1#title a:active, #header .module-navlinks li a:active {
+    color: $*color_header_link_active; }
 
 /* Navigation
 ***************************************************************************/

--- a/styles/easyread/layout.s2
+++ b/styles/easyread/layout.s2
@@ -466,6 +466,11 @@ html body {
     $page_title_font
 }
 
+#header h1#title a {
+    color: $*color_page_title;
+    text-decoration: none;
+}
+
 #header h2#subtitle {
     font-style: italic;
     margin-top: 0;

--- a/styles/fantaisie/layout.s2
+++ b/styles/fantaisie/layout.s2
@@ -607,6 +607,10 @@ h1#title {
     padding: 0;
 }
 
+h1#title a {
+    text-decoration: none;
+}
+
 #header .module-navlinks ul {
     list-style: none;
     margin: 0;

--- a/styles/fiveam/layout.s2
+++ b/styles/fiveam/layout.s2
@@ -397,7 +397,7 @@ a, a:link, a:active, a:visited {
     text-transform: lowercase;
     }
 
-h1#title {
+h1#title, h1#title a {
     border-top: 2px solid $*color_header_border;
     color: $*color_page_title;
     padding-top: 1.3em;

--- a/styles/fluidmeasure/layout.s2
+++ b/styles/fluidmeasure/layout.s2
@@ -187,6 +187,9 @@ H1, H2, H3, H4, H5 { font-weight: normal; font-style: italic;}
 
 #lj_controlstrip { z-index: 200 !important;}
 
+#title a { color: $*color_page_title;
+    text-decoration: none; }
+
 #canvas { background-color: $*color_entry_title_background;
     padding: 1px;}
 #canvas > .inner:first-child { 

--- a/styles/funkycircles/layout.s2
+++ b/styles/funkycircles/layout.s2
@@ -311,6 +311,10 @@ h1#title {
     box-shadow: inset -.667em .067em .667em $*color_shadow;
     }
 
+h1#title a {
+    color: $*color_page_title;
+    }
+
 h2#subtitle,
 h2#pagetitle {
     background: transparent;

--- a/styles/goldleaf/layout.s2
+++ b/styles/goldleaf/layout.s2
@@ -2099,10 +2099,10 @@ $topnav_display
     vertical-align:top;
 }
 
-.module a { $module_link_colors }
-.module a:visited { $module_link_visited_colors }
-.module a:hover { $module_link_hover_colors }
-.module a:active { $module_link_active_colors }
+h1#title a, .module a { $module_link_colors }
+h1#title a:visited, .module a:visited { $module_link_visited_colors }
+h1#title a:hover, .module a:hover { $module_link_hover_colors }
+h1#title a:active, .module a:active { $module_link_active_colors }
 
 .module h2 {
     $module_title_font

--- a/styles/headsup/layout.s2
+++ b/styles/headsup/layout.s2
@@ -390,6 +390,11 @@ $header_margintop }
     text-align: $*image_foreground_header_alignment;
     }
 
+h1#title a {
+    color: $*color_page_title;
+    text-decoration: none;
+    }
+
 /*--- Journal Navigation ---*/
 
 .navigation {

--- a/styles/hibiscus/layout.s2
+++ b/styles/hibiscus/layout.s2
@@ -268,6 +268,7 @@ a:hover { text-decoration: underline; }
 #pagetitle { margin: 0;
     padding: .25em; }
 #title { padding-top: 0; }
+#title a { color: $*color_page_title; }
 #pagetitle { font-size: medium;
     margin-top: 1em; }
 

--- a/styles/leftovers/layout.s2
+++ b/styles/leftovers/layout.s2
@@ -133,6 +133,10 @@ div.navigation ul { display: inline; padding: 0; margin: 0; }
     margin: 0;
 }
 
+#title a {
+    color: $*color_page_title;
+}
+
 #subtitle {
     font-weight: normal;
     text-transform: lowercase;

--- a/styles/lefty/layout.s2
+++ b/styles/lefty/layout.s2
@@ -393,6 +393,10 @@ padding: 0.625em 1.25em 0.625em 4.5em;
 margin:0;
 }
 
+#header h1 a {
+color: $*color_page_title;
+}
+
 #header h2 {
 text-decoration: none;
 display: inline-block;

--- a/styles/librariansdream/layout.s2
+++ b/styles/librariansdream/layout.s2
@@ -391,6 +391,11 @@ body {
     padding: .15em 0;
 }
 
+#header h1 a {
+    color: $*color_page_title;
+    text-decoration: none;
+}
+
 .one-column #header .module-navlinks {width:100%;}
 
 /* entry */

--- a/styles/lineup/layout.s2
+++ b/styles/lineup/layout.s2
@@ -241,6 +241,10 @@ h1#title {
     text-transform: uppercase;
     }
 
+h1#title a {
+    color: $*color_page_title;
+    }
+
 h2#subtitle,
 h2#pagetitle {
     color: $*color_page_title;

--- a/styles/marginless/layout.s2
+++ b/styles/marginless/layout.s2
@@ -220,6 +220,11 @@ H1, H2, H3 {
     margin: 0;
 }
 
+h1#title a {
+    color: $*color_page_title;
+    text-decoration: none;
+}
+
 blockquote {
     font-style: italic;
     padding: 1em 1em .5em 2em;

--- a/styles/modish/layout.s2
+++ b/styles/modish/layout.s2
@@ -73,6 +73,11 @@ body {
     font-style: italic;
     font-weight: normal; }
 
+#title a,
+#title a:visited { color: $*color_page_title;
+    text-decoration: none; }
+#title a:hover { text-decoration: underline; }
+
 
 /* main column */
 

--- a/styles/modular/layout.s2
+++ b/styles/modular/layout.s2
@@ -191,6 +191,11 @@ h1, h2, h3, h4 {
     font-family: $*font_journal_title;
     }
 
+h1#title a {
+    color: $*color_page_title;
+    }
+
+h1#title a,
 .entry-title a,
 .comment-title a { text-decoration: none; }
 

--- a/styles/nouveauoleanders/layout.s2
+++ b/styles/nouveauoleanders/layout.s2
@@ -584,6 +584,10 @@ body {
         margin-right: 200px;
         }
 
+    #title a {
+        color: $*color_page_title;
+        }
+
     #subtitle, #pagetitle {
         margin-left: 2em;
         margin-right: 2em;

--- a/styles/paletteable/layout.s2
+++ b/styles/paletteable/layout.s2
@@ -244,6 +244,11 @@ dl dt {
     padding: .5em 1em;
     }
 
+#header a {
+    color: $*color_page_title;
+    text-decoration: none;
+    }
+
 /*--- Journal Navigation ---*/
 
 .navigation {

--- a/styles/patsy/layout.s2
+++ b/styles/patsy/layout.s2
@@ -308,6 +308,10 @@ h1#title {
     padding: 0;
     margin: 0; }
 
+h1#title a {
+    color: $*color_page_title;
+    }
+
 h2#subtitle {
     font-weight: normal;
     text-transform: lowercase;

--- a/styles/pattern/layout.s2
+++ b/styles/pattern/layout.s2
@@ -600,19 +600,19 @@ hr,
     padding: .5em 0;
 }
 
-#header h1 {
+#header h1, #header h2 {
     font-style: italic;
     margin: 0;
     padding: 0;
     text-transform: lowercase;
 }
 
+#header h1 a {
+    text-decoration: none;
+}
+
 #header h2 {
-    font-style: italic;
     line-height: 1em;
-    margin: 0;
-    padding: 0;
-    text-transform: lowercase;
 }
 
 $header_css

--- a/styles/planetcaravan/layout.s2
+++ b/styles/planetcaravan/layout.s2
@@ -415,7 +415,11 @@ a:hover {text-decoration:underline;}
     text-align:center;
     }
 
-h1#title {font-weight: normal; letter-spacing: .1em;}
+h1#title, h1#title a {
+    font-weight: normal;
+    letter-spacing: .1em;
+    color: $*color_page_title;
+}
 
 h2#pagetitle, h2#subtitle {font-weight: normal; padding:.25em; margin:0; color: $*color_journal_subtitle; letter-spacing: .1em;}
 

--- a/styles/practicality/layout.s2
+++ b/styles/practicality/layout.s2
@@ -285,7 +285,8 @@ ol {
     padding: .1em .5em;
     }
 
-h1#title {
+h1#title, h1#title a {
+    color: $*color_page_title;
     font-variant: small-caps;
     text-align: right;
     }

--- a/styles/refriedtablet/layout.s2
+++ b/styles/refriedtablet/layout.s2
@@ -204,8 +204,10 @@ h2#subtitle {
     padding-bottom: 0;
 }
 
-h1#title {
+h1#title, h1#title a {
     line-height: 1em;
+    color: $*color_page_title;
+    text-decoration: none;
 }
 
 h1#title:after {

--- a/styles/seamless/layout.s2
+++ b/styles/seamless/layout.s2
@@ -373,6 +373,10 @@ function print_stylesheet () {
         font-weight: lighter; 
         }
 
+        h1#title a {
+        color: $*color_page_title;
+        }
+
         h2#subtitle { 
         letter-spacing: -0.07em;
         color: $*color_page_subtitle;     

--- a/styles/skittlishdreams/layout.s2
+++ b/styles/skittlishdreams/layout.s2
@@ -702,10 +702,11 @@ html body {
 
 /*--- Header ---*/
 
-#header {
+#header, #header a {
     $header_colors
     border-bottom: 2px solid $header_bottom_color;
     padding: 0;
+    text-decoration: none;
     }
 
 @media $medium_media_query {

--- a/styles/snakesandboxes/layout.s2
+++ b/styles/snakesandboxes/layout.s2
@@ -349,6 +349,10 @@ input, select {
     padding: 1em;
 }
 
+h1#title a {
+    color: $*color_page_title;
+    }
+
 h1#title,
 h2#pagetitle,
 h2#subtitle {

--- a/styles/steppingstones/layout.s2
+++ b/styles/steppingstones/layout.s2
@@ -168,6 +168,11 @@ dl dt { font-weight: bold; }
     padding: .5em 1em;
     }
 
+#title a {
+    color: $*color_page_title;
+    text-decoration: none;
+    }
+
 #pagetitle {
     font-size: large;
     text-align: right;

--- a/styles/strata/layout.s2
+++ b/styles/strata/layout.s2
@@ -122,6 +122,10 @@ h1#title, h2#subtitle, h2#pagetitle {
     text-align: right;
 }
 
+h1#title a {
+    color: $*color_page_title;
+    }
+
 /* -- primary -- */
 #content { padding: 20px 0; }
 

--- a/styles/summertime/layout.s2
+++ b/styles/summertime/layout.s2
@@ -630,7 +630,12 @@ h2#pagetitle {
     padding: 0 1.5px 0;
 }
 
-#header a {
+#header-primary a {
+    color: $*color_page_title;
+    text-decoration: none;
+    }
+
+#header-secondary a {
     background-color: $*color_header_icons_background;
     background-repeat: no-repeat;
     border-radius: 50%;
@@ -644,8 +649,8 @@ h2#pagetitle {
     width: 45px;
 }
 
-#header a.current,
-#header a:hover {
+#header-secondary a.current,
+#header-secondary a:hover {
     background-color: $*color_header_icons_background_alt;
     transition: all .65s ease-out;
     -moz-transition: all .65s ease-out;
@@ -653,73 +658,73 @@ h2#pagetitle {
     -webkit-transition: all .65s ease-out;
 }
 
-#header a:hover {
+#header-secondary a:hover {
     transform: rotate(360deg);
     -moz-transform: rotate(360deg);
     -o-transform: rotate(360deg);
     -webkit-transform: rotate(360deg);
 }
 
-#header a.recent {
+#header-secondary a.recent {
     background-image: url($*image_recent) ;
 }
 
-#header a.current.recent,
-#header a.recent:hover {
+#header-secondary a.current.recent,
+#header-secondary a.recent:hover {
     background-image: url($*image_recent_alt);
 }
 
-#header a.archive {
+#header-secondary a.archive {
     background-image: url($*image_archive);
 }
 
-#header a.current.archive,
-#header a.archive:hover {
+#header-secondary a.current.archive,
+#header-secondary a.archive:hover {
     background-image: url($*image_archive_alt);
 }
 
-#header a.read {
+#header-secondary a.read {
     background-image: url($*image_reading);
 }
 
-#header a.current.read,
-#header a.read:hover {
+#header-secondary a.current.read,
+#header-secondary a.read:hover {
     background-image: url($*image_reading_alt);
 }
 
-#header a.network {
+#header-secondary a.network {
     background-image: url($*image_network);
 }
 
-#header a.current.network,
-#header a.network:hover {
+#header-secondary a.current.network,
+#header-secondary a.network:hover {
     background-image: url($*image_network_alt);
 }
 
-#header a.tags {
+#header-secondary a.tags {
     background-image: url($*image_tags);
 }
 
-#header a.current.tags,
-#header a.tags:hover {
+#header-secondary a.current.tags,
+#header-secondary a.tags:hover {
     background-image: url($*image_tags_alt);
 }
 
-#header a.memories {
+#header-secondary a.memories {
     background-image: url($*image_memories);
 }
 
-#header a.current.memories,
-#header a.memories:hover {
+#header-secondary a.current.memories,
+#header-secondary a.memories:hover {
     background-image: url($*image_memories_alt);
 }
 
-#header a.userinfo {
+#header-secondary a.userinfo {
     background-image: url($*image_profile);
 }
 
-#header a.current.userinfo,
-#header a.userinfo:hover {
+#header-secondary a.current.userinfo,
+#header-secondary a.userinfo:hover {
     background-image: url($*image_profile_alt);
 }
 

--- a/styles/tectonic/layout.s2
+++ b/styles/tectonic/layout.s2
@@ -456,6 +456,10 @@ h2#subtitle {
     text-transform: uppercase;
     }
 
+h1#title a {
+    color: $*color_page_title;
+    }
+
 /*--- Journal Navigation ---*/
 
 .navigation {

--- a/styles/tranquilityiii/layout.s2
+++ b/styles/tranquilityiii/layout.s2
@@ -137,6 +137,10 @@ dl dt { font-weight: bold; }
     margin: 1em;
     }
 
+#title a {
+    color: $*color_page_title;
+    }
+
 #title,
 #subtitle,
 #pagetitle {


### PR DESCRIPTION
For most styles, the only adjustment needed was to reapply color_page_title to the header link.  For styles that didn't define color_page_title, I used color_page_text instead.  (This fixed a bug in Brittle, which was using an undefined color_page_title.)

I also removed underlining of links where appropriate.  I did my best to blend my changes in with the existing style.

Some styles needed no adjustment.  These were in the minority.

The style that needed the most attention was Summertime.  I added new basic styling for `#header-primary a` and moved the existing styling for `#header a` to `#header-secondary a`.

Fixes #2159.