### PR TITLE
Error loudly when renamed-to tag isn't canonical.

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -4098,6 +4098,8 @@ taglib.error.mergenoname=You did not provide a tag name you want to merge to.
 
 taglib.error.mergetoexisting=The tag name '[[tagname]]' is already in use, but you did not select it. Please select the tag or merge to a different tag name.
 
+taglib.error.notcanonical=The tag name '[[beforetag]]' is too long or not canonical. You may want to try '[[aftertag]]' instead.
+
 taglib.error.toomany3=Adding this tag would exceed your maximum of [[max]] tags.  You will not be able to add new tags until you delete [[excess]] existing [[?excess|tag|tags]].
 
 talk.agerestriction.18plus=18+

--- a/cgi-bin/LJ/Tags.pm
+++ b/cgi-bin/LJ/Tags.pm
@@ -1262,6 +1262,10 @@ sub rename_usertag {
     my $newname = LJ::Tags::validate_tag($newkw);
     return $err->( LJ::Lang::ml( 'taglib.error.invalid', { tagname => LJ::ehtml( $newkw ) } ) )
         unless $newname;
+    return $err->( LJ::Lang::ml( 'taglib.error.notcanonical',
+                                 { beforetag => LJ::ehtml( $newkw ),
+                                   aftertag => LJ::ehtml( $newname ) } ) )
+        unless $newkw eq $newname; # Far from ideal UX-wise.
 
     # get a list of keyword ids to operate on
     my $kwid;


### PR DESCRIPTION
Fixes #1590.