### PR TITLE
reinstate use lines for Net::OpenID modules

### DIFF
--- a/cgi-bin/LJ/OpenID.pm
+++ b/cgi-bin/LJ/OpenID.pm
@@ -16,6 +16,8 @@ package LJ::OpenID;
 use strict;
 use Digest::SHA1 qw(sha1 sha1_hex);
 use LJ::OpenID::Cache;
+use Net::OpenID::Server;
+use Net::OpenID::Consumer;
 
 sub server {
     my ( $get, $post ) = @_;


### PR DESCRIPTION
Fixes errors with OpenID following code push due to 83aa72a