### PR TITLE
[#2432] Enable responsive comment thread indentation (opt-in)

### DIFF
--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -487,6 +487,9 @@ class Comment extends EntryLite
 
     function print_edit_text () "Print the text that says when this comment was edited.";
 
+    function depth_zones () : string[] "Returns an array of all the thread depth zones that apply to the comment, based on the configured nesting limits. Available depth zones are 'mobile', 'desktop', and 'none'.";
+    function print_depth_indicator () "Prints a span indicating the comment's depth, with CSS classes to allow different styling at different widths.";
+
 }
 
 class Icon
@@ -1380,6 +1383,23 @@ property string comment_time_format {
     grouped = 1;
 }
 
+property string comment_indent_style {
+    des = "Indentation for nested comment threads";
+    values = "responsive|Responsive|static|Static (25px)";
+    note = "PREVIEW FEATURE. Responsive indentation is much nicer on mobile, but in very deep threads it stops indenting and uses more compact styling to show thread depth. Static indentation will keep indenting indefinitely, but is often unusable on mobile.";
+}
+
+property int comment_indent_limit_mobile {
+    des = "Beyond this depth, use compact styling to indicate thread depth (mobile). Ignored for static indentation.";
+}
+property int comment_indent_limit_desktop {
+    des = "Beyond this depth, use compact styling to indicate thread depth (desktop). Ignored for static indentation.";
+    max = 180;
+}
+property string comment_indent_depth_caption {
+    des = "Caption for thread depth indicators";
+}
+
 property string[] userpics_style_group {
     des = "Select the size of icons";
     grouptype = "datetime";
@@ -1447,6 +1467,10 @@ set entry_date_format = "med";
 set entry_time_format = "short";
 set comment_date_format = "iso";
 set comment_time_format = "short";
+set comment_indent_style = "static";
+set comment_indent_limit_mobile = 8;
+set comment_indent_limit_desktop = 180;
+set comment_indent_depth_caption = "Depth: ";
 set entry_userpic_style = "";
 set comment_userpic_style = "";
 set userpics_position = "left";
@@ -4309,7 +4333,7 @@ function print_module_navlinks( bool apply_class_to_link ) {
             $class = "$k " + $class;
             if ($p.view == $k) { $class = "current " + $class; }
           }
-          
+
           $links[size $links] = { "class" => $class, "item" => """<a href="$p.view_url{$k}"$css>"""+lang_viewname($k)+"""</a>""" };
       }
     print_module_list($links);
@@ -5098,6 +5122,28 @@ function Comment::print_edit_text() {
         print "<div class='edittime'><em>$*text_comment_edittime $editreason";
         $this->print_edittime();
         print "</em></div>";
+    }
+}
+
+function Comment::depth_zones() : string[] {
+    if ($this.depth <= $*comment_indent_limit_mobile) {
+        return ["desktop", "mobile"];
+    }
+    elseif ($this.depth <= $*comment_indent_limit_desktop) {
+        return ["desktop"];
+    }
+    else {
+        return ["none"];
+    }
+}
+
+function Comment::print_depth_indicator() {
+    if ($*comment_indent_style == "responsive") {
+        "<span class='thread-depth";
+        foreach var string zone ($this->depth_zones()) {
+            " indent-$zone";
+        }
+        "'>$*comment_indent_depth_caption$this.depth</span>";
     }
 }
 
@@ -6303,9 +6349,17 @@ function EntryPage::print_comments (Comment[] cs) {
 
         # actually print the comment
         var string parity = $c.depth % 2 ? "odd" : "even";
-        var int indent = ($c.depth - 1) * 25;
-        "<div class='comment-thread comment-depth-$parity comment-depth-$c.depth'>\n";
-        "<div id='$c.dom_id' class='dwexpcomment' style='margin-left: ${indent}px; margin-top: 5px;";
+        var int mod5 = $c.depth % 5;
+        "<div data-comment-depth='$c.depth' style='--comment-depth: $c.depth; --comment-indent-limit-mobile: ${*comment_indent_limit_mobile}' class='comment-thread";
+        foreach var string zone ($c->depth_zones()) {
+            " comment-depth-indent-$zone";
+        }
+        " comment-depth-$parity comment-depth-mod5-$mod5 comment-depth-$c.depth'>\n";
+        "<div id='$c.dom_id' class='dwexpcomment' style='";
+        if ($*comment_indent_style == "static") {
+            var int indent = ($c.depth - 1) * 25;
+            "margin-left: ${indent}px; margin-top: 5px;";
+        }
         if ($c.hidden_child) {
             " display: none;";
         }
@@ -6367,6 +6421,7 @@ function EntryPage::print_comment (Comment c) {
     $c->print_wrapper_start();
     """<div class="header">\n""";
     """<div class="inner">\n""";
+    $c->print_depth_indicator();
     $c->print_subject();
     $c->print_metatypes();
     $c->print_time();
@@ -6401,6 +6456,7 @@ function EntryPage::print_comment (Comment c) {
 function EntryPage::print_comment_partial (Comment c) {
     $c->print_wrapper_start();
     if ($c.deleted) {
+        $c->print_depth_indicator();
         print $*text_deleted;
         if ($c.hide_children) {
             var Link expand_link = $c->get_link("expand_comments");
@@ -6412,6 +6468,7 @@ function EntryPage::print_comment_partial (Comment c) {
         }
     }
     elseif ($c.fromsuspended) {
+        $c->print_depth_indicator();
         print $*text_fromsuspended;
         if ($c.hide_children) {
             var Link expand_link = $c->get_link("expand_comments");
@@ -6423,6 +6480,7 @@ function EntryPage::print_comment_partial (Comment c) {
         }
     }
     elseif ($c.screened_noshow) {
+        $c->print_depth_indicator();
         print $*text_screened;
         if ($c.hide_children) {
             var Link expand_link = $c->get_link("expand_comments");
@@ -6435,6 +6493,7 @@ function EntryPage::print_comment_partial (Comment c) {
     }
     else {
         var string poster = defined $c.poster ? $c.poster->as_string() : "<i>$*text_poster_anonymous</i>";
+        $c->print_depth_indicator();
         $c->print_subject();
         $c->print_poster(); " - ";
         $c->print_time();

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -3765,30 +3765,48 @@ function generate_font_css(string font_base, string font_fallback, string font_s
     return generate_font_css("", $font_base, $font_fallback, $font_size, $font_unit);
 }
 
-function generate_media_query(string user_breakpoint, int sidebar_width_multiplier, string default_min_width): string {
-    # use the user-provided breakpoint width
-    var string min_width = $user_breakpoint;
+function generate_invisible_css() : string {
+    return "    /* yes on screenreaders, no on display */
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+";
+}
 
-    # no user-provided breakpoint width, base our min-width as a multiplier on the sidebar width
-    if ($min_width == "" and $*sidebar_width != "") {
+function generate_media_query(string user_breakpoint, int sidebar_width_multiplier, string default_break_width, string min_or_max): string {
+    # use the user-provided breakpoint width
+    var string break_width = $user_breakpoint;
+
+    # no user-provided breakpoint width, base our break_width as a multiplier on the sidebar width
+    if ($break_width == "" and $*sidebar_width != "") {
         # set the min width in ems
-        $min_width = $*sidebar_width->css_multiply_length($sidebar_width_multiplier);
+        $break_width = $*sidebar_width->css_multiply_length($sidebar_width_multiplier);
     }
 
     # $*sidebar_width wasn't in a format we expected, fall back to a default
-    if ($min_width == "") {
-        $min_width = $default_min_width;
+    if ($break_width == "") {
+        $break_width = $default_break_width;
     }
 
-    return "only screen and (min-width: $min_width)";
+    return "only screen and ($min_or_max-width: $break_width)";
+}
+
+function generate_small_media_query(): string {
+    return generate_media_query($*medium_breakpoint_width, 3, "40em", "max");
 }
 
 function generate_medium_media_query(): string {
-    return generate_media_query($*medium_breakpoint_width, 3, "40em");
+    return generate_media_query($*medium_breakpoint_width, 3, "40em", "min");
 }
 
 function generate_large_media_query(): string {
-    return generate_media_query($*large_breakpoint_width, 4, "64em");
+    return generate_media_query($*large_breakpoint_width, 4, "64em", "min");
 }
 
 function Page::print_meta_tags() {

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -38,6 +38,11 @@ propgroup presentation {
     property use entry_management_links;
     property use comment_management_links;
 
+    property use comment_indent_style;
+    property use comment_indent_limit_mobile;
+    property use comment_indent_limit_desktop;
+    property use comment_indent_depth_caption;
+
 }
 
 set layout_type = "one-column";
@@ -247,8 +252,11 @@ propgroup customcss {
 }
 
 function Page::print_default_stylesheet() {
+    var string small_media_query = generate_small_media_query();
     var string medium_media_query = generate_medium_media_query();
     var string large_media_query = generate_large_media_query();
+
+    var string make_invisible = generate_invisible_css();
 
     var string page_background = generate_background_css ($*image_background_page_url, $*image_background_page_repeat, $*image_background_page_position, $*color_page_background);
     var string header_background = generate_background_css ($*image_background_header_url, $*image_background_header_repeat, $*image_background_header_position, $*color_header_background);
@@ -313,6 +321,44 @@ function Page::print_default_stylesheet() {
                  }
              """;
          }
+
+    var string responsive_indent_css = "";
+        if ($*comment_indent_style == "responsive") {
+            $responsive_indent_css = """
+            /* Basic responsive comment thread indentation */
+            .comment-thread {
+                margin-top: 5px;
+                }
+
+            @media $small_media_query {
+                /* Mobile indents */
+                .comment-depth-indent-mobile {
+                    margin-left: 10px;
+                    }
+
+                .thread-depth.indent-mobile {
+                    $make_invisible
+                    }
+                }
+
+            @media $medium_media_query {
+                .comment-depth-indent-desktop {
+                    margin-left: 20px;
+                    }
+
+                .thread-depth.indent-desktop {
+                    $make_invisible
+                    }
+                }
+
+            .comment-depth-1 {
+                margin-left: 0;
+                }
+
+            """;
+        }
+
+
     print_custom_control_strip_css();
 
     """
@@ -605,6 +651,8 @@ ul.entry-interaction-links li {
 /* comments */
 
 .comment-posted {font-weight:bold;}
+
+$responsive_indent_css
 
 .comment-wrapper {
     padding: .5em 0;

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -500,6 +500,7 @@ h2#pagetitle {
 
 .entry .entry-title {
     $entry_title_font
+    overflow-wrap: break-word;
 }
 
 .entry .entry-title, .entry .entry-title a {
@@ -509,6 +510,10 @@ h2#pagetitle {
 .no-subject .entry .entry-title {
     background: none;
     border: none;
+}
+
+.entry .contents {
+    overflow-wrap: break-word;
 }
 
 .entry a { $entry_link_colors }
@@ -558,6 +563,10 @@ h2#pagetitle {
     margin-bottom: 1em;
 }
 
+.metadata-item, .poster-ip {
+    overflow-wrap: break-word;
+}
+
 .tag ul {
     display: inline;
     margin-left: 0;
@@ -605,6 +614,7 @@ ul.entry-interaction-links li {
 .comment .comment-title {
     $comment_title_font
     margin: 0;
+    overflow-wrap: break-word;
 }
 
 .comment .comment-title, .comment .comment-title a {
@@ -614,6 +624,10 @@ ul.entry-interaction-links li {
 .no-subject .comment .comment-title {
     background: none;
     border: none;
+}
+
+.comment .contents {
+    overflow-wrap: break-word;
 }
 
 ul.comment-management-links {
@@ -710,10 +724,13 @@ table.month td p {
 .module h2 {
     $module_title_colors
     $module_title_font
+    overflow-wrap: break-word;
 }
 
 .module-content {
     $module_font
+    overflow-x: auto;
+    overflow-wrap: break-word;
 }
 
 .module-content ul {
@@ -768,7 +785,7 @@ ul.userlite-interaction-links.text-links {
     max-width: 100%;
 }
 
-.search-form .search-box-item, 
+.search-form .search-box-item,
 .search-form .search-button-item {
     display: block
 }

--- a/styles/practicality/layout.s2
+++ b/styles/practicality/layout.s2
@@ -153,6 +153,8 @@ function print_stylesheet () {
     var string medium_media_query = generate_medium_media_query();
     var string small_media_query = generate_small_media_query();
 
+    var string make_invisible = generate_invisible_css();
+
     var string page_subtitle_font = generate_font_css($*font_journal_subtitle, $*font_base, $*font_fallback, $*font_journal_subtitle_size, $*font_journal_subtitle_units);
     var string entry_title_font = generate_font_css($*font_entry_title, $*font_base, $*font_fallback, $*font_entry_title_size, $*font_entry_title_units);
 
@@ -229,6 +231,92 @@ function print_stylesheet () {
                 }
             """;
         }
+
+    var string responsive_indent_css = "";
+        if ($*comment_indent_style == "responsive") {
+            $responsive_indent_css = """
+            /* Responsive comment thread indentation */
+            .comment-thread {
+                margin-top: 7px;
+                }
+
+            @media $small_media_query {
+                /* Mobile indents */
+                .comment-depth-indent-mobile {
+                    margin-left: 10px;
+                    }
+
+                /* Establish an anchoring containing block for thread lines */
+                .comment-thread {
+                    position: relative;
+                    }
+
+                /* Once the thread lines absolute themselves off the page, don't
+                   scroll for them. Content shouldn't be affected because it
+                   gets overflow-x:auto-ed well before becoming the section
+                   container's problem. Make sure to set comment_indent_limit_mobile
+                   low enough to work for 320px viewport widths, because if
+                   there's slop it'll get cut off. */
+                #comments {
+                    overflow-x: hidden;
+                    }
+
+                /* Go-behind thread lines for non-indented threads */
+                .comment-thread::before {
+                    content: "";
+                    width: 2px;
+                    /* Leave a gap between threads, so it's easier to see the
+                    /transition between two replies to the same parent */
+                    height: 100%;
+                    display: block;
+                    position: absolute;
+                    background-color: ${*color_entry_border};
+                    z-index: -1;
+                    /* Since the thread blocks stay at the same indent level from
+                       here on out, we need to manually indent each add'l line. */
+                    left: calc( (var(--comment-depth) - var(--comment-indent-limit-mobile)) * 10px);
+                    top: 0;
+                    border-radius: 1px;
+                    }
+
+                /* On-the-left thread lines for threads that still get indented */
+                .comment-thread.comment-depth-indent-mobile::before {
+                    left: -10px; /* Let the compounding margins handle the indent */
+                    }
+
+                /* Skip the first one */
+                .comment-thread.comment-depth-1::before {
+                    display:none;
+                    }
+
+                /* Color every fifth one differently for easy counting */
+                .comment-thread.comment-depth-mod5-1::before {
+                    background-color: ${*color_entry_background};
+                    }
+
+                /* Hide numeric indicators if indent is working */
+                .thread-depth.indent-mobile {
+                    $make_invisible
+                    }
+                }
+
+            @media $medium_media_query {
+                .comment-depth-indent-desktop {
+                    margin-left: 20px;
+                    }
+
+                .thread-depth.indent-desktop {
+                    $make_invisible
+                    }
+                }
+
+            .comment-depth-1 {
+                margin-left: 0;
+                }
+
+            """;
+        }
+
 """
 
 /*--------------------*/
@@ -841,6 +929,12 @@ td.day {
 hr.above-entry-interaction-links, hr.below-reply-container {
     display: none;
     }
+
+.comment-wrapper {
+    min-width: 14em;
+    }
+
+$responsive_indent_css
 
 .comment {
     background: $*color_entry_background;

--- a/styles/practicality/layout.s2
+++ b/styles/practicality/layout.s2
@@ -151,6 +151,7 @@ function Page::print() {
 
 function print_stylesheet () {
     var string medium_media_query = generate_medium_media_query();
+    var string small_media_query = generate_small_media_query();
 
     var string page_subtitle_font = generate_font_css($*font_journal_subtitle, $*font_base, $*font_fallback, $*font_journal_subtitle_size, $*font_journal_subtitle_units);
     var string entry_title_font = generate_font_css($*font_entry_title, $*font_base, $*font_fallback, $*font_entry_title_size, $*font_entry_title_units);
@@ -168,32 +169,62 @@ function print_stylesheet () {
     var string userpic_css = "";
         if ($*userpics_position == "left") {
             $userpic_css = """
+            /* Float placeholder for userpic */
+            .entry .contents > .inner::before,
+            .comment .contents > .inner::before {
+                content: "";
+                display: block;
+                position: static;
+                width: 140px;
+                height: 100px;
+                float: left;
+                }
+
             .has-userpic .entry .userpic,
             .has-userpic .comment .userpic {
-                float: left;
+                position: absolute;
+                left: 10px;
+                top: -20px;
                 }
             .has-userpic .entry .header,
             .has-userpic .comment .header {
                 text-align: right;
                 }
-            .has-userpic .entry .header {
+            .has-userpic .entry .header .datetime {
+                display: block;
                 margin-left: $entry_header_margin;
                 }
-            .has-userpic .comment .header {
+            .has-userpic .comment .header .datetime {
+                display: block;
                 margin-left: $comment_header_margin;
                 }
             """;
         }
         elseif ($*userpics_position == "right") {
             $userpic_css = """
-            .has-userpic .entry .userpic,
-            .has-userpic .comment .userpic {
+            /* Float placeholder for userpic */
+            .entry .contents > .inner::before,
+            .comment .contents > .inner::before {
+                content: "";
+                display: block;
+                position: static;
+                width: 140px;
+                height: 100px;
                 float: right;
                 }
-            .has-userpic .entry .header {
+
+            .has-userpic .entry .userpic,
+            .has-userpic .comment .userpic {
+                position: absolute;
+                right: 10px;
+                top: -20px;
+                }
+            .has-userpic .entry .header .datetime {
+                display: block;
                 margin-right: $entry_header_margin;
                 }
-            .has-userpic .comment .header {
+            .has-userpic .comment .header .datetime {
+                display: block;
                 margin-right: $comment_header_margin;
                 }
             """;
@@ -248,6 +279,12 @@ ol {
 #canvas {
     width: 90%;
     margin: 0 auto;
+    }
+
+@media $small_media_query {
+    #canvas {
+        width: calc(100% - 10px);
+        }
     }
 
 #primary > .inner:first-child {
@@ -494,9 +531,23 @@ ul.userlite-interaction-links.text-links {
     margin: 0 0 15px 0;
     }
 
+/* Provide an anchor for absolute positioning of descendents like userpic */
+.entry .contents {
+  position: relative;
+}
+
+/* Don't allow one overflowing flist entry to trash the whole page's layout */
+.entry .contents > .inner {
+    overflow-x: auto;
+}
+
 .entry-content {
     margin: 10px 0 0;
     min-height: 100px;
+    }
+
+.entry-content td, .entry-content th {
+    border: 1px solid $*color_entry_border;
     }
 
 .entry .header {
@@ -529,7 +580,6 @@ h3.entry-title a:visited {
 
 .has-userpic .entry .userpic {
     border: none;
-    margin: -20px 10px 10px 10px;
     }
 
 .entry .userpic img {
@@ -799,6 +849,16 @@ hr.above-entry-interaction-links, hr.below-reply-container {
     padding: 1em;
     }
 
+/* Provide an anchor for absolute positioning of descendents like userpic */
+.comment .contents {
+  position: relative;
+}
+
+/* Don't allow one overflowing comment to trash the whole page's layout */
+.comment .contents > .inner {
+    overflow-x: auto;
+}
+
 .comment a { color: $*color_entry_link; }
 .comment a:visited { color: $*color_entry_link_visited; }
 .comment a:hover { color: $*color_entry_link_hover; }
@@ -841,7 +901,6 @@ textarea.textbox {
 .has-userpic .comment .userpic {
     border: none;
     display: block;
-    margin: -1em .5em .5em .5em;
     }
 
 .comment .userpic img {


### PR DESCRIPTION
(Previous rambling description moved to comments of #2432.)

This PR is now ready for review and merge as a "special preview" or "beta" or what have you. It does a couple of things: 

- **Adds some core2 features to enable responsive comment indentation.** See the commit message for full details, but basically this is a double opt-in: layouts have to enable it, and users have to turn it on after choosing a supported layout. 
- **Adds really basic responsive indent in Tabula Rasa and all descendents.** 
- **Adds a more advanced responsive indent in Practicality.**
- Adds some CSS convenience functions to core2, for making things invisible and doing mobile-only media queries. 
- Fixes or improves some unrelated mobile-frendliness stuff in Tabula Rasa and Practicality.

This screenshot is super long and I think basically un-previewable (and I think actually mobile browsers will refuse to load it at full resolution), but here's what the enhanced threading on Practicality looks like: 

[(click through for outrageously long screenshot)](https://user-images.githubusercontent.com/484309/59155217-50825b00-8a39-11e9-95e3-447d2a2a1998.png)

Once this is shipped, we should mention it in a broadcast-y venue and try to get peoples' feedback on it. Basically people will need to switch to a Practicality theme, go to their options page, and set "Indentation for nested comment threads" to "Responsive". They can also try it on any Tabula Rasa-based layout, but the results might be underwhelming. (They also might be underwhelming but still an improvement.) 