### PR TITLE
Add S3 support to BlobStore

### DIFF
--- a/bin/checkconfig.pl
+++ b/bin/checkconfig.pl
@@ -296,6 +296,9 @@ my %modules = (
     "Text::Wrap" => {
         ver => '2013.0523', # issue #1447
     },
+    "Moose" => {
+        opt => "Used for BlobStore support of S3",
+    },
 );
 
 

--- a/bin/upgrading/migrate-mogilefs.pl
+++ b/bin/upgrading/migrate-mogilefs.pl
@@ -26,72 +26,121 @@ use MogileFS::Client;
 
 use DW::BlobStore;
 
-my ( $nextfid, $endfid, $conf );
+use constant BLOCK_SIZE => 1_000;
+
+my ( $startfid, $endfid, $max_workers, $conf );
 GetOptions(
-    'start-fid=i'       => \$nextfid,
+    'start-fid=i'       => \$startfid,
     'end-fid=i'         => \$endfid,
+    'num-workers=i'     => \$max_workers,
     'mogilefs-config=s' => \$conf,
 );
-$nextfid ||= 0;
+$startfid ||= 0;
 $endfid ||= 1_000_000_000;
+$max_workers ||= 10;
 
 die "Must provide valid --mogilefs-config=FILEPATH argument.\n"
     unless $conf && -e $conf;
 
-my $dbh = get_mogilefs_dbh();
 my $mogc = get_mogilefs_client();
 
-# Main loop; just get some files and do cool things with them. In essence we're just getting
-# them from MogileFS and storing them to BlobStore.
-while ( 1 ) {
-    my $files = get_some_files( $dbh, $nextfid+1, $endfid );
-    if ( ! defined $files ) {
-        say "Looks like we're done, good-bye!";
-        exit;
-    }
+my $queue = [];
+my $cur_workers = 0;
+my $num_workers = 0;
+my $enqueued = 0;
+while ( $startfid <= $endfid ) {
+    my $files = get_files( $startfid, $startfid + ( BLOCK_SIZE - 1 ) );
+    $startfid += BLOCK_SIZE;
+    next unless $files;
 
     foreach my $fid ( keys %$files ) {
-        $nextfid = $fid if $fid > $nextfid;
+        $enqueued++;
+        push @$queue, $files->{$fid};
+        next if scalar @$queue < BLOCK_SIZE;
+
+        $0 = sprintf( 'migrate-mogilefs: enqueued %d, workers %d',
+                $enqueued, $num_workers );
+
+        if ( $cur_workers >= $max_workers ) {
+            wait;
+            $cur_workers--;
+        }
+
+        make_worker( $queue );
+
+        $num_workers++;
+        $cur_workers++;
+        $queue = [];
+    }
+}
+
+if ( $queue && @$queue ) {
+    make_worker( $queue );
+    $cur_workers++;
+}
+
+while ( $cur_workers > 0 ) {
+    wait;
+    $cur_workers--;
+}
+say "All done.";
+
+sub make_worker {
+    my $queue = $_[0];
+
+    if ( my $pid = fork ) {
+        return;
+    }
+
+    my $pos = 0;
+    my $llen = scalar @$queue;
+    foreach my $file ( @$queue ) {
+        $pos++;
+        $0 = sprintf( 'migrate-mogilefs [%d/%d] = %0.2f%%',
+            $pos, $llen, 100*($pos/$llen) );
 
         # Quick check to make sure this file isn't already in BlobStore
-        if ( DW::BlobStore->exists( $files->{$fid}->{class} => $files->{$fid}->{key} ) ) {
-            say "$fid: OK EXISTS";
+        if ( DW::BlobStore->exists( $file->{class} => $file->{key} ) ) {
+            say "$file->{fid}: OK EXISTS";
             next;
         }
 
-        my $data = $mogc->get_file_data( $files->{$fid}->{key} );
+        my $data = $mogc->get_file_data( $file->{key} );
         unless ( $data ) {
-            say "$fid: ERR NODATA";
+            say "$file->{fid}: ERR NODATA";
             next;
         }
 
         my $size = length $$data;
-        unless ( $size == $files->{$fid}->{size} ) {
-            say "$fid: ERR WRONGSIZE $size $files->{$fid}->{size}";
+        unless ( $size == $file->{size} ) {
+            say "$file->{fid}: ERR WRONGSIZE $size $file->{size}";
             next;
         }
 
         # It's a file and the length is write, let's store it to BlobStore with the
         # right data...
-        my $rv = DW::BlobStore->store( $files->{$fid}->{class} => $files->{$fid}->{key}, $data );
+        my $rv = DW::BlobStore->store( $file->{class} => $file->{key}, $data );
         if ( $rv ) {
-            say "$fid: OK STORE";
+            say "$file->{fid}: OK STORE";
         } else {
-            say "$fid: ERR STORE";
+            say "$file->{fid}: ERR STORE";
         }
     }
+
+    exit;
 }
 
-sub get_some_files {
-    my ( $dbh, $start_fid, $end_fid ) = @_;
+sub get_files {
+    my ( $start_fid, $end_fid ) = @_;
+
+    my $dbh = get_mogilefs_dbh();
 
     my $rows = $dbh->selectall_arrayref(
         q{SELECT f.fid, f.dkey, f.length, d.namespace, c.classname
           FROM file f, domain d, class c
-          WHERE f.fid >= ? AND f.fid < ? AND
+          WHERE f.fid >= ? AND f.fid <= ? AND
                 d.dmid = f.dmid AND c.dmid = f.dmid AND c.classid = f.classid
-          ORDER BY f.fid
-          LIMIT 100},
+        },
         undef, $start_fid, $end_fid,
     );
     return undef unless $rows && scalar @$rows;
@@ -99,6 +148,7 @@ sub get_some_files {
     my $out = {};
     foreach my $row ( @$rows ) {
         $out->{$row->[0]} = {
+            fid    => $row->[0],
             key    => $row->[1],
             size   => $row->[2],
             domain => $row->[3],
@@ -127,11 +177,11 @@ sub get_mogilefs_dbh {
 
 sub get_mogilefs_client {
     my $mogclient = MogileFS::Client->new(
-		domain   => $LJ::MOGILEFS_CONFIG{domain},
-		root     => $LJ::MOGILEFS_CONFIG{root},
-		hosts    => $LJ::MOGILEFS_CONFIG{hosts},
-		timeout  => $LJ::MOGILEFS_CONFIG{timeout},
-	)
+       domain   => $LJ::MOGILEFS_CONFIG{domain},
+       root     => $LJ::MOGILEFS_CONFIG{root},
+       hosts    => $LJ::MOGILEFS_CONFIG{hosts},
+       timeout  => $LJ::MOGILEFS_CONFIG{timeout},
+   )
         or die "Failed to create MogileFS::Client!\n";
     return $mogclient;
 }

--- a/bin/upgrading/migrate-mogilefs.pl
+++ b/bin/upgrading/migrate-mogilefs.pl
@@ -1,0 +1,137 @@
+#!/usr/bin/perl
+#
+# bin/upgrading/migrate-mogilefs.pl
+#
+# Move files out of a MogileFS cluster and into the current BlobStore
+# primary storage.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2017 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use v5.10;
+use strict;
+BEGIN { require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+use Carp qw/ croak /;
+use DBI;
+use Getopt::Long;
+use MogileFS::Client;
+
+use DW::BlobStore;
+
+my ( $nextfid, $endfid, $conf );
+GetOptions(
+    'start-fid=i'       => \$nextfid,
+    'end-fid=i'         => \$endfid,
+    'mogilefs-config=s' => \$conf,
+);
+$nextfid ||= 0;
+$endfid ||= 1_000_000_000;
+
+die "Must provide valid --mogilefs-config=FILEPATH argument.\n"
+    unless $conf && -e $conf;
+
+my $dbh = get_mogilefs_dbh();
+my $mogc = get_mogilefs_client();
+
+# Main loop; just get some files and do cool things with them. In essence we're just getting
+# them from MogileFS and storing them to BlobStore.
+while ( 1 ) {
+    my $files = get_some_files( $dbh, $nextfid+1, $endfid );
+    if ( ! defined $files ) {
+        say "Looks like we're done, good-bye!";
+        exit;
+    }
+
+    foreach my $fid ( keys %$files ) {
+        $nextfid = $fid if $fid > $nextfid;
+
+        # Quick check to make sure this file isn't already in BlobStore
+        if ( DW::BlobStore->exists( $files->{$fid}->{class} => $files->{$fid}->{key} ) ) {
+            say "$fid: OK EXISTS";
+            next;
+        }
+
+        my $data = $mogc->get_file_data( $files->{$fid}->{key} );
+        unless ( $data ) {
+            say "$fid: ERR NODATA";
+            next;
+        }
+
+        my $size = length $$data;
+        unless ( $size == $files->{$fid}->{size} ) {
+            say "$fid: ERR WRONGSIZE $size $files->{$fid}->{size}";
+            next;
+        }
+
+        # It's a file and the length is write, let's store it to BlobStore with the
+        # right data...
+        my $rv = DW::BlobStore->store( $files->{$fid}->{class} => $files->{$fid}->{key}, $data );
+        if ( $rv ) {
+            say "$fid: OK STORE";
+        } else {
+            say "$fid: ERR STORE";
+        }
+    }
+}
+
+sub get_some_files {
+    my ( $dbh, $start_fid, $end_fid ) = @_;
+
+    my $rows = $dbh->selectall_arrayref(
+        q{SELECT f.fid, f.dkey, f.length, d.namespace, c.classname
+          FROM file f, domain d, class c
+          WHERE f.fid >= ? AND f.fid < ? AND
+                d.dmid = f.dmid AND c.dmid = f.dmid AND c.classid = f.classid
+          ORDER BY f.fid
+          LIMIT 100},
+        undef, $start_fid, $end_fid,
+    );
+    return undef unless $rows && scalar @$rows;
+
+    my $out = {};
+    foreach my $row ( @$rows ) {
+        $out->{$row->[0]} = {
+            key    => $row->[1],
+            size   => $row->[2],
+            domain => $row->[3],
+            class  => $row->[4],
+        };
+    }
+    return $out;
+}
+
+sub get_mogilefs_dbh {
+    my %config;
+    open FILE, "<$conf" or die;
+    foreach my $line ( <FILE> ) {
+        my ( $key, $val ) = ( $1, $2 )
+            if $line =~ /^db_(\w+)\s*=\s*(.+?)$/;
+        next unless $key && $val;
+
+        $config{$key} = $val;
+    }
+    close FILE;
+
+    my $dbh = DBI->connect($config{dsn}, $config{user}, $config{pass})
+        or die "Failed to connect to MogileFS.\n";
+    return $dbh;
+}
+
+sub get_mogilefs_client {
+    my $mogclient = MogileFS::Client->new(
+		domain   => $LJ::MOGILEFS_CONFIG{domain},
+		root     => $LJ::MOGILEFS_CONFIG{root},
+		hosts    => $LJ::MOGILEFS_CONFIG{hosts},
+		timeout  => $LJ::MOGILEFS_CONFIG{timeout},
+	)
+        or die "Failed to create MogileFS::Client!\n";
+    return $mogclient;
+}

--- a/bin/upgrading/migrate-userpics.pl
+++ b/bin/upgrading/migrate-userpics.pl
@@ -83,8 +83,8 @@ ERRMSG
 }
 
 # make sure ljconfig is setup right (or so we hope)
-die "Please define \%LJ::BLOBSTORE in your site config\n"
-    unless %LJ::BLOBSTORE && scalar keys %LJ::BLOBSTORE;
+die "Please define \@LJ::BLOBSTORES in your site config\n"
+    unless @LJ::BLOBSTORES && scalar @LJ::BLOBSTORES;
 
 # setup stderr if we're in best effort mode
 if ($besteffort) {

--- a/cgi-bin/DW/BlobStore.pm
+++ b/cgi-bin/DW/BlobStore.pm
@@ -56,7 +56,7 @@ sub _get_blobstores {
         } elsif ( $name eq 's3' ) {
             push @{$blobstores ||= []}, DW::BlobStore::S3->init( %$config );
         } else {
-            $log->logcroack( 'Invalid blobstore type: ' . $name );
+            $log->logcroak( 'Invalid blobstore type: ' . $name );
         }
 
         $idx += 2;

--- a/cgi-bin/DW/BlobStore/LocalDisk.pm
+++ b/cgi-bin/DW/BlobStore/LocalDisk.pm
@@ -24,6 +24,8 @@ my $log = Log::Log4perl->get_logger( __PACKAGE__ );
 
 use Digest::MD5 qw/ md5_hex /;
 
+sub type { 'localdisk' }
+
 sub init {
 	my ( $class, %args ) = @_;
 	$log->logcroak( 'LocalDisk configuration must include "path" element.' )

--- a/cgi-bin/DW/BlobStore/MogileFS.pm
+++ b/cgi-bin/DW/BlobStore/MogileFS.pm
@@ -25,17 +25,17 @@ my $log = Log::Log4perl->get_logger( __PACKAGE__ );
 use Digest::MD5 qw/ md5_hex /;
 
 sub init {
-	my $class = $_[0];
+	my ( $class, %args ) = @_;
 
     eval 'use MogileFS::Client;';
     $log->logcroak( "Couldn't load MogileFS: $@" )
     	if $@;
 
     my $mogclient = MogileFS::Client->new(
-		domain   => $LJ::MOGILEFS_CONFIG{domain},
-		root     => $LJ::MOGILEFS_CONFIG{root},
-		hosts    => $LJ::MOGILEFS_CONFIG{hosts},
-		timeout  => $LJ::MOGILEFS_CONFIG{timeout},
+		domain   => $args{domain},
+		root     => $args{root},
+		hosts    => $args{hosts},
+		timeout  => $args{timeout},
 	) or $log->logcroak( 'Could not initialize MogileFS' );
 
 	$log->debug( 'Initialized MogileFS blobstore' );

--- a/cgi-bin/DW/BlobStore/MogileFS.pm
+++ b/cgi-bin/DW/BlobStore/MogileFS.pm
@@ -24,6 +24,8 @@ my $log = Log::Log4perl->get_logger( __PACKAGE__ );
 
 use Digest::MD5 qw/ md5_hex /;
 
+sub type { 'mogilefs' }
+
 sub init {
 	my ( $class, %args ) = @_;
 

--- a/cgi-bin/DW/BlobStore/S3.pm
+++ b/cgi-bin/DW/BlobStore/S3.pm
@@ -7,7 +7,7 @@
 # Authors:
 #     Mark Smith <mark@dreamwidth.org>
 #
-# Copyright (c) 2016 by Dreamwidth Studios, LLC.
+# Copyright (c) 2016-2017 by Dreamwidth Studios, LLC.
 #
 # This program is free software; you may redistribute it and/or modify it under
 # the same terms as Perl itself.  For a copy of the license, please reference
@@ -21,5 +21,156 @@ use v5.10;
 use Log::Log4perl;
 my $log = Log::Log4perl->get_logger( __PACKAGE__ );
 
+use Digest::MD5 qw/ md5_hex /;
+use Paws;
+use Paws::Credential::InstanceProfile;
+
+sub init {
+    my ( $class, %args ) = @_;
+
+    foreach my $required ( qw/ access_key secret_key region prefix bucket / ) {
+        $log->logcroak( 'S3 configuration must include config: ', $required )
+            unless exists $args{$required};
+    }
+
+    $log->logcroak( 'Prefix does not match required regex: [a-zA-Z0-9_-]+$.' )
+        if defined $args{prefix} && $args{prefix} !~ /^[a-zA-Z0-9_-]+$/;
+
+    my $credentials = Paws::Credential::InstanceProfile->new;
+    if ( defined $args{access_key} && defined $args{secret_key} ) {
+        $log->warning( 'Using INSECURE AWS configuration!' );
+        $credentials = Paws::Credential::Local->new(
+            access_key => $args{access_key},
+            secret_key => $args{secret_key},
+        );
+    }
+
+    my $paws = Paws->new(
+        config => {
+            credentials => $credentials,
+            region      => $args{region},
+        },
+    )
+        or $log->logcroak('Failed to initialize Paws object.');
+    my $s3 = $paws->service('S3')
+        or $log->logcroak('Failed to initialize Paws::S3 object.');
+
+    $log->debug( "Initializing blobstore for S3" );
+    my $self = {
+        s3     => $s3,
+        bucket => $args{bucket},
+        prefix => $args{prefix}
+    };
+    return bless $self, $class;
+}
+
+sub get_location_for_key {
+    my ( $self, $namespace, $key ) = @_;
+
+    # Hash the key, we create two layers of directory structure so the files
+    # spread across 256^2 directories
+    my $hash = md5_hex( $key );
+
+    # Create the fully qualified path including optional configured prefix
+    my $fqfn =
+        ( defined $self->{prefix} ? $self->{prefix} . '/' : '' ) .
+        $namespace . '/' .
+        substr( $hash, 0, 2 ) . '/' .
+        substr( $hash, 2, 2 ) . '/' .
+        $hash;
+    $log->debug( "($namespace, $key) => $fqfn" );
+    return $fqfn;
+}
+
+sub store {
+    my ( $self, $namespace, $key, $blobref ) = @_;
+    $log->logcroak( 'Unable to store empty file.' )
+        unless defined $$blobref && length $$blobref;
+    my $fqfn = $self->get_location_for_key( $namespace, $key );
+
+    my $res = eval { $self->{s3}->PutObject(
+        Bucket => $self->{bucket},
+        Key    => $fqfn,
+        Body   => $$blobref,
+    ) };
+    if ( $@ && $@->isa( 'Paws::Exception' ) ) {
+        $log->error( "Failed to store to ( $namespace, $key ): " . $@->message );
+        return 0;
+    }
+
+    $log->debug( "Wrote ", length $$blobref, " bytes to: $fqfn" );
+    return 1;
+}
+
+sub exists {
+    my ( $self, $namespace, $key ) = @_;
+    my $fqfn = $self->get_location_for_key( $namespace, $key );
+
+    my $res = eval { $self->{s3}->HeadObject(
+        Bucket => $self->{bucket},
+        Key    => $fqfn,
+    ) };
+    if ( $@ && $@->isa( 'Paws::Exception' ) ) {
+        $log->error( "Failed to check exists on ( $namespace, $key ): ", $@->message );
+        return 0;
+    }
+
+    $log->debug( 'Found path exists in S3: ', $fqfn );
+    return 1;
+}
+
+sub retrieve {
+    my ( $self, $namespace, $key ) = @_;
+    my $fqfn = $self->get_location_for_key( $namespace, $key );
+
+    my $res = eval { $self->{s3}->GetObject(
+        Bucket => $self->{bucket},
+        Key    => $fqfn,
+    ) };
+    if ( $@ && $@->isa( 'Paws::Exception' ) ) {
+        $log->error( "Failed to retrieve from ( $namespace, $key ): " . $@->message );
+        return undef;
+    }
+    return \$res->Body;
+}
+
+sub delete {
+    my ( $self, $namespace, $key ) = @_;
+    my $fqfn = $self->get_location_for_key( $namespace, $key );
+
+    my $res = eval { $self->{s3}->DeleteObject(
+        Bucket => $self->{bucket},
+        Key    => $fqfn,
+    ) };
+    if ( $@ && $@->isa( 'Paws::Exception' ) ) {
+        $log->error( "Failed to delete ( $namespace, $key ): ", $@->message );
+        return 0;
+    }
+
+    $log->debug( 'Deleted path from S3: ', $fqfn );
+    return 1;
+}
+
+
+################################################################################
+#
+# Paws::Credential::Local
+#
+# Implements the Paws::Credential role for passing in the access credentials
+# directly. You would think this would be a default package supplied
+# by the library...
+#
+
+package Paws::Credential::Local;
+
+use Moose;
+
+has access_key => (is => 'ro');
+has secret_key => (is => 'ro');
+has session_token => (is => 'ro', default => sub { undef });
+
+with 'Paws::Credential';
+
+no Moose;
 
 1;

--- a/cgi-bin/DW/BlobStore/S3.pm
+++ b/cgi-bin/DW/BlobStore/S3.pm
@@ -25,6 +25,8 @@ use Digest::MD5 qw/ md5_hex /;
 use Paws;
 use Paws::Credential::InstanceProfile;
 
+sub type { 's3' }
+
 sub init {
     my ( $class, %args ) = @_;
 

--- a/etc/config-private.pl
+++ b/etc/config-private.pl
@@ -86,11 +86,11 @@
     %OFFICIAL_JOURNALS = (
         news => 1,
     );
-    
+
     # the "news" journal, to be specially displayed on the front page, etc
     $NEWS_JOURNAL = "news";
 
-    # temporary config variables to trigger special import workflow, in the form of 
+    # temporary config variables to trigger special import workflow, in the form of
     #    username => 1
     # turned on for the duration of the import
     # %LJ::ALLOW_COMM_IMPORT = (
@@ -171,8 +171,37 @@
     # sites/single servers, the localdisk mode is useful. For production
     # systems S3 should be used.
     # %BLOBSTORE = (
+    #     # Local disk configuration, can be used to store everything on one machine
     #     localdisk => {
     #         path => "$LJ::HOME/var/blobstore",
+    #     },
+    #
+    #     # S3 configuration, requires separate setup and maintenance of an S3
+    #     # bucket with appropriate ACLs
+    #     s3 => {
+    #         # WARNING:
+    #         # The preferred/secure method of providing access is by using IAM Roles. If
+    #         # you are running Dreamwidth in EC2, please leave access_key/secret_key undef
+    #         # and assign your instance a role that has the appropriate permissions.
+    #         #
+    #         # If you are operating outside of EC2, you can specify access keys here and
+    #         # we will use them directly.
+    #         access_key => undef,
+    #         secret_key => undef,
+    #
+    #         # The name of your bucket. This is created in the S3 control panel.
+    #         bucket_name => 'my-bucket-name',
+    #
+    #         # The name of the region in AWS nomenclature. If you're in US Standard then
+    #         # this is us-east-1.
+    #         region => 'us-east-1',
+    #
+    #         # This is used in case you have multiple DWs using the same bucket,
+    #         # i.e. in our Hack setup. In that case we set the prefix to be different
+    #         # per environment so each user doesn't collide. This is prefixed to the
+    #         # files written. It can be undef which means don't use a prefix.
+    #         # If it is defined, it should match regex [a-zA-Z0-9_-]+.
+    #         prefix => undef,
     #     },
     # );
 }


### PR DESCRIPTION
This implements S3 support for BlobStore using the Paws SDK, which seems
to work fairly well. This also updates the BlobStore initialization code
to not be magical about what fallbacks are valid, it's now just an array
that can be configured directly by the admin.

AWS credentials are by default handled using IAM roles/instance
profiles, which is the secure way to do it if you are running a server
in EC2. This is highly recommended, but fallback support is provided for
specifing the keys directly (for now?).