### PR TITLE
Some tweaks to fix XML issues and bad MySQL

### DIFF
--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Comments.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Comments.pm
@@ -573,7 +573,7 @@ sub try_work {
 sub do_authed_comment_fetch {
     my ( $class, $data, $mode, $startid, $numitems, $log ) = @_;
     my $authas = $data->{usejournal} ? "&authas=$data->{usejournal}" : '';
-    my $url = "http://www.$data->{hostname}/export_comments.bml?get=$mode&startid=$startid&numitems=$numitems&props=1$authas";
+    my $url = "https://www.$data->{hostname}/export_comments.bml?get=$mode&startid=$startid&numitems=$numitems&props=1$authas";
 
     # see if the file is cached and recent. this is mostly a hack useful for debugging
     # when something goes bad, or if we somehow get stuck in a loop. at least we won't

--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Entries.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Entries.pm
@@ -288,7 +288,7 @@ sub try_work {
         my $hash = $class->call_xmlrpc( $data, 'getevents',
             {
                 ver         => 1,
-                itemids     => join( ',', @_ ),
+                itemids     => join( ',', @_ ) . ",",
                 selecttype  => 'multiple',
                 lineendings => 'unix',
             }
@@ -301,7 +301,6 @@ sub try_work {
             $temp_fail->( $xmlrpc_fail );
             return 0;
         }
-
         # good, import this event
         $process_entry->( $_ )
             foreach @{ $hash->{events} || [] };


### PR DESCRIPTION
So the trailing comma thing seems weird, but I looked at the XMLRPC code and for selecttype=multiple, it splits the ids by trailing comma (see: https://github.com/dreamwidth/dw-free/blob/0a51d28ff8431ada1b622b1df3086443986f24c1/cgi-bin/LJ/Protocol.pm#L2359 ) which causes the last id on the list to be dropped (resulting in an empty list passed to the MySQL IN clause when there's only one item.