### PR TITLE
Quickreply tweaks: combined Android rampage and claustrophobia edition

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -922,9 +922,11 @@ sub create_qr_div {
             form_url             => LJ::create_url( '/talkpost_do', host => $LJ::DOMAIN_WEB ),
             hidden_form_elements => $hidden_form_elements,
             can_checkspell       => $LJ::SPELLER ? 1 : 0,
-            minimal              => $opts{minimal} ? 1 : 0,
             post_disabled        => $post_disabled,
             post_button_class    => $post_disabled ? 'ui-state-disabled' : '',
+
+            # Currently unused, but might come back.
+            minimal => $opts{minimal} ? 1 : 0,
 
             current_icon_kw => $userpic_kw,
             current_icon    => LJ::Userpic->new_from_keyword( $remote, $userpic_kw ),

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -99,6 +99,7 @@ $icon-control-height: 2.2em;
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
+        align-items: flex-start;
     }
 
     span#quotebuttonspan {

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -85,7 +85,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
       id = 'submitpost'
   ) -%]
 
-  [%- UNLESS minimal -%]
   [%- form.submit(
       name = 'submitpview'
       value = dw.ml( 'talk.btn.preview' ),
@@ -93,7 +92,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) -%]
   <span id='quotebuttonspan' data-quote-error="[%- 'talk.error.quickquote' | ml -%]"></span>
-  [%- END -%]
 
   [%- form.submit(
       name = 'submitmoreopts'

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -92,13 +92,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
       id = 'submitpview'
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) -%]
-  [%- IF can_checkspell -%]
-    <div>[%- form.checkbox(
-      label = dw.ml( '/talkread.bml.qr.spellcheck' )
-      name = 'do_spellcheck'
-      id = 'do_spellcheck'
-    ) -%]</div>
-  [%- END -%]
   <span id='quotebuttonspan' data-quote-error="[%- 'talk.error.quickquote' | ml -%]"></span>
   [%- END -%]
 

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -36,7 +36,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <div class='qr-icon-controls'>
       [%- IF remote.can_use_iconbrowser -%]
         <input type="button" value="Browse" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" />
-      [%- END -%]
+      [%- END %]
 
       <input type='button' id='randomicon' value='Random' />
 
@@ -77,36 +77,37 @@ the same terms as Perl itself.  For a copy of the license, please reference
   [%- IF post_disabled -%]
   <div class='ui-state-error'>[%- '/talkpost.bml.error.nocomment_quick' | ml -%]</div>
   [%- END -%]
-  [%- form.submit(
+  [% form.submit(
       name = 'submitpost'
       value = dw.ml( '/talkread.bml.button.post' ),
       disabled = post_disabled,
       class = post_button_class,
       id = 'submitpost'
-  ) -%]
+  ) %]
 
-  [%- form.submit(
+  [% form.submit(
       name = 'submitpview'
       value = dw.ml( 'talk.btn.preview' ),
       id = 'submitpview'
   ) -%]
-  [%- form.hidden( name = 'submitpreview', value = 0 ) -%]
+  [%- form.hidden( name = 'submitpreview', value = 0 ) %]
+
   <span id='quotebuttonspan' data-quote-error="[%- 'talk.error.quickquote' | ml -%]"></span>
 
-  [%- form.submit(
+  [% form.submit(
       name = 'submitmoreopts'
       value = dw.ml( '/talkread.bml.button.more' ),
       id = 'submitmoreopts'
-  ) -%]
+  ) %]
 
-  [%- help.icon -%]
-  [%- IF journal.is_iplogging -%]
+  [% help.icon %]
+  [%- IF journal.is_iplogging %]
     <div class='de'>[%- '/talkpost.bml.logyourip' | ml -%]</div>
-    [%- help.iplogging -%]
-  [%- END -%]
-  [%- IF journal.is_linkstripped -%]
+    [% help.iplogging %]
+  [% END -%]
+  [%- IF journal.is_linkstripped %]
     <div class='de'>[%- '/talkpost.bml.linkstripped' | ml -%]</div>
-  [%- END -%]
+  [% END -%]
 </div>
 
 </form></div>


### PR DESCRIPTION
Man, that one person's persistent Android Firefox issues are really getting my goat. The real problem is that the site scheme entry pages are still non-responsive junk. Android browsers see that as a cue to try and Frankenstein them into a mobile page, which can make a mess because robots are people too I guess, idk, maybe the real Frankenstein was the friends we made along the way.

But anyway, until #2427 is for real, the best option is to accept that Android browsers will do weird stuff on site scheme and either remove some of the specific stumbling blocks they're hitting (axing spellcheckbox), or limit the damage they can do once they stumble (stop stretching). 

Fixes #2519.