### PR TITLE
[#1944] Include the comment URL on screening/unscreening confirmation page

### DIFF
--- a/htdocs/talkscreen.bml
+++ b/htdocs/talkscreen.bml
@@ -135,6 +135,19 @@ _info?><?_code
     my $itemlink = $e->url;
     my $linktext = BML::ml( '.link', { aopts => "href='$itemlink'" } );
 
+    my $commentlink = LJ::Talk::talkargs( $itemlink, "view=" . $talkid, "", "" ) . LJ::Talk::comment_anchor( $talkid );
+
+    $body .= "==AWLC==";
+
+    $body .= "<span class=\"ljuser\" lj:user=\"lexie\" style=\"white-space: nowrap;\">lexie</span>";
+    $body .= $post->{'posterid'};
+
+    $body .= "post->parenttalkid = " . $post->{'parenttalkid'} . "; post->itemid = " . $post->{'itemid'} . "; post->journalid = " . $post->{'journalid'};
+    $body .= "; post->posterid = " . $post->{'posterid'};
+    $body .= "; itemlink = " . $itemlink;
+    $body .= "; talkid = " . $talkid;
+    $body .= "Comment link is " . $commentlink;
+
     if ($mode eq 'screen') {
         my $can_screen = LJ::Talk::can_screen($remote, $u, $up, $post->{'userpost'});
         return $error->($ML{'.error.privs.screen'}) unless $can_screen;

--- a/htdocs/talkscreen.bml
+++ b/htdocs/talkscreen.bml
@@ -137,24 +137,14 @@ _info?><?_code
 
     my $commentlink = LJ::Talk::talkargs( $itemlink, "view=" . $talkid, "", "" ) . LJ::Talk::comment_anchor( $talkid );
 
-    $body .= "==AWLC==";
-
-    $body .= "<span class=\"ljuser\" lj:user=\"lexie\" style=\"white-space: nowrap;\">lexie</span>";
-    $body .= $post->{'posterid'};
-
-    $body .= "post->parenttalkid = " . $post->{'parenttalkid'} . "; post->itemid = " . $post->{'itemid'} . "; post->journalid = " . $post->{'journalid'};
-    $body .= "; post->posterid = " . $post->{'posterid'};
-    $body .= "; itemlink = " . $itemlink;
-    $body .= "; talkid = " . $talkid;
-    $body .= "Comment link is " . $commentlink;
-
     if ($mode eq 'screen') {
         my $can_screen = LJ::Talk::can_screen($remote, $u, $up, $post->{'userpost'});
         return $error->($ML{'.error.privs.screen'}) unless $can_screen;
         if ($POST{'confirm'} eq 'Y') {
             return $error->( $ML{'error.invalidform'} ) unless LJ::check_form_auth();
         } else {
-            $body .= "<?h1 $ML{'.screen.sure.title'} h1?><?p $ML{'.screen.sure.body'} p?>";
+            $body .= "<?h1 $ML{'.screen.sure.title'} h1?>";
+            $body .= "<p>" . BML::ml('.screen.sure.body', { aopts => "href='$commentlink'" }) . "</p>";
             $body .= "<p><form method='POST' action='talkscreen'><center>\n";
             $body .= LJ::form_auth();
             $body .= LJ::html_hidden(mode => 'screen', 'talkid' => $talkid,
@@ -179,7 +169,8 @@ _info?><?_code
         if ($POST{'confirm'} eq 'Y') {
             return $error->( $ML{'error.invalidform'} ) unless LJ::check_form_auth();
         } else {
-            $body .= "<?h1 $ML{'.unscreen.sure.title'} h1?><?p $ML{'.unscreen.sure.body'} p?>";
+            $body .= "<?h1 $ML{'.unscreen.sure.title'} h1?>";
+            $body .= "<p>" . BML::ml('.unscreen.sure.body', { aopts => "href='$commentlink'" }) . "</p>";
             $body .= "<p><form method='POST' action='talkscreen'><center>\n";
             $body .= LJ::form_auth();
             $body .= LJ::html_hidden(mode => 'unscreen', 'talkid' => $talkid,
@@ -208,7 +199,8 @@ _info?><?_code
         if ($POST{confirm} eq 'Y') {
             return $error->( $ML{'error.invalidform'} ) unless LJ::check_form_auth();
         } else {
-            $body .= "<?h1 $ML{'.freeze.sure.title'} h1?><?p $ML{'.freeze.sure.body'} p?>";
+            $body .= "<?h1 $ML{'.freeze.sure.title'} h1?>";
+            $body .= "<p>" . BML::ml('.freeze.sure.body', { aopts => "href='$commentlink'" }) . "</p>";
             $body .= "<p><form method='post' action='talkscreen'><center>\n";
             $body .= LJ::form_auth();
             $body .= LJ::html_hidden(mode => 'freeze', 'talkid' => $talkid,
@@ -235,7 +227,8 @@ _info?><?_code
         if ($POST{confirm} eq 'Y') {
             return $error->( $ML{'error.invalidform'} ) unless LJ::check_form_auth();
         } else {
-            $body .= "<?h1 $ML{'.unfreeze.sure.title'} h1?><?p $ML{'.unfreeze.sure.body'} p?>";
+            $body .= "<?h1 $ML{'.unfreeze.sure.title'} h1?>";
+            $body .= "<p>" . BML::ml('.unfreeze.sure.body', { aopts => "href='$commentlink'" }) . "</p>";
             $body .= "<p><form method='post' action='talkscreen'><center>\n";
             $body .= LJ::form_auth();
             $body .= LJ::html_hidden(mode => 'unfreeze', 'talkid' => $talkid,

--- a/htdocs/talkscreen.bml.text
+++ b/htdocs/talkscreen.bml.text
@@ -11,7 +11,7 @@
 
 .freeze.doit=Yes, freeze this thread
 
-.freeze.sure.body=Are you sure you want to freeze this thread?  No further responses will be allowed to it or any of the comments underneath it.
+.freeze.sure.body=Are you sure you want to freeze <a [[aopts]]>this thread</a>?  No further responses will be allowed to it or any of the comments underneath it.
 
 .freeze.sure.title=Freeze this thread?
 
@@ -23,7 +23,7 @@
 
 .screen.doit=Yes, screen this comment
 
-.screen.sure.body=Are you sure you want to screen this comment?
+.screen.sure.body=Are you sure you want to screen <a [[aopts]]>this comment</a>?
 
 .screen.sure.title=Screen this comment?
 
@@ -35,7 +35,7 @@
 
 .unfreeze.doit=Yes, unfreeze this thread
 
-.unfreeze.sure.body=Are you sure you want to unfreeze this thread?
+.unfreeze.sure.body=Are you sure you want to unfreeze <a [[aopts]]>this thread</a>?
 
 .unfreeze.sure.title=Unfreeze this thread?
 
@@ -45,7 +45,7 @@
 
 .unscreen.doit=Yes, unscreen this comment
 
-.unscreen.sure.body=Are you sure you want to unscreen this comment?
+.unscreen.sure.body=Are you sure you want to unscreen <a [[aopts]]>this comment</a>?
 
 .unscreen.sure.title=Unscreen this comment?
 


### PR DESCRIPTION
As part of @kaberett’s volunteer weekend. For #1944.

Notes:

* This is based on https://github.com/dreamwidth/dw-free/blob/2fb06b1291a99409c61e91f701f8cbbe6e8645f1/htdocs/talkpost_do.bml#L215
* These are the test cases I’m planning to cover:
    - [x] Screen a top-level comment
    - [x] Screen a comment that’s nested in a thread
    - [x] Unscreen a top-level comment
    - [x] Unscreen a comment that’s nested in a thread
    - [x] Freeze a top-level thread
    - [x] Freeze a nested thread
    - [x] Unfreeze a top-level thread
    - [x] Unfreeze a nested thread

Todo:

* [x] Send in a CLA
* [x] Construct the correct URL in the other test cases
* [x] Integrate the link properly in the text, not just splurged onto the page
* [x] Testing!
