### PR TITLE
Upgrade to reCAPTCHA v2 API. Fixes #2331

### DIFF
--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -1,6 +1,6 @@
 Business::CreditCard
 Cache::Memcached
-Captcha::reCAPTCHA
+Captcha::reCAPTCHA@0.99
 Class::Autouse
 Class::Data::Inheritable
 Class::Trigger


### PR DESCRIPTION
BIG IMPORTANT NOTE: the API keys may have to be regenerated for v2! I do not have existing v1 keys so I couldn't test if they're forwards compatible, but I had to specify which version I wanted keys for when I generated the v2 ones.