### PR TITLE
Talkform / QR: Fix bugs with preview button

### DIFF
--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -925,9 +925,11 @@ sub create_qr_div {
             form_url             => LJ::create_url( '/talkpost_do', host => $LJ::DOMAIN_WEB ),
             hidden_form_elements => $hidden_form_elements,
             can_checkspell       => $LJ::SPELLER ? 1 : 0,
-            minimal              => $opts{minimal} ? 1 : 0,
             post_disabled        => $post_disabled,
             post_button_class    => $post_disabled ? 'ui-state-disabled' : '',
+
+            # Currently unused, but might come back.
+            minimal => $opts{minimal} ? 1 : 0,
 
             current_icon_kw => $userpic_kw,
             current_icon    => LJ::Userpic->new_from_keyword( $remote, $userpic_kw ),

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -212,6 +212,7 @@ jQuery(function($) {
     });
 
     $("#submitpview").on("click", function(e){
+        $("#qrform").data("stayOnPage", false);
         $("#qrform input[name='submitpreview']").val(1);
         $("#qrform").attr("action", Site.siteroot + "/talkpost_do" );
     });

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -213,6 +213,11 @@ jQuery(function($) {
 
     $("#submitpview").on("click", function(e){
         $("#qrform").data("stayOnPage", false);
+        // Why use a hidden input for the real "submitpreview" instead of just
+        // relying on the button? Because we disable the submit buttons to guard
+        // against double-submits, and that causes the preview button's value to
+        // appear as falsy when the form data arrives back in perl-land, which
+        // in turn causes surprise posts.
         $("#qrform input[name='submitpreview']").val(1);
         $("#qrform").attr("action", Site.siteroot + "/talkpost_do" );
     });

--- a/htdocs/js/jquery.talkform.js
+++ b/htdocs/js/jquery.talkform.js
@@ -74,6 +74,17 @@ jQuery(function($){
     });
 
     // submit handlers :|
+
+    // If JS is disabled, the preview button works normally.
+    // If JS is enabled, we disable the submit buttons to guard against
+    // double-submits, and that causes the preview button's value to appear as
+    // falsy when the form data arrives back in perl-land. So if the user
+    // clicked preview, we need to preserve that info in a non-disabled input.
+    $('#submitpview').click(function(e) {
+        this.name = 'submitpview';
+        $('#previewplaceholder').prop('name', 'submitpreview');
+    });
+
     commentForm.submit(function(e) {
         // idek what would blow up if you sent name/pwd when usertype is
         // something other than user, but the old js did this so whatever

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -87,14 +87,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
       id = 'submitpost'
   ) %]
 
-  [%- UNLESS minimal -%]
   [% form.submit(
       name = 'submitpview'
       value = dw.ml( 'talk.btn.preview' ),
       id = 'submitpview'
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) %]
-  [%- END -%]
 
   [% form.submit(
       name = 'submitmoreopts'

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -464,6 +464,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
       [%- form.submit(
         name = "submitpreview"
         value = dw.ml('talk.btn.preview')
+        id = "submitpview"
+      ) -%]
+      [%- form.hidden(
+        name = "previewplaceholder"
+        id = "previewplaceholder"
+        value = 1
       ) -%]
       [%- IF can_checkspell -%]
         [%- form.checkbox(


### PR DESCRIPTION
Wow, that preview button is tricky, isn't it. 

I think it's sorted out, now. More info in the commit messages. Note that the bug with the talkform hasn't ever gone live -- prod still has the typo that was preventing the bug. 