### PR TITLE
API release hotfixes

### DIFF
--- a/cgi-bin/DW/API/Key.pm
+++ b/cgi-bin/DW/API/Key.pm
@@ -170,7 +170,7 @@ sub delete {
 
     my $dbw = LJ::get_db_writer() or croak "Failed to get database";
     $dbw->do(
-        q{UPDATE api_key SET state = 'D' WHERE state = 'A' hash = ?},
+        q{UPDATE api_key SET state = 'D' WHERE state = 'A' AND hash = ?},
         undef, $self->{keyhash}
     );
 

--- a/cgi-bin/DW/Controller/API/REST.pm
+++ b/cgi-bin/DW/Controller/API/REST.pm
@@ -28,7 +28,6 @@ use DW::API::Key;
 use JSON;
 use YAML::XS qw'LoadFile';
 use JSON::Validator 'validate_json';
-use Scalar::Util 'blessed';
 use Hash::MultiValue;
 
 use Carp qw/ croak /;
@@ -316,7 +315,7 @@ sub schema {
         
         # turn on coercion for params, because perl doesn't care about scalar types but JSON does
         # so we're more flexible on input than output
-        if (defined(blessed($self)) && blessed($self) eq 'DW::API::Parameter') {
+        if (ref($self) eq 'DW::API::Parameter') {
             $validator = $validator->coerce({'booleans' => 1, 'numbers' => 1, 'strings' => 1});
         }
 

--- a/cgi-bin/DW/Controller/API/REST.pm
+++ b/cgi-bin/DW/Controller/API/REST.pm
@@ -317,7 +317,7 @@ sub schema {
         # turn on coercion for params, because perl doesn't care about scalar types but JSON does
         # so we're more flexible on input than output
         if (defined(blessed($self)) && blessed($self) eq 'DW::API::Parameter') {
-            $validator = $validator->coerce(1);
+            $validator = $validator->coerce({'booleans' => 1, 'numbers' => 1, 'strings' => 1});
         }
 
         $self->{validator} = $validator;

--- a/cgi-bin/DW/Controller/API/REST.pm
+++ b/cgi-bin/DW/Controller/API/REST.pm
@@ -316,7 +316,7 @@ sub schema {
         
         # turn on coercion for params, because perl doesn't care about scalar types but JSON does
         # so we're more flexible on input than output
-        if (blessed($self) eq 'DW::API::Parameter') {
+        if (defined(blessed($self)) && blessed($self) eq 'DW::API::Parameter') {
             $validator = $validator->coerce(1);
         }
 

--- a/cgi-bin/DW/Controller/API/REST.pm
+++ b/cgi-bin/DW/Controller/API/REST.pm
@@ -28,6 +28,7 @@ use DW::API::Key;
 use JSON;
 use YAML::XS qw'LoadFile';
 use JSON::Validator 'validate_json';
+use Scalar::Util 'blessed';
 use Hash::MultiValue;
 
 use Carp qw/ croak /;
@@ -159,7 +160,7 @@ sub _dispatcher {
     # match path parameters to their names
     my $path = $self->{path}{name};
     my $path_params = {};
-    my @path_names = ($path =~ /{([\w]+)}/);
+    my @path_names = ($path =~ /{([\w]+)}/g);
     for (my $i = 0; $i < @path_names; $i++) {
         $path_params->{$path_names[$i]} = $path_args[$i];
     }
@@ -312,6 +313,13 @@ sub schema {
 
         # make a validator against the schema
         my $validator = JSON::Validator->new->schema($self->{schema});
+        
+        # turn on coercion for params, because perl doesn't care about scalar types but JSON does
+        # so we're more flexible on input than output
+        if (blessed($self) eq 'DW::API::Parameter') {
+            $validator = $validator->coerce(1);
+        }
+
         $self->{validator} = $validator;
     } else {
         croak "No schema defined!";

--- a/cgi-bin/DW/Controller/API/REST/Icons.pm
+++ b/cgi-bin/DW/Controller/API/REST/Icons.pm
@@ -29,7 +29,7 @@ sub rest_get {
     my $u = LJ::load_user( $args->{path}{username});
 
     # if we're given a picid, try to load that userpic
-    if ($args->{path}{picid} ne "") {
+    if (defined($args->{path}{picid}) && $args->{path}{picid} ne "") {
         my $userpic = LJ::Userpic->get( $u, $args->{path}{picid} );
         if ( defined $userpic ) {
             return $self->rest_ok( $userpic );

--- a/cgi-bin/LJ/Userpic.pm
+++ b/cgi-bin/LJ/Userpic.pm
@@ -1308,7 +1308,7 @@ sub TO_JSON {
     my @keywords = $self->keywords;
     my $returnval = { 
         username => $self->u->user,
-        picid => $self->picid,
+        picid => $self->picid + 0, # so we return an int, not a string
         url => $self->url,
         comment => $self->comment,
         keywords => \@keywords,

--- a/cgi-bin/LJ/Userpic.pm
+++ b/cgi-bin/LJ/Userpic.pm
@@ -1308,7 +1308,7 @@ sub TO_JSON {
     my @keywords = $self->keywords;
     my $returnval = { 
         username => $self->u->user,
-        picid => $self->picid + 0, # so we return an int, not a string
+        picid => int($self->picid),
         url => $self->url,
         comment => $self->comment,
         keywords => \@keywords,


### PR DESCRIPTION
-Fix SQL statement for deleting API keys
-Actually return picid as an integer, like we claim we do
-Capture all path parameters, not just the first one
-Loosen JSON validation for incoming data, because Perl doesn't care