### PR TITLE
Styles: Modernize image constraints

### DIFF
--- a/styles/abstractia/layout.s2
+++ b/styles/abstractia/layout.s2
@@ -1227,14 +1227,20 @@ q {
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* To constrain the width and prevent layout breaking */
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
+    height: max-content;
     max-width: 100%;
-    height: auto;
-}
-
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
 }
 
 .entry .tag,.footer .multiform-checkbox {

--- a/styles/bases/layout.s2
+++ b/styles/bases/layout.s2
@@ -564,14 +564,20 @@ ul ul {list-style: circle;}
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* To constrain the width and prevent layout breaking */
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
+    height: max-content;
     max-width: 100%;
-    height: auto;
-}
-
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
 }
 
 /* ====================== HEADER ======================= */

--- a/styles/blanket/layout.s2
+++ b/styles/blanket/layout.s2
@@ -682,14 +682,20 @@ h3.entry-title a {
     list-style-position: inside;
     }
 
-/* To constrain the width and prevent layout breaking */
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
+    height: max-content;
     max-width: 100%;
-    height: auto;
-}
-
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
 }
 
 .metadata {

--- a/styles/brittle/layout.s2
+++ b/styles/brittle/layout.s2
@@ -573,14 +573,20 @@ li.page-separator { display: none; }
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* To constrain the width and prevent layout breaking */
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
+    height: max-content;
     max-width: 100%;
-    height: auto;
-}
-
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
 }
 
 .entry .header {

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -532,14 +532,20 @@ h2#pagetitle {
     list-style-position: inside;
     }
 
-/* To constrain the width and prevent layout breaking */
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
+    height: max-content;
     max-width: 100%;
-    height: auto;
-}
-
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
 }
 
 .metadata ul {

--- a/styles/drifting/layout.s2
+++ b/styles/drifting/layout.s2
@@ -738,14 +738,20 @@ function Page::print_default_stylesheet()
         list-style-position: inside;
         }
 
-    /* To constrain the width and prevent layout breaking */
+    /* Constrain image dimensions.
+        Job 1: Don't trash the layout sideways.
+        Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+          portrait of someone is nonsense.
+        Job 3: Defend the native aspect ratio.
+        Job 4: Respect the width/height HTML attributes for scaling down OR up
+          (within the limits of the container), but if they conflict with the aspect
+          ratio, treat them as maximums and let the aspect ratio win. */
     .entry-content img, .comment-content img {
+        height: max-content;
         max-width: 100%;
-        height: auto;
-    }
-
-    @media $large_media_query {
-        .entry-content img, .comment-content img { max-width: none; }
+        max-height: 95vh;
+        object-fit: contain;
+        object-position: left;
     }
 
     .entry .subject {

--- a/styles/easyread/layout.s2
+++ b/styles/easyread/layout.s2
@@ -614,14 +614,20 @@ h2.module-header a {
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* To constrain the width and prevent layout breaking */
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
+    height: max-content;
     max-width: 100%;
-    height: auto;
-}
-
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
 }
 
 /* Set height to keep spacing */

--- a/styles/goldleaf/layout.s2
+++ b/styles/goldleaf/layout.s2
@@ -1385,14 +1385,20 @@ a, a:link, a:visited, a:active, a:hover{
     list-style-position: inside;
 }
 
-/* To constrain the width and prevent layout breaking */
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
+    height: max-content;
     max-width: 100%;
-    height: auto;
-}
-
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
 }
 
 .metadata ul {

--- a/styles/mobility/layout.s2
+++ b/styles/mobility/layout.s2
@@ -314,11 +314,6 @@ function print_stylesheet () {
         margin: 0; 
     }
 
-    .entry-content img {
-        max-height: 100%; 
-        max-width: 100%;  
-    }
-
     .bottom-metadata { 
          margin-top: 1em; 
     }

--- a/styles/negatives/layout.s2
+++ b/styles/negatives/layout.s2
@@ -584,14 +584,20 @@ function Page::print_default_stylesheet()
         list-style-position: inside;
         }
 
-    /* To constrain the width and prevent layout breaking */
+    /* Constrain image dimensions.
+        Job 1: Don't trash the layout sideways.
+        Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+          portrait of someone is nonsense.
+        Job 3: Defend the native aspect ratio.
+        Job 4: Respect the width/height HTML attributes for scaling down OR up
+          (within the limits of the container), but if they conflict with the aspect
+          ratio, treat them as maximums and let the aspect ratio win. */
     .entry-content img, .comment-content img {
+        height: max-content;
         max-width: 100%;
-        height: auto;
-        }
-
-    @media $large_media_query {
-        .entry-content img, .comment-content img { max-width: none; }
+        max-height: 95vh;
+        object-fit: contain;
+        object-position: left;
     }
 
 

--- a/styles/skittlishdreams/layout.s2
+++ b/styles/skittlishdreams/layout.s2
@@ -963,14 +963,20 @@ body { $page_background $page_font margin: 0; padding: 0; }
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* To constrain the width and prevent layout breaking */
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
+    height: max-content;
     max-width: 100%;
-    height: auto;
-    }
-
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
 }
 
 .page-recent .security-public.restrictions-none.journal-type-P.has-userpic.no-subject .entry-content,

--- a/styles/snakesandboxes/layout.s2
+++ b/styles/snakesandboxes/layout.s2
@@ -312,10 +312,6 @@ pre {
     word-wrap: break-word;
 }
 
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
-}
-
 blockquote {
     border: 1px dotted $*color_elements_border;
     margin: 2em;

--- a/styles/summertime/layout.s2
+++ b/styles/summertime/layout.s2
@@ -568,7 +568,7 @@ pre {
     overflow: auto;
 }
 
-img, embed {
+embed {
     max-width: 100%;
     max-height: auto;
 }

--- a/styles/trifecta/layout.s2
+++ b/styles/trifecta/layout.s2
@@ -901,10 +901,6 @@ pre {
     word-wrap: break-word;
 }
 
-@media $large_media_query {
-    .entry-content img, .comment-content img { max-width: none; }
-}
-
 .metadata {
     font-style: italic;
 }

--- a/styles/venture/layout.s2
+++ b/styles/venture/layout.s2
@@ -1702,7 +1702,21 @@ $display_topnav_css
     padding: 0 0 0 2em;
     }
 
-.entry-content img { max-width: 100%; }
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win. */
+.entry-content img, .comment-content img {
+    height: max-content;
+    max-width: 100%;
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
+}
 
 .entry ol { list-style: decimal-leading-zero; }
 


### PR DESCRIPTION
Within the content of an entry or comment:

- Large images should never overflow their container boundaries, EVER. 
- Portrait-orientation images should be viewable in toto on a single screen without scrolling. 
- Images should never get their aspect ratios messed up. 
- If a user used width and/or height attributes in an `img` tag to make it smaller or larger than the native pixel size, we should respect that (_as long as it's within the container boundaries_). 

Well, CSS lets you do all that now. [Demo page](http://www.sedumphotos.net/nfagerlund/imgtest.html) — try zooming up or down, and try opening the web inspector and messing with the div width and/or the img height/width attributes. 