### PR TITLE
[#1303] Fix wandering tagnav dialog

### DIFF
--- a/htdocs/js/journals/jquery.tag-nav.js
+++ b/htdocs/js/journals/jquery.tag-nav.js
@@ -38,7 +38,7 @@
                             my: "center top",
                             at: "center bottom",
                             of: this,
-                            collision: "flipfit"
+                            collision: "flip"
                         },
                         width: "auto",
                         open: function(e, ui) {
@@ -104,11 +104,13 @@ var hash = location.hash;
 if ( hash.indexOf( "#tagnav-" ) == 0 ) {
     $(window).load(function() {
         var tagnav_tag = decodeURIComponent(hash.slice(8));
+        var scrollPosition = $(window).scrollTop();
 
         $(".tag-nav-trigger").click();
         $(".tag a").filter(function() {
             var text = $(this).text();
             return text === tagnav_tag || text.replace(/ /g, '+') === tagnav_tag;
         }).click();
+        $(window).scrollTop(scrollPosition);
     })
 }


### PR DESCRIPTION
The "flipfit" collision recovery option moves the dialog until it fits inside
the current viewport. But in a long journal entry in one of the normal journal
styles (not siteviews), it's meant to be off-screen, down by where the tags
live. (In siteviews this isn't an issue because the tags live ABOVE the entry.)

If you change it to just "flip", it starts off-screen (as is proper), but then
the jQuery UI dialog script calls `.focus()` on part of the dialog, which causes
the browser to scroll down to put it into view. So THAT's obnoxious. But you can
recover by just scrolling the viewport back to where it was. (Why not just
scroll to 0? Because the user might have already scrolled a little bit before
the `load` event fired, or they might be using the back button and the browser
remembers its prior position.)