### PR TITLE
[#2430] fix error_ml arguments

### DIFF
--- a/cgi-bin/DW/Controller.pm
+++ b/cgi-bin/DW/Controller.pm
@@ -42,9 +42,8 @@ sub needlogin {
 
 # returns an error page using a language string
 sub error_ml {
-    my ($string, $opts) = @_;
     return DW::Template->render_template(
-        'error.tt', { message => LJ::Lang::ml( $string ), opts => $opts }
+        'error.tt', { message => LJ::Lang::ml( $_[0], $_[1] ), opts => $_[2] }
     );
 }
 

--- a/cgi-bin/DW/Controller/Customize/Advanced.pm
+++ b/cgi-bin/DW/Controller/Customize/Advanced.pm
@@ -260,7 +260,7 @@ sub layers_handler {
     return error_ml(($remote->{user} eq $u->{user} ?
             '/customize/advanced/layers.tt.error.youcantuseadvanced' :
             '/customize/advanced/layers.tt.error.usercantuseadvanced' ),
-            {authas => $rv->{authas_html} })
+            undef, { authas => $rv->{authas_html} })
         unless $u->can_create_s2_styles || $viewall;
 
     if ($POST->{'action:create'} && !$noactions) {
@@ -432,7 +432,7 @@ sub styles_handler {
     return error_ml( ($remote->{user} eq $u->{user} ?
             '/customize/advanced/styles.tt.error.youcantuseadvanced' :
             '/customize/advanced/styles.tt.error.usercantuseadvanced'),
-            { authas => $rv->{authas_html} } )
+            undef, { authas => $rv->{authas_html} } )
         unless $u->can_create_s2_styles || $viewall;
 
     return error_ml('/customize/advanced/index.tt.error.advanced.editing.denied')


### PR DESCRIPTION
The previous change to error_ml dropped any message arguments for LJ::Lang::ml
on the floor, because the expected inputs weren't well documented.

This changes error_ml to accept an input format similar to success_ml, where
the message arguments are in the first hashref, and any page variables are
in a subsequent hashref.

The two places where page variables had begun being passed into error_ml are
updated to pass in undef for the message arguments, so everything should line
up correctly.

Fixes #2430.