### PR TITLE
[#2427] Responsive site-scheme comment pages (minimal)

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -215,8 +215,6 @@ sub make_journal {
             )
     );
 
-    # Include any head stc or js head content
-    LJ::Hooks::run_hooks( "need_res_for_journals", $u );
     my $extra_js = LJ::statusvis_message_js($u);
 
     # this will cause double-JS and likely cause issues if called during siteviews

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -4988,7 +4988,10 @@ sub Siteviews__need_res {
 sub Siteviews__active_resource_group {
     my ( $ctx, $this, $grp ) = @_;
     die "Siteviews doesn't work standalone" unless $ctx->[S2::SCRATCH]->{siteviews_enabled};
-    LJ::set_active_resource_group($grp);
+    my $remote = LJ::get_remote();
+    if ( LJ::BetaFeatures->user_in_beta( $remote => "mobilesiteschemecomments") ) {
+        LJ::set_active_resource_group($grp);
+    }
 }
 
 sub Siteviews__start_capture {

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -185,7 +185,7 @@ sub make_journal {
 
         # used if we're using our jquery library
         LJ::need_res(
-            { group => "jquery" }, qw(
+            { group => "all" }, qw(
                 js/md5.js
                 js/login-jquery.js
                 )
@@ -193,7 +193,7 @@ sub make_journal {
     }
 
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.widget.js
             js/jquery/jquery.ui.tooltip.js
@@ -1849,7 +1849,7 @@ sub use_journalstyle_entry_page {
 sub tracking_popup_js {
     return LJ::is_enabled('esn_ajax')
         ? (
-        { group => 'jquery' }, qw(
+        { group => 'all' }, qw(
             js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.widget.js
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -4985,6 +4985,12 @@ sub Siteviews__need_res {
     LJ::need_res($res);
 }
 
+sub Siteviews__active_resource_group {
+    my ( $ctx, $this, $grp ) = @_;
+    die "Siteviews doesn't work standalone" unless $ctx->[S2::SCRATCH]->{siteviews_enabled};
+    LJ::set_active_resource_group($grp);
+}
+
 sub Siteviews__start_capture {
     my ( $ctx, $this ) = @_;
     die "Siteviews doesn't work standalone" unless $ctx->[S2::SCRATCH]->{siteviews_enabled};

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -4994,6 +4994,13 @@ sub Siteviews__active_resource_group {
     }
 }
 
+sub Siteviews__in_mobile_beta {
+    my ( $ctx, $this, $res ) = @_;
+    die "Siteviews doesn't work standalone" unless $ctx->[S2::SCRATCH]->{siteviews_enabled};
+    my $remote = LJ::get_remote();
+    return LJ::BetaFeatures->user_in_beta( $remote => "mobilesiteschemecomments") ? 1 : 0;
+}
+
 sub Siteviews__start_capture {
     my ( $ctx, $this ) = @_;
     die "Siteviews doesn't work standalone" unless $ctx->[S2::SCRATCH]->{siteviews_enabled};

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -413,7 +413,7 @@ sub EntryPage {
     }
 
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.tooltip.js
             js/jquery.ajaxtip.js

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -59,7 +59,6 @@ sub ReplyPage {
 
     $p->{'head_content'} .= $LJ::COMMON_CODE{'chalresp_js'};
 
-    LJ::need_res('stc/display_none.css');
     LJ::need_res( LJ::S2::tracking_popup_js() );
 
     # include JS for quick reply, icon browser, and ajax cut tag

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1826,7 +1826,7 @@ sub init_iconbrowser_js {
 
     my @list = $jquery
         ? (
-        { group => 'jquery' },
+        { group => 'all' },
 
         # base libraries
         'js/jquery/jquery.ui.core.js',
@@ -1885,14 +1885,14 @@ sub init_s2journal_js {
 
     # load for everywhere you can reply (ReplyPage, lastn, AND entries)
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery.replyforms.js
             )
     );
 
     # load for quick reply (every view except ReplyPage)
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.core.js
             stc/jquery/jquery.ui.core.css
             js/jquery/jquery.ui.widget.js
@@ -1904,7 +1904,7 @@ sub init_s2journal_js {
 
     # load only for ReplyPage
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery.talkform.js
             stc/css/components/talkform.css
             )
@@ -1916,7 +1916,7 @@ sub init_s2journal_js {
     # if we're using the site skin, don't override the jquery-ui theme,
     # as that's already included
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             stc/jquery/jquery.ui.theme.smoothness.css
             )
     ) unless $opts{siteskin};
@@ -1924,7 +1924,7 @@ sub init_s2journal_js {
     # load for ajax cuttag - again, only needed on lastn-type pages
     LJ::need_res('js/cuttag-ajax.js') if $opts{lastn};
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.widget.js
             js/jquery.cuttag-ajax.js
             )
@@ -1945,12 +1945,12 @@ sub init_s2journal_shortcut_js {
 
     my $connect_string = "";
 
-    LJ::need_res( { group => "jquery" }, "js/shortcuts.js" );
-    LJ::need_res( { group => "jquery" }, "js/jquery.shortcuts.nextentry.js" );
+    LJ::need_res( { group => "all" }, "js/shortcuts.js" );
+    LJ::need_res( { group => "all" }, "js/jquery.shortcuts.nextentry.js" );
 
     $p->{'head_content'} .= "  <script type='text/javascript'>\n  var dw_shortcuts = {\n";
     if ( $remote->prop("opt_shortcuts") ) {
-        LJ::need_res( { group => "jquery" }, "js/mousetrap.js" );
+        LJ::need_res( { group => "all" }, "js/mousetrap.js" );
         $p->{'head_content'} .= "    keyboard: {\n";
 
         my $nextKey = $remote->prop("opt_shortcuts_next");
@@ -1960,7 +1960,7 @@ sub init_s2journal_shortcut_js {
         $connect_string = ",";
     }
     if ( $remote->prop("opt_shortcuts_touch") ) {
-        LJ::need_res( { group => "jquery" }, "js/jquery.touchSwipe.js" );
+        LJ::need_res( { group => "all" }, "js/jquery.touchSwipe.js" );
         my $nextTouch = $remote->prop("opt_shortcuts_touch_next");
         my $prevTouch = $remote->prop("opt_shortcuts_touch_prev");
         $p->{'head_content'} .=

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1922,7 +1922,6 @@ sub init_s2journal_js {
     ) unless $opts{siteskin};
 
     # load for ajax cuttag - again, only needed on lastn-type pages
-    LJ::need_res('js/cuttag-ajax.js') if $opts{lastn};
     LJ::need_res(
         { group => "all" }, qw(
             js/jquery/jquery.ui.widget.js

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -4493,7 +4493,7 @@ sub statusvis_message_js {
     $statusvis_full = "memorial" if $u->is_memorial;
     $statusvis_full = "readonly" if $u->is_readonly;
 
-    LJ::need_res("js/statusvis_message.js");
+    LJ::need_res( { group => 'all' }, "js/statusvis_message.js");
     return
           "<script>Site.StatusvisMessage=\""
         . LJ::Lang::ml("statusvis_message.$statusvis_full")

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -4493,7 +4493,7 @@ sub statusvis_message_js {
     $statusvis_full = "memorial" if $u->is_memorial;
     $statusvis_full = "readonly" if $u->is_readonly;
 
-    LJ::need_res( { group => 'all' }, "js/statusvis_message.js");
+    LJ::need_res( { group => 'all' }, "js/statusvis_message.js" );
     return
           "<script>Site.StatusvisMessage=\""
         . LJ::Lang::ml("statusvis_message.$statusvis_full")

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -561,12 +561,7 @@ sub start_request {
         );
 
         LJ::need_res(
-            { priority => $LJ::LIB_RES_PRIORITY, group => "default" }, qw (
-                stc/lj_base.css
-                )
-        );
-        LJ::need_res(
-            { priority => $LJ::LIB_RES_PRIORITY, group => "jquery" }, qw (
+            { priority => $LJ::LIB_RES_PRIORITY, group => "all" }, qw (
                 stc/lj_base.css
                 )
         );

--- a/etc/config-local.pl
+++ b/etc/config-local.pl
@@ -160,10 +160,9 @@
 #            start_time => 0,
 #            end_time => "Inf",
 #        },
-#        "s2comments" => {
+#        "mobilesiteschemecomments" => {
 #            start_time => 0,
 #            end_time => "Inf",
-#            sitewide => 1,
 #        },
 #    );
 

--- a/htdocs/scss/skins/_compatibility-styles.scss
+++ b/htdocs/scss/skins/_compatibility-styles.scss
@@ -1,0 +1,20 @@
+// Style translations for widgets that sometimes show up in pages written for
+// the old non-Foundation site skins. These rules should mostly use @extend
+// rules to style these widgets in terms of existing classes from the modern
+// site skins.
+
+.action-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    margin-top: 20px;
+
+    .inner {
+        @extend .panel;
+        @extend .callout;
+        display: block;
+        padding: 5px;
+        text-align: center;
+    }
+}

--- a/htdocs/scss/skins/_entry-styles.scss
+++ b/htdocs/scss/skins/_entry-styles.scss
@@ -1,0 +1,338 @@
+/**
+* Site-wide customizations to journal entry pages
+*/
+
+.entry, #comments {
+  // Working with typography in Foundation is annoying because they set
+  // everything to an absolute size in rems, so you can't just make one section
+  // a little bit smaller. So we need all this manual stuff.
+
+  font-size: 0.85rem;
+
+  // Things I'm leaving alone:
+  // form elements except for textarea, tables
+
+  // Things that are normal text:
+  p, ul, ol, dl, label {
+    font-size: 1em;
+  }
+
+  // Things that are a little askew from normal text:
+  aside { font-size: 0.875em; }
+  blockquote cite { font-size: 0.8125em; }
+  blockquote {
+    margin: 1.25em;
+  }
+
+  // Things that are their own thing:
+  h1 { font-size: 1.189em; }
+  h2 { font-size: 1.189em; }
+  h3 { font-size: 1.3055em; }
+  h4 { font-size: .8085em; }
+  h5 { font-size: 1em; }
+  h6 { font-size: .9em; }
+
+  .comment-title {
+    font-size: 1.3em;
+  }
+
+  .partial .comment-title {
+    font-size: 1em;
+    display: inline;
+    font-weight: normal;
+    font-family: inherit;
+  }
+
+  textarea {
+    font-family: monospace;
+    font-size: 16px;
+  }
+
+  // Foundation likes stretching selects to 100% for some reason
+  select {
+    width: auto;
+  }
+
+  .usercontent, .currents, .comment-title {
+    overflow-wrap: break-word;
+  }
+
+  /* Constrain image dimensions.
+      Job 1: Don't trash the layout sideways.
+      Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+        portrait of someone is nonsense.
+      Job 3: Defend the native aspect ratio.
+      Job 4: Respect the width/height HTML attributes for scaling down OR up
+        (within the limits of the container), but if they conflict with the aspect
+        ratio, treat them as maximums and let the aspect ratio win. */
+  .usercontent img {
+    height: auto;
+    max-width: 100%;
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
+  }
+
+
+}
+
+// Basics
+
+.poster {
+  display: block;
+}
+
+.userpic a {
+  display: block;
+  line-height: 0;
+}
+
+.entry-interaction-links li,
+.comment-interaction-links li,
+.view-flat,
+.view-threaded,
+.view-top-only,
+.expand_all {
+  &::before {
+    content: "(";
+  }
+  &::after {
+    content: ")";
+  }
+}
+
+ul.icon-links,
+ul.text-links {
+  margin: 0;
+  display: inline;
+
+  // Need an ID to match specificity of a default #content ul li rule.
+  #content & li {
+    display: inline;
+    list-style: none;
+    margin-left: 0;
+    margin-right: 8px;
+    margin-bottom: 2px;
+  }
+}
+
+.bottomcomment,
+.entry .footer .inner,
+.comment-pages {
+  text-align: center;
+
+  hr {
+    width: 100%;
+  }
+}
+
+
+// Entry styles
+
+
+.entry {
+  .header .inner {
+    display: flex;
+    align-items: flex-end;
+  }
+
+  .userpic {
+    display: inline-block;
+    margin-right: .3rem;
+  }
+
+  .poster-info {
+    display: inline-block;
+    vertical-align: bottom;
+
+    .datetime {
+      font-style: italic;
+      &::before {
+          content: "@";
+      }
+    }
+  }
+
+  .metadata ul {
+    margin: 0;
+    list-style: none;
+
+    // Need an ID to match specificity of a default #content ul li rule.
+    #content & li {
+      margin-left: 0;
+    }
+  }
+
+  .metadata-label, .tag-text {
+    font-weight: bold;
+  }
+
+  .tag ul {
+    list-style: none;
+    display: inline;
+    margin-left: 0;
+
+    // Need an ID to match specificity of a default #content ul li rule.
+    #content & li {
+      display: inline;
+      margin-left: 0;
+    }
+  }
+
+  .entry-title {
+    font-size: 1.5em;
+    font-style: italic;
+    font-weight: bold;
+    margin: 10px 0;
+  }
+
+  @media #{$medium-up} {
+    .currents {
+      margin-left: 50px;
+    }
+
+    .contents {
+      margin-left: 30px;
+    }
+  }
+
+}
+
+ul.entry-management-links {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+}
+
+.entry-interaction-links, .comment-pages {
+  font-weight: bold;
+}
+
+.comment-pages span {
+  margin: 0 4px;
+}
+
+
+// Comment styles
+
+.comment {
+  min-width: 28em;
+  @media #{$small-only} {
+    min-width: 70vw;
+  }
+
+  .header {
+    border-bottom: 1px solid $soft-accent-color;
+    border-right: 1px solid $soft-accent-color;
+
+    line-height: 1.1;
+
+    .comment-wrapper-odd > & {
+      background-color: $secondary-color;
+    }
+
+    .comment-wrapper-even > & {
+      background-color: $secondary-color-alternate;
+    }
+
+    .comment-wrapper.screened > & {
+      // TODO: Need a background color!
+      // Temp attempt stolen from callout panel:
+      background-color: change-color($primary-color, $lightness:lightness($panel-bg));
+      // Color from old tropo: #c29b9b;
+    }
+
+    .userpic, .comment-info {
+      display: table-cell;
+      vertical-align: top;
+    }
+
+    input {
+      margin: 0;
+    }
+
+    // On mobile, just accept that these headers will spill into multiple lines,
+    // and try to save space by flowing text around the userpic.
+    @media #{$small-only} {
+      font-size: 0.9em;
+
+      & > .inner {
+        position: relative; // keep icon from shrinking at edge of viewport
+      }
+
+      .userpic {
+        display: block;
+        position: absolute; // remove userpic from layout of .inner
+
+        // deal with tall aspect userpics
+        img {
+          height: auto;
+          max-width: 75px;
+          max-height: 75px;
+          object-fit: contain;
+          object-position: left;
+        }
+      }
+
+      .comment-info {
+        display: block;
+        min-height: 75px;
+      }
+
+      .has-userpic & .comment-info::before { // add userpic placeholder to layout of .comment-info
+        content: "";
+        display: block;
+        float: left;
+        width: 75px;
+        height: 75px;
+      }
+    }
+
+  }
+
+  .footer {
+    margin-top: .6em;
+    margin-bottom: 1em;
+  }
+
+}
+
+.comment-info {
+  padding-left: .8em;
+
+  & > span, & > ul, & > div {
+    margin-right: .9em;
+  }
+
+  .comment-title {
+    min-height: 0.6em; // take up space when the inner span is invisible.
+    margin: 0;
+  }
+
+  .datetime, .poster-ip, .commentpermalink, .multiform-checkbox {
+    font-size: .8em;
+  }
+
+}
+
+// Single-line collapsed comments -- more rightward slop, but easier to track
+.comment-wrapper.partial {
+  white-space: nowrap;
+  .comment-title {
+    font-size: 1em;
+    display: inline;
+    font-weight: normal;
+  }
+
+  .poster {
+    display: inline;
+  }
+}
+
+// Submit buttons get standard button styles, but input type="button"s don't.
+#qrform input[type="button"] {
+  @include button;
+  margin-bottom: 3px;
+}
+

--- a/htdocs/scss/skins/_global-styles.scss
+++ b/htdocs/scss/skins/_global-styles.scss
@@ -6,4 +6,4 @@ Should only @import other stylesheets
 $include-html-classes: true;
 @import "foundation/foundation";
 
-@import "skins/skin-colors", "skins/community-menu";
+@import "skins/skin-colors", "skins/community-menu", "skins/compatibility-styles";

--- a/htdocs/scss/skins/_global-styles.scss
+++ b/htdocs/scss/skins/_global-styles.scss
@@ -6,4 +6,4 @@ Should only @import other stylesheets
 $include-html-classes: true;
 @import "foundation/foundation";
 
-@import "skins/skin-colors", "skins/community-menu", "skins/compatibility-styles";
+@import "skins/skin-colors", "skins/community-menu", "skins/compatibility-styles", "skins/entry-styles";

--- a/htdocs/scss/skins/_skin-colors.scss
+++ b/htdocs/scss/skins/_skin-colors.scss
@@ -8,13 +8,20 @@
 * rather than hardcoding random colors here
 */
 
+// Variant color variables -- most site skins can just ignore these, but we'll
+// use an explicit value if it exists.
+
+$background-color-alternate:    darken( $background-color, 5% ) !default;
+$background-color-inactive:     tint( $inactive-color, 50% ) !default;
+$secondary-color-alternate:     darken( $secondary-color, 15% ) !default;
+$text-color-disabled:           scale-color($text-color, $lightness: 50%) !default;
+$anchor-font-color-visited:     shade( $anchor-font-color, 20% ) !default;
+$page-title-color:              $primary-color !default;
+$border-color:                  $input-border-color !default;
+
 /**
  * Links and a pseudo link class
  */
-
-$anchor-font-color-visited: shade( $anchor-font-color, 20% ) !default;
-$page-title-color: $primary-color !default;
-$border-color: $input-border-color !default;
 
 a:visited {
     color: $anchor-font-color-visited;
@@ -121,7 +128,7 @@ li.token {
 
 // Enabled and disabled text
 div.enabled, div.enabled * { color: $text-color; }
-div.disabled, div.disabled * { color: scale-color($text-color, $lightness: 50%); }
+div.disabled, div.disabled * { color: $text-color-disabled; }
 
 // date and time picker
 .picker__holder {
@@ -210,7 +217,7 @@ div.disabled, div.disabled * { color: scale-color($text-color, $lightness: 50%);
         color: $inactive-color;
     }
     .finished:before {
-        background-color: tint( $inactive-color, 50% );
+        background-color: $background-color-inactive;
         color: $inactive-color;
     }
 }
@@ -230,9 +237,9 @@ div.disabled, div.disabled * { color: scale-color($text-color, $lightness: 50%);
 
 // alternating row colors
 .odd, tr.odd th, tr.odd td {
-    background-color: $background_color;
+    background-color: $background-color;
 }
 
 .even, tr.even th, tr.even td {
-    background-color: darken($background_color, 5%);
+    background-color: $background-color-alternate;
 }

--- a/htdocs/scss/skins/lynx.scss
+++ b/htdocs/scss/skins/lynx.scss
@@ -13,6 +13,7 @@ $text-color: $_black;
 $primary-text-color: $_white;
 $inactive-color: $_dark-gray;
 $background-color: $_white;
+$soft-accent-color: $_white;
 
 @import "skins/alert-colors";
 

--- a/styles/siteviews/layout.s2
+++ b/styles/siteviews/layout.s2
@@ -5,6 +5,7 @@ layerinfo is_internal = "1";
 
 class Siteviews {
     function builtin need_res(string res);
+    function builtin active_resource_group(string grp);
     function builtin start_capture();
     function builtin end_capture() : string;
 
@@ -20,6 +21,7 @@ property builtin Siteviews SITEVIEWS {
 
 function Page::print() {
     if ( $*SITEVIEWS ) {
+        $*SITEVIEWS->active_resource_group("foundation");
         $*SITEVIEWS->start_capture();
         $this->print_head();
         $this->print_default_stylesheet();

--- a/styles/siteviews/layout.s2
+++ b/styles/siteviews/layout.s2
@@ -6,6 +6,7 @@ layerinfo is_internal = "1";
 class Siteviews {
     function builtin need_res(string res);
     function builtin active_resource_group(string grp);
+    function builtin in_mobile_beta() : bool;
     function builtin start_capture();
     function builtin end_capture() : string;
 
@@ -42,7 +43,9 @@ function Page::print_title() {
 
 function Page::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/layout.css" );
+    if ( not $*SITEVIEWS->in_mobile_beta() ) {
+        $*SITEVIEWS->need_res( "stc/siteviews/layout.css" );
+    }
 }
 
 function Page::print_theme_stylesheet() {}
@@ -102,7 +105,9 @@ function IconsPage::print_title() {
 
 function IconsPage::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/allpics.css" );
+    if ( not $*SITEVIEWS->in_mobile_beta() ) {
+        $*SITEVIEWS->need_res( "stc/allpics.css" );
+    }
 }
 
 function IconsPage::print_body() {
@@ -191,13 +196,17 @@ set comment_time_format = "short_24";
 
 function EntryPage::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/entrypage.css" );
+    if ( not $*SITEVIEWS->in_mobile_beta() ) {
+        $*SITEVIEWS->need_res( "stc/entrypage.css" );
+    }
 
 }
 
 function ReplyPage::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/replypage.css" );
+    if ( not $*SITEVIEWS->in_mobile_beta() ) {
+        $*SITEVIEWS->need_res( "stc/replypage.css" );
+    }
 
 }
 

--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -19,6 +19,22 @@
 
 .betafeature.updatepage.title=New Create Entries Page
 
+.betafeature.mobilesiteschemecomments.cantadd=Sorry, your account is not eligible to test this feature.
+
+.betafeature.mobilesiteschemecomments.off<<
+<p>Activate a modern, mobile-friendly version of the site-styled comment pages. These are the version of the comment pages that appear on journals that don't display comments in their own style, or when you specifically request site-styled comment pages. This revised version will look somewhat different than what you're used to, but should still feel familiar.</p>
+
+<p>TODO: post a link for reporting bugs.</p>
+.
+
+.betafeature.mobilesiteschemecomments.on<<
+<p>You are currently testing the mobile-friendly version of the site-styled comment pages. These are the version of the comment pages that appear on journals that don't display comments in their own style, or when you specifically request site-styled comment pages.</p>
+
+<p>TODO: post a link for reporting bugs.</p>
+.
+
+.betafeature.mobilesiteschemecomments.title=Mobile-friendly Site-style Comments
+
 .nofeatures=There are no features currently available for beta testing.
 
 .staytuned.newscomm=Stay tuned to [[news]] for upcoming testing opportunities. Thank you.


### PR DESCRIPTION
OK, this is probably at a stage where it'd be useful to have someone look at it.

This is the minimal form of #2427. It is gated behind a beta feature. It is deployed on my dreamhack at http://rr-thrice.hack.dreamwidth.net.

### Goals: 

- _Mostly_ reproduce the current site-scheme comment page layout. (It's going to look somewhat different; the radically different base CSS just makes that unavoidable. But all the essentials ought to be in place.) 
- Make site-scheme comments not completely broken on mobile. Among other things, it should help with the outrageous layout crimes we keep seeing from those Android browsers. 

### Specifically _not_ the goal:

- Redesign the site-scheme comment pages to be a _good reading experience_ on mobile. 

This is just a patch job, and it deliberately doesn't do anything about the outlandish amounts of sideways slop, the various wastes of precious horizontal space, or the fact that indentation is a completely useless way to represent comment threading once you're on a screen where a two-paragraph comment will take up 100% of the available vertical room. It also doesn't do anything about #2411.
 
What it _does_ do is make sure the full width of a comment or entry can fit on the screen at a reasonable font size, and that the various controls have usable dimensions. 

### Things that aren't done or that I'm not satisfied with

- The icons page gets affected by this switch too, so it also needs some new CSS. It's simpler than the entry page, at least. Might even be able to punt and use Foundation's built-in grid stuff, if it's available as mixins and not just as markup classes. 
- The reply page is affected too... but actually, it's not in too bad a shape. I'm as amazed as you are. The talkform doesn't look _the same,_ but it also doesn't look _worse._
- The CSS is kind of messy. Needs a cleanup before it's ready for primetime.
- IDK if there's actually anything that can be done about it, but 80% of the effort on this was fighting with Foundation's global styles. Especially on the typographical basics. (The full 16px seemed way too fluffy, so I set the base font size to .85rem, and Foundation REALLY didn't want me doing that.) 
- Should probably go through that thread Momiji linked me about the last time she tried to re-create this page's design from scratch, and make sure I have an answer to all of the notable complaints from it. (I feel like a lot of those got answered by changes to the markup, which should mean I inherit the win without any extra effort. But we'll see.) 
- Light style might be less lite in Foundation land. I think at least an extra 100kb of CSS... maybe more images as well? I'm not quite sure how to measure this, especially the JS (since it's not getting minified in this dev env). But otoh, most of that should be cached if you've ever visited a main site page. Only time it might hose you is if you're coming from /mobile? Just too much about this bit that I'm unsure about.