### PR TITLE
userpicfactory.js: Revert to using an on-load handler

### DIFF
--- a/htdocs/js/userpicfactory.js
+++ b/htdocs/js/userpicfactory.js
@@ -76,7 +76,8 @@ function toggleBorder (evt) {
     }
 }
 
-document.addEventListener("DOMContentLoaded", function () {
+// This setup actually does need to be on the load event.
+DOM.addEventListener(window, "load", function () {
     if (!origW || !origH)
         return;
 


### PR DESCRIPTION
SOMETHING breaks if you try to do this setup as soon as the DOM is ready. Either
it's relying on image dimensions that aren't available until the image content
is loaded (been there), or there's some kind of existing race condition that
isn't exposed until this code gets faster. Hard to say, tbh.