### PR TITLE
Talkform: always include quote button

### DIFF
--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -375,12 +375,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
       ) -%]
       [%- help_icon( 'autoformat' ) -%]
 
-      [%# NF: original comment said "only show quick quote button on initial composition," but this seems goofy anyway? -%]
-      [%- IF remote -%]
-        [%- UNLESS errors -%]
-          <input type="button" id="comment-text-quote" value="Quote" class="js-only" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
-        [%- END -%]
-      [%- END -%]
+      <input type="button" id="comment-text-quote" value="Quote" class="js-only" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
 
       [%- IF remote.can_manage_community -%]
         [%- form.checkbox(


### PR DESCRIPTION
I ported this logic over from the original talkform, because I was trying to be
thorough:

https://github.com/dreamwidth/dw-free/pull/2479/files#diff-339927c4adfb5b1e94ddf9bb2910209eL2158

But it made no sense to me at the time, and now that I've had time to reflect,
I'm pretty sure it's nonsense. There's no good reason to exclude the quote
button for anonymous users, and there's not even a great reason to exclude it on
error-fixes or captchas -- yeah, it's not very useful, but why bother
reconfiguring the form? Anyway, bye.