### PR TITLE
[#1852] Include both absolute and relative timestamps in the inbox

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2638,7 +2638,7 @@ sub nth_entry_seen {
 }
 
 sub sitescheme_secs_to_iso {
-    my ( $secs, %opts ) = @_;
+    my ( $secs, $opts ) = @_;
     my $remote = LJ::get_remote();
     my @ret;
 
@@ -2653,7 +2653,7 @@ sub sitescheme_secs_to_iso {
     my $has_tz = '';  # don't display timezone unless requested below
 
     # if opts has a true tz key, get the remote user's timezone if possible
-    if ( $opts{tz} ) {
+    if ( $opts->{tz} ) {
         $s2_datetime = DateTime_tz( $secs, $remote );
         $has_tz = defined $s2_datetime ? "(local)" : "UTC";
     }

--- a/cgi-bin/LJ/Widget/InboxFolder.pm
+++ b/cgi-bin/LJ/Widget/InboxFolder.pm
@@ -190,7 +190,13 @@ sub render_body {
                   . LJ::img( $bookmark, "", { class => 'InboxItem_Bookmark' } )
                   . "</a>";
 
-        my $when = LJ::diff_ago_text( $inbox_item->when_unixtime );
+        # For clarity, we display both a relative time (e.g. "5 days ago")
+        # and an absolute time (e.g. "2019-05-11 14:34 UTC") in the
+        # notification list.
+        my $event_time = $inbox_item->when_unixtime;
+        my $relative_time = LJ::diff_ago_text( $event_time );
+        my $absolute_time = LJ::S2::sitescheme_secs_to_iso( $event_time, { tz => "UTC" } );
+
         my $contents = $inbox_item->as_html || '';
 
         my $row_class = ($rownum++ % 2 == 0) ? "InboxItem_Meta odd" : "InboxItem_Meta even";
@@ -228,7 +234,7 @@ sub render_body {
                     <span class="$read_class" id="${name}_Title_$qid">$title</span>
                     $content_div
                     </td>
-                    <td class="time detail">$when</td>
+                    <td class="time detail">$absolute_time<br>$relative_time</td>
                 </tr>
         };
     }


### PR DESCRIPTION
Closes #1852. This displays both the absolute time and the relative time in inbox notifications.

Screenshot:

<img width="745" alt="Screenshot 2019-05-11 at 21 44 31" src="https://user-images.githubusercontent.com/301220/57574727-43704d00-7436-11e9-94af-891e3961de12.png">

Or if you have a timezone set:

<img width="745" alt="Screenshot 2019-05-11 at 21 24 33" src="https://user-images.githubusercontent.com/301220/57574734-70bcfb00-7436-11e9-8f3c-65d272091ca6.png">

I’ve checked, and this respects your timezone and 12h/24h time format preferences. Huzzah for reusable code!

I could only find one use of the `sitescheme_secs_to_iso` routine elsewhere – see https://github.com/dreamwidth/dw-free/blob/2fb06b1291a99409c61e91f701f8cbbe6e8645f1/cgi-bin/LJ/Talk.pm#L3801 – and it doesn't pass any extra options, so I think changing the hash/hash reference here is fine.