### PR TITLE
Adds missing space to the .message.explicit.communityreasons string.

### DIFF
--- a/views/journal/adult_content.tt.text
+++ b/views/journal/adult_content.tt.text
@@ -39,7 +39,7 @@
 
 .message.explicit.bycommunity=You're about to view content that community administrators on [[journal]] have marked as <strong>inappropriate for anyone under the age of 18</strong>. To continue, you must confirm that you're at least 18 years of age.
 
-.message.explicit.communityreason=[[journal]] provided the following reason for this community being marked"suitable for 18+": <strong>[[reason]]</strong>.
+.message.explicit.communityreason=[[journal]] provided the following reason for this community being marked "suitable for 18+": <strong>[[reason]]</strong>.
 
 .message.explicit.journalreason=[[journal]] provided the following reason for this journal being marked "suitable for 18+": <strong>[[reason]]</strong>.
 


### PR DESCRIPTION
Fixes #2172.

I *think* I've remembered how to edit strings, but It's Been A While so please tell me if I've screwed up/should be putting stuff in deadphrases/etc.