### PR TITLE
Change userlog.ip to varchar(45). Fixes #1818.

### DIFF
--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -1770,7 +1770,7 @@ CREATE TABLE userlog (
     action        VARCHAR(30) NOT NULL,
     actiontarget  INT UNSIGNED,
     remoteid      INT UNSIGNED,
-    ip            VARCHAR(15),
+    ip            VARCHAR(45),
     uniq          VARCHAR(15),
     extra         VARCHAR(255),
 
@@ -4072,6 +4072,12 @@ EOF
     if ( column_type( 'userpic2', 'description' ) eq "varchar(255)" ) {
         do_alter( 'userpic2',
             "ALTER TABLE userpic2 MODIFY COLUMN description VARCHAR(600) BINARY NOT NULL default ''");
+    }
+
+    # widen ip column for IPv6 addresses
+    if ( column_type("userlog", "ip") eq "varchar(15)" ) {
+        do_alter( "spamreports",
+                  "ALTER TABLE userlog MODIFY ip VARCHAR(45)" );
     }
 
 });


### PR DESCRIPTION
Minimally tested by checking the column was indeed set to varchar(45). Can't test further as dreamacks are IPv4-only. Anyone working outside those limits is welcome to test further, as hinted in https://github.com/dreamwidth/dw-free/issues/1818#issuecomment-354332036.