### PR TITLE
[#2227] remove remaining references to AIM

### DIFF
--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
@@ -535,7 +535,6 @@ sub get_foaf_from {
     my %wanted_text_items = (
         'foaf:name' => 'name',
         'foaf:icqChatID' => 'icq',
-        'foaf:aimChatID' => 'aolim',
         'foaf:jabberID' => 'jabber',
         'foaf:yahooChatID' => 'yahoo',
         'ya:bio' => 'bio',

--- a/cgi-bin/DW/Worker/ContentImporter/Local/Bio.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/Local/Bio.pm
@@ -59,7 +59,7 @@ sub merge_bio_items {
 
     $u->set_bio( $items->{'bio'} ) if defined( $items->{'bio'} );
 
-    foreach my $prop ( qw/ icq aolim jabber yahoo journaltitle journalsubtitle / ) {
+    foreach my $prop ( qw/ icq jabber yahoo journaltitle journalsubtitle / ) {
         $u->set_prop( $prop => $items->{$prop} )
             if defined $items->{$prop};
     }

--- a/cgi-bin/LJ/Directory/Constraint/ContactInfo.pm
+++ b/cgi-bin/LJ/Directory/Constraint/ContactInfo.pm
@@ -49,8 +49,8 @@ sub matching_uids {
     my $dbr = LJ::get_dbh("directory") || LJ::get_db_reader();
 
     my @propids;
-    # FIRST: check whether we get maches based on IM services
-    foreach my $service (qw(aolim icq yahoo jabber skype google_talk)) {
+    # FIRST: check whether we get matches based on IM services
+    foreach my $service (qw(icq yahoo jabber skype google_talk)) {
         my $p = LJ::get_prop("user", $service);
         push @propids, $p->{upropid};
     }

--- a/cgi-bin/LJ/Feed.pm
+++ b/cgi-bin/LJ/Feed.pm
@@ -605,7 +605,7 @@ sub create_view_foaf {
 
     # setup userprops we will need
     $u->preload_props( qw{
-        aolim icq yahoo jabber icbm url urlname country city journaltitle
+        icq yahoo jabber icbm url urlname country city journaltitle
     } );
 
     # create bare foaf document, for now
@@ -665,7 +665,6 @@ sub create_view_foaf {
 
     # contact type information
     my %types = (
-        aolim => 'aimChatID',
         icq => 'icqChatID',
         yahoo => 'yahooChatID',
         jabber => 'jabberID',

--- a/htdocs/manage/profile/index.bml
+++ b/htdocs/manage/profile/index.bml
@@ -54,7 +54,7 @@ body<=
     # props in this list will be preloaded on page load and saved on post
     my @uprops = qw/
         opt_whatemailshow comm_theme
-        ao3 aolim delicious deviantart diigo etsy ffnet github google_talk
+        ao3 delicious deviantart diigo etsy ffnet github google_talk
         icq instagram jabber last_fm_user livejournal pinboard pinterest
         plurk ravelry skype tumblr twitter yahoo
         url urlname gender
@@ -404,7 +404,6 @@ body<=
 
             foreach my $p (
                            ["ao3", $ML{ '.services.ao3' }, 40],
-                           ["aolim", $ML{'.chat.aolim'}, 28],
                            ["delicious", $ML{ '.services.delicious' }, 40],
                            ["deviantart", $ML{'.services.deviantart'}, 20],
                            ["diigo", $ML{ '.services.diigo' }, 16],


### PR DESCRIPTION
The profile display was removed in #2234, but the Edit Profile page
still contained the AIM field in the form, and I found a few other
references to the defunct userprop sprinkled throughout odd corners
of the codebase.