### PR TITLE
Make methods return sensibly for expunged users.

### DIFF
--- a/htdocs/support/see_request.bml
+++ b/htdocs/support/see_request.bml
@@ -289,7 +289,9 @@ body<=
             my $media_usage = DW::Media->get_usage_for_user( $u );
             my $media_quota = DW::Media->get_quota_for_user( $u );
             my $megabytes  = sprintf( "%0.3f MB", $media_usage / 1024 / 1024 );
-            my $percentage = sprintf( "%0.1f%%", $media_usage / ( $media_quota || 1 ) * 100 );
+            my $percentage = ( $media_quota != 0 )
+                ? sprintf( "%0.1f%%", $media_usage / $media_quota * 100 )
+                : $ML{'.noquota'};
 
             $ret .= "<br />$ML{'.media'}: $megabytes ($percentage)";
         }

--- a/htdocs/support/see_request.bml
+++ b/htdocs/support/see_request.bml
@@ -289,7 +289,7 @@ body<=
             my $media_usage = DW::Media->get_usage_for_user( $u );
             my $media_quota = DW::Media->get_quota_for_user( $u );
             my $megabytes  = sprintf( "%0.3f MB", $media_usage / 1024 / 1024 );
-            my $percentage = sprintf( "%0.1f%%", $media_usage / $media_quota * 100 );
+            my $percentage = sprintf( "%0.1f%%", $media_usage / ( $media_quota || 1 ) * 100 );
 
             $ret .= "<br />$ML{'.media'}: $megabytes ($percentage)";
         }

--- a/htdocs/support/see_request.bml.text
+++ b/htdocs/support/see_request.bml.text
@@ -95,6 +95,8 @@
 
 .none=None
 
+.noquota=no quota
+
 .not.have.access=You don't have authorization to answer people's support requests in this category.
 
 .nothaveprivilege=You don't have the necessary privileges to view this request. 


### PR DESCRIPTION
- Per bug spec, DW::Media->get_active_for_user, DW::Media->get_quota_for_user,
  DW::Media->get_usage_for_use, and LJ::User->can_upload_media now all return
  sensible values for an expunged user.
- This exposed a division by 0 in htdocs/support/see_request.bml, which I
  also fixed.

Fixes #2200