### PR TITLE
Talkform: Don't treat users as logged-out if there's a captcha

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1569,6 +1569,24 @@ sub talkform {
 
         # Partial form was submitted; pick up where we left off.
         $default_usertype = $form->{usertype};
+
+        # EXCEPT: there's an annoying special behavior with the "cookieuser"
+        # usertype. It can survive certain partial form submissions (like the
+        # "More options" button), but as soon as it passes through
+        # LJ::Talk::Post::init() (which is when we find out whether a captcha is
+        # needed, for example), it gets munged into the "user" type and a few
+        # other properties get added. So if it's "user", we have to check those
+        # other properties to see whether it was actually meant to be
+        # "cookieuser". (Why not just preserve "cookieuser" through init()?
+        # Because an unknowable amount of things check for usertype eq user, and
+        # I'm not ready to hunt them all down yet.)
+        if (   $form->{usertype} eq 'user'
+            && $form->{userpost}
+            && $form->{cookieuser}
+            && $form->{userpost} eq $form->{cookieuser} )
+        {
+            $default_usertype = 'cookieuser';
+        }
     }
     elsif ($remote) {
 

--- a/htdocs/js/talkpost.js
+++ b/htdocs/js/talkpost.js
@@ -191,7 +191,7 @@ if (document.getElementById) {
     }
     form.onsubmit = submitHandler;
 
-    window.onload = function () {
+    document.addEventListener("DOMContentLoaded", function () {
         hideMe(otherljuser_row);
         hideMe(lj_more);
         hideMe(oid_more);
@@ -200,7 +200,7 @@ if (document.getElementById) {
         if (radio_remote && radio_remote.checked) handleRadios(1);
         if (radio_oidlo && radio_oidlo.checked) handleRadios(3);
         if (radio_oidli && radio_oidli.checked) handleRadios(4);
-    }
+    });
 
 }
 


### PR DESCRIPTION
I WONDERED if I'd missed something in [that confusing default usertype
subroutine.](https://github.com/dreamwidth/dw-free/pull/2479/files#diff-339927c4adfb5b1e94ddf9bb2910209eL1575) Anyway, the "cookieuser" usertype turns out to be as ephemeral as
the morning dew, so we can't just automatically believe the partial form
submission when it says the usertype is "user".