### PR TITLE
[#2508] Fix endless and expanding choir of dead-eyed faces

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1546,9 +1546,14 @@ sub talkform {
         return "Cannot load comment information." unless $comment;
     }
 
-    my $subjecticons = LJ::Talk::get_subjecticons();
-    my $entry        = LJ::Entry->new( $journalu, ditemid => $opts->{ditemid} );
-    my @userpics     = LJ::icons_for_remote($remote);
+    my $subjecticons    = LJ::Talk::get_subjecticons();
+    my @subjecticon_ids = ('none');
+    foreach my $sublist ( $subjecticons{lists}->{sm}, $subjecticons{lists}->{md} ) {
+        push( @subjecticon_ids, map { $_->{id} } @$sublist );
+    }
+
+    my $entry    = LJ::Entry->new( $journalu, ditemid => $opts->{ditemid} );
+    my @userpics = LJ::icons_for_remote($remote);
 
     my $basesubject = $form->{subject} || "";
     if ( !$editid && $opts->{replyto} && !$basesubject && $parpost->{'subject'} ) {
@@ -1589,7 +1594,7 @@ sub talkform {
         form_url             => LJ::create_url( '/talkpost_do', host => $LJ::DOMAIN_WEB ),
         errors               => $opts->{errors},
         create_link          => '',
-        subjecticons         => $subjecticons,
+        subjecticon_ids      => \@subjecticon_ids,
 
         public_entry     => $entry->security eq 'public',
         default_usertype => $default_usertype,

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -343,23 +343,17 @@ the same terms as Perl itself.  For a copy of the license, please reference
       "id='subjectIconImage' title='Click to change the subject icon' onclick='subjectIconListToggle();' style='cursor:pointer;cursor:hand'"
     ) -%]
 
-    [%# Include the none subjecticon in the menu %]
-    [%- subjecticons.lists.values.0.unshift( subjecticons.pic.none ) -%]
     <blockquote style="display: none;" id="subjectIconList">
-      <table summary='' border='0' cellspacing='5' cellpadding='0' style='border: 1px solid #AAAAAA'> [%# aaaaaa indeed, my dude %]
-        [%- FOREACH list IN subjecticons.lists.values -%]
-          <tr>
-            [%- FOREACH pic IN list -%]
-              <td valign="middle" align="center">
-                [%- print_subjecticon_by_id(
-                  pic.id,
-                  "id='${pic.id}' onclick='subjectIconChange(this)' style='cursor: pointer; cursor: hand;'"
-                ) -%]
-              </td>
-            [%- END -%]
-          </tr>
+      <div style='display: flex; flex-wrap: wrap; align-items: center; width: 390px; border: 1px solid #AAAAAA'> [%# aaaaaa indeed, my dude %]
+        [%- FOREACH id IN subjecticon_ids -%]
+          <div style="width: 32px;">
+            [%- print_subjecticon_by_id(
+              id,
+              "id='${id}' onclick='subjectIconChange(this)' style='cursor: pointer; cursor: hand; margin-left: auto; margin-right: auto; display: block;'"
+            ) -%]
+          </div>
         [%- END -%]
-      </table>
+      </div>
     </blockquote>
 
     <div id='ljnohtmlsubj' class='ljdeem'><span style='font-size: 8pt; font-style: italic;'>


### PR DESCRIPTION
Fixes #2508.

I forgot that:

1. The stuff a TT template gets is passed by reference, so you need to never
   mutate it or else the changes escape back into perl land.
2. I'm caching the subjecticons hashref now.

The result was that every time a user loaded the talkform, it would add another
"none" icon onto the canonical list, and it would keep expanding until the
mod_perl process got killed.