### PR TITLE
Talkform: Fix incorrect 'for' ID on logged-in OpenID label

### DIFF
--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -113,7 +113,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
                 [%- END
               %] />
 
-              <label for='talkpostfromoid'[% UNLESS remote.allowed %] class="disabled"[% END %]>
+              <label for='talkpostfromoidli'[% UNLESS remote.allowed %] class="disabled"[% END %]>
                 [% dw.img( 'id_openid', '' ) %]
                 [% '/talkpost.bml.opt.openid.loggedin' | ml %]
                 [% remote.display_name %]


### PR DESCRIPTION
It looks like I faithfully preserved this bug from the old implementation. 😫

If a label uses the wrong 'for' ID, it won't select the radio button when you
click the label.