### PR TITLE
1661 banned behaviour

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -3359,6 +3359,7 @@ sub init {
     my $parent = {
         state     => $parpost->{state},
         talkid    => $partid,
+        posterid  => $parpost->{posterid},
     };
     my $comment = {
         u               => $up,

--- a/htdocs/talkpost_do.bml
+++ b/htdocs/talkpost_do.bml
@@ -176,6 +176,15 @@ body<=
     return LJ::bad_input($ML{'/talkpost.bml.error.noreply_readonly_journal'})
         if $journalu && $journalu->is_readonly;
 
+    # don't allow user A to reply to a comment by user B if user B has banned user A
+    if ( defined $remote ) {    #skip this if not logged in
+        my $parentu = LJ::load_userid( $parent->{posterid} );
+        return LJ::bad_input( $ML{'.error.banned.reply'} )
+            if ( defined $parentu && $parentu->has_banned( $remote ) );
+            #we check whether parentu is defined because it won't be
+            #if the parent is an anonymous comment.
+    }
+
     ## insertion or editing
     my $wasscreened = ($parent->{state} eq 'S');
     my $err;

--- a/htdocs/talkpost_do.bml
+++ b/htdocs/talkpost_do.bml
@@ -176,6 +176,10 @@ body<=
     return LJ::bad_input($ML{'/talkpost.bml.error.noreply_readonly_journal'})
         if $journalu && $journalu->is_readonly;
 
+    # is the current user banned by the author of the original post?
+    return LJ::bad_input( $ML{'.error.banned.entryowner'} )
+        if ( defined $remote && $entryu->has_banned( $remote ) );  
+
     # don't allow user A to reply to a comment by user B if user B has banned user A
     if ( defined $remote ) {    #skip this if not logged in
         my $parentu = LJ::load_userid( $parent->{posterid} );

--- a/htdocs/talkpost_do.bml
+++ b/htdocs/talkpost_do.bml
@@ -178,15 +178,15 @@ body<=
 
     # is the current user banned by the author of the original post?
     return LJ::bad_input( $ML{'.error.banned.entryowner'} )
-        if ( defined $remote && $entryu->has_banned( $remote ) );  
+        if defined $remote && $entryu->has_banned( $remote );  
 
-    # don't allow user A to reply to a comment by user B if user B has banned user A
-    if ( defined $remote ) {    #skip this if not logged in
+    # Don't allow user A to reply to a comment by user B if user B has banned user A.
+    # We check whether $remote is defined because it won't be if we aren't logged in.
+    # We check if $parentu is defined because it won't be if the parent is an anonymous comment.
+    if ( defined $remote ) { 
         my $parentu = LJ::load_userid( $parent->{posterid} );
         return LJ::bad_input( $ML{'.error.banned.reply'} )
-            if ( defined $parentu && $parentu->has_banned( $remote ) );
-            #we check whether parentu is defined because it won't be
-            #if the parent is an anonymous comment.
+            if defined $parentu && $parentu->has_banned( $remote );
     }
 
     ## insertion or editing

--- a/htdocs/talkpost_do.bml.text
+++ b/htdocs/talkpost_do.bml.text
@@ -9,6 +9,8 @@
 
 .error.banned.reply=You have been banned from replying to this user's comments.
 
+.error.banned.entryowner=You have been banned from commenting on entries by this user.
+
 .error.blankmessage=Your message is blank.  Please enter something in the message field.
 
 .error.confused_identity=You entered an account name but selected "post anonymously" or as the currently logged in account.  Please clear the textbox or select the correct posting mode and try again.

--- a/htdocs/talkpost_do.bml.text
+++ b/htdocs/talkpost_do.bml.text
@@ -7,6 +7,8 @@
 
 .error.banned.comm=You are not allowed to post in this community.
 
+.error.banned.reply=You have been banned from replying to this user's comments.
+
 .error.blankmessage=Your message is blank.  Please enter something in the message field.
 
 .error.confused_identity=You entered an account name but selected "post anonymously" or as the currently logged in account.  Please clear the textbox or select the correct posting mode and try again.


### PR DESCRIPTION
revision of PR 1693, incorporating requested style changes.

This *partially* fixes bug 1661, in that banned users can no longer comment through the main talkpost_do.bml Reply screen. They still can through quickreply, or probably email, because that appears to use totally separate logic and I don't understand where/how. But perhaps it's a start.

Please unassign me from 1661 once this is merged.