### PR TITLE
Prevent buying items for expunged users.

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -5304,6 +5304,8 @@ widget.shopcart.total=Total:
 
 widget.shopitemoptions.error.banned=You are restricted from making purchases for this journal.
 
+widget.shopitemoptions.error.expungedusername=You cannot buy items for purged usernames. If you're trying to buy a rename token to rename to a purged username, buy it for yourself.
+
 widget.shopitemoptions.error.invalidusername=The username you entered is invalid or the user does not exist.
 
 widget.shopitemoptions.error.nocart=Unable to get a shopping cart for you.  Please try again later.

--- a/cgi-bin/LJ/Widget/ShopItemOptions.pm
+++ b/cgi-bin/LJ/Widget/ShopItemOptions.pm
@@ -101,6 +101,9 @@ sub handle_post {
         return ( error => $class->ml( 'widget.shopitemoptions.error.invalidusername' ) )
             unless LJ::isu( $target_u );
 
+        return ( error => $class->ml( 'widget.shopitemoptions.error.expungedusername' ) )
+            if $target_u->is_expunged;
+
         return ( error => $class->ml( 'widget.shopitemoptions.error.banned' ) )
             if $remote && $target_u->has_banned( $remote );
 


### PR DESCRIPTION
As discussed in comments on the bug, this applies to all items, not
just rename tokens.

Fixes #2204.