### PR TITLE
Remove obsolete text from create entries success

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1043,16 +1043,6 @@ sub _do_post {
                 ml_string => ".new.links.view" }
         );
 
-        if ( $form_req->{props}->{opt_backdated} ) {
-            # we have to do some gymnastics to figure out the entry date
-            my $e = LJ::Entry->new_from_url( $itemlink );
-            my ( $y, $m, $d ) = ( $e->{eventtime} =~ /^(\d+)-(\d+)-(\d+)/ );
-            push @links, {
-                url => $ju->journal_base . "/$y/$m/$d/",
-                ml_string => ".new.links.backdated",
-            }
-        }
-
         push @links, (
             { url => $edititemlink,
                 ml_string => ".new.links.edit" },

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -503,18 +503,9 @@ _c?>
 
                     $$body .= sprintf( " p?><?p %s %s", $ML{'.extradata.subj'}, $subject );
 
-                    my $backdatedlink = '';
-                    if ( $POST{prop_opt_backdated} or $GET{prop_opt_backdated} ) {
-                        # we have to do some gymnastics to figure out the entry date
-                        my $e = LJ::Entry->new_from_url( $itemlink );
-                        my ( $y, $m, $d ) = ( $e->{eventtime} =~ /^(\d+)-(\d+)-(\d+)/ );
-                        my $url = $ju->journal_base . "/$y/$m/$d/";
-                        $backdatedlink = "<li><a href=\"$url\">"
-                                       . "$ML{'.success.links.backdated'}</a></li>";
-                    }
 
                     $$body .= " p?><?p $ML{'.success.links'} p?><ul>" .
-                        "<li><a href=\"$itemlink\">$ML{'.success.links.view'}</a></li>" . $backdatedlink .
+                        "<li><a href=\"$itemlink\">$ML{'.success.links.view'}</a></li>" . 
                         "<li><a href=\"$edititemlink\">$ML{'.success.links.edit'}</a></li>" .
                         "<li><a href=\"/tools/memadd?journal=$juser&itemid=$itemid\">$ML{'.success.links.memories'}</a></li>" .
                         "<li><a href=\"/edittags?journal=$juser&itemid=$itemid\">$ML{'.success.links.tags'}</a></li>" .


### PR DESCRIPTION
Fixes #1665.

Somewhat skimpy testing makes it look as though this works for both the old update page and the new one.