### PR TITLE
don't apply convert_user_mentions to imported and syndicated content

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1614,7 +1614,7 @@ sub clean_event {
 
     # First pass, convert user mentions like @foo into user HTML. This syntax needs to be
     # supported everywhere, so we do this before Markdown-izing.
-    convert_user_mentions($ref);
+    convert_user_mentions( $ref, $opts );
 
     # Markdown is processed at this point. Since the Markdown module converts our input
     # into an output HTML, it needs to be run now so we can pass it through our HTML cleaner
@@ -1715,7 +1715,7 @@ sub clean_comment {
 
     # First pass, convert user mentions like @foo into user HTML. This syntax needs to be
     # supported everywhere, so we do this before Markdown-izing.
-    convert_user_mentions($ref);
+    convert_user_mentions( $ref, $opts );
 
     # preprocess with markdown if desired
     if ( $opts->{editor} && $opts->{editor} eq "markdown" ) {
@@ -1871,7 +1871,10 @@ sub quote_html {
 }
 
 sub convert_user_mentions {
-    my $ref = $_[0];
+    my ( $ref, $opts ) = @_;
+
+    return if $opts->{is_syndicated};
+    return if $opts->{is_imported};
 
     my $usertag = sub {
         my ( $user, $site ) = ( $_[0], $_[1] || $LJ::DOMAIN );

--- a/cgi-bin/LJ/Comment.pm
+++ b/cgi-bin/LJ/Comment.pm
@@ -879,6 +879,7 @@ sub body_html {
     $opts->{editor}       = $self->prop("editor");
     $opts->{journal}      = $self->journal->user;
     $opts->{ditemid}      = $self->entry->ditemid;
+    $opts->{is_imported}  = $self->import_source;
 
     my $body = $self->body_raw;
     LJ::CleanHTML::clean_comment( \$body, $opts ) if $body;

--- a/cgi-bin/LJ/Comment.pm
+++ b/cgi-bin/LJ/Comment.pm
@@ -1861,4 +1861,26 @@ sub is_edited {
     return $_[0]->edit_time ? 1 : 0;
 }
 
+sub import_source {
+    my $self = $_[0];
+    my $u    = $self->journal;
+    my $jid  = $u->id;
+
+    my $mc = LJ::MemCache::get( [ $jid, "talksource:$jid:$self->{jtalkid}" ] );
+    return $mc if defined $mc;
+
+    my $p = LJ::get_prop( talk => 'import_source' );
+    return 0 unless $p;
+
+    my $db =
+        $u->selectrow_array(
+        q{SELECT value FROM talkprop2 WHERE journalid=? AND tpropid=? AND jtalkid=?},
+        undef, $jid, $p->{id}, $self->{jtalkid} )
+        || 0;
+    return 0 if $u->err;    # but don't cache on error
+
+    LJ::MemCache::set( [ $jid, "talksource:$jid:$self->{jtalkid}" ], $db );
+    return $db;
+}
+
 1;

--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -515,6 +515,28 @@ sub _load_text {
     return 1;
 }
 
+sub import_source {
+    my $self = $_[0];
+    my $u    = $self->{u};
+    my $jid  = $u->id;
+
+    my $mc = LJ::MemCache::get( [ $jid, "logsource:$jid:$self->{jitemid}" ] );
+    return $mc if defined $mc;
+
+    my $p = LJ::get_prop( log => 'import_source' );
+    return 0 unless $p;
+
+    my $db =
+        $u->selectrow_array(
+        q{SELECT value FROM logprop2 WHERE journalid=? AND propid=? AND jitemid=?},
+        undef, $jid, $p->{id}, $self->{jitemid} )
+        || 0;
+    return 0 if $u->err;    # but don't cache on error
+
+    LJ::MemCache::set( [ $jid, "logsource:$jid:$self->{jitemid}" ], $db );
+    return $db;
+}
+
 sub slug {
     my $self = $_[0];
     my $u    = $self->{u};

--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -928,6 +928,8 @@ sub event_html {
     $opts->{unsuspend_supportid} = $suspend_msg ? $self->prop("unsuspend_supportid") : 0;
     $opts->{journal}             = $self->{u}->user;
     $opts->{ditemid}             = $self->{ditemid};
+    $opts->{is_imported}         = $self->import_source;
+    $opts->{is_syndicated}       = $self->{u}->is_syndicated;
 
     $self->_load_text unless $self->{_loaded_text};
     my $event = $self->{event};

--- a/doc/raw/memcache-keys.txt
+++ b/doc/raw/memcache-keys.txt
@@ -15,6 +15,7 @@
 <uid> talk2ct:<uid> == # rows for user
 <uid> talkleftct:<uid> == # rows for user
 <uid> talkroot:<uid>:<jtalkid> == scalar: root of the thread containing this comment
+<uid> talksource:<uid>:<jtalkid> == scalar: the import source (zero if none)
 
 <uid> logtext:<cid>:<uid>:<jitemid> == [ subject, text ]
 <uid> logprop:<uid>:<jitemid> == { propname => $value, ... }
@@ -24,6 +25,7 @@
 <uid> log2lt:<uid> == packed data: array of recent log2 entries in rlogtime order, last 2 weeks by default
 <uid> rp:<uid>:<jitemid> == scalar, the replycount value
 <uid> logslug:<uid>:<jitemid> == scalar, the slug for this entry
+<uid> logsource:<uid>:<jitemid> == scalar: the import source (zero if none)
 
 <uid> memkwid:<uid> == hashref of 'memories' keyword ids to keywords.
 <uid> memkwcnt:<uid>:<w|t>:<f|v|u> == hashref of 'memories' keyword ids to keyword counts.  <w|t> is filter oWner|oTher.  <f|v|u> is security Friends|priVate|pUblic


### PR DESCRIPTION
NOTE: I haven't even tested to see if this compiles!  It involves adding new methods and memcache keys related to whether a given entry or comment has been imported.  The SQL is based off my reading of the erase-imported-content worker.

Just throwing this up for review and as a possible base for subsequent work.