### PR TITLE
Remove non-standard form control styling from non-foundation site skins

### DIFF
--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -130,12 +130,6 @@ $meta-input-height: 2.2em;
 
     textarea, select, input[type="text"] {
         margin-right: 0; // Fix for site scheme.
-        &:hover {
-            // Fix for site scheme. Too distracting.
-            -moz-box-shadow: inherit;
-            -webkit-box-shadow: inherit;
-            box-shadow: inherit;
-        }
     }
 
     textarea#body {

--- a/htdocs/stc/base-colors-dark.css
+++ b/htdocs/stc/base-colors-dark.css
@@ -112,9 +112,3 @@
   border-color: #444;
   background-color: #4b4b4b;
 }
-
-input.text:hover, textarea.text:hover {
-  -moz-box-shadow: inset 0 2px 4px #444;
-  -webkit-box-shadow:inset 0 2px 4px #444;
-  box-shadow: inset 0 2px 4px #444;
-}

--- a/htdocs/stc/base-colors-light.css
+++ b/htdocs/stc/base-colors-light.css
@@ -53,7 +53,7 @@
   background-color:#f2f2f2;
 }
 .kwmenu .selected, #iconselector_icons_list .iconselector_selected {
-  border-color: #444; 
+  border-color: #444;
   background-color:#f2f2f2;
 }
 
@@ -112,10 +112,4 @@
 #plaintext-tools {
   border-color: #efefef;
   background-color: #f2f2f2;
-}
-
-input.text:hover, textarea.text:hover {
-  -moz-box-shadow: inset 0 1px 2px #999;
-  -webkit-box-shadow:inset 0 1px 2px #999;
-  box-shadow: inset 0 1px 2px #999;
 }

--- a/htdocs/stc/blueshift/blueshift.css
+++ b/htdocs/stc/blueshift/blueshift.css
@@ -810,15 +810,6 @@ input.create-account {
     background: #D6DCE9;
     border: 2px solid #3960A0;
 }
-input.text,
-textarea.text,
-select.select,
-.autocomplete_container {
-    background: #fff url("/img/input-bg.gif") repeat-x 0 -1px;
-    border: 1px solid #bbb;
-    border-top: 1px solid #999;
-    border-left: 1px solid #999;
-}
 .detail {
 
 }

--- a/htdocs/stc/celerity/celerity.css
+++ b/htdocs/stc/celerity/celerity.css
@@ -676,16 +676,6 @@ hr.hr {
     background-color: #999966;
 }
 
-input.text,
-textarea.text,
-select.select,
-.autocomplete_container {
-    background: #fff url("/img/input-bg.gif") repeat-x 0 -1px;
-    border: 1px solid #bbb;
-    border-top: 1px solid #999;
-    border-left: 1px solid #999;
-}
-
 .appwidget .more-link {
     color: #999966 !important;
     background: url('/img/arrow-double-black.gif') no-repeat 0 60%;
@@ -696,12 +686,6 @@ select.select,
 }
 .message blockquote {
     border: 1px solid #aaa;
-}
-
-/* Quick Reply table */
-
-#qrformdiv table {
-    border: 1px solid #999;
 }
 
 /* MonthPage */

--- a/htdocs/stc/gradation/gradation.css
+++ b/htdocs/stc/gradation/gradation.css
@@ -923,12 +923,6 @@ div#cf-edit select {
     background-color: #222;
 }
 
-/* Quick Reply table */
-
-#qrformdiv table {
-    border: 1px solid #888;
-}
-
 /* MonthPage */
 
 #archive-month .navigation li, #archive-month .navigation a {display: inline; }

--- a/htdocs/stc/lynx/lynx.css
+++ b/htdocs/stc/lynx/lynx.css
@@ -114,8 +114,6 @@ table.grid, table.grid td {
     border: 1px solid #999;
 }
 
-.text { color: #000; background: #fff; border-color: #777; }
-
 /* Temporary page-specific */
 /* profile.css */
 .field_name, .section_subhead { background: #eee; }
@@ -139,12 +137,6 @@ td.odd { background-color: #c0c0c0; }
 td.even { background-color: #e2e2e2; }
 td.screened { background-color: #707070; }
 td.highlight { background-color: #eeeeee; }
-
-/* Quick Reply table */
-
-#qrformdiv table {
-    border: 1px solid #999;
-}
 
 /* MonthPage */
 


### PR DESCRIPTION
...With the exception of gradation, which, as a dark-mode theme, is actually
doing something relevant.

On some of the siteschemes (light/lynx mode, especially), this styling is uglifying the new quickreply. And in general, messing with the platform's default form controls seems likely to be a source of Bad Times. 

These style rules date back at least 10 years — it looks like they were copied out of lj_base.css or something into the theme files, and then accumulated some additional dust over time. Whatever they were trying to accomplish probably isn't still relevant.