### PR TITLE
keep selected tagnav, even with special chars

### DIFF
--- a/htdocs/js/journals/jquery.tag-nav.js
+++ b/htdocs/js/journals/jquery.tag-nav.js
@@ -103,12 +103,12 @@ jQuery(document).ready(function() {
 var hash = location.hash;
 if ( hash.indexOf( "#tagnav-" ) == 0 ) {
     $(window).load(function() {
-        var tagnav_tag = decodeURI(hash.slice(8));
+        var tagnav_tag = decodeURIComponent(hash.slice(8));
 
         $(".tag-nav-trigger").click();
         $(".tag a").filter(function() {
             var text = $(this).text();
-            return text === tagnav_tag || text.replace(' ', '+') === tagnav_tag;
+            return text === tagnav_tag || text.replace(/ /g, '+') === tagnav_tag;
         }).click();
     })
 }


### PR DESCRIPTION
fixes #2396
replace all spaces, not just first, and handle wider range of percent-escaped chars