### PR TITLE
Control strip: Don't rely on .userpic class to fix gap below icon

### DIFF
--- a/htdocs/stc/controlstrip.css
+++ b/htdocs/stc/controlstrip.css
@@ -58,6 +58,12 @@ html body
     text-decoration: underline;
 }
 
+/* Don't add extra height at bottom of userpic box */
+#lj_controlstrip_userpic a {
+    display: block;
+    line-height: 0;
+}
+
 #lj_controlstrip img {
     background: none;
     margin: 0;

--- a/views/journal/controlstrip.tt
+++ b/views/journal/controlstrip.tt
@@ -12,7 +12,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 <div id='lj_controlstrip'>
 
-<div class="userpic" id="[%- IF remote -%]lj_controlstrip_userpic[%- ELSE -%]lj_controlstrip_loggedout_userpic[%- END -%]">
+<div id='[%- IF remote -%]lj_controlstrip_userpic[%- ELSE -%]lj_controlstrip_loggedout_userpic[%- END -%]'>
   [% userpic_html %]
 </div>
 


### PR DESCRIPTION
Journal styles routinely mess with that class, therefore it's not safe to use in
the controlstrip.