### PR TITLE
Remove code related to HTTPS-everywhere beta, now that it's live for all users.

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1842,6 +1842,10 @@ general /views/media/home.tt.edit
 general /views/media/index.tt.title
 general /views/media/index.tt.intro
 general /views/media/index.tt.intro.edit
+general /views/beta.tt.betafeature.httpseverywhere.cantadd
+general /views/beta.tt.betafeature.httpseverywhere.on
+general /views/beta.tt.betafeature.httpseverywhere.off
+general /views/beta.tt.betafeature.httpseverywhere.title
 
 general email.newacct5.body
 

--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -481,15 +481,7 @@ sub trans {
         }
     }
 
-    # force SSL if not currently and user is in httpseverywhere beta
     my $remote = LJ::get_remote();
-    if ( $apache_r->is_initial_req && $LJ::USE_SSL && ! $is_ssl && $remote &&
-            ( $apache_r->method eq 'GET' || $apache_r->method eq 'HEAD' ) &&
-            $remote->is_in_beta( 'httpseverywhere' ) ) {
-
-        my $url = LJ::create_url( $uri, keep_query_string => 1, ssl => 1 );
-        return redir( $apache_r, $url );
-    }
 
     # block on IP address for anonymous users but allow users to log in,
     # and logged in users to go through

--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -3,20 +3,6 @@
 
 .betafeature.btn.on=Turn ON beta testing
 
-.betafeature.httpseverywhere.cantadd=Sorry, your account is not eligible to test this feature.
-
-.betafeature.httpseverywhere.off<<
-<p>Activate HTTPS Everywhere. This will force your account to use a secure connection whenever
-you're logged in and browsing.</p>
-.
-
-.betafeature.httpseverywhere.on<<
-<p>You currently have HTTPS Everywhere enabled. Toggle off if you wish to resume browsing
-the site normally (unencrypted).</p>
-.
-
-.betafeature.httpseverywhere.title=HTTPS Everywhere
-
 .betafeature.updatepage.cantadd=Sorry, your account is not eligible to test this feature.
 
 .betafeature.updatepage.off<<


### PR DESCRIPTION
Note: this requires the httpseverywhere section to be removed from %BETA_FEATURES in the config files, though it looks like any failure isn't user-facing.

Fixes #2300