### PR TITLE
Fix thick-bottomed userpic boxes

### DIFF
--- a/htdocs/stc/jquery.contextualhover.css
+++ b/htdocs/stc/jquery.contextualhover.css
@@ -32,6 +32,12 @@
     padding: 2px;
 }
 
+/* Don't add extra height at bottom of userpic box */
+.ContextualPopup .Userpic a {
+    display: block;
+    line-height: 0;
+}
+
 .ContextualPopup .Userpic img {
     height: auto;
     width: auto;

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -311,6 +311,12 @@ function Page::print_default_stylesheet() {
              .comment .userpic {
                  text-align: right;
                  }
+
+             /* Don't add extra height at bottom of userpic box */
+             .userpic .a {
+                display: block;
+                line-height: 0;
+                }
              """;
          }
     print_custom_control_strip_css();
@@ -774,7 +780,7 @@ ul.userlite-interaction-links.text-links {
     max-width: 100%;
 }
 
-.search-form .search-box-item, 
+.search-form .search-box-item,
 .search-form .search-button-item {
     display: block
 }

--- a/views/journal/controlstrip.tt
+++ b/views/journal/controlstrip.tt
@@ -12,7 +12,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 <div id='lj_controlstrip'>
 
-<div id='[%- IF remote -%]lj_controlstrip_userpic[%- ELSE -%]lj_controlstrip_loggedout_userpic[%- END -%]'>
+<div class="userpic" id="[%- IF remote -%]lj_controlstrip_userpic[%- ELSE -%]lj_controlstrip_loggedout_userpic[%- END -%]">
   [% userpic_html %]
 </div>
 


### PR DESCRIPTION
A normal `<a>` is an inline element whose height is derived from font metrics and
line-height, rather than from the height of the box-things in it. The `<a>` around
a userpic thus adds some extra height to the surrounding div, making styling
difficult and often adding visual glitches. If you make it a block element
and remove the line-height, it will fit snugly to its `<img>` contents instead.

Before:

![Screen Shot 2019-06-12 at 10 50 46 AM](https://user-images.githubusercontent.com/484309/59375882-eb15bf00-8d03-11e9-922a-be9466fbf62e.png)

After:

![Screen Shot 2019-06-12 at 10 51 11 AM](https://user-images.githubusercontent.com/484309/59375917-fec12580-8d03-11e9-8e45-0f58f9456959.png)

Before:

![Screen Shot 2019-06-12 at 11 11 28 AM](https://user-images.githubusercontent.com/484309/59375902-f4069080-8d03-11e9-9243-3301e5bda176.png)

After:

![Screen Shot 2019-06-12 at 11 11 00 AM](https://user-images.githubusercontent.com/484309/59375939-0a145100-8d04-11e9-847f-624cbda6db99.png)

