### PR TITLE
avoid db replication get/set race in saving community settings

### DIFF
--- a/cgi-bin/DW/Setting/CommunityMembership.pm
+++ b/cgi-bin/DW/Setting/CommunityMembership.pm
@@ -74,9 +74,8 @@ sub save {
 
     my $remote = LJ::get_remote();
 
-    my ( $current_comm_membership, $current_comm_postlevel ) = $u->get_comm_settings;
     my $val = $class->get_arg( $args, "communitymembership" );
-    $u->set_comm_settings( $remote, { membership => $val, postlevel => $current_comm_postlevel });
+    $u->set_comm_settings( $remote, { membership => $val });
 
     return 1;
 }

--- a/cgi-bin/DW/Setting/CommunityPostLevel.pm
+++ b/cgi-bin/DW/Setting/CommunityPostLevel.pm
@@ -79,7 +79,6 @@ sub save {
 
     my $remote = LJ::get_remote();
 
-    my ( $current_comm_membership, $current_comm_postlevel ) = $u->get_comm_settings;
     my $val = $class->get_arg( $args, "communitypostlevel" );
 
     # postlevel and nonmember_posting are a single setting in the UI, but separate options in the backend
@@ -90,7 +89,7 @@ sub save {
         $nonmember_posting = 1;
     }
 
-    $u->set_comm_settings( $remote, { membership => $current_comm_membership, postlevel => $val });
+    $u->set_comm_settings( $remote, { postlevel => $val });
     $u->set_prop({ nonmember_posting => $nonmember_posting });
 
     # unconditionally give posting access to all members

--- a/cgi-bin/LJ/Community.pm
+++ b/cgi-bin/LJ/Community.pm
@@ -534,13 +534,17 @@ sub set_comm_settings {
     die "User cannot modify this community"
         unless $u->can_manage_other( $c );
 
-    die "Membership and posting levels are not available"
-        unless $opts->{membership} && $opts->{postlevel};
+    my @settings = qw/membership postlevel/;
+    my $updates = join(', ', map { $opts{$_} ? "$_=?" : () } @settings);
+    my @update_values = map { $opts{$_} || () } @settings;
+
+    die "Membership or posting level is not available"
+        unless @update_values;
 
     my $cid = $c->userid;
 
     my $dbh = LJ::get_db_writer();
-    $dbh->do("REPLACE INTO community (userid, membership, postlevel) VALUES (?,?,?)" , undef, $cid, $opts->{membership}, $opts->{postlevel});
+    $dbh->do("INSERT INTO community (userid, membership, postlevel) VALUES (?,?,?) ON DUPLICATE KEY UPDATE $updates" , undef, $cid, $opts->{membership} || 'open', $opts->{postlevel} || 'members', @update_values);
 
     my $memkey = [ $cid, "commsettings:$cid" ];
     LJ::MemCache::delete($memkey);


### PR DESCRIPTION
by supporting UPDATE of an individual setting in set_comm_settings.
fixes #2014