### PR TITLE
[#2353] early return from active_sessions

### DIFF
--- a/cgi-bin/LJ/Session.pm
+++ b/cgi-bin/LJ/Session.pm
@@ -65,6 +65,8 @@ sub instance {
 
 sub active_sessions {
     my ( $class, $u ) = @_;
+    return unless $u && !$u->is_expunged;
+
     my $sth = $u->prepare( "SELECT userid, sessid, exptype, auth, timecreate, timeexpire, ipfixed "
             . "FROM sessions WHERE userid=? AND timeexpire > UNIX_TIMESTAMP()" );
     $sth->execute( $u->{userid} );


### PR DESCRIPTION
If the user is expunged, the question of whether they have
any active sessions is irrelevant.

Fixes #2353.