### PR TITLE
Clarify Support "No HTML allowed" messages

### DIFF
--- a/htdocs/support/act.bml
+++ b/htdocs/support/act.bml
@@ -81,7 +81,7 @@ body<=
      # textarea for their message body
      $ret .= '<tr valign="top"><td align="right">' . $ML{'.message'} . '</td><td colspan="2">';
      $ret .= '<textarea rows="10" cols="50" name="body"></textarea><br />';
-     $ret .= "\n<?de $ML{'.no.html.allowed2'} de?><br />\n";
+     $ret .= "\n<?de $ML{'.no.html.allowed3'} de?><br />\n";
      $ret .= '<input type="submit" name="submitpost" value="'. $ML{'.postbutton'} . '" />';
      $ret .= "\n</td></tr></table></form>";
 

--- a/htdocs/support/act.bml.text
+++ b/htdocs/support/act.bml.text
@@ -25,7 +25,7 @@
 
 .more.info=More Information:
 
-.no.html.allowed2=No HTML is allowed.  Don't worry about escaping &lt; and &gt;<br />URLs are automatically link-ified, so just reference those.
+.no.html.allowed3=Any HTML in your submission will be escaped, not rendered. Don't worry about escaping &lt; and &gt; if you're includnig sample code.<br />URLs are automatically link-ified, so just reference those.
 
 .not.allowed.request=You aren't allowed to lock this request.
 

--- a/htdocs/support/see_request.bml.text
+++ b/htdocs/support/see_request.bml.text
@@ -91,7 +91,7 @@
 
 .no=No
 
-.no.html.allowed2=There's no HTML allowed, so don't worry about escaping &lt; and &gt;<br />URLs are automatically link-ified, so just reference those.
+.no.html.allowed3=Any HTML in your submission will be escaped, not rendered. Don't worry about escaping &lt; and &gt; if you're including example code.<br />URLs are automatically link-ified, so just reference those.
 
 .none=None
 

--- a/views/support/request/form.tt
+++ b/views/support/request/form.tt
@@ -78,7 +78,7 @@ END -%]
 -%]
 </li>
 <li>
-<p style='padding-left: 12em'>[%- '.no.html.allowed2' | ml -%]</p></li>
+<p style='padding-left: 12em'>[%- '.no.html.allowed3' | ml -%]</p></li>
 </ul>
 </fieldset>
 

--- a/views/support/submit.tt
+++ b/views/support/submit.tt
@@ -80,7 +80,7 @@ reference 'perldoc perlartistic' or 'perldoc perlgpl'.
             </p></div>
 
             <p><label class='emphasis' for='question'>[% '.question' | ml %]</label></p>
-            <p id='question_note' class='compressed'>[% '.question.note' | ml %]</p>
+            <p id='question_note' class='compressed'>[% '.question.note2' | ml %]</p>
             <div style='margin-left: 30px'><p>
             <textarea aria-describedby='question_note' id='question' name='message' rows='15' cols='70' wrap='soft'>[% message | html %]</textarea>
             </p></div>

--- a/views/support/submit.tt.text
+++ b/views/support/submit.tt.text
@@ -33,7 +33,7 @@ If you have any additional questions or comments, you can add them to your reque
 
 .summary=Summary
 
-.question.note=Don't include confidential information like your password or phone number. Don't use HTML in your submission.
+.question.note2=Don't include confidential information like your password or phone number. Any HTML in your submission will be escaped, not rendered. Don't worry about escaping &lt; and &gt; if you're including sample code.
 
 .title=Submit Support Request
 


### PR DESCRIPTION
Fixes #2209.

(NB the line on submit.tt ends up quite lengthy, rather than wrapping at ~textbox width, but I'm... not dealing with that unless anyone is particularly keen on it.)