### PR TITLE
[#2549] Return to journal pages on logout

### DIFF
--- a/cgi-bin/DW/Controller/Auth.pm
+++ b/cgi-bin/DW/Controller/Auth.pm
@@ -15,7 +15,7 @@
 # 'perldoc perlartistic' or 'perldoc perlgpl'.
 #
 
-package DW::Controller::Rename;
+package DW::Controller::Auth;
 
 use strict;
 use v5.10;
@@ -49,6 +49,16 @@ sub logout_handler {
         elsif ( exists $post_args->{logout_all} ) {
             $remote->logout_all;
             $vars->{success} = 'all';
+        }
+
+        # If the logout form asked to be sent back to the original page (with a
+        # hidden 'ret=1' form input), do so (as long as the logout was
+        # successful).
+        if ( $vars->{success} && $post_args->{ret} ) {
+            my $referer = $r->header_in('Referer');
+            if ( $referer && LJ::check_referer( '', $referer ) ) {
+                return $r->redirect($referer);
+            }
         }
     }
 

--- a/views/journal/controlstrip.tt
+++ b/views/journal/controlstrip.tt
@@ -25,6 +25,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- IF remote.sessid -%]
           [%- form.hidden( name = "sessid", value = remote.sessid ) -%]
         [%- END -%]
+        [%- form.hidden( name = "ret", value = 1 ) -%]
+
         [% remote.display %]
         [% form.submit(
             id = "Logout",


### PR DESCRIPTION
This restores the ability to click the log out button in the controlstrip and
get returned to the same page, much beloved by RPers and other multi-account
users.

Unlike the original implementation, I'm using a hidden form input instead of a
URL parameter (`?ret=1`) -- since this is a POST action, it seems like the
arguments should all arrive via POST data.

This also fixes an inconsequential copypasta glitch in the controller's name.

----

I only tested this briefly. 

- Works when logging out from control strip (returns you to page).
- Works when logging out elsewhere (goes to logout page). 
- Properly sends you to the logout page with error displayed if you, e.g., delete the control strip's form auth input with the web inspector on a journal page. 
- Seems to properly reject bad referers. (Had to test that with just dumping debug data to the page; guess I could also steal a live form_auth and try to post from somewhere random, but I didn't do that.) 

I'm passing the referer directly to that `LJ::check_referer()` function, because I didn't trust the fallback of grabbing it out of BML. (Maybe that works fine on non-BML pages? Couldn't tell.) 