### PR TITLE
Quickreply: WELCOME BACK, quick-er reply

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -922,11 +922,9 @@ sub create_qr_div {
             form_url             => LJ::create_url( '/talkpost_do', host => $LJ::DOMAIN_WEB ),
             hidden_form_elements => $hidden_form_elements,
             can_checkspell       => $LJ::SPELLER ? 1 : 0,
+            minimal              => $opts{minimal} ? 1 : 0,
             post_disabled        => $post_disabled,
             post_button_class    => $post_disabled ? 'ui-state-disabled' : '',
-
-            # Currently unused, but might come back.
-            minimal => $opts{minimal} ? 1 : 0,
 
             current_icon_kw => $userpic_kw,
             current_icon    => LJ::Userpic->new_from_keyword( $remote, $userpic_kw ),

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -85,12 +85,14 @@ the same terms as Perl itself.  For a copy of the license, please reference
       id = 'submitpost'
   ) %]
 
+  [%- UNLESS minimal -%]
   [% form.submit(
       name = 'submitpview'
       value = dw.ml( 'talk.btn.preview' ),
       id = 'submitpview'
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) %]
+  [%- END -%]
 
   <span id='quotebuttonspan' data-quote-error="[%- 'talk.error.quickquote' | ml -%]"></span>
 


### PR DESCRIPTION
This reverts commit 73c14ed166556b9cf3c3e108443daed131f39356, or at least the
part where we expose the preview button on the reading/recent pages. That
doesn't work yet.

The quote button can stay, though.