### PR TITLE
Styles: Wrong keyword value in image fix

### DIFF
--- a/styles/abstractia/layout.s2
+++ b/styles/abstractia/layout.s2
@@ -1236,7 +1236,7 @@ q {
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
-    height: max-content;
+    height: auto;
     max-width: 100%;
     max-height: 95vh;
     object-fit: contain;

--- a/styles/bases/layout.s2
+++ b/styles/bases/layout.s2
@@ -573,7 +573,7 @@ ul ul {list-style: circle;}
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
-    height: max-content;
+    height: auto;
     max-width: 100%;
     max-height: 95vh;
     object-fit: contain;

--- a/styles/blanket/layout.s2
+++ b/styles/blanket/layout.s2
@@ -691,7 +691,7 @@ h3.entry-title a {
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
-    height: max-content;
+    height: auto;
     max-width: 100%;
     max-height: 95vh;
     object-fit: contain;

--- a/styles/brittle/layout.s2
+++ b/styles/brittle/layout.s2
@@ -582,7 +582,7 @@ li.page-separator { display: none; }
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
-    height: max-content;
+    height: auto;
     max-width: 100%;
     max-height: 95vh;
     object-fit: contain;

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -541,7 +541,7 @@ h2#pagetitle {
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
-    height: max-content;
+    height: auto;
     max-width: 100%;
     max-height: 95vh;
     object-fit: contain;

--- a/styles/drifting/layout.s2
+++ b/styles/drifting/layout.s2
@@ -747,7 +747,7 @@ function Page::print_default_stylesheet()
           (within the limits of the container), but if they conflict with the aspect
           ratio, treat them as maximums and let the aspect ratio win. */
     .entry-content img, .comment-content img {
-        height: max-content;
+        height: auto;
         max-width: 100%;
         max-height: 95vh;
         object-fit: contain;

--- a/styles/easyread/layout.s2
+++ b/styles/easyread/layout.s2
@@ -623,7 +623,7 @@ h2.module-header a {
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
-    height: max-content;
+    height: auto;
     max-width: 100%;
     max-height: 95vh;
     object-fit: contain;

--- a/styles/goldleaf/layout.s2
+++ b/styles/goldleaf/layout.s2
@@ -1394,7 +1394,7 @@ a, a:link, a:visited, a:active, a:hover{
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
-    height: max-content;
+    height: auto;
     max-width: 100%;
     max-height: 95vh;
     object-fit: contain;

--- a/styles/negatives/layout.s2
+++ b/styles/negatives/layout.s2
@@ -593,7 +593,7 @@ function Page::print_default_stylesheet()
           (within the limits of the container), but if they conflict with the aspect
           ratio, treat them as maximums and let the aspect ratio win. */
     .entry-content img, .comment-content img {
-        height: max-content;
+        height: auto;
         max-width: 100%;
         max-height: 95vh;
         object-fit: contain;

--- a/styles/skittlishdreams/layout.s2
+++ b/styles/skittlishdreams/layout.s2
@@ -972,7 +972,7 @@ body { $page_background $page_font margin: 0; padding: 0; }
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
-    height: max-content;
+    height: auto;
     max-width: 100%;
     max-height: 95vh;
     object-fit: contain;

--- a/styles/venture/layout.s2
+++ b/styles/venture/layout.s2
@@ -1711,7 +1711,7 @@ $display_topnav_css
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win. */
 .entry-content img, .comment-content img {
-    height: max-content;
+    height: auto;
     max-width: 100%;
     max-height: 95vh;
     object-fit: contain;


### PR DESCRIPTION
I used a Firefox-ism that isn't broadly supported! When an image with height and
width attributes gets shrunk to fit, this can cause some white space above and
below it in other browsers. `height: auto;` is equivalent to what I meant here.
(It overrides the height attribute, but sets it to match the native aspect ratio
for the width we ended up using. 99.5% of the time this is correct; the other
.5%, you can override it with an inline `min-height`.)