### PR TITLE
Use the right CSS property in FAQ css (fixes #1886)

### DIFF
--- a/htdocs/stc/faq.css
+++ b/htdocs/stc/faq.css
@@ -1,5 +1,5 @@
 #faq ul, #faq ol {
     margin-left: 3em;
     margin-bottom: 2em;
-    list-style-type: outside;
+    list-style-position: outside;
 }


### PR DESCRIPTION
'outside' is a list-style-position, not a list-style-type.  This seems
to result in certain versions of certain browsers displaying unordered
lists as though they were ordered lists, which is less than ideal.

Hopefully fixes #1886