### PR TITLE
[#2275] Remove an unused variable in Protocol.pm

### DIFF
--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1491,10 +1491,7 @@ sub postevent
                 my $modlist = LJ::load_userids(@$mods);
 
                 my @emails;
-                my $ct;
                 foreach my $mod (values %$modlist) {
-                    last if $ct > 20;  # don't send more than 20 emails.
-
                     next unless $mod->is_visible;
 
                     LJ::Event::CommunityModeratedEntryNew->new( $mod, $uowner, $modid )->fire;


### PR DESCRIPTION
Per the issue notes, there's no limit on community moderators anywhere else and this `last` statement will never execute, so just remove it.

Fixes #2275.