### PR TITLE
Don't proxy RSS images

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -818,7 +818,7 @@ sub clean
 
                     my $sanitize_url = sub {
                         my $url = canonical_url( $_[0], 1 );
-                        return $url unless $LJ::IS_SSL;
+                        return $url unless $LJ::IS_SSL && ! $to_external_site;
                         return https_url( $url, journal => $journal, ditemid => $ditemid );
                     };
 


### PR DESCRIPTION
When we're cleaning content for display on an external site (such as in
feeds), we don't want to convert links into Dreamwidth proxy URLs. It
won't work very well and it's unnecessary.