### PR TITLE
Change several JS setup handlers to DOMContentLoaded

### DIFF
--- a/htdocs/inbox/index.bml
+++ b/htdocs/inbox/index.bml
@@ -222,7 +222,7 @@ var pageNum;
 var cur_folder = '<?_code return $POST{view} || $GET{view} || undef; _code?>';
 var itemid = <?_code return int( $POST{itemid} || $GET{itemid} || 0 ) _code?>;
 
-DOM.addEventListener(window, "load", setup, cur_folder);
+document.addEventListener("DOMContentLoaded", setup, cur_folder);
 
 var tableview;
 var checkallButton;

--- a/htdocs/js/editicons.js
+++ b/htdocs/js/editicons.js
@@ -150,4 +150,4 @@ function updateMakeDefaultType(multi) {
   }
 }
 
-DOM.addEventListener(window, "load", setup);
+document.addEventListener("DOMContentLoaded", setup);

--- a/htdocs/js/esn_inbox.js
+++ b/htdocs/js/esn_inbox.js
@@ -3,7 +3,7 @@ var ESN_Inbox = {
     "selected_qids": []
 };
 
-DOM.addEventListener(window, "load", function (evt) {
+document.addEventListener("DOMContentLoaded", function (evt) {
   for (var i=0; i<folders.length; i++) {
       var folder = folders[i];
 

--- a/htdocs/js/livejournal.js
+++ b/htdocs/js/livejournal.js
@@ -52,15 +52,8 @@ LiveJournal.initPage = function () {
     LiveJournal.run_hook("page_load");
 };
 
-// Set up two different ways to test if the page is loaded yet.
-// The proper way is using DOMContentLoaded, but only Mozilla supports it.
-{
-    // Others
-    DOM.addEventListener(window, "load", LiveJournal.initPage);
-
-    // Mozilla
-    DOM.addEventListener(window, "DOMContentLoaded", LiveJournal.initPage);
-}
+// Do setup once the page is ready
+DOM.addEventListener(window, "DOMContentLoaded", LiveJournal.initPage);
 
 // Set up a timer to keep the inbox count updated
 LiveJournal.initInboxUpdate = function () {

--- a/htdocs/js/userpicfactory.js
+++ b/htdocs/js/userpicfactory.js
@@ -76,7 +76,7 @@ function toggleBorder (evt) {
     }
 }
 
-DOM.addEventListener(window, "load", function () {
+document.addEventListener("DOMContentLoaded", function () {
     if (!origW || !origH)
         return;
 


### PR DESCRIPTION
The `DOMContentLoaded` event on `document` is the correct target for most setup
stuff, but a lot of ancient code uses the `load` event on `window` instead,
because support for `DOMContentLoaded` was sparse.

Nowadays everything supports `DOMContentLoaded`.

This will break support for some features in IE8.

This MIGHT fix the issue where the inbox buttons refuse to respond to anything until a massive fanfiction.net image timeout finishes happening. 

References:

- https://developer.mozilla.org/en-US/docs/Web/API/Window/load_event
- https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event