### PR TITLE
Preserve note field itself and its value.

### DIFF
--- a/cgi-bin/DW/Controller/Shop.pm
+++ b/cgi-bin/DW/Controller/Shop.pm
@@ -7,7 +7,7 @@
 # Authors:
 #      Mark Smith <mark@dreamwidth.org>
 #
-# Copyright (c) 2010-2013 by Dreamwidth Studios, LLC.
+# Copyright (c) 2010-2018 by Dreamwidth Studios, LLC.
 #
 # This program is free software; you may redistribute it and/or modify it under
 # the same terms as Perl itself. For a copy of the license, please reference
@@ -98,6 +98,7 @@ sub shop_transfer_points_handler {
 
         if ( !$u ) {
             $errs{foruser} = LJ::Lang::ml( 'shop.item.points.canbeadded.notauser' );
+            $rv->{can_have_reason} = DW::Shop::Item::Points->can_have_reason;
 
         } elsif ( my $item = DW::Shop::Item::Points->new( target_userid => $u->id, from_userid => $remote->id, points => $points, transfer => 1 ) ) {
             # provisionally create the item to access object methods
@@ -125,6 +126,7 @@ sub shop_transfer_points_handler {
 
         } else {
             $errs{foruser} = LJ::Lang::ml( 'shop.item.points.canbeadded.itemerror' );
+            $rv->{can_have_reason} = DW::Shop::Item::Points->can_have_reason;
         }
 
         # copy down anon value and reason

--- a/views/shop/transferpoints.tt
+++ b/views/shop/transferpoints.tt
@@ -3,7 +3,7 @@
 Authors:
     Mark Smith <mark@dreamwidth.org>
 
-Copyright (c) 2015 by Dreamwidth Studios, LLC.
+Copyright (c) 2015-2018 by Dreamwidth Studios, LLC.
 
 This program is free software; you may redistribute it and/or modify it under
 the same terms as Perl itself.  For a copy of the license, please reference
@@ -74,7 +74,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
             </td></tr>
             [% IF can_have_reason %]
                 <tr><td>[% '.buying.note' | ml %]</td><td>
-                [% form.textarea(name = 'reason', rows = '6', cols = '60', wrap = 'soft') %]
+                [% form.textarea( name = 'reason', rows = '6', cols = '60', wrap = 'soft', value = reason ) %]
                 </td></tr>
             [% END %]
             <tr><td></td><td><input type='checkbox' name='anon' id='anon'> <label for='anon'>[% '.anon' | ml %]</label></td></tr>


### PR DESCRIPTION
- Make sure "can_have_reason" is set in all code paths.

- Preserve note field value, since this won't be done automagically until
  conversion to Foundation (see bug #975).

Fixes #1627.