### PR TITLE
Load GTop module

### DIFF
--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -105,6 +105,7 @@ use LJ::ModuleCheck;
 use IO::Socket::INET;
 use IO::Socket::SSL;
 use Mozilla::CA;
+use GTop;
 
 use LJ::UniqCookie;
 use LJ::WorkerResultStorage;


### PR DESCRIPTION
The check it was previously doing must have implicitly loaded the module.