### PR TITLE
Allow email spell-checking to be overridden

### DIFF
--- a/cgi-bin/DW/Controller/Admin/SupportCat.pm
+++ b/cgi-bin/DW/Controller/Admin/SupportCat.pm
@@ -113,7 +113,7 @@ sub category_controller {
             if $cat->{basepoints} < 0 || $cat->{basepoints} > 255;
         if ( $cat->{replyaddress} ) {
             my @errors = ();
-            LJ::check_email( $cat->{replyaddress}, \@errors );
+            LJ::check_email( $cat->{replyaddress}, \@errors, $post_args, \( $vars->{email_checkbox} ) );
             $errors->add_string( 'replyaddress', $_ ) foreach @errors;
         }
 

--- a/cgi-bin/DW/Controller/ChangeEmail.pm
+++ b/cgi-bin/DW/Controller/ChangeEmail.pm
@@ -63,7 +63,7 @@ sub changeemail_handler {
     
         my @errors = ();
 
-        LJ::check_email( $post->{email}, \@errors );
+        LJ::check_email( $post->{email}, \@errors, $post, \( $vars->{email_checkbox} ) );
 
         my $blocked = 0;
 

--- a/cgi-bin/DW/Controller/Create.pm
+++ b/cgi-bin/DW/Controller/Create.pm
@@ -65,6 +65,7 @@ sub create_handler {
     my $rate_ok = 1;
 
     my $errors = DW::FormErrors->new;
+    my $email_checkbox;
     if ( $r->did_post ) {
         $post = $r->post_args;
 
@@ -162,7 +163,7 @@ sub create_handler {
 
         # check the email address
         my @email_errors;
-        LJ::check_email( $email, \@email_errors );
+        LJ::check_email( $email, \@email_errors, $post, \$email_checkbox );
         $errors->add_string( 'email', $_ ) foreach @email_errors;
         $errors->add( 'email', 'widget.createaccount.error.email.lj_domain', { domain => $LJ::USER_DOMAIN } )
             if $LJ::USER_EMAIL and $email =~ /\@\Q$LJ::USER_DOMAIN\E$/i;
@@ -291,6 +292,7 @@ sub create_handler {
 
         formdata        => $post,
         errors          => $errors,
+        email_checkbox  => $email_checkbox,
     };
 
     if ( $code_valid && $rate_ok ) {

--- a/cgi-bin/DW/Controller/Support/Submit.pm
+++ b/cgi-bin/DW/Controller/Support/Submit.pm
@@ -55,7 +55,7 @@ sub submit_handler {
         }
 
         if ( $post_args->{email} ) {
-            my @errors;
+            my @errors = ();
             LJ::check_email( $post_args->{email}, \@errors, $post_args, \( $vars->{email_checkbox} ) );
             $errors->add_string( 'email', $_ ) foreach @errors;
         } elsif ( $req{reqtype} eq 'email' ) {

--- a/cgi-bin/DW/Controller/Support/Submit.pm
+++ b/cgi-bin/DW/Controller/Support/Submit.pm
@@ -55,8 +55,8 @@ sub submit_handler {
         }
 
         if ( $post_args->{email} ) {
-            my @errors = ();
-            LJ::check_email( $post_args->{email}, \@errors );
+            my @errors;
+            LJ::check_email( $post_args->{email}, \@errors, $post_args, \( $vars->{email_checkbox} ) );
             $errors->add_string( 'email', $_ ) foreach @errors;
         } elsif ( $req{reqtype} eq 'email' ) {
             $errors->add( 'email', '.error.email.required' );

--- a/cgi-bin/DW/Setting/ProfileEmail.pm
+++ b/cgi-bin/DW/Setting/ProfileEmail.pm
@@ -60,6 +60,9 @@ sub save {
     # ensure a valid email address is given.
     my @errors;
     if ( $email ) {
+        # force_spelling because /manage/profile can't present unsaved edits
+        # back to you (nor hold them out of sight), so there's no opportunity
+        # to show an override checkbox
         LJ::check_email( $email, \@errors, { force_spelling => 1 } );
     }
 

--- a/cgi-bin/DW/Setting/ProfileEmail.pm
+++ b/cgi-bin/DW/Setting/ProfileEmail.pm
@@ -60,11 +60,11 @@ sub save {
     # ensure a valid email address is given.
     my @errors;
     if ( $email ) {
-        LJ::check_email( $email, \@errors );
+        LJ::check_email( $email, \@errors, { force_spelling => 1 } );
     }
 
     if ( @errors ) {
-        $class->errors( "email" => $class->ml( 'setting.profileemail.error.email.invalid' ) ) ;
+        $class->errors( "email" => join( '<br />', @errors ) ) ;
     } else {
         $u->profile_email( $email );
     }

--- a/cgi-bin/DW/Shop/Item.pm
+++ b/cgi-bin/DW/Shop/Item.pm
@@ -75,7 +75,7 @@ sub new {
     } elsif ( my $email = $args{target_email} ) {
         # email address must be valid
         my @email_errors;
-        LJ::check_email( $email, \@email_errors );
+        LJ::check_email( $email, \@email_errors, { force_spelling => delete $args{force_spelling} } );
         return undef if @email_errors;
     } else {
         return undef;

--- a/cgi-bin/LJ/HTMLControls.pm
+++ b/cgi-bin/LJ/HTMLControls.pm
@@ -56,12 +56,12 @@ sub html_datetime
 
     $ret .= html_select( { name => "${name}_mm",
                            id => "${id}_mm",
-                           selected => $mm,
+                           selected => sprintf( '%02d', $mm ),
                            class => 'select',
                            title => 'month',
                            disabled => $disabled, @tabindex_arg, %extra_opts,
                          },
-                         map { $_, LJ::Lang::month_long_ml($_) } (1..12) );
+                         map { sprintf( '%02d', $_ ), LJ::Lang::month_long_ml($_) } (1..12) );
     ++$tabindex_arg[1] if defined $tabindex;
     $ret .= html_text( { name => "${name}_dd",
                          id => "${id}_dd",

--- a/cgi-bin/LJ/Sysban.pm
+++ b/cgi-bin/LJ/Sysban.pm
@@ -528,7 +528,7 @@ sub create {
 # returns: nothing on success, error message on failure
 # </LJFUNC>
 sub validate {
-    my ($what, $value, $opts) = @_;
+    my ($what, $value, $opts, $post) = @_;
 
     # bail early if the ban already exists
     return "This is already banned"
@@ -555,7 +555,7 @@ sub validate {
             my $email = shift;
 
             my @err;
-            LJ::check_email($email, \@err);
+            LJ::check_email($email, \@err, $post);
             return @err ? shift @err : 0;
         },
         'email_domain' => sub {

--- a/cgi-bin/LJ/User/Message.pm
+++ b/cgi-bin/LJ/User/Message.pm
@@ -489,6 +489,8 @@ sub check_email
 
     my $use_errcode = $opts{errcode};
 
+    my $force_spelling = $opts{force_spelling};
+
     # Trim off whitespace and force to lowercase.
     $email =~ s/^\s+//;
     $email =~ s/\s+$//;
@@ -535,17 +537,20 @@ sub check_email
                          "Your email address domain is invalid.");
     }
 
-    # Catch misspellings of gmail.com, yahoo.com, hotmail.com, outlook.com,
-    # aol.com, live.com.
-    # https://github.com/dreamwidth/dw-free/issues/993#issuecomment-357466645
-    # explains where 3 comes from.
-    my $tf_domain = Text::Fuzzy->new( $domain, max => 3, trans => 1 );
-    my @common_domains = ( 'gmail.com', 'yahoo.com', 'hotmail.com',
-                           'outlook.com', 'aol.com', 'live.com' );
-    my $nearest = $tf_domain->nearest( \@common_domains );
-    return $reject->( "bad_spelling",
-                      "You gave $email as your email address. Are you sure you didn't mean $common_domains[$nearest]?" )
-        if defined $nearest && $tf_domain->last_distance > 0;
+    unless ( $force_spelling ) {
+        # Catch misspellings of gmail.com, yahoo.com, hotmail.com, outlook.com,
+        # aol.com, live.com.
+        # https://github.com/dreamwidth/dw-free/issues/993#issuecomment-357466645
+        # explains where 3 comes from.
+        my $tf_domain = Text::Fuzzy->new( $domain, max => 3, trans => 1 );
+        my @common_domains = ( 'gmail.com', 'yahoo.com', 'hotmail.com',
+                               'outlook.com', 'aol.com', 'live.com',
+                               'mail.com', 'ymail.com' );
+        my $nearest = $tf_domain->nearest( \@common_domains );
+        return $reject->( "bad_spelling",
+                          "You gave $email as your email address. Are you sure you didn't mean $common_domains[$nearest]?" )
+            if defined $nearest && $tf_domain->last_distance > 0;
+    }
 
     # Catch web addresses (two or more w's followed by a dot)
     if ($username =~ /^www*\./)

--- a/cgi-bin/LJ/User/Message.pm
+++ b/cgi-bin/LJ/User/Message.pm
@@ -497,10 +497,6 @@ sub check_email
     my $reject = sub {
         my $errcode = shift;
         my $errmsg = shift;
-        # TODO: add $opts to end of check_email and make option
-        #       to either return error codes, or let caller supply
-        #       a subref to resolve error codes into native language
-        #       error messages (probably via BML::ML hash, or something)
         push @$errors, $errmsg if ref( $errors );
         push @$errorcodes, $errcode if ref( $errorcodes );
         return;

--- a/cgi-bin/LJ/User/Message.pm
+++ b/cgi-bin/LJ/User/Message.pm
@@ -505,7 +505,7 @@ sub check_email
     # Empty email addresses are not good.
     unless ($email) {
         return $reject->("empty",
-                         "Your email address cannot be blank.");
+                         "The email address cannot be blank.");
     }
 
     # Check that the address is of the form username@some.domain.
@@ -521,7 +521,7 @@ sub check_email
     # Check the username for invalid characters.
     unless ($username =~ /^[^\s\",;\(\)\[\]\{\}\<\>]+$/) {
         return $reject->("bad_username",
-                         "You have invalid characters in your email address username.");
+                         "You have invalid characters in the email address username.");
     }
 
     # Check the domain name.
@@ -529,7 +529,7 @@ sub check_email
     unless ($domain =~ /^[\w-]+(?:\.[\w-]+)*\.(\w+)$/ && $valid_tlds->{$1})
     {
         return $reject->("bad_domain",
-                         "Your email address domain is invalid.");
+                         "The email address domain is invalid.");
     }
 
     # Catch misspellings of gmail.com, yahoo.com, hotmail.com, outlook.com,
@@ -548,18 +548,18 @@ sub check_email
     if ( ref( $checkbox ) && ( $bad_spelling || $force_spelling ) ) {
         $$checkbox = "<input type=\"checkbox\" name=\"force_spelling\" id=\"force_spelling\" "
                    . ( $force_spelling ? "checked=\"checked\" " : "" ) . "/>&nbsp;"
-                   . "<label for=\"force_spelling\">Yes I'm sure, override spell-check</label>";
+                   . "<label for=\"force_spelling\">Yes I'm sure this is correct</label>";
     }
     if ( $bad_spelling && ! $force_spelling ) {
         return $reject->( "bad_spelling",
-                "You gave $email as your email address. Are you sure you didn't mean $common_domains[$nearest]?" );
+                "You gave $email as the email address. Are you sure you didn't mean $common_domains[$nearest]?" );
     }
 
     # Catch web addresses (two or more w's followed by a dot)
     if ($username =~ /^www*\./)
     {
         return $reject->("web_address",
-                         "You gave $email as your email address, but it looks more like a web address to me.");
+                         "You gave $email as the email address, but it looks more like a web address to me.");
     }
 }
 

--- a/cgi-bin/LJ/Widget/ShopItemOptions.pm
+++ b/cgi-bin/LJ/Widget/ShopItemOptions.pm
@@ -130,7 +130,7 @@ sub handle_post {
 
     } elsif ( $post->{for} eq 'new' ) {
         my @email_errors;
-        LJ::check_email( $post->{email}, \@email_errors );
+        LJ::check_email( $post->{email}, \@email_errors, $post, $opts{email_checkbox} );
         if ( @email_errors ) {
             return ( error => join( ', ', @email_errors ) );
         } else {
@@ -158,7 +158,7 @@ sub handle_post {
     # conflict or something
     if ( $post->{accttype} ) {
         my ( $rv, $err ) = $cart->add_item(
-            DW::Shop::Item::Account->new( type => $post->{accttype}, user_confirmed => $post->{alreadyposted}, %item_data )
+            DW::Shop::Item::Account->new( type => $post->{accttype}, user_confirmed => $post->{alreadyposted}, force_spelling => $post->{force_spelling}, %item_data )
         );
         return ( error => $err ) unless $rv;
     } elsif ( $post->{item} eq "rename" ) {

--- a/htdocs/admin/sysban.bml
+++ b/htdocs/admin/sysban.bml
@@ -235,7 +235,7 @@ RETURN
         return $err->("Invalid form") unless LJ::check_form_auth();
 
         $ret = "<form method='post' action='sysban'> " . LJ::form_auth() . 
-                "<select name='bantype'>";
+                "<select name='bantype' onchange=\"\$('spelling').style.display = ( this.value.endsWith('email') ? 'block' : 'none' )\">";
         foreach my $type ( sort @sysban_privs ) {
             if ( $type eq $bantype ) {
                 $ret .=  "<option selected value='$type'>$type</option>\n";
@@ -243,6 +243,7 @@ RETURN
                 $ret .=  "<option value='$type'>$type</option>\n";
             }
         }
+        my $spellstyle = ( $bantype =~ /email$/ ) ? "" : "display: none";
         $ret .= <<FORM;
 </select>
 Value: <input type='text' name='value'>
@@ -252,7 +253,11 @@ Duration: <select name='bandays'>
 <option value='30'>1 month</option>
 <option value='0'>forever</option>
 </select>
-Note (required): <textarea name='note' rows='3' cols='80'></textarea> 
+<div id="spelling" style="$spellstyle">
+<input type="checkbox" name="force_spelling" id="force_spelling">&nbsp;<label for="force_spelling">Override email spell-check</label>
+</div>
+Note (required):<br />
+<textarea name='note' rows='3' cols='80'></textarea>
 <br />
 <input type='submit' name='add' value='Add'>
 </form>
@@ -273,7 +278,7 @@ FORM
         return $err->("You do not have the correct privileges") unless 
             $remote && $remote->has_priv( $priv, $bantype );
 
-        my $notvalid = LJ::Sysban::validate( $bantype, $value );
+        my $notvalid = LJ::Sysban::validate( $bantype, $value, undef, \%POST );
         return $err->("Ban not valid: $notvalid") if $notvalid;
 
         my $create = LJ::Sysban::create(

--- a/htdocs/manage/circle/invite.bml
+++ b/htdocs/manage/circle/invite.bml
@@ -76,8 +76,8 @@ _c?>
 
         if ($email) {
             my @errs;
-            LJ::check_email($email, \@errs, \%POST, \$email_checkbox);
-            $bogus->("email", BML::ml('.error.bademail2', {'errormsg' => @errs})) if @errs;
+            LJ::check_email( $email, \@errs, \%POST, \$email_checkbox );
+            $bogus->( "email", @errs ) if @errs;
 
             if ($LJ::USER_EMAIL && $email =~ /$LJ::USER_DOMAIN$/) {
                 $bogus->("email", $ML{'.error.useralreadyhasaccount'});

--- a/htdocs/manage/circle/invite.bml
+++ b/htdocs/manage/circle/invite.bml
@@ -62,6 +62,7 @@ _c?>
         @invitecodes = sort { ( $a->timesent || 0 ) <=> ( $b->timesent || 0 ) } @invitecodes;
     }
 
+    my $email_checkbox;
     my $validate_form = sub {
         my $rv = 1;
         my $bogus = sub {
@@ -75,7 +76,7 @@ _c?>
 
         if ($email) {
             my @errs;
-            LJ::check_email($email, \@errs);
+            LJ::check_email($email, \@errs, \%POST, \$email_checkbox);
             $bogus->("email", BML::ml('.error.bademail2', {'errormsg' => @errs})) if @errs;
 
             if ($LJ::USER_EMAIL && $email =~ /$LJ::USER_DOMAIN$/) {
@@ -219,6 +220,9 @@ _c?>
     $body .= LJ::html_submit($ML{'.btn.invite2'});
     if ($inerr->("email")) {
         $body .= "<br />" . $inerr->("email");
+    }
+    if ( $email_checkbox ) {
+        $body .= "<br />" . $email_checkbox;
     }
 
     if ( $LJ::USE_ACCT_CODES ) {

--- a/htdocs/manage/profile/index.bml
+++ b/htdocs/manage/profile/index.bml
@@ -637,6 +637,14 @@ body<=
         }
 
         my $save_rv = LJ::Setting->save_all( $u, \%POST, \@settings );
+        if ( LJ::Setting->save_had_errors( $save_rv ) ) {
+            my @save_errors;
+            for ( keys %$save_rv ) {
+                my $e = $save_rv->{$_}->{save_errors};
+                push @save_errors, $e->{(keys $e)[0]};
+            }
+            return LJ::error_list( @save_errors );
+        }
 
         $u->update_self( \%update );
 

--- a/htdocs/shop/account.bml
+++ b/htdocs/shop/account.bml
@@ -147,9 +147,8 @@ body<=
         $ret .= "<td>" . LJ::html_check( {
             name => 'anonymous',
             value => 1,
-            selected => $remote ? 0 : 1,
             disabled => $remote ? 0 : 1,
-            selected => $POST{anonymous},
+            selected => $POST{anonymous} || ! $remote,
         } ) . "</td></tr>";
 
         if ( DW::Shop::Item::Account->can_have_reason ) {

--- a/htdocs/shop/account.bml
+++ b/htdocs/shop/account.bml
@@ -68,6 +68,7 @@ body<=
     }
 
     my $post_fields = {};
+    my $email_checkbox;
     if ( LJ::did_post() ) {
         return "<?h1 $ML{'Error'} h1?><?p $ML{'error.invalidform'} p?>"
             unless LJ::check_form_auth();
@@ -78,8 +79,8 @@ body<=
             # need to do this because all of these form fields are in the BML page instead of in the widget
             LJ::Widget->use_specific_form_fields( post => \%POST,
                                                   widget => "ShopItemOptions",
-                                                  fields => [ qw( for username email deliverydate_mm deliverydate_dd deliverydate_yyyy anonymous reason alreadyposted ) ] );
-            my %from_post = LJ::Widget->handle_post( \%POST, ( 'ShopItemOptions' ) );
+                                                  fields => [ qw( for username email deliverydate_mm deliverydate_dd deliverydate_yyyy anonymous reason alreadyposted force_spelling ) ] );
+            my %from_post = LJ::Widget->handle_post( \%POST, 'ShopItemOptions' => { email_checkbox => \$email_checkbox } );
             $error = $from_post{error} if $from_post{error};
         } else {
             $error = $ML{'.error.noselection'};
@@ -128,12 +129,14 @@ body<=
                 $ret .= LJ::html_hidden( username => '(random)' );
             }
         } else { # $for eq 'new'
-            $ret .= "<tr><td>$ML{'.giftfor.email'}</td><td>" . LJ::html_text( { name => 'email', value => LJ::ehtml( $POST{email} ) } ) . "</td></tr>";
+            $ret .= "<tr><td>$ML{'.giftfor.email'}</td><td>" . LJ::html_text( { name => 'email', value => LJ::ehtml( $POST{email} ) } );
+            $ret .= "<br />$email_checkbox" if $email_checkbox;
+            $ret .= "</td></tr>";
         }
 
         $ret .= "<tr><td>$ML{'.giftfor.deliverydate'}</td>";
         my $deliverydate = $POST{deliverydate_mm} && $POST{deliverydate_dd} && $POST{deliverydate_yyyy}
-                    ? "$POST{deliverydate_yyyy}-$POST{deliverydate_mm}-$POST{deliverydate_dd}"
+                    ? sprintf( '%04d-%02d-%02d', $POST{deliverydate_yyyy}, $POST{deliverydate_mm}, $POST{deliverydate_dd} )
                     : DateTime->today->date;
         $ret .= "<td>" . LJ::html_datetime( {
             name => 'deliverydate',

--- a/htdocs/shop/confirm.bml
+++ b/htdocs/shop/confirm.bml
@@ -63,8 +63,14 @@ body<=
     return BML::redirect( "$LJ::SITEROOT/shop/receipt?ordernum=$ordernum" )
         unless $cart->state == $DW::Shop::STATE_OPEN;
 
+    # check email early so we can re-render the form on error
+    my ( $email_checkbox, @email_errors );
+    if ( LJ::did_post() ) {
+        LJ::check_email( $POST{email}, \@email_errors, \%POST, \$email_checkbox );
+    }
+
     # if they didn't post, give them a form
-    unless ( LJ::did_post() ) {
+    if ( ! LJ::did_post() || @email_errors ) {
         # set the payerid for later
         $eng->payerid( $payerid )
             if $payerid;
@@ -83,7 +89,14 @@ body<=
         # get their email address if they're not logged in
         unless ( $cart->userid ) {
             $ret .= "<?p $ML{'.confirm.email'} p?>";
-            $ret .= "<?p $ML{'.confirm.email.label'} " . LJ::html_text( { name => 'email' } ) . " p?>";
+            $ret .= "<?p $ML{'.confirm.email.label'} " . LJ::html_text( { name => 'email', value => $POST{email} } ) . " p?>";
+            if ( @email_errors ) {
+                $ret .= "<div class='error-box'><?p " . join( '<br />', @email_errors ) . " p?>";
+                if ( $email_checkbox ) {
+                    $ret .= "<?p $email_checkbox p?>";
+                }
+                $ret .= "</div>";
+            }
         }
 
         $ret .= "<?p " . LJ::html_submit( confirm => $ML{'.btn.confirm'} );
@@ -100,10 +113,7 @@ body<=
         my $u = LJ::load_userid( $cart->userid );
         $cart->email( $u->email_raw );
     } else {
-        my @email_errors;
-        LJ::check_email( $POST{email}, \@email_errors );
-        return join( ", ", @email_errors ) if @email_errors;
-
+        # email checked above
         $cart->email( $POST{email} );
     }
 

--- a/htdocs/support/append_request.bml
+++ b/htdocs/support/append_request.bml
@@ -19,7 +19,7 @@ body<=
 <?_code
 {
     use strict;
-    use vars qw(%FORM);
+    use vars qw(%FORM %POST);
 
     my $r = DW::Request->get;
 
@@ -158,7 +158,7 @@ body<=
                 $email = $eu->email_raw if $eu;
             }
 
-            LJ::check_email($email, \@email_errors);
+            LJ::check_email( $email, \@email_errors, \%POST );
             @email_errors = map { "<strong>$email:</strong> $_" } @email_errors;
             return LJ::bad_input(@email_errors) if @email_errors;
 

--- a/htdocs/tools/tellafriend.bml
+++ b/htdocs/tools/tellafriend.bml
@@ -22,12 +22,16 @@ _c?>
                   itemid       => 'digits',
                   mode         => '.',
                   toemail      => '.',
-                  fromname     => '.',
                   subject      => '.',
                   body         => '.',
                   body_start   => '.',
                   url          => '.',
                   );
+
+ my $user = $POST{'user'} || $GET{'user'};
+ my $journal = $POST{'journal'} || $GET{'journal'};
+ my $itemid = $POST{'itemid'} || $GET{'itemid'};
+ my $toemail = $POST{'toemail'};
 
  $title = BML::ml( ".title" );
  $body = "";
@@ -71,9 +75,8 @@ _c?>
  # Tell a friend form submitted
  if ($POST{'mode'} eq "mail")
  {
-     my $email = $POST{'toemail'};
      my @errors;
-     my @emails = split /,/, $email;
+     my @emails = split /,/, $toemail;
 
      push @errors, BML::ml( ".error.noemail" ) unless (scalar @emails);
      foreach my $em ( @emails ) {
@@ -91,45 +94,51 @@ _c?>
      }
      push @errors, "<?requirepost?>" unless LJ::did_post();
      push @errors, BML::ml( ".error.maximumemails" ) unless ($u->rate_log('tellafriend', scalar @emails));
-     push @errors, BML::ml( ".error.characterlimit" ) if (length($POST{'toemail'}) > 150);
+     push @errors, BML::ml( ".error.characterlimit" ) if (length($toemail) > 150);
      if (@errors) {
          # This piece left uncommented causes the Error page to have two titles displaying "Error"
          # Without the line, it displays "Tell a friend!" first, then "Error" which seems more helpful.
          # $title = BML::ml( ".errorpage.title" );
          $body = LJ::bad_input(@errors);
+
+         # Fall through and show form below
+     } else {
+         # All valid, go ahead and send
+
+         my $msg_body = $POST{'body_start'};
+         if ($POST{'body'} ne '') {
+             $msg_body .= $custom_msg . "\n-----\n" .
+                          $POST{'body'} . "\n-----";
+         }
+         $msg_body .= $msg_footer;
+
+         LJ::send_mail({
+             'to' => $toemail,
+             'from' => $u->{'emailpref'},
+             'fromname' => $u->user . BML::ml( ".via" ) . " $LJ::SITENAMESHORT",
+             'charset' => 'utf-8',
+             'subject' => $POST{'subject'},
+             'body' => $msg_body,
+         });
+
+         my $referer = BML::get_client_header('Referer');
+         my $tolist = $toemail;
+         $tolist =~ s/(,\s*)/<br \/>/g;
+         $body .= "<?h1 " . BML::ml( ".sentpage.title" ) . " h1?>";
+         $body .= "<?p <a href='$referer'>" . BML::ml( ".sentpage.body.tellanother" ) . "</a> p?>\n";
+         $body .= "<?p " . BML::ml( ".sentpage.body.mailedlist" ) . "<br />"
+                  . $tolist . " p?>";
          return;
      }
-
-     my $msg_body = $POST{'body_start'};
-     if ($POST{'body'} ne '') {
-         $msg_body .= $custom_msg . "\n-----\n" .
-                      $POST{'body'} . "\n-----";
-     }
-     $msg_body .= $msg_footer;
-
-     LJ::send_mail({
-         'to' => $POST{'toemail'},
-         'from' => $u->{'emailpref'},
-         'fromname' => $u->user . BML::ml( ".via" ) . " $LJ::SITENAMESHORT",
-         'charset' => 'utf-8',
-         'subject' => $POST{'subject'},
-         'body' => $msg_body,
-     });
-
-     my $referer = BML::get_client_header('Referer');
-     my $tolist = $POST{'toemail'};
-     $tolist =~ s/(,\s*)/<br \/>/g;
-     $body .= "<?h1 " . BML::ml( ".sentpage.title" ) . " h1?>";
-     $body .= "<?p <a href='$referer'>" . BML::ml( ".sentpage.body.tellanother" ) . "</a> p?>\n";
-     $body .= "<?p " . BML::ml( ".sentpage.body.mailedlist" ) . "<br />"
-              . $tolist . " p?>";
-     return;
  }
 
  my @warn;
  # Display form with info filled in
  $body .= "<form method='post' action='tellafriend'>";
  $body .= LJ::html_hidden({ name => 'mode', value => 'mail' });
+ $body .= LJ::html_hidden({ name => 'user', value => $user });
+ $body .= LJ::html_hidden({ name => 'journal', value => $journal });
+ $body .= LJ::html_hidden({ name => 'itemid', value => $itemid });
  $body .= "<table summary='' cellpadding=3 border=0>";
 
  $body .= "<tr><td align=right nowrap>" . BML::ml( ".email.fromfield" ) . "</td><td>" .
@@ -138,25 +147,21 @@ _c?>
 
  $body .= "<tr><td align=right valign='top'>" . BML::ml( ".email.recipientfield" ) . "</td>" .
           "<td>" . LJ::html_text({ name => 'toemail',
+                                   value => $toemail,
                                    size => 60,
                                    maxlength => 150 }) .
           "<br /><span class='detail'>" . BML::ml( ".email.formatinfo" ) . "</span></td></tr>\n";
 
  my ($subject, $msg);
  $subject = BML::ml( ".email.subject.noentry" );
- if ($GET{'itemid'} =~ /^\d+$/)
+ if ($itemid =~ /^\d+$/)
  {
-     my $journal = $GET{'journal'};
-     my $itemid = $GET{'itemid'}+0;
-     my $ditemid = $itemid;
-     my $uj;
-
-     $itemid = int($itemid / 256);
-
-     $uj = LJ::load_user($journal);
+     my $uj = LJ::load_user( $journal );
      return $err->(BML::ml( ".error.unknownjournal" )) unless $uj;
 
-     my $entry = LJ::Entry->new($uj->{'userid'}, jitemid => $itemid);
+     my $jitemid = $itemid + 0;
+     $jitemid = int( $jitemid / 256 );
+     my $entry = LJ::Entry->new($uj->{'userid'}, jitemid => $jitemid);
 
      my $entry_subject = $entry->subject_text;
      my $pu = $entry->poster;
@@ -188,7 +193,6 @@ _c?>
  }
 
  if ($GET{'user'} =~ /^\w{1,15}$/) {
-     my $user = $GET{'user'};
      my $uj = LJ::load_user($user);
      my $url = $uj->journal_base;
 
@@ -218,8 +222,8 @@ _c?>
  $body .= LJ::html_hidden({ name => 'subject', value => "$subject" });
  $body .= LJ::html_hidden({ name => 'body_start', value => $msg });
  $body .= "<tr><td valign=top colspan='2'>" . BML::ml( ".email.body.boxtitle" ) . "<br />" .
-          "<div class='message'><blockquote>" . $display_msg .
-          "<br /><textarea name=body rows=6 cols=55 wrap=soft></textarea>" .
+          "<div class='message'><blockquote>" . $display_msg . "<br />" .
+          LJ::html_textarea({ name => 'body', rows => 6, cols => 55, wrap => 'soft', value => $POST{'body'} }) .
           "$display_msg_footer</blockquote></div></td></tr>\n";
 
  $body .= "<tr><td colspan='2' align='center'><div class='action-box'><div class='inner'>" .

--- a/htdocs/tools/tellafriend.bml
+++ b/htdocs/tools/tellafriend.bml
@@ -26,6 +26,7 @@ _c?>
                   body         => '.',
                   body_start   => '.',
                   url          => '.',
+                  force_spelling => '.',
                   );
 
  my $user = $POST{'user'} || $GET{'user'};
@@ -72,6 +73,8 @@ _c?>
  my $msg_footer = BML::ml( ".email.body.footer1", { user => $u->{user}, sitename => $LJ::SITENAME, sitenameshort => $LJ::SITENAMESHORT, domain =>$LJ::DOMAIN } );
  my $custom_msg = "\n\n" . BML::ml( ".email.body.custom", { user => $u->{user} } );
 
+ my $email_checkbox;
+
  # Tell a friend form submitted
  if ($POST{'mode'} eq "mail")
  {
@@ -80,7 +83,7 @@ _c?>
 
      push @errors, BML::ml( ".error.noemail" ) unless (scalar @emails);
      foreach my $em ( @emails ) {
-        LJ::check_email($em, \@errors);
+        LJ::check_email( $em, \@errors, \%POST, \$email_checkbox );
      }
      # Check for images
      if ($POST{'body'} =~ /<(img|image)\s+src/i) {
@@ -150,7 +153,11 @@ _c?>
                                    value => $toemail,
                                    size => 60,
                                    maxlength => 150 }) .
-          "<br /><span class='detail'>" . BML::ml( ".email.formatinfo" ) . "</span></td></tr>\n";
+          "<br /><span class='detail'>" . BML::ml( ".email.formatinfo" ) . "</span>";
+ if ( $email_checkbox ) {
+    $body .= "<br />" . $email_checkbox;
+ }
+ $body .= "</td></tr>\n";
 
  my ($subject, $msg);
  $subject = BML::ml( ".email.subject.noentry" );

--- a/t/check-email.t
+++ b/t/check-email.t
@@ -51,7 +51,7 @@ sub check_email {
     $expected_error ||= "";
 
     my @email_errors;
-    LJ::check_email( $email, \@email_errors, errcode => 1 );
+    LJ::check_email( $email, undef, undef, undef, \@email_errors );
     is_deeply( \@email_errors, $expected_error ? [ $expected_error ] : [], "checked '$email' with error '$expected_error'" );
 }
 

--- a/views/admin/supportcat/category.tt
+++ b/views/admin/supportcat/category.tt
@@ -37,7 +37,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         <div class="row"><div class="medium-4 large-4 column">[% form.checkbox_nested( label=dw.ml( ".field.${checkbox}.label2" ), name=checkbox, value=1, selected=formdata.$checkbox ) %]</div>
         <div class="medium-8 large-8 column"><small>[% ".field.${checkbox}.note" | ml %]</small></div></div>
     [% END %]
-    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.replyaddress.label2' ), name="replyaddress", maxlength=50 ) %]</div>
+    <div class="row"><div class="medium-4 large-4 column">[% form.textbox( label=dw.ml( '.field.replyaddress.label2' ), name="replyaddress", maxlength=50, hint = email_checkbox ) %]</div>
     <div class="medium-8 large-8 column"><small>[% '.field.replyaddress.note' | ml %]</small></div></div>
     <div class="row"><div class="medium-4 large-4 column">[% form.checkbox_nested( label=dw.ml( '.field.no_autoreply.label2' ), name="no_autoreply", value=1, selected=formdata.no_autoreply ) %]</div>
     <div class="medium-8 large-8 column"><small>[% '.field.no_autoreply.note' | ml %]</small></div></div>

--- a/views/changeemail.tt
+++ b/views/changeemail.tt
@@ -61,7 +61,11 @@ the same terms as Perl itself. For a copy of the license, please reference
             [% END %]
         </div><br/>
         <div>[% '.label.newemail' | ml %]<br />
-            <input type='text' name='email' size='50' maxlength='50' tabindex='1' /></div><br />
+            <input type='text' name='email' size='50' maxlength='50' tabindex='1' />
+            [% IF email_checkbox %]
+                <br />[% email_checkbox %]
+            [% END %]
+            </div><br />
             [% UNLESS is_identity %]
                 <div>[% '.label.password2' | ml(remote = remote.ljuser_display) %]<br />
                 <input type='password' name='password' size='50' maxlength='50' tabindex='2' /></div>

--- a/views/create/account.tt
+++ b/views/create/account.tt
@@ -73,6 +73,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
         maxlength = 50
 
         "aria-required" = "true"
+
+        hint = email_checkbox
     ) -%]
 </div>
 

--- a/views/support/request/form.tt
+++ b/views/support/request/form.tt
@@ -107,7 +107,8 @@ END -%]
         <div id='bounce_email' style='display: none'>
         [%- form.textbox( label = dw.ml( '.email.user' )
                 name = 'bounce_email'
-                size = 25
+                size = 25,
+                hint = '<div><input type="checkbox" name="force_spelling" id="force_spelling">&nbsp;<label for="force_spelling" style="float: none">Override email spell-check</label></div>'
         )
         -%]
         </div>

--- a/views/support/submit.tt
+++ b/views/support/submit.tt
@@ -40,6 +40,9 @@ reference 'perldoc perlartistic' or 'perldoc perlgpl'.
             [% IF include_email %]
                 <p><label class='emphasis' for='yourmail'>[% '.yourmail' | ml %]</label></p>
                 <div style='margin-left: 30px'><p><input type='text' aria-describedby='notshow' id='yourmail' name='email' size='30' maxlength='70' value="[% email | html %]" /></p>
+                [% IF email_checkbox %]
+                    <p>[% email_checkbox %]</p>
+                [% END %]
                 <p id='notshow' class='compressed'>[% '.notshow' | ml %]</p></div>
             [% END %]
 


### PR DESCRIPTION
Fixes #2304, in the many, many places where we check email addresses.

Where possible, this gives you a tickbox near the input saying "Yes I'm sure this is correct".

The **display** email, set on the Edit Profile page, is simply excluded from spell-checking because that page doesn't have a way to hold unsaved edits while showing you a checkbox, and reworking it to do so looked too complicated, see 972d7b437ad365077ec3ed40c200a68c0dd6dee9. That page will also now tell you if your email address is more seriously invalid, rather than silently dropping that part of the change.

The sysbans page has similar issues. For that one I've made the ticky always visible up-front (if the type is email).

For the admin console command `email_alias`, you can append `!` to the address to achieve the override, and will be prompted to do so.

Also added `mail.com`, `ymail.com` to known-good domains as per original discussion on #993.