### PR TITLE
Fix quickreply appearing in center of the page on sitescheme/lightscheme

### DIFF
--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -8,7 +8,6 @@ $meta-input-height: 2.2em;
 
 #qrform {
     text-align: left;
-    margin: 0 auto;
     padding: 0 1em;
     clear: both;
 


### PR DESCRIPTION
This left/right margin: auto was doing almost nothing on journal-styled
pages, but was doing the wrong thing on site/light pages (because they don't use
the same structure of nested divs). This should make the quickreply start at
the same indent level as the comment being replied to.