### PR TITLE
Quickreply: Re-redesign to reduce annoyances

### DIFF
--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -1,6 +1,6 @@
 @import "foundation/base";
 
-$meta-input-height: 2.2em;
+$icon-control-height: 2.2em;
 
 #qrdiv * {
     box-sizing: border-box;
@@ -9,19 +9,7 @@ $meta-input-height: 2.2em;
 #qrform {
     text-align: left;
     margin: 0 auto;
-    padding: 0 1em;
     clear: both;
-
-    // Consistent initial font size for every descendent, so we can use ems
-    // for reliable relative sizing later.
-    * {
-        font-size: 13px;
-        @media (pointer: coarse) {
-            // Appease mobile Webkit so it won't *dramatic woodchuck* zoom on
-            // input focus. Minimum font-size to Not Do That: 16px.
-            font-size: 16px;
-        }
-    }
 
     .de {
         font-size: small;
@@ -31,12 +19,25 @@ $meta-input-height: 2.2em;
         margin-bottom: .2em;
     }
 
+    // Consistent em size, to keep these controls aligned while we scale:
+    .qr-icon, .qr-icon-controls * {
+        font-size: .85rem;
+    }
+
+    // Avoid *dramatic woodchuck* zoom on mobile
+    @media (pointer: coarse) {
+        .qr-icon, .qr-icon-controls *, textarea, input[type="text"] {
+            font-size: 16px;
+        }
+    }
+
     .qr-icon {
-        // Same height as qr-meta's stacked select and input
-        width: $meta-input-height * 2 + .2em;
-        height: $meta-input-height * 2 + .2em;
+        // Same height as stacked icon controls
+        width: $icon-control-height * 2 + .2em;
+        height: $icon-control-height * 2 + .2em;
         float: left;
-        position: relative;
+        margin-right: .2em;
+        margin-bottom: .2em;
 
         img {
             max-width: 100%;
@@ -44,68 +45,25 @@ $meta-input-height: 2.2em;
         }
     }
 
-    #lj_userpicselect {
-        width: 100%;
-        height: 100%;
-        border: none;
-        padding: 0;
-        margin: 0;
-        background: none;
-        @include single_transition();
-
-        &:hover, &:focus {
-            // grow down and to the left
-            -webkit-transform: scale(1.1, 1.1) translate(-1px, 3px);
-            -moz-transform: scale(1.1, 1.1) translate(-1px, 3px);
-            -o-transform: scale(1.1, 1.1) translate(-1px, 3px);
-            -ms-transform: scale(1.1, 1.1) translate(-1px, 3px);
-            transform: scale(1.1, 1.1) translate(-1px, 3px);
-
-            &:after {
-                content: "Browse";
-                display: block;
-                position: absolute;
-                top: 0;
-                margin: 0 auto;
-                font-weight: bold;
-                line-height: 60px;
-                color: #000;
-                background-color: #fff;
-                text-align: center;
-                width: 100%;
-                height: 100%;
-                opacity: .7;
-            }
-        }
-    }
-
-    .qr-meta {
-        margin-left: $meta-input-height * 2 + .5em; // width of .qr-icon + .3em
-
-        display: -webkit-flex;
-        -webkit-flex-direction: row;
-        -webkit-flex-wrap: wrap;
-
+    .qr-icon-controls {
         display: flex;
-        flex-direction: row;
         flex-wrap: wrap;
 
         & > * {
-            height: $meta-input-height;
+            height: $icon-control-height;
+            margin-bottom: .2em;
+        }
 
-            -webkit-flex-grow: 1;
-            -webkit-flex-shrink: 1;
-
-            flex-grow: 1;
-            flex-shrink: 1;
+        select#prop_picture_keyword {
+            width: 100%;
         }
     }
 
-    .qr-footer {
-        display: -webkit-flex;
-        -webkit-flex-direction: row;
-        -webkit-flex-wrap: wrap;
+    .qr-body * {
+        width: 100%;
+    }
 
+    .qr-footer {
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
@@ -123,11 +81,6 @@ $meta-input-height: 2.2em;
         }
     }
 
-    select, input[type="text"]  {
-        max-width: 100%;
-        flex-basis: 20%;
-    }
-
     textarea, select, input[type="text"] {
         margin-right: 0; // Fix for site scheme.
         &:hover {
@@ -136,14 +89,6 @@ $meta-input-height: 2.2em;
             -webkit-box-shadow: inherit;
             box-shadow: inherit;
         }
-    }
-
-    textarea#body {
-        width: 100%;
-    }
-
-    select, input, textarea {
-        padding: .15em;
     }
 
     .invisible {
@@ -161,13 +106,7 @@ $meta-input-height: 2.2em;
 
 @media #{$medium-up} {
     #qrform {
-        .qr-meta, .qr-body, .qr-footer {
-            margin-left: $meta-input-height * 2 + .5em; // width of .qr-icon + .3em
-            max-width: 38rem;
-        }
-
-        select, input, textarea {
-            padding: .3em;
-        }
+        padding: 0 1em;
+        max-width: 45rem;
     }
 }

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -16,31 +16,36 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <div id='qrformdiv'><form id='qrform' name='qrform' method='POST' action='[%- form_url | url -%]'>
 [%- dw.form_auth -%]
 [%- hidden_form_elements -%]
-<div class='qr-icon'>
+
+<div class='qr-meta'>
+  <div class='qr-icon'>
     [%- IF current_icon -%]
-      [%- IF remote.can_use_iconbrowser -%]
-        <button id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
-            [%- current_icon.imgtag -%]
-        </button>
-      [%- ELSE -%]
-        [%- current_icon.imgtag -%]
-      [%- END -%]
+      [%- current_icon.imgtag -%]
     [%- ELSE -%]
       [%- dw.img( "nouserpic_sitescheme", "" ) -%]
     [%- END -%]
+  </div>
+
+  [%- IF remote.icons.size > 0 -%]
+    <div class='qr-icon-controls'>
+      <input type='button' id='randomicon' value='Random' />
+
+      [%- IF remote.can_use_iconbrowser -%]
+        <input type="button" value="Browse" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" />
+      [%- END -%]
+
+      <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
+      [%- form.select(
+          name = 'prop_picture_keyword',
+          id = 'prop_picture_keyword',
+          selected = current_icon_kw,
+          items = remote.icons
+      ) -%]
+    </div>
+  [%- END -%]
 </div>
 
-<div class="qr-meta">
-  [%- IF remote.icons.size > 0 -%]
-    <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
-    [%- form.select(
-        name = 'prop_picture_keyword',
-        id = 'prop_picture_keyword',
-        selected = current_icon_kw,
-        items = remote.icons
-    ) -%]
-  [%- END -%]
-
+<div class="qr-body">
   [%- form.textbox(
         label = dw.ml( '/talkpost.bml.opt.subject2' )
         labelclass = 'invisible'
@@ -50,9 +55,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         id = 'subject'
         placeholder = dw.ml( '/talkpost.bml.opt.subject2' )
   ) -%]
-</div>
 
-<div class="qr-body">
   [%- form.textarea(
     label = dw.ml( '/talkpost.bml.opt.message2' )
     labelclass = 'invisible'
@@ -91,7 +94,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
     ) -%]</div>
   [%- END -%]
   <span id='quotebuttonspan' data-quote-error="[%- 'talk.error.quickquote' | ml -%]"></span>
-  <input type='button' id='randomicon' value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
   [%- END -%]
 
   [%- form.submit(


### PR DESCRIPTION
- The "click icon to browse" behavior came from the quicker-reply form, but
  apparently no one ever understood how to use it! Discard it and bring back
  the browse button.
- Remove prefixes for flexbox styles; it's 2019.
- Always put subject field on its own line, instead of combined with userpic
  dropdown. Saving space like this wasn't popular, and added complexity.
- Move browse and random button up next to the userpic dropdown. There's not
  currently a good way to make everything line up square if we're doing this, so
  go ahead and embrace the ragged-right margin for the time being. Function over
  form. 🤘🏼
- Don't set a base font-size for anything except the icon controls, until it's
  necessary to avoid woodchuck zoom. This got very nasty due to some wild
  interactions between Android browser font boosts, unexpected user-agent styles
  for textareas (did you know they often default to 13px font size when other
  things default to 16px? did you know selects and buttons often default to
  something more like 11px? buddy, SAME), and the brittle inherited styles on
  the site-scheme entry pages. So try going hands-off as much as possible, and
  see what still needs fixing after that.
- Increase the max-width on desktop, since some people found it too small.

![Screenshot_2019-06-23 betagal It's me again, what's up (1)](https://user-images.githubusercontent.com/484309/59975284-92e48580-956b-11e9-916c-3188a9d66a93.png)

![Screenshot_2019-06-23 betagal It's me again, what's up ](https://user-images.githubusercontent.com/484309/59975285-95df7600-956b-11e9-8c0e-ad2b5b0645f7.png)

![IMG_9CF9C4FA054C-1](https://user-images.githubusercontent.com/484309/59975287-9841d000-956b-11e9-9075-f47b2d7d15c2.jpeg)

I'm kind of annoyed by how it looks on very-narrow mobile, but it's still an improvement over the table-based one, and I'll need to revisit all of this when it comes time for the Talkform Unification anyway. I also would like to let it escape its container boundaries and take up the entire viewport if necessary, but that's going to take some more research and possibly some changes to S2's comment printing functions, yikes. 