### PR TITLE
Quickreply Re-re-re-design: Brutalist Ziggurat Edition 

### DIFF
--- a/htdocs/js/jquery.iconselector.js
+++ b/htdocs/js/jquery.iconselector.js
@@ -319,7 +319,7 @@ jQuery(function($) {
     var browseButton = $("#lj_userpicselect");
     if (browseButton.length > 0) {
         $("#prop_picture_keyword").iconselector({
-            selectorButtons: "#lj_userpicselect",
+            selectorButtons: "#lj_userpicselect, .lj_userpicselect_extra",
             metatext: browseButton.data("iconbrowserMetatext"),
             smallicons: browseButton.data("iconbrowserSmallicons")
         });

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -11,37 +11,49 @@ $icon-control-height: 2.2em;
     padding: 0 1em;
     clear: both;
 
+    // .de means warnings/alerts.
     .de {
         font-size: small;
     }
 
     input, button, textarea, select {
-        margin-bottom: .2em;
-    }
-
-    // Consistent em size, to keep these controls aligned while we scale:
-    .qr-icon, .qr-icon-controls * {
-        font-size: .85rem;
+        margin-bottom: 3px;
     }
 
     // Avoid *dramatic woodchuck* zoom on mobile
     @media (pointer: coarse) {
-        .qr-icon, .qr-icon-controls *, textarea, input[type="text"] {
+        select, textarea, input[type="text"] {
             font-size: 16px;
         }
     }
 
+    .qr-meta {
+        display: flex;
+        align-items: flex-end;
+    }
+
     .qr-icon {
         // Same height as stacked icon controls
-        width: $icon-control-height * 2 + .2em;
-        height: $icon-control-height * 2 + .2em;
-        float: left;
-        margin-right: .2em;
-        margin-bottom: .2em;
+        width: 55px;
+        height: 55px;
+        flex-shrink: 0;
+        margin-right: 3px;
+        margin-bottom: 3px;
 
         img {
             max-width: 100%;
             max-height: 100%;
+        }
+    }
+
+    .qr-icon-controls {
+        & > * {
+            margin-bottom: 3px;
+        }
+
+        select#prop_picture_keyword {
+            display: block;
+            width: 100%;
         }
     }
 
@@ -76,20 +88,6 @@ $icon-control-height: 2.2em;
             &::after {
                 opacity: .7;
             }
-        }
-    }
-
-    .qr-icon-controls {
-        display: flex;
-        flex-wrap: wrap;
-
-        & > * {
-            height: $icon-control-height;
-            margin-bottom: .2em;
-        }
-
-        select#prop_picture_keyword {
-            width: 100%;
         }
     }
 

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -45,6 +45,40 @@ $icon-control-height: 2.2em;
         }
     }
 
+    button.lj_userpicselect_extra {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        border: none;
+        padding: 0;
+        margin: 0;
+        background: none;
+        cursor: pointer;
+
+        &::after {
+            content: "Browse";
+            display: block;
+            position: absolute;
+            top: 0;
+            margin: 0 auto;
+            font-weight: bold;
+            line-height: 60px;
+            color: #000;
+            background-color: #fff;
+            text-align: center;
+            width: 100%;
+            height: 100%;
+            opacity: 0;
+            @include single_transition();
+        }
+
+        &:hover, &:focus {
+            &::after {
+                opacity: .7;
+            }
+        }
+    }
+
     .qr-icon-controls {
         display: flex;
         flex-wrap: wrap;

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -19,10 +19,16 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 <div class='qr-meta'>
   <div class='qr-icon'>
+    [%- IF remote.can_use_iconbrowser -%]
+      <button type='button' class='lj_userpicselect_extra'>
+    [%- END -%]
     [%- IF current_icon -%]
       [%- current_icon.imgtag -%]
     [%- ELSE -%]
       [%- dw.img( "nouserpic_sitescheme", "" ) -%]
+    [%- END -%]
+    [%- IF remote.can_use_iconbrowser -%]
+      </button>
     [%- END -%]
   </div>
 

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -28,11 +28,11 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
   [%- IF remote.icons.size > 0 -%]
     <div class='qr-icon-controls'>
-      <input type='button' id='randomicon' value='Random' />
-
       [%- IF remote.can_use_iconbrowser -%]
         <input type="button" value="Browse" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" />
       [%- END -%]
+
+      <input type='button' id='randomicon' value='Random' />
 
       <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
       [%- form.select(


### PR DESCRIPTION
In this re-adjustment, I'm giving up entirely on trying to make two rows of
controls align cleanly with the icon preview, because:

1. In the best case scenario, it was looking better but working worse (due to
   adding unnecessary length to the icon selector dropdown, etc.),
2. In the more common scenario, it was also looking worse, due to stretching the
   buttons in a way that didn't make sense when compared to the buttons below,
3. TBH it wasn't even working a lot of the time, because of how different
   platforms style their form controls! Rounded corners or weird user-agent
   !important rules about height and font size were making things not line up
   squarely anyway, like 40% of the time!!!

Farewell you beautiful dream (of perfectly straightened picture frames). In its
place, we get a brutalist-in-the-good-sense rethink of the icon controls:

- Consistent and platform-appropriate button styling.
- Ragged-right margin.
- The dropdown only sticks out as far as it needs to, and doesn't get weird
  vertical stretch.
- A cool triangular ziggurat kind of shape. 📐🏕🏔

In summary: Looks worse, works better.

Also included:

- Bring back the click-on-icon browse button (as a bonus, not the sole instance). 
- Switch position of random and browse buttons (by popular demand). 