### PR TITLE
Fix glitch in "don't autoformat" text string

### DIFF
--- a/htdocs/talkpost.bml.text
+++ b/htdocs/talkpost.bml.text
@@ -73,7 +73,7 @@
 
 .opt.noanonpost.nonpublic=You can't comment anonymously on a protected entry.
 
-.opt.noautoformat=Don't auto-format:
+.opt.noautoformat=Don't auto-format
 
 .opt.noimage=No Image
 


### PR DESCRIPTION
The colon was because this label expected to go _before_ the checkbox it applied to,
which 1. is wrong and 2. no longer happens now that it's using the standard form
control helpers.