### PR TITLE
Remove IP::Country::Fast from checkconfig.pl (fixes #2179)

### DIFF
--- a/bin/checkconfig.pl
+++ b/bin/checkconfig.pl
@@ -192,9 +192,6 @@ my %modules = (
         'deb' => 'libmail-gnupg-perl',
         'opt' => "Required for email posting.",
     },
-    "IP::Country::Fast" => {
-        'opt' => "Required for country lookup with IP address.",
-    },
     "GTop" => {},
     "Apache2::RequestRec"   => {
         'deb' => "libapache2-mod-perl2",


### PR DESCRIPTION
A nice, easy fix for #2179 to remind myself how this stuff works.