### PR TITLE
Talkform javascript: fix typo

### DIFF
--- a/htdocs/js/jquery.talkform.js
+++ b/htdocs/js/jquery.talkform.js
@@ -82,7 +82,7 @@ jQuery(function($){
             $('#password').val('');
         }
         // prevent double-submits
-        $form.find('input[type="submit"]').prop("disabled", true);
+        commentForm.find('input[type="submit"]').prop("disabled", true);
     });
 
 });


### PR DESCRIPTION
This was a copy-paste error, whoops.