### PR TITLE
Quick-reply, 4th of July edition: don't squish, smarter button positions

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -786,11 +786,15 @@ sub icons_for_remote {
                 push @pics, [ $res{"pickw_$i"}, $res{"pickwurl_$i"} ];
             }
             @pics = sort { lc( $a->[0] ) cmp lc( $b->[0] ) } @pics;
+            my $defaultpicurl =
+                  $res{defaultpicurl}
+                ? $res{defaultpicurl}
+                : $LJ::IMGPREFIX . $LJ::Img::img{nouserpic_sitescheme}->{src};
             @pics = (
                 {
                     value => "",
                     text  => LJ::Lang::ml('/talkpost.bml.opt.defpic'),
-                    data  => { url => $res{defaultpicurl} }
+                    data  => { url => $defaultpicurl }
                 },
                 map { { value => $_->[0], text => $_->[0], data => { url => $_->[1] } } } @pics
             );

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -786,10 +786,8 @@ sub icons_for_remote {
                 push @pics, [ $res{"pickw_$i"}, $res{"pickwurl_$i"} ];
             }
             @pics = sort { lc( $a->[0] ) cmp lc( $b->[0] ) } @pics;
-            my $defaultpicurl =
-                  $res{defaultpicurl}
-                ? $res{defaultpicurl}
-                : $LJ::IMGPREFIX . $LJ::Img::img{nouserpic_sitescheme}->{src};
+            my $defaultpicurl = $res{defaultpicurl}
+                || ( $LJ::IMGPREFIX . $LJ::Img::img{nouserpic_sitescheme}->{src} );
             @pics = (
                 {
                     value => "",

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -127,6 +127,11 @@ $icon-control-height: 2.2em;
 
         input {
             margin-left: 5px;
+            float: right;
+
+            @supports (display: flex) {
+                float: none;
+            }
         }
     }
 

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -19,6 +19,7 @@ $icon-control-height: 2.2em;
     // .de means warnings/alerts.
     .de {
         font-size: small;
+        width: 100%;
     }
 
     input, button, textarea, select {
@@ -102,13 +103,21 @@ $icon-control-height: 2.2em;
 
     .qr-footer {
         display: flex;
-        flex-direction: row;
+        flex-direction: row-reverse;
         flex-wrap: wrap;
         align-items: flex-start;
+
+        input {
+            margin-left: 5px;
+        }
     }
 
     #comment-text-quote {
-        margin-left: auto;
+        margin-right: auto;
+    }
+
+    #submitmoreopts {
+        margin-left: 0;
     }
 
     textarea, select, input[type="text"] {

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -59,7 +59,9 @@ $icon-control-height: 2.2em;
 
         select#prop_picture_keyword {
             display: block;
-            width: 100%;
+            @supports (display: flex) {
+                width: 100%;
+            }
         }
     }
 

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -97,8 +97,24 @@ $icon-control-height: 2.2em;
         }
     }
 
-    .qr-body * {
-        width: 100%;
+    .qr-body {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-end;
+
+        #subject {
+            // size=50 in html is a presentational hint for width, so need to
+            // set width to SOMETHING to keep it from messing up the flex.
+            width: 70%;
+            flex-grow: 1;
+            flex-shrink: 1;
+        }
+        #comment-text-quote {
+            margin-left: 5px;
+        }
+        #body {
+            width: 100%;
+        }
     }
 
     .qr-footer {
@@ -110,10 +126,6 @@ $icon-control-height: 2.2em;
         input {
             margin-left: 5px;
         }
-    }
-
-    #comment-text-quote {
-        margin-right: auto;
     }
 
     #submitmoreopts {
@@ -130,9 +142,3 @@ $icon-control-height: 2.2em;
     }
 }
 
-// When we're down to ~two buttons per row, avoid messy clumping:
-@media #{$small-only} {
-    .qr-footer > * {
-        flex-grow: 1;
-    }
-}

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -8,8 +8,13 @@ $icon-control-height: 2.2em;
 
 #qrform {
     text-align: left;
-    padding: 0 1em;
+    padding: .5em;
     clear: both;
+
+    @media #{$medium-up} {
+        padding: .5em 1em;
+        max-width: 45rem;
+    }
 
     // .de means warnings/alerts.
     .de {
@@ -120,12 +125,5 @@ $icon-control-height: 2.2em;
 @media #{$small-only} {
     .qr-footer > * {
         flex-grow: 1;
-    }
-}
-
-@media #{$medium-up} {
-    #qrform {
-        padding: 0 1em;
-        max-width: 45rem;
     }
 }

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -62,6 +62,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
         placeholder = dw.ml( '/talkpost.bml.opt.subject2' )
   ) -%]
 
+  <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+
   [%- form.textarea(
     label = dw.ml( '/talkpost.bml.opt.message2' )
     labelclass = 'invisible'
@@ -93,8 +95,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) %]
   [%- END -%]
-
-  <input type="button" id="comment-text-quote" value="Quote" class="js-only" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
 
   [% form.submit(
       name = 'submitmoreopts'

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -19,7 +19,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 <div class='qr-meta'>
   <div class='qr-icon'>
-    [%- IF remote.can_use_iconbrowser -%]
+    [%- IF remote.can_use_iconbrowser AND remote.icons.size > 0 -%]
       <button type='button' class='lj_userpicselect_extra'>
     [%- END -%]
     [%- IF current_icon -%]
@@ -27,7 +27,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%- ELSE -%]
       [%- dw.img( "nouserpic_sitescheme", "" ) -%]
     [%- END -%]
-    [%- IF remote.can_use_iconbrowser -%]
+    [%- IF remote.can_use_iconbrowser AND remote.icons.size > 0 -%]
       </button>
     [%- END -%]
   </div>


### PR DESCRIPTION
Fixes #2528 
Fixes #2535 
Fixes #2545

I'm still poking at issues #2521 and #2522, because they bring up a bunch of sticky layout questions. But those really only mess with the uppermost section of the ziggurat, so there's no reason they should delay this batch of improvements. 

These should be pretty uncontroversial **(FAMOUS LAST WORDS)** -- 

- No one likes it when the reply form squishes down to a little chiclet.
- There's pretty strong consensus that the post button should go on the right. (I changed my mind after using it on the wrong side for a few days -- turns out I DO actually have a strong opinion about this.)
- It sounds like a lot of people were confused by the quote button's previous locations (like, on talkform it looks like part of the auto-format decision group). Having it by the subject makes some amount of consistent sense, and at least shouldn't be any _more_ confusing. It also shouldn't shrink the subject by too much, now that we aren't shrinking the form to chiclet size. 

## Screamshots

Desktop, site scheme, deep thread: 

![Screenshot_2019-07-02 betagal It's me again, what's up (2)](https://user-images.githubusercontent.com/484309/60532278-ccc33380-9cb1-11e9-832c-28b6fe7c1e77.png)

Desktop, journal style, deep thread: 

![Screenshot_2019-07-02 betagal It's me again, what's up ](https://user-images.githubusercontent.com/484309/60532280-cd5bca00-9cb1-11e9-847b-c78bb0b6387a.png)

Mobile-size, journal style: 

<img src="https://user-images.githubusercontent.com/484309/60532279-ccc33380-9cb1-11e9-8e9f-6aae6ad4acce.png" width="320">

And just for good measure, here's what it looks like in a _really old_ browser that hasn't been updated since 2012:

<img width="994" alt="Screen Shot 2019-07-02 at Jul 2, 10 24AM" src="https://user-images.githubusercontent.com/484309/60533106-a7372980-9cb3-11e9-971d-440830220c3d.png">

This is the final release of Camino (RIP), and it shows what the form looks like if you have NO flexbox support. It degrades relatively gracefully — the icon controls go below the icon preview instead of beside, and the submit buttons are in the wrong order/wrong alignment, because I'm using flexbox to make the post button go on the far right. (This is the right thing to do IMO, because 1. post should be first in the tab order, and 2. if the buttons wrap on mobile, post should be _closest_ to the body field while remaining on the right. Re-ordering the buttons would sacrifice at least point number 2, even though we could get number 1 back by using positive values in `taborder` (which is Considered Harmful).)