### PR TITLE
[#2434] Don't insert jQuery script tags into main body content

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -4187,7 +4187,7 @@ talk.error.notauthorised.comm.open=This protected entry is viewable by community
 
 talk.error.purged=This journal has been deleted and purged.
 
-talk.error.quickquote=If you'd like to quote a portion of the original message, highlight it then press 'Quote'.
+talk.error.quickquote=To quote a portion of the original message, highlight it and press Quote.
 
 talk.error.readonly_journal=This journal is read-only. You can't comment in it.
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2176,7 +2176,7 @@ sub talkform {
         my $hidebutton = ( $opts->{errors} && @{ $opts->{errors} } );
         unless ( $hidebutton ) {
             my $alerttext = LJ::Lang::ml( 'talk.error.quickquote' );
-            $ret .= "<span id='quotebuttonspan' data-quote-error=\"$alerttext\"></span>";
+            $ret .= qq{<span id="quotebuttonspan" data-quote-error="$alerttext"></span>};
         }
     }
 
@@ -2343,7 +2343,7 @@ sub icon_dropdown {
         if ( $remote && $remote->can_use_userpic_select ) {
             my $metatext = $remote->iconbrowser_metatext ? "true" : "false";
             my $smallicons = $remote->iconbrowser_smallicons ? "true" : "false";
-            $ret .= '<input type="button" id="lj_userpicselect" value="Browse" data-iconbrowser-metatext="' . $metatext . '" data-iconbrowser-smallicons="' . $smallicons . '"/>';
+            $ret .= qq{<input type="button" id="lj_userpicselect" value="Browse" data-iconbrowser-metatext="$metatext" data-iconbrowser-smallicons="$smallicons"/>};
         }
 
         # random icon button - hidden for non-JS

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2174,11 +2174,9 @@ sub talkform {
 
         # only show quick quote button on initial composition
         my $hidebutton = ( $opts->{errors} && @{ $opts->{errors} } );
-        unless ($hidebutton) {
-            $ret .= "<span id='quotebuttonspan'></span>";
-            $ret .= "<script type='text/javascript' language='JavaScript'>\n<!--\n";
-            $ret .= LJ::Talk::js_quote_button('commenttext');
-            $ret .= "-->\n</script>\n";
+        unless ( $hidebutton ) {
+            my $alerttext = LJ::Lang::ml( 'talk.error.quickquote' );
+            $ret .= "<span id='quotebuttonspan' data-quote-error=\"$alerttext\"></span>";
         }
     }
 
@@ -2422,6 +2420,11 @@ sub init_iconbrowser_js {
 sub init_s2journal_js {
     my %opts = @_;
 
+    # load for everywhere you can reply (ReplyPage, lastn, AND entries)
+    LJ::need_res( { group => "jquery" }, qw(
+            js/jquery.quotebutton.js
+        ) );
+
     # load for quick reply (every view except ReplyPage)
     LJ::need_res(
         { group => "jquery" }, qw(
@@ -2511,58 +2514,6 @@ sub js_iconbrowser_button {
         })
         </script>
     };
-}
-
-# generate the javascript code for the quick quote button
-# arg1: element corresponds to textarea of caller (body or commenttext)
-# arg2: boolean to hide the button HTML (optional)
-sub js_quote_button {
-    my ($element) = @_;
-    return '' unless $element;
-
-    my $alerttext  = LJ::Lang::ml('talk.error.quickquote');
-    my $quote_func = <<"QUOTE";
-    var helped = 0; var pasted = 0;
-    function quote(e) {
-        var text = '';
-
-        if (document.getSelection) {
-            text = document.getSelection();
-        } else if (document.selection) {
-            text = document.selection.createRange().text;
-        } else if (window.getSelection) {
-            text = window.getSelection();
-        }
-
-        text = text.toString().replace(/^\\s+/, '').replace(/\\s+\$/, '');
-
-        if (text == '') {
-            if (helped != 1 && pasted != 1) {
-                helped = 1;
-                alert("$alerttext");
-            }
-        } else {
-            pasted = 1;
-        }
-
-        var element = text.search(/\\n/) == -1 ? 'q' : 'blockquote';
-        var textarea = document.getElementById('$element');
-        textarea.focus();
-        textarea.value = textarea.value + "<" + element + ">" + text + "</" + element + ">";
-        textarea.caretPos = textarea.value;
-        textarea.focus();
-    }
-QUOTE
-
-    return <<"QQ";
-jQuery(function(jQ){
-    $quote_func
-
-    jQ("<input type='button' value='Quote' />")
-        .appendTo("#quotebuttonspan")
-        .click(quote);
-    });
-QQ
 }
 
 # <LJFUNC>

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2341,8 +2341,9 @@ sub icon_dropdown {
 
         # userpic browse button
         if ( $remote && $remote->can_use_userpic_select ) {
-            $ret .= '<input type="button" id="lj_userpicselect" value="Browse" />';
-            $ret .= LJ::Talk::js_iconbrowser_button();
+            my $metatext = $remote->iconbrowser_metatext ? "true" : "false";
+            my $smallicons = $remote->iconbrowser_smallicons ? "true" : "false";
+            $ret .= '<input type="button" id="lj_userpicselect" value="Browse" data-iconbrowser-metatext="' . $metatext . '" data-iconbrowser-smallicons="' . $smallicons . '"/>';
         }
 
         # random icon button - hidden for non-JS
@@ -2494,26 +2495,6 @@ sub init_s2journal_shortcut_js {
 "$connect_string\n    touch: {\n      nextEntry: '$nextTouch',\n      prevEntry: '$prevTouch'\n    }\n";
     }
     $p->{'head_content'} .= "  };\n  </script>\n";
-}
-
-# generate the javascript code for the icon browser
-sub js_iconbrowser_button {
-    my $remote           = LJ::get_remote();
-    my $iconbrowser_opts = to_json(
-        {
-            selectorButtons => "#lj_userpicselect",
-            metatext        => LJ::JSON->to_boolean( $remote->iconbrowser_metatext ),
-            smallicons      => LJ::JSON->to_boolean( $remote->iconbrowser_smallicons ),
-        }
-    );
-
-    return qq {
-        <script type="text/javascript">
-        jQuery(function(jQ){
-            jQ("#prop_picture_keyword").iconselector($iconbrowser_opts);
-        })
-        </script>
-    };
 }
 
 # <LJFUNC>

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2174,8 +2174,8 @@ sub talkform {
 
         # only show quick quote button on initial composition
         my $hidebutton = ( $opts->{errors} && @{ $opts->{errors} } );
-        unless ( $hidebutton ) {
-            my $alerttext = LJ::Lang::ml( 'talk.error.quickquote' );
+        unless ($hidebutton) {
+            my $alerttext = LJ::Lang::ml('talk.error.quickquote');
             $ret .= qq{<span id="quotebuttonspan" data-quote-error="$alerttext"></span>};
         }
     }
@@ -2341,9 +2341,10 @@ sub icon_dropdown {
 
         # userpic browse button
         if ( $remote && $remote->can_use_userpic_select ) {
-            my $metatext = $remote->iconbrowser_metatext ? "true" : "false";
+            my $metatext   = $remote->iconbrowser_metatext   ? "true" : "false";
             my $smallicons = $remote->iconbrowser_smallicons ? "true" : "false";
-            $ret .= qq{<input type="button" id="lj_userpicselect" value="Browse" data-iconbrowser-metatext="$metatext" data-iconbrowser-smallicons="$smallicons"/>};
+            $ret .=
+qq{<input type="button" id="lj_userpicselect" value="Browse" data-iconbrowser-metatext="$metatext" data-iconbrowser-smallicons="$smallicons"/>};
         }
 
         # random icon button - hidden for non-JS
@@ -2422,9 +2423,11 @@ sub init_s2journal_js {
     my %opts = @_;
 
     # load for everywhere you can reply (ReplyPage, lastn, AND entries)
-    LJ::need_res( { group => "jquery" }, qw(
+    LJ::need_res(
+        { group => "jquery" }, qw(
             js/jquery.quotebutton.js
-        ) );
+            )
+    );
 
     # load for quick reply (every view except ReplyPage)
     LJ::need_res(

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -959,8 +959,6 @@ sub create_qr_div {
                 icon      => LJ::help_icon_html( "userpics",  " " ),
                 iplogging => LJ::help_icon_html( "iplogging", " " ),
             },
-
-            ejs => sub { return LJ::ejs(@_) },
         }
     );
 }

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -935,7 +935,6 @@ sub create_qr_div {
             post_disabled        => $post_disabled,
             post_button_class    => $post_disabled ? 'ui-state-disabled' : '',
 
-            quote_button_js => LJ::Talk::js_quote_button('body'),
             iconbrowser_js  => $remote->can_use_userpic_select
             ? LJ::Talk::js_iconbrowser_button()
             : "",

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -935,10 +935,6 @@ sub create_qr_div {
             post_disabled        => $post_disabled,
             post_button_class    => $post_disabled ? 'ui-state-disabled' : '',
 
-            iconbrowser_js  => $remote->can_use_userpic_select
-            ? LJ::Talk::js_iconbrowser_button()
-            : "",
-
             current_icon_kw => $userpic_kw,
             current_icon    => LJ::Userpic->new_from_keyword( $remote, $userpic_kw ),
 
@@ -946,9 +942,11 @@ sub create_qr_div {
                 ljuser => $remote->ljuser_display,
                 user   => $remote->user,
 
-                icons_url           => $remote->allpics_base,
-                icons               => \@pics,
-                can_use_iconbrowser => $remote->can_use_userpic_select,
+                icons_url               => $remote->allpics_base,
+                icons                   => \@pics,
+                can_use_iconbrowser     => $remote->can_use_userpic_select,
+                iconbrowser_metatext    => $remote->iconbrowser_metatext ? "true" : "false",
+                iconbrowser_smallicons  => $remote->iconbrowser_smallicons ? "true" : "false",
             },
 
             journal => {

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -942,11 +942,11 @@ sub create_qr_div {
                 ljuser => $remote->ljuser_display,
                 user   => $remote->user,
 
-                icons_url               => $remote->allpics_base,
-                icons                   => \@pics,
-                can_use_iconbrowser     => $remote->can_use_userpic_select,
-                iconbrowser_metatext    => $remote->iconbrowser_metatext ? "true" : "false",
-                iconbrowser_smallicons  => $remote->iconbrowser_smallicons ? "true" : "false",
+                icons_url              => $remote->allpics_base,
+                icons                  => \@pics,
+                can_use_iconbrowser    => $remote->can_use_userpic_select,
+                iconbrowser_metatext   => $remote->iconbrowser_metatext ? "true" : "false",
+                iconbrowser_smallicons => $remote->iconbrowser_smallicons ? "true" : "false",
             },
 
             journal => {

--- a/htdocs/js/jquery.iconselector.js
+++ b/htdocs/js/jquery.iconselector.js
@@ -314,3 +314,14 @@
     };
 
 })(jQuery);
+
+jQuery(function($) {
+    var browseButton = $("#lj_userpicselect");
+    if (browseButton.length > 0) {
+        $("#prop_picture_keyword").iconselector({
+            selectorButtons: "#lj_userpicselect",
+            metatext: browseButton.data("iconbrowserMetatext"),
+            smallicons: browseButton.data("iconbrowserSmallicons")
+        });
+    }
+});

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -85,7 +85,7 @@ $.extend( $.dw.quickreply, {
 
 })(jQuery);
 
-jQuery(document).ready(function($) {
+jQuery(function($) {
     function submitform(e) {
         e.preventDefault();
         e.stopPropagation();

--- a/htdocs/js/jquery.quotebutton.js
+++ b/htdocs/js/jquery.quotebutton.js
@@ -2,7 +2,7 @@
 // page text wrapped in a quote element. #body is what the quickreply form uses,
 // and #commenttext is like some old talkpost_do shenanigans that will take some
 // extra effort to dispose of.
-jQuery(function(jQ){
+jQuery(function($){
     var helped = 0; var pasted = 0;
     function quote(e) {
         var textarea = $('textarea#body');
@@ -42,7 +42,7 @@ jQuery(function(jQ){
         textarea.focus();
     }
 
-    jQ("<input type='button' value='Quote' />")
+    $("<input type='button' value='Quote' />")
         .appendTo("#quotebuttonspan")
         .click(quote);
 });

--- a/htdocs/js/jquery.quotebutton.js
+++ b/htdocs/js/jquery.quotebutton.js
@@ -1,0 +1,48 @@
+// On pages with a reply form, create a quote button that pastes in selected
+// page text wrapped in a quote element. #body is what the quickreply form uses,
+// and #commenttext is like some old talkpost_do shenanigans that will take some
+// extra effort to dispose of.
+jQuery(function(jQ){
+    var helped = 0; var pasted = 0;
+    function quote(e) {
+        var textarea = $('textarea#body');
+        if (textarea.length === 0) {
+            textarea = $('textarea#commenttext');
+            if (textarea.length === 0) {
+                return;
+            }
+        }
+        textarea = textarea.get(0);
+
+        var text = '';
+
+        if (document.getSelection) {
+            text = document.getSelection();
+        } else if (document.selection) {
+            text = document.selection.createRange().text;
+        } else if (window.getSelection) {
+            text = window.getSelection();
+        }
+
+        text = text.toString().replace(/^\s+/, '').replace(/\s+$/, '');
+
+        if (text == '') {
+            if (helped != 1 && pasted != 1) {
+                helped = 1;
+                alert( $(e.target).parent('#quotebuttonspan').data('quoteError') );
+            }
+        } else {
+            pasted = 1;
+        }
+
+        var element = text.search(/\n/) == -1 ? 'q' : 'blockquote';
+        textarea.focus();
+        textarea.value = textarea.value + "<" + element + ">" + text + "</" + element + ">";
+        textarea.caretPos = textarea.value;
+        textarea.focus();
+    }
+
+    jQ("<input type='button' value='Quote' />")
+        .appendTo("#quotebuttonspan")
+        .click(quote);
+});

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -1,4 +1,7 @@
 @import "foundation/base";
+
+$meta-input-height: 2.2em;
+
 #qrdiv * {
     box-sizing: border-box;
 }
@@ -29,9 +32,9 @@
     }
 
     .qr-icon {
-        // Same height as qr-meta's stacked select and input = 2em + 2em + .2em
-        width: 4.2em;
-        height: 4.2em;
+        // Same height as qr-meta's stacked select and input
+        width: $meta-input-height * 2 + .2em;
+        height: $meta-input-height * 2 + .2em;
         float: left;
         position: relative;
 
@@ -77,7 +80,7 @@
     }
 
     .qr-meta {
-        margin-left: 4.5em;
+        margin-left: $meta-input-height * 2 + .5em; // width of .qr-icon + .3em
 
         display: -webkit-flex;
         -webkit-flex-direction: row;
@@ -88,7 +91,7 @@
         flex-wrap: wrap;
 
         & > * {
-            height: 2em;
+            height: $meta-input-height;
 
             -webkit-flex-grow: 1;
             -webkit-flex-shrink: 1;
@@ -156,7 +159,7 @@
 @media #{$medium-up} {
     #qrform {
         .qr-meta, .qr-body, .qr-footer {
-            margin-left: 4.5em;
+            margin-left: $meta-input-height * 2 + .5em; // width of .qr-icon + .3em
             max-width: 38rem;
         }
 

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -19,7 +19,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <div class='qr-icon'>
     [%- IF current_icon -%]
       [%- IF remote.can_use_iconbrowser -%]
-        <button id="lj_userpicselect">[%- current_icon.imgtag -%]</button>
+        <button id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
+            [%- current_icon.imgtag -%]
+        </button>
       [%- ELSE -%]
         [%- current_icon.imgtag -%]
       [%- END -%]
@@ -116,4 +118,3 @@ jQuery(function(jQ){
   jQ("body").append(jQ("<div id='qrdiv'></div>").html("[% ejs(quickreply) %]").hide());
 });
 </script>
-[%- iconbrowser_js -%]

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -88,7 +88,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
       id = 'do_spellcheck'
     ) -%]</div>
   [%- END -%]
-  <span id='quotebuttonspan'></span>
+  <span id='quotebuttonspan' data-quote-error="[%- 'talk.error.quickquote' | ml -%]"></span>
   <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
   [%- END -%]
 
@@ -115,6 +115,5 @@ the same terms as Perl itself.  For a copy of the license, please reference
 jQuery(function(jQ){
   jQ("body").append(jQ("<div id='qrdiv'></div>").html("[% ejs(quickreply) %]").hide());
 });
-[%- quote_button_js -%]
 </script>
 [%- iconbrowser_js -%]

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -12,7 +12,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- dw.need_res( "stc/css/components/quick-reply.css" ) -%]
 
-[%- quickreply = BLOCK -%]
+<div id='qrdiv' style="display: none;">
 <div id='qrformdiv'><form id='qrform' name='qrform' method='POST' action='[%- form_url | url -%]'>
 [%- dw.form_auth -%]
 [%- hidden_form_elements -%]
@@ -111,10 +111,4 @@ the same terms as Perl itself.  For a copy of the license, please reference
 </div>
 
 </form></div>
-[%- END -%]
-
-<script type='text/javascript'>
-jQuery(function(jQ){
-  jQ("body").append(jQ("<div id='qrdiv'></div>").html("[% ejs(quickreply) %]").hide());
-});
-</script>
+</div>


### PR DESCRIPTION
Fixes #2434. 

Currently, several parts of the reply forms will only work if all deferred javascript resources are loaded during the page's `<head>`. This PR decouples those features from the position of the global script tags, so they'll continue to work if the deferred JS gets moved to the bottom of the `<body>`. These changes should have zero effect on existing behavior, but will enable some future feature work.