### PR TITLE
[#1568] Use a named constant for username maxlength

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1859,3 +1859,5 @@ general /profile.bml.service.delicious
 general /profile.bml.im.yim
 general /profile.bml.label.yahooid
 general /manage/profile/index.bml.chat.yahooid
+
+general error.usernamelong

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -920,8 +920,6 @@ error.unknownmode=Unknown mode.
 
 error.usernameinvalid=This account name contains invalid characters.
 
-error.usernamelong=This account name is too long.  Account names can't be longer than 25 characters.
-
 error.usernamelong1=This account name is too long. Account names can't be longer than [[maxlength]] characters.
 
 error.username_notfound=This account name wasn't found.

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -922,6 +922,8 @@ error.usernameinvalid=This account name contains invalid characters.
 
 error.usernamelong=This account name is too long.  Account names can't be longer than 25 characters.
 
+error.usernamelong1=This account name is too long. Account names can't be longer than [[maxlength]] characters.
+
 error.username_notfound=This account name wasn't found.
 
 error.utf8=Invalid UTF-8 Input

--- a/cgi-bin/DW/Controller/Create.pm
+++ b/cgi-bin/DW/Controller/Create.pm
@@ -293,6 +293,8 @@ sub create_handler {
         formdata        => $post,
         errors          => $errors,
         email_checkbox  => $email_checkbox,
+
+        username_maxlength => $LJ::USERNAME_MAXLENGTH,
     };
 
     if ( $code_valid && $rate_ok ) {

--- a/cgi-bin/LJ/CreatePage.pm
+++ b/cgi-bin/LJ/CreatePage.pm
@@ -33,8 +33,9 @@ sub verify_username {
     if ($given_username && !$user) {
         $error = LJ::Lang::ml('error.usernameinvalid');
     }
-    if (length $given_username > 25) {
-        $error = LJ::Lang::ml('error.usernamelong');
+    if (length $given_username > $LJ::USERNAME_MAXLENGTH) {
+        $error = LJ::Lang::ml('error.usernamelong1', 
+            { maxlength => $LJ::USERNAME_MAXLENGTH });
     }
 
     my $u = LJ::load_user($user);

--- a/cgi-bin/LJ/CreatePage.pm
+++ b/cgi-bin/LJ/CreatePage.pm
@@ -33,7 +33,7 @@ sub verify_username {
     if ($given_username && !$user) {
         $error = LJ::Lang::ml('error.usernameinvalid');
     }
-    if (length $given_username > $LJ::USERNAME_MAXLENGTH) {
+    if ( length $given_username > $LJ::USERNAME_MAXLENGTH ) {
         $error = LJ::Lang::ml('error.usernamelong1', 
             { maxlength => $LJ::USERNAME_MAXLENGTH });
     }

--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -348,9 +348,12 @@ no strict "vars";
         /latest
         /edittags
     );
-    
+
     # Selective screening limit. No user can have more than this.
     $LJ::SEL_SCREEN_LIMIT ||= 500;
+
+    # maximum length of a username (NB do not change without changing width of database fields to match. And perhaps other stuff.
+    $USERNAME_MAXLENGTH = 25;
 }
 
 

--- a/cgi-bin/LJ/Session.pm
+++ b/cgi-bin/LJ/Session.pm
@@ -934,8 +934,8 @@ sub get_cookie_path {
 
 sub get_path_user {
     my ( $path ) = @_;
-    return unless $path =~ m!^/(\w{1,25})\b!;
-    # FIXME: username length should be a named constant (#1568)
+    my $exp = '^/(\w{1,' . $LJ::USERNAME_MAXLENGTH . '})\b';
+    return unless $path =~ /$exp/;
 
     return lc $1;
 }

--- a/cgi-bin/LJ/Session.pm
+++ b/cgi-bin/LJ/Session.pm
@@ -934,8 +934,7 @@ sub get_cookie_path {
 
 sub get_path_user {
     my ( $path ) = @_;
-    my $exp = '^/(\w{1,' . $LJ::USERNAME_MAXLENGTH . '})\b';
-    return unless $path =~ /$exp/;
+    return unless $path =~ m!^/(\w{1,$LJ::USERNAME_MAXLENGTH})\b!;
 
     return lc $1;
 }

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -1283,7 +1283,7 @@ sub canonical_username {
     my $input = lc( $_[0] // '' );
     my $user = "";
     my $exp = '^\s*([a-z0-9_\-]{1,' . $LJ::USERNAME_MAXLENGTH . '})\s*$';
-    if ( $input =~ $exp ) {  # good username
+    if ( $input =~ /$exp/ ) {  # good username
         $user = $1;
         $user =~ s/-/_/g;
     }

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -1282,7 +1282,8 @@ use Carp;
 sub canonical_username {
     my $input = lc( $_[0] // '' );
     my $user = "";
-    if ( $input =~ /^\s*([a-z0-9_\-]{1,25})\s*$/ ) {  # good username
+    my $exp = '^\s*([a-z0-9_\-]{1,' . $LJ::USERNAME_MAXLENGTH . '})\s*$';
+    if ( $input =~ $exp ) {  # good username
         $user = $1;
         $user =~ s/-/_/g;
     }

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -1283,7 +1283,7 @@ sub canonical_username {
     my $input = lc( $_[0] // '' );
     my $user = "";
     my $exp = '^\s*([a-z0-9_\-]{1,' . $LJ::USERNAME_MAXLENGTH . '})\s*$';
-    if ( $input =~ /$exp/ ) {  # good username
+    if ( $input =~ m/^\s*([a-z0-9_z\-]{1,$LJ::USERNAME_MAXLENGTH})\s*$/ ) {
         $user = $1;
         $user =~ s/-/_/g;
     }

--- a/etc/config.pl
+++ b/etc/config.pl
@@ -660,6 +660,12 @@
         comment_html_anon => 1,      # HTML comments from anon commenters?
         comment_html_auth => 0,      # HTML comments from non-anon commenters?
     );
+
+    # Global constant for the max length of a username. Do not change without
+    # checking for implications re database field lengths, etc. In fact, probably
+    # do not change.
+    $USERNAME_MAXLENGTH = 25;   
+
 }
 
 1;

--- a/etc/config.pl
+++ b/etc/config.pl
@@ -660,12 +660,6 @@
         comment_html_anon => 1,      # HTML comments from anon commenters?
         comment_html_auth => 0,      # HTML comments from non-anon commenters?
     );
-
-    # Global constant for the max length of a username. Do not change without
-    # checking for implications re database field lengths, etc. In fact, probably
-    # do not change.
-    $USERNAME_MAXLENGTH = 25;   
-
 }
 
 1;

--- a/htdocs/tools/tellafriend.bml
+++ b/htdocs/tools/tellafriend.bml
@@ -199,8 +199,7 @@ _c?>
             : BML::ml( ".email.subject.entrynosubject", { sitenameshort => $LJ::SITENAMESHORT } );
  }
 
- my $exp = '^\w{1,' . $LJ::USERNAME_MAXLENGTH . '}$';
- if ($GET{'user'} =~ /$exp/) {
+ if ($GET{'user'} =~ /^\w{1,$LJ::USERNAME_MAXLENGTH}$/) {
      my $user = $GET{'user'};
      my $uj = LJ::load_user($user);
      my $url = $uj->journal_base;

--- a/htdocs/tools/tellafriend.bml
+++ b/htdocs/tools/tellafriend.bml
@@ -199,7 +199,9 @@ _c?>
             : BML::ml( ".email.subject.entrynosubject", { sitenameshort => $LJ::SITENAMESHORT } );
  }
 
- if ($GET{'user'} =~ /^\w{1,15}$/) {
+ my $exp = '^\w{1,' . $LJ::USERNAME_MAXLENGTH . '}$';
+ if ($GET{'user'} =~ /$exp/) {
+     my $user = $GET{'user'};
      my $uj = LJ::load_user($user);
      my $url = $uj->journal_base;
 

--- a/views/create/account.tt
+++ b/views/create/account.tt
@@ -44,9 +44,10 @@ the same terms as Perl itself.  For a copy of the license, please reference
             name = "user"
             id   = "js-user"
 
-            # maxlength 26, so if people don't notice that they hit the limit,
+            # maxlength is one over the actual max, so if people 
+            # don't notice that they hit the limit,
             # we give them a warning. (some people don't notice/proofread)
-            maxlength = 26
+            maxlength = username_maxlength + 1
 
             "aria-required" = "true"
             class = "journaltype-textbox user-textbox"


### PR DESCRIPTION
A partial fix for #1568. This just takes @swaldman3’s PR #1610, rebases it against the current tip of develop, and addresses the outstanding comments.

As noted in that PR, there are probably other cases that have been missed.

e.g. https://github.com/dreamwidth/dw-free/blob/4ca92d214e6a92e94ad19f3058633fa4e4201f2c/views/directory/index.tt#L92-L97 looks plausibly in need of using-a-constant

But going through and evaluating all of those takes time, and it’s nearly my bedtime here. 😴 

(I count ~16.5k occurrences of the strings “15” or “25” somewhere in the codebase. Heuristics will cut that down somewhat, but some of them need inspecting manually.)

I figured better to get _some_ of this code into the main branch, and other occurrences can be added as and when, than try to get something perfect.