### PR TITLE
[#2308] tweaks to Markdown username conversion

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1755,12 +1755,18 @@ sub clean_as_markdown {
         }
     };
 
+    # First pass is just to look for an edge case where an unescaped
+    # username that needs to be converted is the first item in the string.
+    $$ref =~ s!^\@([\w\d_-]+)(?:\.([\w\d\.]+))?(?=$|\W)!$usertag->($1, $2)!mge;
+
+    # Second pass is to look for all other occurrences of unescaped usernames.
+    # If we find an escaped username, remove the escape sequence and continue.
     # We also have to look for (and explicitly ignore) Markdown-supported escape
     # sequences here, to avoid parsing edge cases like '\\@foo' incorrectly
     # (note that's two user-supplied backslashes).  That's why the (\\.) case is
     # actually (\\.) and not (\\\@).
     $$ref =~ s!(\\.)|(?<=[^\w/])\@([\w\d_-]+)(?:\.([\w\d\.]+))?(?=$|\W)!
-        defined($1) ? $1 : $usertag->($2, $3)
+        defined($1) ? ( $1 eq '\@' ? '@' : $1 ) : $usertag->($2, $3)
         !mge;
 
     # Second, markdown-ize the result, complete with <user> tags.

--- a/t/cleaner-markdown.t
+++ b/t/cleaner-markdown.t
@@ -5,7 +5,7 @@
 # Authors:
 #      Jen Griffin <kareila@livejournal.com>
 #
-# Copyright (c) 2017 by Dreamwidth Studios, LLC.
+# Copyright (c) 2017-2018 by Dreamwidth Studios, LLC.
 #
 # This program is free software; you may redistribute it and/or modify it under
 # the same terms as Perl itself.  For a copy of the license, please reference
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More tests => 6;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::CleanHTML;
@@ -36,6 +36,14 @@ my $clean = sub {
 # plain text user tag
 is( $clean->('@system'), "<p>$lju_sys</p>",
     "user tag in plain text converted" );
+
+# escaped plain text user tag
+is( $clean->('\@system'), '<p>@system</p>',
+    "escaped user tag in plain text not converted, backslash removed" );
+
+# plain text user tag with escape character escaped
+is( $clean->('\\\@system'), "<p>\\$lju_sys</p>",
+    "user tag in plain text converted when escape character is escaped" );
 
 # plain URL containing user tag
 # (Markdown conversion sets preformatted flag, so this won't linkify)


### PR DESCRIPTION
- Find and convert usernames at the beginning of the string -- fixes #2308.

- Print '\\@user' as '@user' not '\\@user' -- the Markdown conversion wasn't removing the escape character.