### PR TITLE
[#2410] Make less-quick-reply stop trashing the layout on mobile

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2232,12 +2232,8 @@ sub init_s2journal_js {
             js/jquery/jquery.ui.widget.js
             js/jquery.quickreply.js
             js/jquery.threadexpander.js
-        ) ) unless $opts{noqr};
-
-    # this is only used on lastn-type pages (DayPage, RecentPage, FriendsPage)
-    LJ::need_res( { group => "jquery" }, qw(
             stc/css/components/quick-reply.css
-        ) ) if $opts{lastn};
+        ) ) unless $opts{noqr};
 
     # load for userpicselect
     LJ::need_res( init_iconbrowser_js( 1 ) ) if $opts{iconbrowser};

--- a/htdocs/js/jquery.iconselector.js
+++ b/htdocs/js/jquery.iconselector.js
@@ -15,7 +15,7 @@
                 });
         }
 
-        return $(this).wrap("<span class='iconselect_trigger_wrapper'></span>");
+        return $(this);
     };
 
     // selected icon

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -208,6 +208,7 @@ jQuery(document).ready(function($) {
         // take a random number, ignoring the "(default)" option
         var randomnumber = Math.floor(Math.random() * (iconslist.length-1) ) + 1;
         iconslist.selectedIndex = randomnumber;
+        $( iconslist ).trigger("change");
     });
 });
 

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -65,10 +65,42 @@
 
     .qr-meta {
         margin-left: 55px;
+        display: -webkit-flex;
+        -webkit-flex-direction: row;
+        -webkit-flex-wrap: wrap;
+
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+
+        &>* {
+            -webkit-flex-grow: 1;
+            -webkit-flex-shrink: 1;
+
+            flex-grow: 1;
+            flex-shrink: 1;
+        }
+    }
+
+    .qr-footer {
+        display: -webkit-flex;
+        -webkit-flex-direction: row;
+        -webkit-flex-wrap: wrap;
+
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+
+    span#quotebuttonspan {
+        // This only exists to get something appended to it by jQuery. Its child
+        // input is the real flex item.
+        display: contents;
     }
 
     textarea, select, input[type="text"] {
-        width: 100%;
+        max-width: 100%;
+        flex-basis: 20%;
     }
 
     select, input, textarea {
@@ -78,16 +110,6 @@
 @media only screen and (min-width: 40em) {
 
     #qrform {
-        display: table;
-
-        .qr-meta {
-            display: -webkit-flex;
-            -webkit-flex-direction: row;
-
-            display: flex;
-            flex-direction: row;
-        }
-
         .qr-body, .qr-footer {
             margin-left: 55px;
         }

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -9,6 +9,17 @@
     padding: 0 1em;
     clear: both;
 
+    // Consistent initial font size for every descendent, so we can use ems
+    // for reliable relative sizing later.
+    * {
+        font-size: .75rem;
+        @media (pointer: coarse) {
+            // Appease mobile Webkit so it won't *dramatic woodchuck* zoom on
+            // input focus. Minimum font-size to Not Do That: 16px.
+            font-size: 16px;
+        }
+    }
+
     .de {
         font-size: small;
     }
@@ -18,8 +29,9 @@
     }
 
     .qr-icon {
-        width: 50px;
-        height: 50px;
+        // Same height as qr-meta's stacked select and input = 2em + 2em + .2em
+        width: 4.2em;
+        height: 4.2em;
         float: left;
         position: relative;
 
@@ -65,7 +77,8 @@
     }
 
     .qr-meta {
-        margin-left: 55px;
+        margin-left: 4.5em;
+
         display: -webkit-flex;
         -webkit-flex-direction: row;
         -webkit-flex-wrap: wrap;
@@ -74,7 +87,9 @@
         flex-direction: row;
         flex-wrap: wrap;
 
-        &>* {
+        & > * {
+            height: 2em;
+
             -webkit-flex-grow: 1;
             -webkit-flex-shrink: 1;
 
@@ -115,7 +130,7 @@
     }
 
     select, input, textarea {
-        padding: .25em;
+        padding: .15em;
     }
 }
 
@@ -129,12 +144,12 @@
 @media #{$medium-up} {
     #qrform {
         .qr-meta, .qr-body, .qr-footer {
-            margin-left: 55px;
+            margin-left: 4.5em;
             max-width: 38rem;
         }
 
         select, input, textarea {
-            padding: .5em;
+            padding: .3em;
         }
     }
 }

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -117,8 +117,15 @@
         padding: .25em;
     }
 }
-@media only screen and (min-width: 40em) {
 
+// When we're down to ~two buttons per row, avoid messy clumping:
+@media #{$small-only} {
+    .qr-footer > *, #quotebuttonspan input {
+        flex-grow: 1;
+    }
+}
+
+@media #{$medium-up} {
     #qrform {
         .qr-meta, .qr-body, .qr-footer {
             margin-left: 55px;

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -103,6 +103,10 @@
         flex-basis: 20%;
     }
 
+    textarea#body {
+        width: 100%;
+    }
+
     select, input, textarea {
         padding: .25em;
     }
@@ -110,8 +114,9 @@
 @media only screen and (min-width: 40em) {
 
     #qrform {
-        .qr-body, .qr-footer {
+        .qr-meta, .qr-body, .qr-footer {
             margin-left: 55px;
+            max-width: 38rem;
         }
 
         select, input, textarea {

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -123,6 +123,13 @@
     textarea, select, input[type="text"] {
         max-width: 100%;
         flex-basis: 20%;
+        margin-right: 0; // Fix for site scheme.
+        &:hover {
+            // Fix for site scheme. Too distracting.
+            -moz-box-shadow: inherit;
+            -webkit-box-shadow: inherit;
+            box-shadow: inherit;
+        }
     }
 
     textarea#body {
@@ -131,6 +138,11 @@
 
     select, input, textarea {
         padding: .15em;
+    }
+
+    .invisible {
+        // Fix for site scheme; a ".comment .invisible" rule was setting position: relative.
+        position: absolute;
     }
 }
 

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -96,6 +96,12 @@
         // This only exists to get something appended to it by jQuery. Its child
         // input is the real flex item.
         display: contents;
+
+        // Separate the "submit" buttons from the "misc" ones, if there's space.
+        // Quote is the first "misc" button.
+        input {
+            margin-left: auto;
+        }
     }
 
     textarea, select, input[type="text"] {

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -7,6 +7,7 @@
     text-align: left;
     margin: 0 auto;
     padding: 0 1em;
+    clear: both;
 
     .de {
         font-size: small;

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -156,19 +156,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
       class = post_button_class,
       id = 'submitpost'
   ) -%]
-  <span id='quotebuttonspan'></span>
-  <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
   [%- form.submit(
       name = 'submitpview'
       value = dw.ml( 'talk.btn.preview' ),
       id = 'submitpview'
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) -%]
-  [%- form.submit(
-      name = 'submitmoreopts'
-      value = dw.ml( '/talkread.bml.button.more' ),
-      id = 'submitmoreopts'
-  ) -%]
   [%- IF can_checkspell -%]
     [%- form.checkbox(
       label = dw.ml( '/talkread.bml.qr.spellcheck' )
@@ -176,6 +169,13 @@ the same terms as Perl itself.  For a copy of the license, please reference
       id = 'do_spellcheck'
     ) -%]
   [%- END -%]
+  <span id='quotebuttonspan'></span>
+  <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
+  [%- form.submit(
+      name = 'submitmoreopts'
+      value = dw.ml( '/talkread.bml.button.more' ),
+      id = 'submitmoreopts'
+  ) -%]
   [%- IF journal.is_iplogging -%]
     <div class='de'>[%- '/talkpost.bml.logyourip' | ml -%]</div>
     [%- help.iplogging -%]

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -12,88 +12,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- dw.need_res( "stc/css/components/quick-reply.css" ) -%]
 
-[%- IF minimal -%]
 [%- quickreply = BLOCK -%]
-
-<div id='qrformdiv'><form id='qrform' name='qrform' method='POST' action='[%- form_url | url -%]'>
-[%- dw.form_auth -%]
-[%- hidden_form_elements -%]
-<div class='qr-icon'>
-    [%- IF current_icon -%]
-      [%- IF remote.can_use_iconbrowser -%]
-        <button id="lj_userpicselect">[%- current_icon.imgtag -%]</button>
-      [%- ELSE -%]
-        [%- current_icon.imgtag -%]
-      [%- END -%]
-    [%- ELSE -%]
-      [%- dw.img( "nouserpic_sitescheme", "" ) -%]
-    [%- END -%]
-</div>
-<div class="qr-meta">
-  [%- IF remote.icons.size > 0 -%]
-    <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
-    [%- form.select(
-        name = 'prop_picture_keyword',
-        id = 'prop_picture_keyword',
-        selected = current_icon_kw,
-        items = remote.icons
-    ) -%]
-  [%- END -%]
-
-  [%- form.textbox(
-        label = dw.ml( '/talkpost.bml.opt.subject2' )
-        labelclass = 'invisible'
-        size = 50
-        maxlength = 100
-        name = 'subject'
-        id = 'subject'
-        placeholder = dw.ml( '/talkpost.bml.opt.subject2' )
-  ) -%]
-</div>
-<div class="qr-body">
-  [%- form.textarea(
-    label = dw.ml( '/talkpost.bml.opt.message2' )
-    labelclass = 'invisible'
-    rows = 10
-    cols = 80
-    wrap = 'soft'
-    name = 'body'
-    id = 'body'
-  ) -%]
-</div>
-<div class="qr-footer">
-  [%- IF post_disabled -%]
-  <div class='ui-state-error'>[%- '/talkpost.bml.error.nocomment_quick' | ml -%]</div>
-  [%- END -%]
-  [%- form.submit(
-      name = 'submitpost'
-      value = dw.ml( '/talkread.bml.button.post' ),
-      disabled = post_disabled,
-      class = post_button_class,
-      id = 'submitpost'
-  ) -%]
-  [%- form.submit(
-      name = 'submitmoreopts'
-      value = dw.ml( '/talkread.bml.button.more' ),
-      id = 'submitmoreopts'
-  ) -%]
-
-
-  [%- IF journal.is_iplogging -%]
-    <div class='de'>[%- '/talkpost.bml.logyourip' | ml -%]</div>
-    [%- help.iplogging -%]
-  [%- END -%]
-
-  [%- IF journal.is_linkstripped -%]
-    <div class='de'>[%- '/talkpost.bml.linkstripped' | ml -%]</div>
-  [%- END -%]
-</div>
-
-</form></div>
-[%- END -%]
-[%- ELSE -%]
-[%- quickreply = BLOCK -%]
-
 <div id='qrformdiv'><form id='qrform' name='qrform' method='POST' action='[%- form_url | url -%]'>
 [%- dw.form_auth -%]
 [%- hidden_form_elements -%]
@@ -154,6 +73,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
       class = post_button_class,
       id = 'submitpost'
   ) -%]
+
+  [%- UNLESS minimal -%]
   [%- form.submit(
       name = 'submitpview'
       value = dw.ml( 'talk.btn.preview' ),
@@ -169,6 +90,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
   [%- END -%]
   <span id='quotebuttonspan'></span>
   <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
+  [%- END -%]
+
   [%- form.submit(
       name = 'submitmoreopts'
       value = dw.ml( '/talkread.bml.button.more' ),
@@ -186,7 +109,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
 </div>
 
 </form></div>
-[%- END -%]
 [%- END -%]
 
 <script type='text/javascript'>

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -163,11 +163,11 @@ the same terms as Perl itself.  For a copy of the license, please reference
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) -%]
   [%- IF can_checkspell -%]
-    [%- form.checkbox(
+    <div>[%- form.checkbox(
       label = dw.ml( '/talkread.bml.qr.spellcheck' )
       name = 'do_spellcheck'
       id = 'do_spellcheck'
-    ) -%]
+    ) -%]</div>
   [%- END -%]
   <span id='quotebuttonspan'></span>
   <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -130,11 +130,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         placeholder = dw.ml( '/talkpost.bml.opt.subject2' )
   ) -%]
 
-  <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
-
   [%- help.icon -%]
-
-  <span id='quotebuttonspan'></span>
 </div>
 
 <div class="qr-body">
@@ -160,6 +156,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
       class = post_button_class,
       id = 'submitpost'
   ) -%]
+  <span id='quotebuttonspan'></span>
+  <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
   [%- form.submit(
       name = 'submitpview'
       value = dw.ml( 'talk.btn.preview' ),

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -10,9 +10,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
 
-[%- IF minimal -%]
 [%- dw.need_res( "stc/css/components/quick-reply.css" ) -%]
 
+[%- IF minimal -%]
 [%- quickreply = BLOCK -%]
 
 <div id='qrformdiv'><form id='qrform' name='qrform' method='POST' action='[%- form_url | url -%]'>
@@ -93,94 +93,100 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- END -%]
 [%- ELSE -%]
 [%- quickreply = BLOCK -%]
+
 <div id='qrformdiv'><form id='qrform' name='qrform' method='POST' action='[%- form_url | url -%]'>
 [%- dw.form_auth -%]
 [%- hidden_form_elements -%]
-
-<table>
-  <tr valign='center'>
-    <td align='right'><b>[%- "/talkpost.bml.opt.from" | ml -%]</b></td>
-    <td align='left'>[%- remote.ljuser -%]</td>
-    <td align='center'>
-      <label for='prop_picture_keyword'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
-      [%- form.select(
-          name = 'prop_picture_keyword',
-          id = 'prop_picture_keyword',
-          selected = current_icon_kw,
-          items = remote.icons
-      ) -%]
-
+<div class='qr-icon'>
+    [%- IF current_icon -%]
       [%- IF remote.can_use_iconbrowser -%]
-        <input type="button" id="lj_userpicselect" value="Browse" />
+        <button id="lj_userpicselect">[%- current_icon.imgtag -%]</button>
+      [%- ELSE -%]
+        [%- current_icon.imgtag -%]
       [%- END -%]
+    [%- ELSE -%]
+      [%- dw.img( "nouserpic_sitescheme", "" ) -%]
+    [%- END -%]
+</div>
 
-      <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
+<div class="qr-meta">
+  [%- IF remote.icons.size > 0 -%]
+    <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
+    [%- form.select(
+        name = 'prop_picture_keyword',
+        id = 'prop_picture_keyword',
+        selected = current_icon_kw,
+        items = remote.icons
+    ) -%]
+  [%- END -%]
 
-      [%- help.icon -%]
+  [%- form.textbox(
+        label = dw.ml( '/talkpost.bml.opt.subject2' )
+        labelclass = 'invisible'
+        size = 50
+        maxlength = 100
+        name = 'subject'
+        id = 'subject'
+        placeholder = dw.ml( '/talkpost.bml.opt.subject2' )
+  ) -%]
 
-      <span id='quotebuttonspan'></span>
-    </td>
-  </tr>
+  <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
 
-  <tr>
-    <td align='right'><label for='subject'><b>[%- '/talkpost.bml.opt.subject' | ml -%]</b></label></td>
-    <td colspan='2' align='left'><input class='textbox' type='text' size='50' maxlength='100' name='subject' id='subject' value='' /></td>
-  </tr>
+  [%- help.icon -%]
 
-  <tr valign='top'>
-    <td align='right'><label for='body'><b>[%- '/talkpost.bml.opt.message' | ml -%]</b></td>
-    <td colspan='3' style='width: 90%'>
-      <textarea class='textbox' rows='10' cols='50' wrap='soft' name='body' id='body' style='width: 99%; height: 99%'></textarea>
-    </td>
-  </tr>
+  <span id='quotebuttonspan'></span>
+</div>
 
-  <tr>
-    <td>&nbsp;</td>
-    <td colspan='3' align='left'>
-      [%- IF post_disabled -%]
-      <div class='ui-state-error'>[%- '/talkpost.bml.error.nocomment_quick' | ml -%]</div>
-      [%- END -%]
-      [%- form.submit(
-          name = 'submitpost'
-          value = dw.ml( '/talkread.bml.button.post' ),
-          disabled = post_disabled,
-          class = post_button_class,
-          id = 'submitpost'
-      ) -%]
-      &nbsp;
-      [%- form.submit(
-          name = 'submitpview'
-          value = dw.ml( 'talk.btn.preview' ),
-          id = 'submitpview'
-      ) -%]
-      [%- form.hidden( name = 'submitpreview', value = 0 ) -%]
-      &nbsp;
-      [%- form.submit(
-          name = 'submitmoreopts'
-          value = dw.ml( '/talkread.bml.button.more' ),
-          id = 'submitmoreopts'
-      ) -%]
+<div class="qr-body">
+  [%- form.textarea(
+    label = dw.ml( '/talkpost.bml.opt.message2' )
+    labelclass = 'invisible'
+    rows = 10
+    cols = 80
+    wrap = 'soft'
+    name = 'body'
+    id = 'body'
+  ) -%]
+</div>
 
-      [%- IF can_checkspell -%]
-        &nbsp;
-        [%- form.checkbox(
-          label = dw.ml( '/talkread.bml.qr.spellcheck' )
-          name = 'do_spellcheck'
-          id = 'do_spellcheck'
-        ) -%]
-      [%- END -%]
+<div class="qr-footer">
+  [%- IF post_disabled -%]
+  <div class='ui-state-error'>[%- '/talkpost.bml.error.nocomment_quick' | ml -%]</div>
+  [%- END -%]
+  [%- form.submit(
+      name = 'submitpost'
+      value = dw.ml( '/talkread.bml.button.post' ),
+      disabled = post_disabled,
+      class = post_button_class,
+      id = 'submitpost'
+  ) -%]
+  [%- form.submit(
+      name = 'submitpview'
+      value = dw.ml( 'talk.btn.preview' ),
+      id = 'submitpview'
+  ) -%]
+  [%- form.hidden( name = 'submitpreview', value = 0 ) -%]
+  [%- form.submit(
+      name = 'submitmoreopts'
+      value = dw.ml( '/talkread.bml.button.more' ),
+      id = 'submitmoreopts'
+  ) -%]
+  [%- IF can_checkspell -%]
+    [%- form.checkbox(
+      label = dw.ml( '/talkread.bml.qr.spellcheck' )
+      name = 'do_spellcheck'
+      id = 'do_spellcheck'
+    ) -%]
+  [%- END -%]
+  [%- IF journal.is_iplogging -%]
+    <div class='de'>[%- '/talkpost.bml.logyourip' | ml -%]</div>
+    [%- help.iplogging -%]
+  [%- END -%]
+  [%- IF journal.is_linkstripped -%]
+    <div class='de'>[%- '/talkpost.bml.linkstripped' | ml -%]</div>
+  [%- END -%]
+</div>
 
-      [%- IF journal.is_iplogging -%]
-        <br><span class='de'>[%- '/talkpost.bml.logyourip' | ml -%]</span>
-        [%- help.iplogging -%]
-      [%- END -%]
-
-      [%- IF journal.is_linkstripped -%]
-        <br><span class='de'>[%- '/talkpost.bml.linkstripped' | ml -%]</span>
-      [%- END -%]
-    </td>
-  </tr>
-</table>
 </form></div>
 [%- END -%]
 [%- END -%]

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -129,8 +129,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
         id = 'subject'
         placeholder = dw.ml( '/talkpost.bml.opt.subject2' )
   ) -%]
-
-  [%- help.icon -%]
 </div>
 
 <div class="qr-body">
@@ -176,6 +174,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
       value = dw.ml( '/talkread.bml.button.more' ),
       id = 'submitmoreopts'
   ) -%]
+
+  [%- help.icon -%]
   [%- IF journal.is_iplogging -%]
     <div class='de'>[%- '/talkpost.bml.logyourip' | ml -%]</div>
     [%- help.iplogging -%]


### PR DESCRIPTION
Resolves #2410.
Fixes one instance of #2421.

This PR rewrites the template for the "less-quick" quick-reply so that it uses a flexible layout similar to the "quicker" quick-reply. To keep things sleek, it moves the "quote" and "random icon" buttons below the body textarea.

This tweaks some tiny amounts of perl (to make the required CSS available on single-entry pages) and javascript (to update the icon preview when the random button fires). 

It also tweaks some less-tiny amounts of SCSS to make sure things display nicely as the page moves up and down the range of sizes.

#### Gif

![resize2](https://user-images.githubusercontent.com/484309/55895531-30d1d200-5b71-11e9-9ee0-7e09b00ee937.gif)

#### Stills

quick-er reply (this branch): 

![image](https://user-images.githubusercontent.com/484309/56053172-3d3c6300-5d08-11e9-8cc1-8357fefb32dc.png)

less-quick reply (this branch):

![image](https://user-images.githubusercontent.com/484309/56053196-5513e700-5d08-11e9-90ff-3fbe347b0651.png)

less-quick reply (mobile, this branch):

<img src="https://user-images.githubusercontent.com/484309/56058621-bb076b00-5d16-11e9-845a-762dfdd216c6.png" height="400">