### PR TITLE
[#2549] Return to same page when logging out from site header

### DIFF
--- a/cgi-bin/DW/Template/Plugin/SiteScheme.pm
+++ b/cgi-bin/DW/Template/Plugin/SiteScheme.pm
@@ -84,10 +84,6 @@ sub challenge_generate {
     return LJ::challenge_generate(@_);
 }
 
-sub show_logout_button {
-    return DW::Request->get->uri !~ m!^/logout!;
-}
-
 sub show_invite_link {
     return $LJ::USE_ACCT_CODES ? 1 : 0;
 }

--- a/schemes/common.tt
+++ b/schemes/common.tt
@@ -107,6 +107,7 @@ the table based way can be removed when the entire site is Foundation-based.
     <form action='[% site.root %]/logout' method='post'>
         [%- dw.form_auth -%]
         [%- remote.ljuser_display -%]
+        <input type="hidden" name="ret" value="1" />
         <input class="logout button secondary" type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />
     </form>
 </div></div>
@@ -176,6 +177,7 @@ the table based way can be removed when the entire site is Foundation-based.
     <form action='[% site.root %]/logout' method='post'>
         [%- dw.form_auth -%]
         [%- remote.ljuser_display -%]
+        <input type="hidden" name="ret" value="1" />
         <input type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />
     </form>
     [%- -%]<ul>

--- a/schemes/common.tt
+++ b/schemes/common.tt
@@ -103,7 +103,6 @@ the table based way can be removed when the entire site is Foundation-based.
 [%- END -%]
 
 <div id='account-links-text' role="navigation" aria-label="[% 'sitescheme.navigation.accountlinks' | ml %]" data-reveal>
-[%- IF dw_scheme.show_logout_button -%]
 <div class='row'><div class='columns'>
     <form action='[% site.root %]/logout' method='post'>
         [%- dw.form_auth -%]
@@ -111,7 +110,6 @@ the table based way can be removed when the entire site is Foundation-based.
         <input class="logout button secondary" type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />
     </form>
 </div></div>
-[%- END -%]
 <div class='row'><div class='small-12 large-12 columns'>
 <ul>
 [%- IF ! identity -%]<li><a href='[% site.root %]/update'>[% 'sitescheme.accountlinks.post' | ml %]</a></li>[%- END -%]
@@ -175,13 +173,11 @@ the table based way can be removed when the entire site is Foundation-based.
     [%- unread = inbox.unread_count -%]
     [%- identity = remote.is_identity -%]
     [%- -%]<div id='account-links-text'>
-    [%- IF dw_scheme.show_logout_button -%]
     <form action='[% site.root %]/logout' method='post'>
         [%- dw.form_auth -%]
         [%- remote.ljuser_display -%]
         <input type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />
     </form>
-    [%- END -%]
     [%- -%]<ul>
     [%- IF ! identity -%]<li><a href='[% site.root %]/update'>[% 'sitescheme.accountlinks.post' | ml %]</a></li>[%- END -%]
     [%- -%]<li><a href='[% remote.journal_base %]/read'>[% 'sitescheme.accountlinks.readinglist' | ml %]</a></li>


### PR DESCRIPTION
Same as #2550 but for site header. This also stops hiding the header username and logout button on /logout, because all that extra complexity bought us was a glitched appearance and worse UX. 