### PR TITLE
DRAFT, DON'T MERGE: QR / Talkform redesigns, revamped site skin comment pages, new icon browser

### DIFF
--- a/cgi-bin/DW/Captcha/textCAPTCHA.pm
+++ b/cgi-bin/DW/Captcha/textCAPTCHA.pm
@@ -101,7 +101,7 @@ sub _print {
     return qq{
 <div id="textcaptcha_container" aria-live="assertive" style="line-height: 1.2em">
     $captcha_load
-<noscript><iframe src="$LJ::SITEROOT/captcha/text/$auth" style="width:100%;height:4em" id="textcaptcha_fallback"></iframe>
+<noscript><iframe src="$LJ::SITEROOT/captcha/text/$auth" style="width:100%;height:8em" id="textcaptcha_fallback"></iframe>
 <label for="textcaptcha_response_noscript">$response_label</label> <input type="text" maxlength="255" autocomplete="off" value="" name="textcaptcha_response_noscript" class="text" id="textcaptcha_response_noscript" size="50" />
 </noscript>
 </div>};

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -283,7 +283,6 @@ sub _init {
     my $vars = {};
 
     my @icons;
-    my $defaulticon;
 
     my %moodtheme;
     my @moodlist;
@@ -309,12 +308,7 @@ sub _init {
     if ($u) {
 
         # icons
-        @icons = grep { !( $_->inactive || $_->expunged ) } LJ::Userpic->load_user_userpics($u);
-
-        @icons = LJ::Userpic->separate_keywords( \@icons )
-            if @icons;
-
-        $defaulticon = $u->userpic;
+        @icons = LJ::icon_keyword_select_items($u);
 
         # moods
         my $theme = DW::Mood->new( $u->{moodthemeid} );
@@ -441,8 +435,7 @@ sub _init {
     $vars = {
         remote => $u,
 
-        icons       => @icons ? [ { userpic => $defaulticon }, @icons ] : [],
-        defaulticon => $defaulticon,
+        icons => \@icons,
 
         icon_browser => {
             metatext   => $u ? $u->iconbrowser_metatext   : "",

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -195,7 +195,7 @@ sub make_journal {
 
         # used if we're using our jquery library
         LJ::need_res(
-            { group => "jquery" }, qw(
+            { group => "all" }, qw(
                 js/md5.js
                 js/login-jquery.js
                 )
@@ -203,7 +203,7 @@ sub make_journal {
     }
 
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.widget.js
             js/jquery/jquery.ui.tooltip.js
@@ -1870,7 +1870,7 @@ sub use_journalstyle_entry_page {
 sub tracking_popup_js {
     return LJ::is_enabled('esn_ajax')
         ? (
-        { group => 'jquery' }, qw(
+        { group => 'all' }, qw(
             js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.widget.js
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -215,8 +215,6 @@ sub make_journal {
             )
     );
 
-    # Include any head stc or js head content
-    LJ::Hooks::run_hooks( "need_res_for_journals", $u );
     my $extra_js = LJ::statusvis_message_js($u);
 
     # this will cause double-JS and likely cause issues if called during siteviews

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -413,7 +413,7 @@ sub EntryPage {
     }
 
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.tooltip.js
             js/jquery.ajaxtip.js

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -59,7 +59,6 @@ sub ReplyPage {
 
     $p->{'head_content'} .= $LJ::COMMON_CODE{'chalresp_js'};
 
-    LJ::need_res('stc/display_none.css');
     LJ::need_res( LJ::S2::tracking_popup_js() );
 
     # include JS for quick reply, icon browser, and ajax cut tag

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1627,8 +1627,7 @@ sub talkform {
             editreason  => $comment ? $comment->edit_reason : '',
             oidurl      => $form->{oidurl},
             oiddo_login => $form->{oiddo_login},
-            user        => $form->{userpost}
-                || $form->{cookieuser},
+            user        => $form->{userpost},
             do_login    => $form->{do_login},
             body        => $form->{body},
             subject     => $basesubject,

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1552,8 +1552,8 @@ sub talkform {
         push( @subjecticon_ids, map { $_->{id} } @$sublist );
     }
 
-    my $entry    = LJ::Entry->new( $journalu, ditemid => $opts->{ditemid} );
-    my @userpics = LJ::icons_for_remote($remote);
+    my $entry = LJ::Entry->new( $journalu, ditemid => $opts->{ditemid} );
+    my @icons = LJ::icons_for_remote($remote);
 
     my $basesubject = $form->{subject} || "";
     if ( !$editid && $opts->{replyto} && !$basesubject && $parpost->{'subject'} ) {
@@ -1649,7 +1649,7 @@ sub talkform {
         remote => $remote
         ? {
             icons_url => $remote ? $remote->allpics_base : '',
-            icons     => \@userpics,
+            icons     => \@icons,
 
             user            => $remote->user,
             display_name    => LJ::ehtml( $remote->display_name ),
@@ -1683,7 +1683,7 @@ sub talkform {
                 && $remote
                 && $remote->can_manage($journalu),
 
-            can_use_iconbrowser    => $remote->can_use_userpic_select,
+            can_use_userpic_select => $remote->can_use_userpic_select && ( scalar(@icons) > 0 ),
             iconbrowser_metatext   => $remote->iconbrowser_metatext ? "true" : "false",
             iconbrowser_smallicons => $remote->iconbrowser_smallicons ? "true" : "false",
             }

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1553,7 +1553,7 @@ sub talkform {
     }
 
     my $entry = LJ::Entry->new( $journalu, ditemid => $opts->{ditemid} );
-    my @icons = LJ::icons_for_remote($remote);
+    my @icons = LJ::icon_keyword_select_items($remote);
 
     my $basesubject = $form->{subject} || "";
     if ( !$editid && $opts->{replyto} && !$basesubject && $parpost->{'subject'} ) {

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1820,12 +1820,18 @@ qq{<input type="button" id="lj_userpicselect" value="Browse" data-iconbrowser-me
 
 # load the javascript libraries for the icon browser
 # args: names of any additional files to load
-# returns: full list of arguments to pass to LJ::need_res
+# returns: nothing, just calls need_res
 sub init_iconbrowser_js {
-    my ( $jquery, @additional ) = @_;
+    my @additional = @_;
 
-    my @list = $jquery
-        ? (
+    # There are three separate implementations of the icon browser.
+
+    # The New-New Icon Browser: Depends on Foundation CSS/JS. Used on: New entry
+    # page (if in "updatepage" beta). Omitted here.
+
+    # The Old-New Icon Browser: Depends on jQuery. Used on: Quick-reply and
+    # talkform on journal pages, talkform on talkpost_do.bml, preview page.
+    LJ::need_res(
         { group => 'jquery' },
 
         # base libraries
@@ -1843,8 +1849,17 @@ sub init_iconbrowser_js {
 
         # additional files from arguments
         @additional,
-        )
-        : (
+    );
+
+    # The Old-Old Icon Browser: Weird ancient technology. Not the exciting kind.
+    # Used on: New entry page (if NOT in "updatepage" beta), inbox's "compose"
+    # page (always).
+    LJ::need_res(
+
+        # Explicitly specify "default" group to keep the CSS out of the
+        # 'all' group, because we almost never want it.
+        { group => 'default' },
+
         # base libraries
         'js/6alib/core.js',
         'js/6alib/dom.js',
@@ -1872,9 +1887,7 @@ sub init_iconbrowser_js {
 
         # additional files from arguments
         @additional,
-        );
-
-    return @list;
+    );
 }
 
 # convenience/deduplication function for QR, cut tag, & icon browser JS loading
@@ -1911,7 +1924,7 @@ sub init_s2journal_js {
     ) if $opts{noqr};
 
     # load for userpicselect
-    LJ::need_res( init_iconbrowser_js(1) ) if $opts{iconbrowser};
+    init_iconbrowser_js() if $opts{iconbrowser};
 
     # if we're using the site skin, don't override the jquery-ui theme,
     # as that's already included

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1922,7 +1922,6 @@ sub init_s2journal_js {
     ) unless $opts{siteskin};
 
     # load for ajax cuttag - again, only needed on lastn-type pages
-    LJ::need_res('js/cuttag-ajax.js') if $opts{lastn};
     LJ::need_res(
         { group => "jquery" }, qw(
             js/jquery/jquery.ui.widget.js

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1615,6 +1615,10 @@ sub talkform {
         subjecticon_ids      => \@subjecticon_ids,
         username_maxlength   => $LJ::USERNAME_MAXLENGTH,
 
+        foundation_beta => LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" )
+            && $LJ::ACTIVE_RES_GROUP
+            && $LJ::ACTIVE_RES_GROUP eq "foundation",
+
         public_entry     => $entry->security eq 'public',
         default_usertype => $default_usertype,
 
@@ -1826,11 +1830,25 @@ sub init_iconbrowser_js {
 
     # There are three separate implementations of the icon browser.
 
-    # The New-New Icon Browser: Depends on Foundation CSS/JS. Used on: New entry
-    # page (if in "updatepage" beta). Omitted here.
+    # The New-New Icon Browser: Depends on Foundation CSS/JS (either site skin
+    # or minimal version). Used on: New entry page (if in "updatepage" beta),
+    # quickreply and talkform on journal pages (if in "s2foundation" beta).
+    LJ::need_res(
+        { group => 'foundation' },
+
+        'js/foundation/foundation/foundation.js',
+        'js/foundation/foundation/foundation.reveal.js',
+        'js/components/jquery.icon-browser.js',
+        'stc/css/components/block-grid.css',
+        'stc/css/components/icon-browser.css',
+
+        # additional files from arguments
+        @additional,
+    );
 
     # The Old-New Icon Browser: Depends on jQuery. Used on: Quick-reply and
-    # talkform on journal pages, talkform on talkpost_do.bml, preview page.
+    # talkform on journal pages (if NOT in "s2foundation" beta), talkform on
+    # talkpost_do.bml (always), preview page (always).
     LJ::need_res(
         { group => 'jquery' },
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1898,14 +1898,14 @@ sub init_s2journal_js {
 
     # load for everywhere you can reply (ReplyPage, lastn, AND entries)
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery.replyforms.js
             )
     );
 
     # load for quick reply (every view except ReplyPage)
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.core.js
             stc/jquery/jquery.ui.core.css
             js/jquery/jquery.ui.widget.js
@@ -1917,7 +1917,7 @@ sub init_s2journal_js {
 
     # load only for ReplyPage
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery.talkform.js
             stc/css/components/talkform.css
             )
@@ -1929,14 +1929,14 @@ sub init_s2journal_js {
     # if we're using the site skin, don't override the jquery-ui theme,
     # as that's already included
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             stc/jquery/jquery.ui.theme.smoothness.css
             )
     ) unless $opts{siteskin};
 
     # load for ajax cuttag - again, only needed on lastn-type pages
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.widget.js
             js/jquery.cuttag-ajax.js
             )
@@ -1957,12 +1957,12 @@ sub init_s2journal_shortcut_js {
 
     my $connect_string = "";
 
-    LJ::need_res( { group => "jquery" }, "js/shortcuts.js" );
-    LJ::need_res( { group => "jquery" }, "js/jquery.shortcuts.nextentry.js" );
+    LJ::need_res( { group => "all" }, "js/shortcuts.js" );
+    LJ::need_res( { group => "all" }, "js/jquery.shortcuts.nextentry.js" );
 
     $p->{'head_content'} .= "  <script type='text/javascript'>\n  var dw_shortcuts = {\n";
     if ( $remote->prop("opt_shortcuts") ) {
-        LJ::need_res( { group => "jquery" }, "js/mousetrap.js" );
+        LJ::need_res( { group => "all" }, "js/mousetrap.js" );
         $p->{'head_content'} .= "    keyboard: {\n";
 
         my $nextKey = $remote->prop("opt_shortcuts_next");
@@ -1972,7 +1972,7 @@ sub init_s2journal_shortcut_js {
         $connect_string = ",";
     }
     if ( $remote->prop("opt_shortcuts_touch") ) {
-        LJ::need_res( { group => "jquery" }, "js/jquery.touchSwipe.js" );
+        LJ::need_res( { group => "all" }, "js/jquery.touchSwipe.js" );
         my $nextTouch = $remote->prop("opt_shortcuts_touch_next");
         my $prevTouch = $remote->prop("opt_shortcuts_touch_prev");
         $p->{'head_content'} .=

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1839,7 +1839,6 @@ sub init_iconbrowser_js {
         'js/foundation/foundation/foundation.js',
         'js/foundation/foundation/foundation.reveal.js',
         'js/components/jquery.icon-browser.js',
-        'stc/css/components/block-grid.css',
         'stc/css/components/icon-browser.css',
 
         # additional files from arguments

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1712,7 +1712,6 @@ sub talkform {
         },
 
         help_icon               => sub { LJ::help_icon_html(@_) },
-        ejs                     => sub { return LJ::ejs(@_) },
         print_subjecticon_by_id => sub { return LJ::Talk::print_subjecticon_by_id(@_) },
     };
 
@@ -1917,6 +1916,7 @@ sub init_s2journal_js {
     LJ::need_res(
         { group => "all" }, qw(
             js/jquery.replyforms.js
+            stc/css/components/quick-reply.css
             )
     );
 
@@ -1928,7 +1928,6 @@ sub init_s2journal_js {
             js/jquery/jquery.ui.widget.js
             js/jquery.quickreply.js
             js/jquery.threadexpander.js
-            stc/css/components/quick-reply.css
             )
     ) unless $opts{noqr};
 

--- a/cgi-bin/LJ/Userpic.pm
+++ b/cgi-bin/LJ/Userpic.pm
@@ -1377,7 +1377,7 @@ sub separate_keywords {
     my @nokw_array;
 
     foreach my $userpic (@$userpics) {
-        my @keywords = $userpic->keywords( raw => 1 );
+        my @keywords = $userpic->keywords( raw => 0 );
         foreach my $keyword (@keywords) {
             if ( defined $keyword ) {
                 push @userpic_array, { keyword => $keyword, userpic => $userpic };

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -933,6 +933,9 @@ sub create_qr_div {
 
             current_icon_kw => $userpic_kw,
             current_icon    => LJ::Userpic->new_from_keyword( $remote, $userpic_kw ),
+            foundation_beta => LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" )
+                && $LJ::ACTIVE_RES_GROUP
+                && $LJ::ACTIVE_RES_GROUP eq "foundation",
 
             remote => {
                 ljuser => $remote->ljuser_display,

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -915,7 +915,7 @@ sub create_qr_div {
     }
 
     # For userpic selector
-    my @pics = icons_for_remote($remote);
+    my @icons = icons_for_remote($remote);
 
     my $post_disabled = $u->does_not_allow_comments_from($remote)
         || $u->does_not_allow_comments_from_unconfirmed_openid($remote);
@@ -939,8 +939,8 @@ sub create_qr_div {
                 user   => $remote->user,
 
                 icons_url              => $remote->allpics_base,
-                icons                  => \@pics,
-                can_use_iconbrowser    => $remote->can_use_userpic_select,
+                icons                  => \@icons,
+                can_use_userpic_select => $remote->can_use_userpic_select && ( scalar(@icons) > 0 ),
                 iconbrowser_metatext   => $remote->iconbrowser_metatext ? "true" : "false",
                 iconbrowser_smallicons => $remote->iconbrowser_smallicons ? "true" : "false",
             },

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -1235,7 +1235,7 @@ sub entry_form {
     );
 
     # libs for userpicselect
-    LJ::need_res( LJ::Talk::init_iconbrowser_js() )
+    LJ::Talk::init_iconbrowser_js()
         if !$altlogin && $remote && $remote->can_use_userpic_select;
 
     $out .= $pic;

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -4495,7 +4495,7 @@ sub statusvis_message_js {
     $statusvis_full = "memorial" if $u->is_memorial;
     $statusvis_full = "readonly" if $u->is_readonly;
 
-    LJ::need_res("js/statusvis_message.js");
+    LJ::need_res( { group => 'all' }, "js/statusvis_message.js" );
     return
           "<script>Site.StatusvisMessage=\""
         . LJ::Lang::ml("statusvis_message.$statusvis_full")

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -925,9 +925,11 @@ sub create_qr_div {
             form_url             => LJ::create_url( '/talkpost_do', host => $LJ::DOMAIN_WEB ),
             hidden_form_elements => $hidden_form_elements,
             can_checkspell       => $LJ::SPELLER ? 1 : 0,
-            minimal              => $opts{minimal} ? 1 : 0,
             post_disabled        => $post_disabled,
             post_button_class    => $post_disabled ? 'ui-state-disabled' : '',
+
+            # Currently unused, but might come back.
+            minimal => $opts{minimal} ? 1 : 0,
 
             current_icon_kw => $userpic_kw,
             current_icon    => LJ::Userpic->new_from_keyword( $remote, $userpic_kw ),

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -2814,6 +2814,80 @@ sub js_dumper {
     }
 }
 
+# INTERLUDE: What's up w/ need_res, res_includes, and set_active_resource_group?
+#
+#     GOOD QUESTION, WONDER-CAT. This is a system for lazy resolution and
+# deduplication of required CSS/JS files. Any component can declare its own
+# dependencies without caring where it's being called from, which theoretically
+# makes things slightly more self-contained and maintainable.
+#     Later (I think?), someone extended it to enable incremental code
+# modernization. A component can declare multiple implementations of a frontend
+# feature, specifying a "resource group" for each implementation. When it's
+# finally time to build a page, the controller sets its preferred resource group
+# and pulls in only frontend code that's compatible with that group.
+#     As for how to use these, well, hmm. They follow a classic LJ design
+# pattern that I like to call "launch some garbage into the void / reach
+# into the void and grab some garbage." Infinite flexibility, zero handrails or
+# validation. So here's the conventions I've been able to puzzle out.
+#
+# * `need_res`: Declares one or more JS/CSS files that need to be loaded for
+# the current page. need_res([<opts hashref>], <path>, [<path>...])
+#     FILE PATHS: Use paths like "js/jquery.replyforms.js" or
+#         "stc/components/quick-reply.css", relative to the top-level "htdocs"
+#         directory. Paths can ONLY go into the "js" (javascript) or "stc" (CSS)
+#         subdirectories. Note that on a live instance of the app, "stc" also
+#         has the compiled contents of the "scss" directory (minus any files
+#         whose names begin with an underscore [_]).
+#     PRIORITY: The opts hashref can have a "priority" key, whose value is
+#         an integer. This affects the order in which files are added to the
+#         page; otherwise the order is effectively random. Files with bigger
+#         priority values get included first. Existing code only seems to
+#         use two values: 0 (normal) and 3 (prerequisites). 0 is never
+#         referenced explicitly, just defaulted to. 3 is always referenced
+#         indirectly, via the $LJ::LIB_RES_PRIORITY variable.
+#     RESOURCE GROUP: The opts hashref can have a "group" key, whose value
+#         is a string. See "KNOWN RESOURCE GROUPS" below for more details. If
+#         you don't specify a group, need_res puts CSS files in the "all" group
+#         and JS files in the "default" (actually legacy) group.
+#
+# * `set_active_resource_group`: Sets the value of a global variable called
+# $LJ::ACTIVE_RES_GROUP, which then affects the behavior of res_includes. It's
+# supposed to be called pretty late in the process of building a page. You can
+# check that variable to see what will _probably_ be happening, but be careful;
+# there aren't a lot of assurances about how accurate it is at any given time.
+#
+# * `res_includes`: Builds the actual HTML tags for the JS/CSS in the current
+# resource group (plus the special "all" group), and returns them as a string.
+# Whatever calls res_includes is responsible for putting the result somewhere
+# useful.
+#     Conceptually, res_includes is only meant to be called once per page, but
+# since Foundation expects JS to go at the bottom of the <body>, it's more like
+# "call half of it twice," via the wrapper functions `res_includes_head`
+# (for CSS and really basic inline JS that everything else relies on) and
+# `res_includes_body` (JS loaded from files).
+#
+# KNOWN RESOURCE GROUPS: There isn't any validation on these, but these are the
+# values that actually get used by something.
+#     - "foundation" - newer pages.
+#     - "jquery" - pages whose JS was modernized in the early '10s.
+#     - "default" - legacy LJ pages that have basically never been modernized.
+#     - "all" - always included, regardless of the current resource group.
+#     - "fragment" - no idea, tbh. Something involving the template system.
+#
+# LIMITATIONS: Lazy resolution basically doesn't work with S2 pages, so they
+# need to know all of their CSS/JS files BEFORE we start rendering markup. In
+# particular, watch out for this when using .tt components that call need_res.
+#     Why? To lazy resolve, you need to call res_includes AFTER the inner
+# content is fully built, which means building the outer frame of the page last.
+# That's easy for site pages, but since journal styles can override the entire
+# HTML document, there's not really any protected "outer" part of the page that
+# core2 can defer.
+# Exceptions to this:
+#     - The "siteviews" layout can lazy-resolve just fine.
+#     - If the "s2foundation" beta is active, S2 pages can lazy-resolve JS (but
+#       not CSS).
+# -NF
+
 # optional first argument: hashref with options
 # other arguments: resources to include
 sub need_res {

--- a/cgi-bin/LJ/Widget.pm
+++ b/cgi-bin/LJ/Widget.pm
@@ -125,28 +125,13 @@ sub render {
         my $opts = { $widget->need_res_opts };
 
         # include any resources that this widget declares
-        if ( defined $opt_hash{stylesheet_override} ) {
-            LJ::need_res( $opt_hash{stylesheet_override} ) if $opt_hash{stylesheet_override};
-
-            # include non-CSS files (we used stylesheet_override above)
-            foreach my $file ( $widget->need_res ) {
-                if ( $file =~ m!^[^/]+\.(js|css)$!i ) {
-                    next if $1 eq 'css';
-                    LJ::need_res( $opts, "js/widgets/$subclass/$file" );
-                    next;
-                }
-                LJ::need_res( $opts, $file ) unless $file =~ /\.css$/i;
+        foreach my $file ( $widget->need_res ) {
+            if ( $file =~ m!^[^/]+\.(js|css)$!i ) {
+                my $prefix = $1 eq 'js' ? "js" : "stc";
+                LJ::need_res( $opts, "$prefix/widgets/$subclass/$file" );
+                next;
             }
-        }
-        else {
-            foreach my $file ( $widget->need_res ) {
-                if ( $file =~ m!^[^/]+\.(js|css)$!i ) {
-                    my $prefix = $1 eq 'js' ? "js" : "stc";
-                    LJ::need_res( $opts, "$prefix/widgets/$subclass/$file" );
-                    next;
-                }
-                LJ::need_res( $opts, $file );
-            }
+            LJ::need_res( $opts, $file );
         }
         LJ::need_res( $opt_hash{stylesheet} ) if $opt_hash{stylesheet};
 

--- a/cgi-bin/LJ/Widget/UserpicSelector.pm
+++ b/cgi-bin/LJ/Widget/UserpicSelector.pm
@@ -21,8 +21,10 @@ use LJ::Talk;
 
 sub need_res {
 
-    # force to not use beta, because this is not used in journal spaces
-    return LJ::Talk::init_iconbrowser_js( 0, 'stc/entry.css' );
+    # Just let need_res work normally for this, instead of using LJ::Widget's
+    # berserk reimplementation of it.
+    LJ::Talk::init_iconbrowser_js('stc/entry.css');
+    return ();
 }
 
 sub handle_post {

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -561,12 +561,7 @@ sub start_request {
         );
 
         LJ::need_res(
-            { priority => $LJ::LIB_RES_PRIORITY, group => "default" }, qw (
-                stc/lj_base.css
-                )
-        );
-        LJ::need_res(
-            { priority => $LJ::LIB_RES_PRIORITY, group => "jquery" }, qw (
+            { priority => $LJ::LIB_RES_PRIORITY, group => "all" }, qw (
                 stc/lj_base.css
                 )
         );

--- a/etc/config-local.pl
+++ b/etc/config-local.pl
@@ -160,10 +160,9 @@
 #            start_time => 0,
 #            end_time => "Inf",
 #        },
-#        "s2comments" => {
+#        "s2foundation" => {
 #            start_time => 0,
 #            end_time => "Inf",
-#            sitewide => 1,
 #        },
 #    );
 

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -49,6 +49,8 @@ function update(data,widget) {
     if ( ! customsubject || cur_subject == "" )
         subject.val(data.subject);
 
+    $("#prop_picture_keyword").change();
+
     // If we previously munged the layout of #qrformdiv, reset it.
     $('#qrformdiv').removeAttr('style').removeClass('width-adjusted');
 
@@ -225,6 +227,9 @@ jQuery(function($) {
         $("#qrform").attr("action", Site.siteroot + "/talkpost_do" );
     });
     $("#submitmoreopts").on("click", function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
         var replyto = Number($("#dtid").val());
         var pid = Number($("#parenttalkid").val());
         var basepath = $("#basepath").val();
@@ -236,7 +241,9 @@ jQuery(function($) {
         }
 
         $("#qrform").data("stayOnPage", false);
+        $("#qrform").submit();
     });
+
 });
 
 

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -212,6 +212,7 @@ jQuery(function($) {
     });
 
     $("#submitpview").on("click", function(e){
+        $("#qrform").data("stayOnPage", false);
         $("#qrform input[name='submitpreview']").val(1);
         $("#qrform").attr("action", Site.siteroot + "/talkpost_do" );
     });

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -213,6 +213,11 @@ jQuery(function($) {
 
     $("#submitpview").on("click", function(e){
         $("#qrform").data("stayOnPage", false);
+        // Why use a hidden input for the real "submitpreview" instead of just
+        // relying on the button? Because we disable the submit buttons to guard
+        // against double-submits, and that causes the preview button's value to
+        // appear as falsy when the form data arrives back in perl-land, which
+        // in turn causes surprise posts.
         $("#qrform input[name='submitpreview']").val(1);
         $("#qrform").attr("action", Site.siteroot + "/talkpost_do" );
     });

--- a/htdocs/js/jquery.replyforms.js
+++ b/htdocs/js/jquery.replyforms.js
@@ -18,29 +18,47 @@ jQuery(function($) {
     $(".js-only").show();
     $(".no-js").hide();
 
-    // Random icon button
-    $("#randomicon").on("click", function(e){
-        e.stopPropagation();
-        e.preventDefault();
-
+    function randomIcon() {
         if ( iconSelect.length === 0 ) return;
 
-        // take a random number, ignoring the "(default)" option
+        // take a random number, ignoring the "(default)" and "(random)" options
         var randomnumber = Math.floor(
-            Math.random() * (iconSelect.prop("length") - 1)
-        ) + 1;
+            Math.random() * (iconSelect.prop("length") - 2)
+        ) + 2;
         iconSelect.prop("selectedIndex", randomnumber);
-        iconSelect.trigger("change");
-    });
+        iconSelect.change();
+    }
 
-    // Icon preview
+    // Add random icon option to menu if there's more than one icon
+    if ( $('option#random').length === 0 && iconSelect.children('option').length > 2 ) {
+        iconSelect.children('option').first()
+            .after('<option value=",random" id="random">(random) 🔀</option>');
+            // Commas are illegal in keywords, so this won't conflict with
+            // anyone's real icons. Since the value immediately changes to
+            // something else if you select it, this should never be
+            // submitted... but if it is, it just reverts to the default icon.
+    }
+
+    // Random icon re-roll button (hidden until random is selected once)
+    $("#randomicon").on("click", randomIcon);
+
     iconSelect.on("change", function(e) {
-        e.stopPropagation();
-        e.preventDefault();
-
-        $(".qr-icon").find("img")
-            .attr("src", $(this).find("option:selected").data("url"))
-            .removeAttr("width").removeAttr("height").removeAttr("alt");
+        var selection = $(this).find("option:selected");
+        if (selection.attr('id') === 'random') {
+            randomIcon();
+            // For easy re-rolls:
+            $("#randomicon").show();
+        } else {
+            // Update icon preview
+            $(".qr-icon").find("img")
+                .attr("src", selection.data("url"))
+                .removeAttr("width").removeAttr("height").removeAttr("alt");
+            if (selection.attr('value') === '') {
+                $(".qr-icon").addClass("default");
+            } else {
+                $(".qr-icon").removeClass("default");
+            }
+        }
     });
 
     // Quote button

--- a/htdocs/js/jquery.replyforms.js
+++ b/htdocs/js/jquery.replyforms.js
@@ -63,13 +63,15 @@ jQuery(function($) {
             $("#randomicon").show();
         } else {
             // Update icon preview
-            $(".qr-icon").find("img")
+            var iconPreview = $(".qr-icon");
+            iconPreview.removeClass("no-label"); // hides browse button in talkform when no JS.
+            iconPreview.find("img")
                 .attr("src", selection.data("url"))
                 .removeAttr("width").removeAttr("height").removeAttr("alt");
             if (selection.attr('value') === '') {
-                $(".qr-icon").addClass("default");
+                iconPreview.addClass("default");
             } else {
-                $(".qr-icon").removeClass("default");
+                iconPreview.removeClass("default");
             }
         }
     });

--- a/htdocs/js/jquery.replyforms.js
+++ b/htdocs/js/jquery.replyforms.js
@@ -42,6 +42,19 @@ jQuery(function($) {
     // Random icon re-roll button (hidden until random is selected once)
     $("#randomicon").on("click", randomIcon);
 
+
+    // New-new icon browser, if available
+    if ( $.fn.iconBrowser ) {
+        iconSelect.iconBrowser({
+            triggerSelector: "#lj_userpicselect",
+            modalId: "js-icon-browser",
+            preferences: {
+                "metatext": $('#lj_userpicselect').data('iconbrowserMetatext'),
+                "smallicons": $('#lj_userpicselect').data('iconbrowserSmallicons')
+            }
+        });
+    }
+
     iconSelect.on("change", function(e) {
         var selection = $(this).find("option:selected");
         if (selection.attr('id') === 'random') {

--- a/htdocs/js/jquery.replyforms.js
+++ b/htdocs/js/jquery.replyforms.js
@@ -17,6 +17,12 @@ jQuery(function($) {
     // Reveal any controls that are hidden when JS is disabled... and vice versa
     $(".js-only").show();
     $(".no-js").hide();
+    // Re-enable submit buttons when page is thawed from bfcache (Safari, Firefox)
+    $(window).on('pageshow', function(e){
+        if ( e.originalEvent.persisted ) {
+            commentForm.find('input[type="submit"]').prop("disabled", false);
+        }
+    });
 
     function randomIcon() {
         if ( iconSelect.length === 0 ) return;

--- a/htdocs/js/jquery.talkform.js
+++ b/htdocs/js/jquery.talkform.js
@@ -6,15 +6,15 @@ jQuery(function($){
     var authForms = $('.from-login');
     var iconSelect = $('#prop_picture_keyword');
 
-    // Reset any input children to their initial values.
+    // Blank out any input children.
     jQuery.fn.extend({
-        resetFormFields: function() {
+        clearFormFields: function() {
             this.find('input').each(function(i, elm){
                 var type = elm.getAttribute('type');
                 if (type === 'checkbox' || type === 'radio') {
-                    elm.checked = elm.defaultChecked;
-                } else {
-                    elm.value = elm.defaultValue;
+                    elm.checked = false;
+                } else if (type === 'text' || type === 'password' ){
+                    elm.value = '';
                 }
             });
             return this;
@@ -24,11 +24,12 @@ jQuery(function($){
     // Tidy up irrelevant controls when choosing who the comment is from
     fromOptions.change(function(e) {
         // When a "from" option is selected, show its associated login form (if
-        // any), and reset the values of any other login forms.
+        // any), and blank out the values of any other login forms so we don't
+        // send contradictory info.
         var associatedLoginForm = document.getElementById( $(this).data('more') );
         authForms.hide();
         $(associatedLoginForm).show();
-        authForms.not(associatedLoginForm).resetFormFields();
+        authForms.not(associatedLoginForm).clearFormFields();
 
         // Icon select menu is only available for logged-in user
         if (this.id === 'talkpostfromremote' || this.id === 'talkpostfromoidli') {
@@ -43,12 +44,6 @@ jQuery(function($){
     fromOptions.filter(':checked').change();
     // confirm the selected icon, to update preview and browse button label.
     iconSelect.change();
-
-    // Clear username when clicked (but not focused, so we don't clear it as a
-    // keyboard or reader user navigates through it)
-    $('#postform #username').click(function(e){
-        this.value = '';
-    });
 
     // subjecticons :|
     $('#subjectIconImage').click(function(){
@@ -88,12 +83,6 @@ jQuery(function($){
     });
 
     commentForm.submit(function(e) {
-        // idek what would blow up if you sent name/pwd when usertype is
-        // something other than user, but the old js did this so whatever
-        if ( ! $('#talkpostfromlj').prop('checked') ) {
-            $('#username').val('');
-            $('#password').val('');
-        }
         // prevent double-submits
         commentForm.find('input[type="submit"]').prop("disabled", true);
     });

--- a/htdocs/js/jquery.talkform.js
+++ b/htdocs/js/jquery.talkform.js
@@ -34,13 +34,15 @@ jQuery(function($){
         if (this.id === 'talkpostfromremote' || this.id === 'talkpostfromoidli') {
             iconSelect.prop('disabled', false);
         } else {
-            iconSelect.val('');
-            iconSelect.prop('disabled', true);
+            iconSelect.val('').change().prop('disabled', true);
         }
     });
 
-    // setup: hide login forms. show the currently relevant one, if any.
+    // setup:
+    // hide login forms. show the currently relevant one, if any.
     fromOptions.filter(':checked').change();
+    // confirm the selected icon, to update preview and browse button label.
+    iconSelect.change();
 
     // Clear username when clicked (but not focused, so we don't clear it as a
     // keyboard or reader user navigates through it)

--- a/htdocs/js/jquery.talkform.js
+++ b/htdocs/js/jquery.talkform.js
@@ -74,6 +74,17 @@ jQuery(function($){
     });
 
     // submit handlers :|
+
+    // If JS is disabled, the preview button works normally.
+    // If JS is enabled, we disable the submit buttons to guard against
+    // double-submits, and that causes the preview button's value to appear as
+    // falsy when the form data arrives back in perl-land. So if the user
+    // clicked preview, we need to preserve that info in a non-disabled input.
+    $('#submitpview').click(function(e) {
+        this.name = 'submitpview';
+        $('#previewplaceholder').prop('name', 'submitpreview');
+    });
+
     commentForm.submit(function(e) {
         // idek what would blow up if you sent name/pwd when usertype is
         // something other than user, but the old js did this so whatever

--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -388,7 +388,7 @@ var postForm = (function($) {
         });
     };
 
-    var initIcons = function($form, icons, iconBrowserOptions) {
+    var initIcons = function($form, iconBrowserOptions) {
         var $preview = $( "#js-icon-preview" );
         if ( $preview.is(".no-icon") ) return;
 
@@ -406,15 +406,12 @@ var postForm = (function($) {
                     '</div>');
 
         function update_icon_preview() {
-            if ( !icons ) return;
-
-            if ( this.selectedIndex != null && icons[this.selectedIndex] ) {
-                if ( icons[this.selectedIndex].src ) {
-                    $("#js-icon-preview-image").attr({
-                        "src": icons[this.selectedIndex].src,
-                        "alt": icons[this.selectedIndex].alt
-                    });
-                }
+            if ( this.selectedIndex != null ) {
+                var selection = $(this).find("option:selected");
+                $("#js-icon-preview-image").attr({
+                    "src": selection.data('url'),
+                    "alt": selection.data('description')
+                });
             }
         }
 
@@ -663,7 +660,7 @@ var postForm = (function($) {
         initCurrents(entryForm, formData.moodpics);
         initSecurity(entryForm, formData.security, { spellcheck: formData.did_spellcheck, edit: formData.edit } );
         initJournal(entryForm);
-        initIcons(entryForm, formData.icons, formData.iconBrowser);
+        initIcons(entryForm, formData.iconBrowser);
         initSlug(entryForm, $("#js-entrytime-date"));
         initTags(entryForm);
         initDate(entryForm);

--- a/htdocs/scss/components/icon-browser.scss
+++ b/htdocs/scss/components/icon-browser.scss
@@ -1,24 +1,133 @@
 @import "foundation/base";
 .icon-browser {
+    // POSITIONING FIXES:
+    // Foundation's "reveal" component assumes pages never scroll sideways, lol.
+    // The icon browser JS fixes the left position, but we also need to handle
+    // the centering at desktop widths. (By default it uses auto-margins for
+    // centering, but that's not reliable once left != 0.)
+
+    // Override the default (100px) gap between top of viewport and top of
+    // modal, bc we want it to be 0 on mobile. (This isn't the "real" top
+    // property, it's just a hint to the reveal-modal js.)
+    top: 0;
+
+    // On mobile, the modal's width is 100vw and we don't need to center
+    // On tablet+, the modal's width is 80%, so 10% margin on each side:
     @media #{$medium-up} {
-        .icon-browser-content {
-            max-height: 70vh;
-            overflow-y: auto;
-            overflow-x: hidden;
+        margin: 4vh 10% 0; // Restore a gap at the top, too.
+    }
+    // Modal's max width is 70em, so from min-width: (1.25 * 70em) we use math:
+    @media only screen and (min-width: 87.5em) {
+        margin: 4vh calc( (100% - 70em) / 2 ) 0;
+    }
+    // And then there's the height. On desktop/tablet, we want to fit the whole
+    // modal on screen and keep the controls in view, with the icon grid
+    // scrolling independently. Only bother with this on browsers w/ non-buggy
+    // flexbox; on old browsers it can just act like it does on mobile.
+    @media #{$medium-up} {
+        // @supports will hide this from IE11, which thinks it can flex but kinda can't.
+        @supports (display: flex) {
+            .icon-browser-flex-wrapper {
+                display: flex;
+                flex-direction: column;
+                max-height: calc(93vh - 3.75rem); // outer container has 1.875rem padding
+                // This should usually leave 3vw gap at bottom, to reassure you that
+                // you're seeing the whole thing and/or leave room for the
+                // horizontal scrollbar.
+            }
+
+            .icon-browser-content {
+                overflow-y: auto;
+                overflow-x: hidden;
+                -webkit-overflow-scrolling: touch;
+            }
         }
+    }
+
+    // Not necessary on site skin, but necessary in most journal styles.
+    box-sizing: border-box;
+    * {
+        box-sizing: border-box;
+    }
+
+    #js-icon-browser-search {
+        width: auto; // don't stretch to 100% on site skin
+        @media (pointer: coarse) {
+            font-size: 16px; // dramatic woodchuck repellent
+        }
+    }
+
+    .icon-browser-content {
+        padding: 4px; // don't clip tops/sides off the box shadows
     }
 
     li {
         @include single-transition(background-color);
     }
+
+    hr {
+        display: block;
+        width: 100%;
+        border-style: solid;
+        border-width: 1px 0 0;
+    }
+
+    .top-controls {
+        // @supports will hide this from IE11, which thinks it can flex but kinda can't.
+        @supports (display: flex) {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        & > * {
+            display: inline-block; // for no-flex browsers
+            // fake row-gap:
+            margin-right: 2em;
+            &:last-child {
+                margin-right: 0;
+            }
+        }
+    }
+
+    .keyword-menu {
+        // Slow yr roll, jumpy!
+        min-height: 2.5em;
+        @media #{$small-only} {
+            min-height: 4.2em;
+        }
+        label.left {
+            float: left;
+            margin-top: calc(.3em + 1px); // match keyword padding + margin + border
+            line-height: 1.5;
+        }
+    }
+
     .keyword {
+        display: inline-block;
+        max-width: 100%;
+        cursor: pointer;
         text-decoration: none;
         border-width: 1px;
         border-style: solid;
-        margin-right: .2em;
-        padding: .2em .3em;
-        line-height: $base-line-height * 1.5;
-        transition: color 300ms ease-out, background-color 300ms ease-out;
+        margin: .2em;
+        margin-left: 0;
+        padding: .1em .3em;
+        line-height: 1.5;
+        transition-duration: 300ms;
+        transition-timing-function: ease-out;
+        transition-property: color, background-color, border-width, margin-top, margin-bottom, margin-right;
+
+        &.active {
+            // Journal styles don't know about ".active" controls so they don't
+            // do the inverted colors thing you see in site skins. But border
+            // thickness will do in a pinch.
+            border-width: 3px;
+            margin: calc(.2em - 2px); // absorb extra border size
+            margin-left: 0;
+        }
     }
 
     a.inactive-toggle {
@@ -26,36 +135,76 @@
         text-decoration: none;
     }
 
-    .icon-browser-item-comment {
-        word-break: break-word;
+    .icon-browser-item-meta {
+        overflow-wrap: break-word;
+        font-size: smaller;
     }
 
     &.no-meta {
         .icon-browser-item-meta {
             display: none;
         }
+    }
+
+    // The image is wrapped in a dummy "a" element, so we can use inherit to
+    // grab a color that fits the journal style.
+    .th.active {
+        border-color: inherit;
+    }
+
+    .js-icon-browser-icon-grid {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, 110px);
+        grid-column-gap: 1rem;
+        grid-row-gap: 1rem;
+
         li {
-            width: auto;
-            clear: none;
-        }
-    }
+            list-style: none;
+            margin: 0;
 
-    .icon-image {
-        width: 100px;
-        height: 100px;
-    }
+            // Basic fallback styles for old browsers:
+            display: inline-block;
+            width: 150px;
+            vertical-align: top;
+            padding-bottom: 1.25rem;
+            padding-right: 0.625rem;
 
-    &.small-icons {
-        .icon-image {
-            float: left;
-            width: 50px;
-            height: 50px;
-            margin-right: 4px;
-
-            img {
-                vertical-align: top;
-                margin-top: 4px; // width of the border around the image
+            // Cool browsers can ignore all that.
+            @supports (display: grid) {
+                width: auto;
+                vertical-align: initial;
+                padding: 0;
             }
         }
     }
+
+    // Pack em in:
+    &.small-icons.no-meta .js-icon-browser-icon-grid {
+        grid-template-columns: repeat(auto-fill, 58px);
+    }
+
+    .icon-browser-icon-image img {
+        max-width: 100%;
+        height: auto;
+        // Foundation's .th thumbnail class sets images to display: inline-block
+        // instead of inline, which makes border-box sizing affect their
+        // height/width attributes. So without this, a 100 x 100 icon will
+        // display as 92 x 92.
+        box-sizing: content-box;
+    }
+
+    &.small-icons {
+        .icon-browser-icon-image img {
+            max-width: 58px; // 50px icon plus borders
+            max-height: 58px;
+            width: auto;
+            // ...but once we're shrinking images anyway, reliable sizing
+            // becomes more important than pixel-for-pixel dimensions.
+            box-sizing: border-box;
+        }
+    }
+
 }

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -145,6 +145,13 @@
                 }
             }
         }
+
+        // Hide browse button in talkform when JS is disabled
+        &.no-label {
+            button::after {
+                opacity: 0 !important;
+            }
+        }
     }
 
     .qr-icon-controls {

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -1,12 +1,10 @@
 @import "foundation/base";
 
-$icon-control-height: 2.2em;
-
 #qrdiv * {
     box-sizing: border-box;
 }
 
-#qrform {
+#qrformdiv {
     text-align: left;
     padding: .5em;
     clear: both;
@@ -24,6 +22,12 @@ $icon-control-height: 2.2em;
 
     input, button, textarea, select {
         margin-bottom: 3px;
+        margin-top: 0;
+    }
+
+    input[type="button"], button {
+        // Avoids double-tap zoom when tapping "random" repeatedly
+        touch-action: manipulation;
     }
 
     // Avoid *dramatic woodchuck* zoom on mobile
@@ -33,89 +37,157 @@ $icon-control-height: 2.2em;
         }
     }
 
+    // If no grid: vertical stack. ID -> icon preview -> icon controls.
     .qr-meta {
-        display: flex;
-        align-items: flex-end;
+
+        display: grid;
+        grid-column-gap: 5px;
+        grid-template-columns: auto 1fr;
+        grid-template-rows: auto auto auto;
+        grid-template-areas:
+            "name name"
+            "icon more"
+            "icon iconctl";
+        .qr-icon {
+            margin-bottom: 3px;
+            grid-area: icon;
+            align-self: self-end;
+        }
+        .qr-icon-controls {
+            grid-area: iconctl;
+        }
+        .ljuser {
+            grid-area: name;
+            margin-bottom: 2px;
+        }
+        #submitmoreopts {
+            grid-area: more;
+            justify-self: start;
+            align-self: self-end;
+        }
     }
 
     .qr-icon {
-        // Same height as stacked icon controls
         width: 55px;
         height: 55px;
-        flex-shrink: 0;
-        margin-right: 3px;
-        margin-bottom: 3px;
 
         img {
             max-width: 100%;
             max-height: 100%;
+
+            @supports (object-position: bottom) {
+                width: 100%;
+                height: 100%;
+                object-fit: contain;
+                object-position: bottom;
+            }
+        }
+
+        a, button {
+            position: relative;
+            display: block;
+
+            width: 100%;
+            height: 100%;
+            border: none;
+            padding: 0;
+            margin: 0;
+            background: none;
+            cursor: pointer;
+
+            &::after {
+                position: absolute;
+
+                display: block; // old browsers
+                display: flex;  // new browsers
+                align-items: flex-end;
+                justify-content: center;
+
+                top: 0;
+                margin: 0;
+                font-size: 11px;
+                font-weight: bold;
+                opacity: 0;
+                background: rgba(255, 255, 255, 0.7); // real old browsers
+                background: radial-gradient(
+                    circle farthest-side at left 50% bottom -60%,
+                    rgba(255, 255, 255, 1.0),
+                    rgba(255, 255, 255, 0.85) 50%,
+                    rgba(255, 255, 255, 0) 67%
+                );
+                color: rgba(0, 0, 0, 0.8);
+                text-shadow: 0px -1px 3px #fff;
+                text-align: center;
+                width: 100%;
+                height: 100%;
+                @include single_transition();
+            }
+
+            &:hover, &:focus {
+                &::after {
+                    opacity: 1;
+                }
+            }
+        }
+
+        a::after {
+            content: "View all icons";
+        }
+
+        button::after {
+            content: "Browse";
+        }
+
+        &.default {
+            a, button {
+                &::after {
+                    opacity: 1;
+                }
+            }
         }
     }
 
     .qr-icon-controls {
-        & > * {
-            margin-bottom: 3px;
+        display: flex;
+        align-items: flex-end;
+        min-width: 0; // let grid shrink it
+
+        #randomicon {
+            margin-left: 5px;
         }
 
         select#prop_picture_keyword {
-            display: block;
-            @supports (display: flex) {
-                width: 100%;
-            }
+            margin-left: 0;
+            max-width: 100%;
+            min-width: 0; // Let grid/flex shrink it
         }
     }
 
-    button.lj_userpicselect_extra {
-        position: relative;
-        width: 100%;
-        height: 100%;
-        border: none;
-        padding: 0;
-        margin: 0;
-        background: none;
-        cursor: pointer;
-
-        &::after {
-            content: "Browse";
-            display: block;
-            position: absolute;
-            top: 0;
-            margin: 0 auto;
-            font-weight: bold;
-            line-height: 60px;
-            color: #000;
-            background-color: #fff;
-            text-align: center;
-            width: 100%;
-            height: 100%;
-            opacity: 0;
-            @include single_transition();
-        }
-
-        &:hover, &:focus {
-            &::after {
-                opacity: .7;
-            }
-        }
+    .ljuser, #submitmoreopts {
+        font-size: smaller;
     }
 
-    .qr-body {
+    .qr-subject {
         display: flex;
-        flex-wrap: wrap;
         align-items: flex-end;
 
         #subject {
             // size=50 in html is a presentational hint for width, so need to
             // set width to SOMETHING to keep it from messing up the flex.
             width: 70%;
+            min-width: 0; // let it shrink
             flex-grow: 1;
             flex-shrink: 1;
         }
         #comment-text-quote {
             margin-left: 5px;
         }
+    }
+
+    .qr-body {
         #body {
             width: 100%;
+            -webkit-overflow-scrolling: touch;
         }
     }
 
@@ -135,16 +207,12 @@ $icon-control-height: 2.2em;
         }
     }
 
-    #submitmoreopts {
-        margin-left: 0;
-    }
-
     textarea, select, input[type="text"] {
-        margin-right: 0; // Fix for site scheme.
+        margin-right: 0; // Fix for old site scheme.
     }
 
     .invisible {
-        // Fix for site scheme; a ".comment .invisible" rule was setting position: relative.
+        // Fix for old site scheme; a ".comment .invisible" rule was setting position: relative.
         position: absolute;
     }
 }

--- a/htdocs/scss/components/talkform.scss
+++ b/htdocs/scss/components/talkform.scss
@@ -1,9 +1,47 @@
-.from-option {
+#talkform-from {
+    margin-bottom: 3px;
     label {
         font-weight: bold;
+        margin-right: 0; // fix for site scheme
     }
 }
 
 .from-login {
     margin-left: 4em;
+}
+
+#subjectIconImage {
+    cursor: pointer;
+    cursor: hand; // ? Old junk, probably
+    margin-bottom: auto;
+    margin-top: auto;
+    margin-left: 5px;
+}
+
+.subjecticon-grid {
+    display: grid;
+    align-items: center;
+    max-width: 370px;
+    grid-template-columns: repeat(auto-fill, 32px);
+    grid-column-gap: 5px;
+    grid-row-gap: 5px;
+    margin-bottom: 3px;
+    border: 1px solid #aaa;
+
+    div {
+        display: inline-block; // for no-grid browsers
+    }
+
+    img {
+        display: block;
+        cursor: pointer;
+        margin-left: auto;
+        margin-right: auto;
+    }
+}
+
+#talkform-misc {
+    input[type="text"] {
+        width: 100%;
+    }
 }

--- a/htdocs/scss/foundation/foundation_minimal.scss
+++ b/htdocs/scss/foundation/foundation_minimal.scss
@@ -1,0 +1,21 @@
+// The minimum of Foundation functionality, to enable shared components in
+// journal styled pages. Do not include both this and foundation.scss; choose
+// ONE.
+
+// The goal of this is to basically act like _base.scss, except we DO want to
+// print the meta.foundation.* classes from _global. For any other styles, we
+// rely on what the components bring with them.
+
+// import the settings we want to work with
+@import "foundation/settings";
+
+$include-html-classes: false;
+
+// import global
+@import "foundation/components/global";
+
+$include-html-classes: true;
+
+// import components we use in journal-styled pages
+@import "foundation/components/reveal";
+@import "foundation/components/thumbs";

--- a/htdocs/scss/skins/_compatibility-styles.scss
+++ b/htdocs/scss/skins/_compatibility-styles.scss
@@ -1,0 +1,20 @@
+// Style translations for widgets that sometimes show up in pages written for
+// the old non-Foundation site skins. These rules should mostly use @extend
+// rules to style these widgets in terms of existing classes from the modern
+// site skins.
+
+.action-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    margin-top: 20px;
+
+    .inner {
+        @extend .panel;
+        @extend .callout;
+        display: block;
+        padding: 5px;
+        text-align: center;
+    }
+}

--- a/htdocs/scss/skins/_entry-styles.scss
+++ b/htdocs/scss/skins/_entry-styles.scss
@@ -1,0 +1,393 @@
+/**
+* Site-wide customizations to journal entry pages
+*/
+
+.entry, #comments, .reply-page-wrapper {
+  // Working with typography in Foundation is annoying because they set
+  // everything to an absolute size in rems, so you can't just make one section
+  // a little bit smaller. So we need all this manual stuff.
+
+  font-size: 0.85rem;
+
+  // Things I'm leaving alone:
+  // form elements except for textarea, tables
+
+  // Things that are normal text:
+  p, ul, ol, dl, label {
+    font-size: 1em;
+  }
+
+  // Things that are a little askew from normal text:
+  aside { font-size: 0.875em; }
+  blockquote cite { font-size: 0.8125em; }
+  blockquote {
+    margin: 1.25em;
+  }
+
+  // Things that are their own thing:
+  h1 { font-size: 1.814em; }
+  h2 { font-size: 1.618em; }
+  h3 { font-size: 1.3055em; }
+  h4 { font-size: 1.121em; }
+  h5 { font-size: 1em; }
+  h6 { font-size: .9em; }
+
+  .comment-title {
+    font-size: 1.3em;
+  }
+
+  .partial .comment-title {
+    font-size: 1em;
+    display: inline;
+    font-weight: normal;
+    font-family: inherit;
+  }
+
+  textarea {
+    font-family: monospace;
+    font-size: 16px;
+  }
+
+  // Foundation likes stretching selects to 100% for some reason
+  select {
+    width: auto;
+  }
+
+  .usercontent, .currents, .comment-title {
+    overflow-wrap: break-word;
+  }
+
+  /* Constrain image dimensions.
+      Job 1: Don't trash the layout sideways.
+      Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+        portrait of someone is nonsense.
+      Job 3: Defend the native aspect ratio.
+      Job 4: Respect the width/height HTML attributes for scaling down OR up
+        (within the limits of the container), but if they conflict with the aspect
+        ratio, treat them as maximums and let the aspect ratio win. */
+  .usercontent img {
+    height: auto;
+    max-width: 100%;
+    max-height: 95vh;
+    object-fit: contain;
+    object-position: left;
+  }
+
+
+}
+
+// Basics
+
+.poster {
+  display: block;
+}
+
+.userpic a {
+  display: block;
+  line-height: 0;
+}
+
+.entry-interaction-links li,
+.comment-interaction-links li,
+.view-flat,
+.view-threaded,
+.view-top-only,
+.expand_all {
+  &::before {
+    content: "(";
+  }
+  &::after {
+    content: ")";
+  }
+}
+
+ul.icon-links,
+ul.text-links {
+  margin: 0;
+  display: inline;
+
+  // Need an ID to match specificity of a default #content ul li rule.
+  #content & li {
+    display: inline;
+    list-style: none;
+    margin-left: 0;
+    margin-right: 8px;
+    margin-bottom: 2px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
+.bottomcomment,
+.entry .footer .inner,
+.comment-pages {
+  text-align: center;
+
+  hr {
+    width: 100%;
+  }
+}
+
+// Primary content: Always an entry on entry page, but is sometimes a
+// comment on reply page.
+
+.entry, .reply-page-wrapper .comment {
+  .header .inner {
+    display: flex;
+    align-items: flex-end;
+    flex-wrap: wrap; // Fitting an OpenID username on mobile: always fun.
+  }
+
+  .userpic {
+    display: inline-block;
+    margin-right: .3rem;
+    flex-shrink: 0;
+  }
+
+  .poster-info {
+    display: inline-block;
+    vertical-align: bottom;
+    min-width: 0;
+
+    .datetime {
+      font-style: italic;
+      &::before {
+          content: "@";
+      }
+    }
+  }
+
+  .entry-title, .comment-title {
+    font-size: 1.5em;
+    font-style: italic;
+    font-weight: bold;
+    margin: 10px 0;
+  }
+
+  @media #{$medium-up} {
+    .contents {
+      margin-left: 30px;
+    }
+  }
+
+}
+
+// Entry only
+
+.entry {
+  .metadata ul {
+    margin: 0;
+    list-style: none;
+
+    // Need an ID to match specificity of a default #content ul li rule.
+    #content & li {
+      margin-left: 0;
+    }
+  }
+
+  .metadata-label, .tag-text {
+    font-weight: bold;
+  }
+
+  .tag ul {
+    list-style: none;
+    display: inline;
+    margin-left: 0;
+
+    // Need an ID to match specificity of a default #content ul li rule.
+    #content & li {
+      display: inline;
+      margin-left: 0;
+    }
+  }
+
+  .entry-title {
+    display: inline-block; // security level icon displays in front of title
+  }
+
+  .access-filter img { // security level icon
+    vertical-align: baseline;
+  }
+
+  @media #{$medium-up} {
+    .currents { // also includes tags
+      margin-left: 50px;
+    }
+  }
+
+}
+
+ul.entry-management-links {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+}
+
+.entry-interaction-links, .comment-pages {
+  font-weight: bold;
+}
+
+.comment-pages span {
+  margin: 0 4px;
+}
+
+// Comment styles
+
+#comments .comment { // Doesn't affect the comment on a reply page
+  min-width: 28em;
+  @media #{$small-only} {
+    min-width: 75vw;
+  }
+
+  .edittime {
+    margin-top: 1.5em;
+  }
+
+  .header {
+    border-bottom: 1px solid $soft-accent-color;
+    border-right: 1px solid $soft-accent-color;
+
+    line-height: 1.1;
+
+    .userpic, .comment-info {
+      display: table-cell;
+      vertical-align: top;
+    }
+
+    input {
+      margin: 0;
+    }
+
+    // On mobile, just accept that these headers will spill into multiple lines,
+    // and try to save space by flowing text around the userpic.
+    @media #{$small-only} {
+      font-size: 0.9em;
+
+      .userpic {
+        float: left;
+        margin-right: .3rem;
+
+        // deal with tall aspect userpics
+        img {
+          height: auto;
+          max-width: 75px;
+          max-height: 75px;
+          object-fit: contain;
+          object-position: left;
+        }
+      }
+
+      .comment-info {
+        display: block;
+        min-height: 75px;
+      }
+    }
+  }
+}
+
+// Comment header backgrounds
+// Structure is:
+// .comment-thread.comment-depth(odd|even)
+  // .dwexpcomment
+    // .comment-wrapper (possibly with .screened)
+      // .comment
+        // .inner
+          // .header (needs background-color)
+.comment-depth-odd > .dwexpcomment .header {
+  background-color: $secondary-color-alternate;
+}
+
+.comment-depth-even > .dwexpcomment .header {
+  background-color: $secondary-color;
+}
+
+.comment-wrapper.screened > .comment .header {
+  // Same background color as callout panels:
+  background-color: change-color($primary-color, $lightness:lightness($panel-bg));
+}
+
+.comment .footer {
+  margin-top: .6em;
+  margin-bottom: 1em;
+}
+
+.comment-info {
+  padding-left: .3em;
+
+  & > span, & > ul, & > div {
+    margin-right: .9em;
+  }
+
+  .comment-title {
+    min-height: 0.6em; // take up space when the inner span is invisible.
+    margin: 0;
+  }
+
+  .datetime, .poster-ip, .commentpermalink, .multiform-checkbox {
+    font-size: .8em;
+  }
+
+}
+
+// Single-line collapsed comments -- more rightward slop, but easier to track
+.comment-wrapper.partial {
+  white-space: nowrap;
+  .comment-title {
+    font-size: 1em;
+    display: inline;
+    font-weight: normal;
+  }
+
+  .poster {
+    display: inline;
+  }
+}
+
+#qrform, #postform {
+  // Submit buttons get standard button styles, but input type="button"s don't.
+  input[type="button"], input[type="submit"] {
+    @include button;
+    &.secondary {
+      @include button-style($bg:$secondary-color, $bg-hover:$secondary-button-bg-hover, $border-color:$secondary-button-border-color);
+    }
+    margin-bottom: 3px;
+  }
+
+  // Foundation default (inline-block) gives worse wrapping on mobile for long labels.
+  label {
+    display: inline;
+  }
+
+  // Foundation likes stretching selects to 100% for some reason
+  select {
+    width: auto;
+  }
+
+  // Shrink secondary inputs a bit
+  .qr-icon-controls, .qr-subject {
+    input[type="text"], select {
+      height: 2.2rem;
+      padding: 0.3em;
+    }
+    input[type="button"], button {
+      height: 2.2rem;
+    }
+  }
+}
+
+// Reply page tweaks
+
+.reply-page-wrapper {
+  div.readlink {
+    text-align: center;
+    font-weight: bold;
+  }
+
+  #content & .comment .reply, // reply action link; need ID to override defaults
+  .entry .footer {
+    display: none;
+  }
+}

--- a/htdocs/scss/skins/_global-styles.scss
+++ b/htdocs/scss/skins/_global-styles.scss
@@ -6,4 +6,4 @@ Should only @import other stylesheets
 $include-html-classes: true;
 @import "foundation/foundation";
 
-@import "skins/skin-colors", "skins/community-menu";
+@import "skins/skin-colors", "skins/community-menu", "skins/compatibility-styles";

--- a/htdocs/scss/skins/_global-styles.scss
+++ b/htdocs/scss/skins/_global-styles.scss
@@ -6,4 +6,4 @@ Should only @import other stylesheets
 $include-html-classes: true;
 @import "foundation/foundation";
 
-@import "skins/skin-colors", "skins/community-menu", "skins/compatibility-styles";
+@import "skins/skin-colors", "skins/community-menu", "skins/compatibility-styles", "skins/entry-styles", "skins/icons-page";

--- a/htdocs/scss/skins/_icons-page.scss
+++ b/htdocs/scss/skins/_icons-page.scss
@@ -1,0 +1,52 @@
+/**
+* Site-skin CSS for user icons pages
+*/
+
+.icon-container {
+  .icon-row {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .icon {
+    display: flex;
+    justify-content: flex-start;
+    margin-bottom: .75rem;
+    min-width: 280px;
+    flex-basis: 50%;
+    flex-grow: 1;
+  }
+
+  .icon-image {
+    flex-shrink: 0;
+    width: 100px;
+
+    a {
+      display: block;
+      line-height: 0;
+    }
+  }
+
+  .icon-info {
+    flex-grow: 1;
+    min-width: 0;
+
+    font-size: .9rem;
+    padding: .2rem 1rem;
+
+    // need one ID to fight a default #content li rule
+    ul, #content & li {
+      list-style: none;
+      display: inline;
+      margin: 0;
+      padding: 0;
+      font-size: .9rem;
+    }
+
+    .comment-text, .description-text, .keywords-label {
+      font-weight: bold;
+    }
+  }
+
+
+}

--- a/htdocs/scss/skins/_skin-colors.scss
+++ b/htdocs/scss/skins/_skin-colors.scss
@@ -8,13 +8,20 @@
 * rather than hardcoding random colors here
 */
 
+// Variant color variables -- most site skins can just ignore these, but we'll
+// use an explicit value if it exists.
+
+$background-color-alternate:    darken( $background-color, 5% ) !default;
+$background-color-inactive:     tint( $inactive-color, 50% ) !default;
+$secondary-color-alternate:     darken( $secondary-color, 15% ) !default;
+$text-color-disabled:           scale-color($text-color, $lightness: 50%) !default;
+$anchor-font-color-visited:     shade( $anchor-font-color, 20% ) !default;
+$page-title-color:              $primary-color !default;
+$border-color:                  $input-border-color !default;
+
 /**
  * Links and a pseudo link class
  */
-
-$anchor-font-color-visited: shade( $anchor-font-color, 20% ) !default;
-$page-title-color: $primary-color !default;
-$border-color: $input-border-color !default;
 
 a:visited {
     color: $anchor-font-color-visited;
@@ -121,7 +128,7 @@ li.token {
 
 // Enabled and disabled text
 div.enabled, div.enabled * { color: $text-color; }
-div.disabled, div.disabled * { color: scale-color($text-color, $lightness: 50%); }
+div.disabled, div.disabled * { color: $text-color-disabled; }
 
 // date and time picker
 .picker__holder {
@@ -210,7 +217,7 @@ div.disabled, div.disabled * { color: scale-color($text-color, $lightness: 50%);
         color: $inactive-color;
     }
     .finished:before {
-        background-color: tint( $inactive-color, 50% );
+        background-color: $background-color-inactive;
         color: $inactive-color;
     }
 }
@@ -230,9 +237,9 @@ div.disabled, div.disabled * { color: scale-color($text-color, $lightness: 50%);
 
 // alternating row colors
 .odd, tr.odd th, tr.odd td {
-    background-color: $background_color;
+    background-color: $background-color;
 }
 
 .even, tr.even th, tr.even td {
-    background-color: darken($background_color, 5%);
+    background-color: $background-color-alternate;
 }

--- a/htdocs/scss/skins/lynx.scss
+++ b/htdocs/scss/skins/lynx.scss
@@ -13,6 +13,7 @@ $text-color: $_black;
 $primary-text-color: $_white;
 $inactive-color: $_dark-gray;
 $background-color: $_white;
+$soft-accent-color: $_white;
 
 @import "skins/alert-colors";
 

--- a/htdocs/talkpost_do.bml
+++ b/htdocs/talkpost_do.bml
@@ -79,7 +79,7 @@ body<=
 
     LJ::need_res('stc/display_none.css');
     # libs for userpicselect
-    LJ::need_res( LJ::Talk::init_iconbrowser_js( 1 ) )
+    LJ::Talk::init_iconbrowser_js()
         if $remote && $remote->can_use_userpic_select;
     LJ::set_active_resource_group( "jquery" );
     LJ::need_res(

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -590,6 +590,9 @@ class Page
     "Extra tags supplied by the server to go in the <head> section of the output HTML document. Layouts
     should include this in the head section if they are writing HTML.";
 
+    var readonly bool show_control_strip
+    "Whether the control strip will be shown on the current page.";
+
     var readonly string stylesheet_url
     "The URL to use in a link element for the server-supported external stylesheet to put stuff in it)";
 
@@ -725,6 +728,9 @@ class Page
 
     function print_theme_stylesheet
     "Prints theme-specific CSS. Should be overwritten by themes that include CSS not part of the layout's default stylesheet.";
+
+    function builtin print_script_tags
+    "Prints the JavaScript tags that this page requires. Used in Page::print_wrapper_end. Do not override this.";
 
     function builtin print_trusted(string key)
     "Prints a trusted string by key.";
@@ -4019,6 +4025,7 @@ function Page::print_wrapper_start(string{} opts)
 function Page::print_wrapper_end()
 "This function concludes the wrapper to the page.  Overriding this function is NOT RECOMMENDED. Overriding this function could prevent sitewide improvements to styles, accessibility, or other functionality from operating in your layout."
 {
+    $this->print_script_tags();
     """</body>""";
 }
 

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -3580,12 +3580,12 @@ var Color hover = isnull $*color_entry_link_hover ? $*color_page_link_hover : $*
 var Color active = isnull $*color_entry_link_active ? $*color_page_link_active : $*color_entry_link_active;
 
 """
-.ContextualPopup {
+.ContextualPopup, .icon-browser {
     background: $background;
     color: $text;
     }
 
-.ContextualPopup a { color: $link; }
+.ContextualPopup a, .icon-browser a { color: $link; }
 .ContextualPopup a:visited { color: $visited; }
 .ContextualPopup a:hover { color: $hover; }
 .ContextualPopup a:active { color: $active; }

--- a/styles/siteviews/layout.s2
+++ b/styles/siteviews/layout.s2
@@ -5,6 +5,7 @@ layerinfo is_internal = "1";
 
 class Siteviews {
     function builtin need_res(string res);
+    function builtin in_foundation_beta() : bool;
     function builtin start_capture();
     function builtin end_capture() : string;
 
@@ -40,7 +41,9 @@ function Page::print_title() {
 
 function Page::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/layout.css" );
+    if ( not $*SITEVIEWS->in_foundation_beta() ) {
+        $*SITEVIEWS->need_res( "stc/siteviews/layout.css" );
+    }
 }
 
 function Page::print_theme_stylesheet() {}
@@ -100,7 +103,9 @@ function IconsPage::print_title() {
 
 function IconsPage::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/allpics.css" );
+    if ( not $*SITEVIEWS->in_foundation_beta() ) {
+        $*SITEVIEWS->need_res( "stc/allpics.css" );
+    }
 }
 
 function IconsPage::print_body() {
@@ -189,13 +194,17 @@ set comment_time_format = "short_24";
 
 function EntryPage::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/entrypage.css" );
+    if ( not $*SITEVIEWS->in_foundation_beta() ) {
+        $*SITEVIEWS->need_res( "stc/entrypage.css" );
+    }
 
 }
 
 function ReplyPage::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/replypage.css" );
+    if ( not $*SITEVIEWS->in_foundation_beta() ) {
+        $*SITEVIEWS->need_res( "stc/replypage.css" );
+    }
 
 }
 

--- a/styles/siteviews/layout.s2
+++ b/styles/siteviews/layout.s2
@@ -446,6 +446,7 @@ function ReplyPage::print_comment (Comment c) {
 
 function ReplyPage::print_body
 {
+    """<div class="reply-page-wrapper">""";
     if (not $.entry.comments.enabled) {
         print safe "<h2>$*text_reply_nocomments_header</h2><p>$*text_reply_nocomments</p>";
         return;
@@ -465,6 +466,7 @@ function ReplyPage::print_body
     ") </div>\n";
     """<h1>Post a comment in response:</h1>""";
     $.form->print();
+    """</div>""";
 }
 
 function EntryPage::print_title() {

--- a/styles/siteviews/themes.s2
+++ b/styles/siteviews/themes.s2
@@ -14,7 +14,9 @@ layerinfo redist_uniq = "siteviews/celerity";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/celerity.css" );
+    if ( not $*SITEVIEWS->in_foundation_beta() ) {
+        $*SITEVIEWS->need_res( "stc/siteviews/celerity.css" );
+    }
 }
 
 #NEWLAYER: siteviews/gradation-horizontal
@@ -24,7 +26,9 @@ layerinfo redist_uniq = "siteviews/gradation-horizontal";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/gradation.css" );
+    if ( not $*SITEVIEWS->in_foundation_beta() ) {
+        $*SITEVIEWS->need_res( "stc/siteviews/gradation.css" );
+    }
 }
 
 #NEWLAYER: siteviews/gradation-vertical
@@ -34,7 +38,9 @@ layerinfo redist_uniq = "siteviews/gradation-vertical";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/gradation.css" );
+    if ( not $*SITEVIEWS->in_foundation_beta() ) {
+        $*SITEVIEWS->need_res( "stc/siteviews/gradation.css" );
+    }
 }
 
 
@@ -45,5 +51,7 @@ layerinfo redist_uniq = "siteviews/lynx";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/lynx.css" );
+    if ( not $*SITEVIEWS->in_foundation_beta() ) {
+        $*SITEVIEWS->need_res( "stc/siteviews/lynx.css" );
+    }
 }

--- a/t/post.t
+++ b/t/post.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 133;
+use Test::More tests => 104;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Test qw( temp_user temp_comm );
@@ -49,8 +49,7 @@ note("Not logged in - init");
     ok( !$vars->{remote} );
 
     # icon
-    ok( !@{ $vars->{icons} },  "No icons." );
-    ok( !$vars->{defaulticon}, "No default icon." );
+    ok( !@{ $vars->{icons} }, "No icons." );
 
     # mood theme
     ok( !keys %{ $vars->{moodtheme} }, "No mood theme." );
@@ -72,54 +71,16 @@ note("Logged in - init");
 
     note("# Icons ");
     note("  no icons");
-    ok( !@{ $vars->{icons} },  "No icons." );
-    ok( !$vars->{defaulticon}, "No default icon." );
+    ok( !@{ $vars->{icons} }, "No icons." );
 
-    note("  no default icon");
+    note("  yes icons");
     my $icon1 = LJ::Userpic->create( $u, data => \$ICON1 );
     my $icon2 = LJ::Userpic->create( $u, data => \$ICON2 );
     $icon1->set_keywords("b, z");
     $icon2->set_keywords("a, c, y");
 
     $vars = DW::Controller::Entry::_init( { remote => $u } );
-    is( @{ $vars->{icons} }, 6, "Has icons (including a blank one in the list for default)" );
-    ok( !$vars->{defaulticon}, "No default icon." );
-
-    my @icon_order = (
-
-        # keyword, userpic object
-        [ undef, undef ],
-        [ "a",   $icon2 ],
-        [ "b",   $icon1 ],
-        [ "c",   $icon2 ],
-        [ "y",   $icon2 ],
-        [ "z",   $icon1 ],
-    );
-    my $count = 0;
-    foreach my $icon ( @{ $vars->{icons} } ) {
-        if ( $count == 0 ) {
-            is( $icon->{keyword}, undef, "No default icon; no keyword." );
-            is( $icon->{userpic}, undef, "No default icon." );
-        }
-        else {
-            is( $icon->{keyword},     $icon_order[$count]->[0],     "Keyword is in proper order." );
-            is( $icon->{userpic}->id, $icon_order[$count]->[1]->id, "Icon is proper icon." );
-        }
-        $count++;
-    }
-
-    note("  with default icon");
-    $icon1->make_default;
-    $vars = DW::Controller::Entry::_init( { remote => $u } );
-    ok( $vars->{defaulticon}, "Has default icon." );
-
-    $icon_order[0] = [ undef, $icon1 ];
-    $count = 0;
-    foreach my $icon ( @{ $vars->{icons} } ) {
-        is( $icon->{keyword},     $icon_order[$count]->[0],     "Keyword is in proper order." );
-        is( $icon->{userpic}->id, $icon_order[$count]->[1]->id, "Icon is proper icon." );
-        $count++;
-    }
+    is( @{ $vars->{icons} }, 6, "Has icons (including an entry for default)" );
 
     note("# Moodtheme");
     note("  default mood theme");
@@ -276,7 +237,6 @@ note("Altlogin - init");
     ok( !$vars->{tags},                "No tags" );
     ok( !keys %{ $vars->{moodtheme} }, "No mood theme." );
     ok( !@{ $vars->{icons} },          "No icons." );
-    ok( !$vars->{defaulticon},         "No default icon." );
     is( @{ $vars->{security} }, 3, "Default security dropdown" );
     ok( !@{ $vars->{journallist} }, "No journal dropdown" );
 

--- a/t/userpic-keyword-select.t
+++ b/t/userpic-keyword-select.t
@@ -1,0 +1,75 @@
+# t/userpic-keyword-select.t
+#
+# Test the LJ::icon_keyword_select_items(user) function, which is used to build
+# a select element for choosing an icon for a post or comment.
+#
+# Authors:
+#      Nick Fagerlund <nick.fagerlund@gmail.com>
+#
+# Copyright (c) 2019 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use warnings;
+
+use Test::More tests => 7;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+use LJ::Test qw( temp_user temp_comm );
+
+use FindBin qw($Bin);
+chdir "$Bin/data/userpics" or die "Failed to chdir to t/data/userpics";
+
+# preload userpics so we don't have to read the file hundreds of times
+open( my $fh, 'good.png' ) or die $!;
+my $ICON1 = do { local $/; <$fh> };
+
+open( my $fh2, 'good.jpg' ) or die $!;
+my $ICON2 = do { local $/; <$fh2> };
+
+note("called with falsy or undefined user object");
+{
+    my $bogususer;
+    my @icons = LJ::icon_keyword_select_items($bogususer);
+    my $empty = [];
+    is_deeply( \@icons, $empty, "No user, empty icons list" );
+}
+
+note("called for user with...");
+{
+    my $u = temp_user();
+    LJ::set_remote($u);
+    my @icons;
+
+    note("  ...no icons");
+    @icons = LJ::icon_keyword_select_items($u);
+    my $empty = [];
+    is_deeply( \@icons, $empty, "No user, empty icons list" );
+
+    note("  ...one icon, one keyword, no default");
+    my $icon1 = LJ::Userpic->create( $u, data => \$ICON1 );
+    $icon1->set_keywords("rad pic");
+    @icons = LJ::icon_keyword_select_items($u);
+    is( @icons, 2, "Select would have two items" );
+    ok(
+        defined $icons[0]->{data}->{url},
+        "Default icon slot still has a URL for a placeholder image, even though there's no default"
+    );
+
+    note("  ...two icons, five keywords, yes default");
+    my $icon2 = LJ::Userpic->create( $u, data => \$ICON2 );
+    $icon1->set_keywords("b, z");
+    $icon2->set_keywords("a, c, y");
+    $icon1->make_default;
+    @icons = LJ::icon_keyword_select_items($u);
+    is( @icons, 6, "Select would have six items" );
+    my @keywords   = map  { $_->{value} } @icons;
+    my $b_keywords = grep { $_ eq 'b' } @keywords;
+    is( $b_keywords, 1, "The 'value' key of each hashref contains the keyword" );
+    is( $icons[0]->{data}->{url},
+        $icon1->url, "First icon slot's URL matches the real default icon's URL" );
+}

--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -19,6 +19,22 @@
 
 .betafeature.updatepage.title=New Create Entries Page
 
+.betafeature.s2foundation.cantadd=Sorry, your account is not eligible to test this feature.
+
+.betafeature.s2foundation.off<<
+<p>Activate several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up some bugs.</p>
+
+<p>TODO: post a link for reporting bugs.</p>
+.
+
+.betafeature.s2foundation.on<<
+<p>You are currently testing several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up some bugs.</p>
+
+<p>TODO: post a link for reporting bugs.</p>
+.
+
+.betafeature.s2foundation.title=Updated journal page components
+
 .nofeatures=There are no features currently available for beta testing.
 
 .staytuned.newscomm=Stay tuned to [[news]] for upcoming testing opportunities. Thank you.

--- a/views/components/icon-browser.tt
+++ b/views/components/icon-browser.tt
@@ -16,48 +16,53 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- dw.need_res( { group => "foundation" },
         "js/components/jquery.icon-browser.js"
-        "stc/css/components/block-grid.css"
         "stc/css/components/icon-browser.css"
     ); -%]
 
-    [%- WRAPPER components/modal.tt id="js-icon-browser" class="icon-browser" -%]
-    <div class="row">
-        <div class="columns medium-2 large-1">
-            <label class='inline' for='js-icon-browser-search'>Search:</label>
-        </div>
-        <div class="columns medium-4 large-4">
-            <input type='search' id='js-icon-browser-search'>
-        </div>
-        <div class="columns medium-3">
-            <button id='js-icon-browser-select'>Select</button>
-        </div>
-        <div class="columns medium-3 large-3">
-                <div class='icon-browser-meta-toggle' id='js-icon-browser-meta-toggle'>
-                    <a href="#" data-action="text">Meta text</a> /
-                    <a href="#" data-action="no-text">No meta text</a>
+    [%- WRAPPER components/modal.tt id="js-icon-browser" class="icon-browser" options="animation:'fade'" -%]
+    <div class="icon-browser-flex-wrapper">
+
+        <div class="row">
+            <div class="columns top-controls">
+                <label class='invisible' for='js-icon-browser-search'>Search</label>
+                <input type='search' id='js-icon-browser-search' placeholder='Search' />
+                <button id='js-icon-browser-select'>Select</button>
+                <div class="display-toggles">
+                    <div class='icon-browser-meta-toggle' id='js-icon-browser-meta-toggle'>
+                        <a href="#" data-action="text">Meta text</a> /
+                        <a href="#" data-action="no-text">No meta text</a>
+                    </div>
+
+                    <div class='icon-browser-size-toggle' id='js-icon-browser-size-toggle'>
+                        <a href="#" data-action="small">Small images</a> /
+                        <a href="#" data-action="large">Large images</a>
+                    </div>
                 </div>
-
-                <div class='icon-browser-size-toggle' id='js-icon-browser-size-toggle'>
-                    <a href="#" data-action="small">Small images</a> /
-                    <a href="#" data-action="large">Large images</a>
-                </div>
+            </div>
         </div>
-    </div>
 
-    <div class="row">
-        <div class="columns keyword-menu">
-            <label class="left">Keywords of selected icon:</label>
-            <div class='keywords'></div>
+        <hr />
+
+        <div class="row">
+            <div class="columns">
+                <label class="inline">Tap to select, tap again to confirm.</label>
+            </div>
         </div>
-    </div>
 
-    <hr>
+        <div class="row">
+            <div class="columns keyword-menu">
+                <label class="left">Keywords of selected icon:</label>
+                <div class='keywords'></div>
+            </div>
+        </div>
 
-    <div class="row"><div class="columns">
+        <hr />
+
         <div id="js-icon-browser-content" class="icon-browser-content">
             <span class="icon-browser-status">Loading...</span>
-            <ul></ul>
+            <ul class="js-icon-browser-icon-grid"></ul>
         </div>
-    </div></div>
+
+    </div>
     [%- END -%]
 [%- END -%]

--- a/views/components/modal.tt
+++ b/views/components/modal.tt
@@ -17,7 +17,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     "js/skins/jquery.focus-on-reveal.js"
 ) -%]
 
-<div id="[%- id -%]" class="reveal-modal [%- class.join(" ") -%]" data-reveal>
+<div id="[%- id -%]" class="reveal-modal [%- class.join(" ") -%]" [% IF options %]data-options="[%- options.dquote -%]" [% END %]data-reveal>
 [%- content -%]
 <a href="#0" class="close-reveal-modal" title="Close">&#215;</a>
 </div>

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -57,12 +57,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <script type="text/javascript">
 var postFormInitData = new Object();
 postFormInitData.edit = [% action.edit ? "true" : "false" %];
-postFormInitData.icons = [
-    [%- FOREACH icon = icons %]
-        { 'src': '[% icon.userpic.url %]', 'alt': [% icon.userpic.description | js %] }
-        [%- UNLESS loop.last %],[% END -%]
-    [% END %]
-];
 
 postFormInitData.moodpics = {
     [%- FOREACH mood = moodtheme.pics.pairs %]

--- a/views/entry/module-icons.tt
+++ b/views/entry/module-icons.tt
@@ -21,9 +21,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <div class="columns">
         <div id="js-icon-preview" class="[% IF icons.size==0 %] no-icon border [% ELSE %] icon [% END %]">
         [% IF icons.size > 0 %]
-            [% IF defaulticon %]
-                <img id="js-icon-preview-image" src="[% defaulticon.url | url %]" alt="[% defaulticon.description | html %]" data-no-ctx="true" />
-            [% END %]
+            <img id="js-icon-preview-image" src="[% icons.0.data.url | url %]" alt="[% icons.0.data.description | html %]" data-no-ctx="true" />
         [% ELSE %]
             <a href='[% site.root %]/manage/icons'>[% 'entryform.userpic.upload' | ml %]</a>
         [% END %]
@@ -36,23 +34,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%- INCLUDE "components/icon-browser.tt" -%]
 
     <div class="row"><div class="columns">
-        [%- iconselect = [] -%]
-        [%- FOREACH icon IN icons -%]
-            [%- IF icon.keyword.defined -%]
-                [%- iconselect.push( icon.keyword, icon.keyword ) -%]
-            [%- ELSE -%]
-                [%- defaulttext = ".keyword.default" | ml -%]
-                [%- iconselect.push( "", defaulttext ) -%]
-            [% END %]
-        [% END %]
-
         [%- form.select(
             name = "icon"
             id = "js-icon-select"
 
-            items = iconselect
+            items = icons
         ) -%]
-
     </div></div>
     [% END %]
 

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -19,7 +19,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 <div class='qr-meta'>
   <div class='qr-icon'>
-    [%- IF remote.can_use_iconbrowser AND remote.icons.size > 0 -%]
+    [%- IF remote.can_use_userpic_select -%]
       <button type='button' class='lj_userpicselect_extra'>
     [%- END -%]
     [%- IF current_icon -%]
@@ -27,14 +27,14 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%- ELSE -%]
       [%- dw.img( "nouserpic_sitescheme", "" ) -%]
     [%- END -%]
-    [%- IF remote.can_use_iconbrowser AND remote.icons.size > 0 -%]
+    [%- IF remote.can_use_userpic_select -%]
       </button>
     [%- END -%]
   </div>
 
   [%- IF remote.icons.size > 0 -%]
     <div class='qr-icon-controls'>
-      [%- IF remote.can_use_iconbrowser -%]
+      [%- IF remote.can_use_userpic_select -%]
         <input type="button" value="Browse" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" />
       [%- END %]
 

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -114,3 +114,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 </form></div>
 </div>
+
+[%- IF remote.can_use_userpic_select AND foundation_beta -%]
+  [%- INCLUDE "components/icon-browser.tt" -%]
+[%- END -%]

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -87,14 +87,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
       id = 'submitpost'
   ) %]
 
-  [%- UNLESS minimal -%]
   [% form.submit(
       name = 'submitpview'
       value = dw.ml( 'talk.btn.preview' ),
       id = 'submitpview'
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) %]
-  [%- END -%]
 
   [% form.submit(
       name = 'submitmoreopts'

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -18,9 +18,15 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- hidden_form_elements -%]
 
 <div class='qr-meta'>
+  [%- remote.ljuser %]
+
+  <a href="#" id="submitmoreopts" name="submitmoreopts">[% '/talkread.bml.button.more' | ml %]</a>
+
   <div class='qr-icon'>
     [%- IF remote.can_use_userpic_select -%]
-      <button type='button' class='lj_userpicselect_extra'>
+      <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
+    [%- ELSE -%]
+      <a href="[% remote.icons_url %]">
     [%- END -%]
     [%- IF current_icon -%]
       [%- current_icon.imgtag -%]
@@ -29,17 +35,13 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%- END -%]
     [%- IF remote.can_use_userpic_select -%]
       </button>
+    [%- ELSE -%]
+      </a>
     [%- END -%]
   </div>
 
   [%- IF remote.icons.size > 0 -%]
     <div class='qr-icon-controls'>
-      [%- IF remote.can_use_userpic_select -%]
-        <input type="button" value="Browse" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" />
-      [%- END %]
-
-      <input type='button' id='randomicon' value='Random' />
-
       <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
       [%- form.select(
           name = 'prop_picture_keyword',
@@ -47,11 +49,14 @@ the same terms as Perl itself.  For a copy of the license, please reference
           selected = current_icon_kw,
           items = remote.icons
       ) -%]
+
+      <input type="button" id="randomicon" value="Random" class="secondary" style="display: none;" />
     </div>
   [%- END -%]
+
 </div>
 
-<div class="qr-body">
+<div class="qr-subject">
   [%- form.textbox(
         label = dw.ml( '/talkpost.bml.opt.subject2' )
         labelclass = 'invisible'
@@ -62,8 +67,10 @@ the same terms as Perl itself.  For a copy of the license, please reference
         placeholder = dw.ml( '/talkpost.bml.opt.subject2' )
   ) -%]
 
-  <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+  <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button secondary" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+</div>
 
+<div class="qr-body">
   [%- form.textarea(
     label = dw.ml( '/talkpost.bml.opt.message2' )
     labelclass = 'invisible'
@@ -91,14 +98,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
       name = 'submitpview'
       value = dw.ml( 'talk.btn.preview' ),
       id = 'submitpview'
+      class = 'secondary'
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) %]
-
-  [% form.submit(
-      name = 'submitmoreopts'
-      value = dw.ml( '/talkread.bml.button.more' ),
-      id = 'submitmoreopts'
-  ) %]
 
   [% help.icon %]
   [%- IF journal.is_iplogging %]

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -354,7 +354,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
           items = remote.icons
         ) -%]
 
-        [%- IF remote.can_use_iconbrowser -%]
+        [%- IF remote.can_use_userpic_select -%]
           <button type="button" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
               Browse
           </button>

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -499,3 +499,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 </table>
 
 </form>
+
+[%- IF remote.can_use_userpic_select AND foundation_beta -%]
+  [%- INCLUDE "components/icon-browser.tt" -%]
+[%- END -%]

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -96,7 +96,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
       [%- END -%]
     </div>
 
-    [%- IF remote.openid_identity -%]
+    [%- IF remote.openid_identity AND default_usertype != 'openid' -%]
+      [%# ...then we're legit logged in as an OpenID user, not just holding a
+      temp $remote on a partial form submission (captcha, error, etc.) -%]
       <div class="from-option
         [%- UNLESS remote.allowed %] from-option-cannot[% END -%]
       " id='from-openid-loggedin'>
@@ -252,7 +254,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
           label = dw.ml('Username')
           size = 13
           maxlength = username_maxlength
-          value = ( comment.user || remote.user )
+          value = comment.user
           style = "background: url('${site.imgroot}/silk/identity/user.png') no-repeat; background-color: #fff; background-position: 0px 50%; padding-left: 18px; color: #00C; font-weight: bold;"
         ) -%]
       </div>
@@ -287,7 +289,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 </div>
 
 <div class='qr-meta'>
-  <div class='qr-icon'>
+  <div class='qr-icon no-label'>
     [%- IF remote.can_use_userpic_select -%]
       <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
     [%- ELSIF remote -%]
@@ -344,10 +346,10 @@ the same terms as Perl itself.  For a copy of the license, please reference
   [%# The current subjecticon, as the button to open the menu. %]
   [%- print_subjecticon_by_id(
     comment.subjecticon,
-    "id='subjectIconImage' role='button' title='Click to change the subject icon'"
+    "id='subjectIconImage' role='button' class='js-only' style='display: none;' title='Click to change the subject icon'"
   ) -%]
 
-  <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button secondary" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+  <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button secondary" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
 </div>
 
 <div style="display: none;" id="subjectIconList">
@@ -582,7 +584,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
         </div>
 
-        [%- IF remote.openid_identity -%]
+        [%- IF remote.openid_identity AND default_usertype != 'openid' -%]
+          [%# ...then we're legit logged in as an OpenID user, not just holding a
+          temp $remote on a partial form submission (captcha, error, etc.) -%]
           <div class="from-option
             [%- UNLESS remote.allowed %] from-option-cannot[% END -%]
           " id='from-openid-loggedin'>
@@ -744,7 +748,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
               label = dw.ml('Username')
               size = 13
               maxlength = username_maxlength
-              value = ( comment.user || remote.user )
+              value = comment.user
               style = "background: url('${site.imgroot}/silk/identity/user.png') no-repeat; background-color: #fff; background-position: 0px 1px; padding-left: 18px; color: #00C; font-weight: bold;"
             ) -%]
           </div>
@@ -808,7 +812,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%# The current subjecticon, as the button to open the menu. %]
     [%- print_subjecticon_by_id(
       comment.subjecticon,
-      "id='subjectIconImage' title='Click to change the subject icon' style='cursor:pointer;cursor:hand'"
+      "id='subjectIconImage' title='Click to change the subject icon' class='js-only' style='display: none;cursor:pointer;cursor:hand'"
     ) -%]
 
     <blockquote style="display: none;" id="subjectIconList">
@@ -839,7 +843,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         ) -%]
 
         [%- IF remote.can_use_userpic_select -%]
-          <button type="button" class="secondary" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
+          <button type="button" class="js-only secondary" style="display: none;" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
               Browse
           </button>
         [%- END -%]

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -464,6 +464,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
       [%- form.submit(
         name = "submitpreview"
         value = dw.ml('talk.btn.preview')
+        id = "submitpview"
+      ) -%]
+      [%- form.hidden(
+        name = "previewplaceholder"
+        id = "previewplaceholder"
+        value = 1
       ) -%]
       [%- IF can_checkspell -%]
         [%- form.checkbox(

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -10,6 +10,490 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 -%]
 
+
+[%- IF foundation_beta -%][%# use new quickreply-style talkform -%]
+
+<div id='qrdiv'><div id='qrformdiv'>
+
+<form id="postform" name="postform" method="POST" action="[% form_url | url %]">
+[%- dw.form_auth -%]
+[%- hidden_form_elements -%]
+
+[%- IF errors -%]
+<ul>
+[% FOREACH error IN errors -%]
+  <li><b>[% error %]</b></li>
+[%- END %]
+</ul>
+<hr />
+[%- END -%]
+
+[%- create_link -%]
+
+[%# "From" fields %]
+
+<div id="talkform-from">
+  <label>[%- '/talkpost.bml.opt.from' | ml %]</label>
+
+  [%- IF comment.editid -%]
+    <div class="from-option" id='from-ljuser'>
+      [%- IF remote.banned -%]
+        [%- IF journal.is_community -%]
+          [%- '/talkpost.bml.opt.bannedfrom.comm' | ml -%]
+        [%- ELSE -%]
+          [%- '/talkpost.bml.opt.bannedfrom' | ml -%]
+        [%- END -%]
+      [%- ELSE -%]
+        [%- dw.img( 'id_user', '' ) -%]
+
+        <label for='talkpostfromremote'>
+          [%- '/talkpost.bml.opt.loggedin' | ml( username => remote.display_name ) -%]
+        </label>
+        [%- IF remote.screened %]
+          [%- '/talkpost.bml.opt.willscreen' | ml -%]
+        [%- END -%]
+        [%- form.hidden( name = 'usertype', value = 'cookieuser' ) -%]
+        [%- form.hidden(
+          name = 'cookieuser'
+          id = 'cookieuser'
+          value = remote.user
+        ) -%]
+      [%- END -%]
+    </div>
+
+  [%- ELSE -%][%# New comment, not editing. -%]
+    [%# Anonymous: -%]
+    <div class="from-option[% UNLESS public_entry AND journal.allows_anon %] from-option-cannot[% END %]" id="from-anon">
+      <input type='radio' name='usertype' value='anonymous' id='talkpostfromanon' [%
+        IF public_entry AND journal.allows_anon -%]
+          [%- IF default_usertype == 'anonymous' -%]
+            checked='checked'
+          [%- END -%]
+        [%- ELSE -%]
+          disabled='disabled'
+        [%- END
+      %] />
+
+      <label for='talkpostfromanon'[% UNLESS public_entry AND journal.allows_anon %] class="disabled"[% END %]>
+        [% dw.img( 'id_anonymous', '' ) %]
+        [% '/talkpost.bml.opt.anonymous' | ml %]
+      </label>
+
+      [%- IF public_entry AND journal.allows_anon -%]
+        [%- IF journal.screens_anon %]
+          [% '/talkpost.bml.opt.willscreen' | ml %]
+        [%- END -%]
+      [%- ELSE -%]
+        [%- IF ! public_entry %]
+          [% '/talkpost.bml.opt.noanonpost.nonpublic' | ml -%]
+        [%- ELSIF ! journal.allows_non_access -%]
+          [% ( journal.is_community ? '/talkpost.bml.opt.membersonly' : '/talkpost.bml.opt.friendsonly' )
+            | ml( username => "$journal.user" )
+          %]
+        [%- ELSE -%]
+          [% '/talkpost.bml.opt.noanonpost' | ml -%]
+        [%- END -%]
+      [%- END -%]
+    </div>
+
+    [%- IF remote.openid_identity -%]
+      <div class="from-option
+        [%- UNLESS remote.allowed %] from-option-cannot[% END -%]
+      " id='from-openid-loggedin'>
+
+        <input type='radio' name='usertype' value='openid_cookie' id='talkpostfromoidli' [%
+          IF remote.allowed -%]
+            [%- IF default_usertype == 'openid_cookie' -%]
+              checked='checked'
+            [%- END -%]
+          [%- ELSE -%]
+            disabled='disabled'
+          [%- END
+        %] />
+
+        <label for='talkpostfromoidli'[% UNLESS remote.allowed %] class="disabled"[% END %]>
+          [% dw.img( 'id_openid', '' ) %]
+          [% '/talkpost.bml.opt.openid.loggedin' | ml %]
+          [% remote.display_name %]
+        </label>
+
+        [%- IF remote.allowed -%]
+          [%- IF remote.screened %] [% '/talkpost.bml.opt.willscreen' | ml -%][%- END -%]
+        [%- ELSE -%]
+
+          [%- IF remote.banned -%][%# p. cut and dried -%]
+            [%- journal.is_community ?
+              '/talkpost.bml.opt.bannedfrom.comm' : '/talkpost.bml.opt.bannedfrom'
+              | ml( journal => journal.user ) -%]
+          [%- ELSIF journal.allows_non_access -%][%# your email's not validated. -%]
+            [%- '/talkpost.bml.opt.noopenidpost' | ml(
+              aopts1 => "href='${site.root}/changeemail'"
+              aopts2 => "href='${site.root}/register'"
+            ) -%]
+          [%- ELSE -%][%# you're not on the access list -%]
+            [%- journal.is_community ?
+              '/talkpost_do.bml.error.notamember' : '/talkpost_do.bml.error.notafriend'
+              | ml( user => journal.user ) -%]
+          [%- END -%]
+
+        [%- END -%]
+      </div>
+
+    [%- ELSE -%][%# not logged in as openid user -%]
+
+      <div class="from-option" id="from-openid-loggedout">
+        <input type='radio' name='usertype' value='openid' data-more="from-openid-more" id='talkpostfromoidlo'[% IF default_usertype == 'openid' %] checked='checked'[% END %] />
+
+        <label for='talkpostfromoidlo'>
+          [% dw.img( 'id_openid', '' ) %]
+          [% '/talkpost.bml.opt.openid' | ml %]
+        </label>
+        [% help_icon( 'openid' ) %]
+        [%- IF journal.screens_all -%]
+          [%- '/talkpost.bml.opt.willscreen' | ml -%]
+        [%- ELSIF journal.screens_non_access -%]
+          [%- '/talkpost.bml.opt.willscreenfriend' | ml -%]
+        [%- ELSIF journal.screens_anon -%]
+          [%- '/talkpost.bml.opt.willscreenopenid' | ml -%]
+        [%- END -%]
+      </div>
+    [%- END -%]
+
+    <div class="from-login" id="from-openid-more">
+      <div>
+        [%- form.textbox(
+          name = 'oidurl'
+          id = 'oidurl'
+          label = dw.ml('/talkpost.bml.login.url')
+          size = 53
+          maxlength = 60
+          value = ( comment.oidurl || remote.openid_identity )
+        ) -%]
+      </div>
+
+      <div>
+        [%- form.checkbox(
+          name = 'oiddo_login'
+          id = 'oidlogincheck'
+          label = dw.ml('/talkpost.bml.loginq')
+          selected = comment.oiddo_login
+        ) -%]
+      </div>
+    </div>
+
+    [%# logged-in site user -%]
+    [%- IF remote && ! remote.openid_identity -%]
+    <div class="from-option
+      [%- UNLESS remote.allowed %] from-option-cannot[% END -%]
+    " id="from-user-loggedin">
+
+      <input type='radio' name='usertype' value='cookieuser' id='talkpostfromremote' [%
+        IF remote.allowed -%]
+          [%- IF default_usertype == 'cookieuser' -%]
+            checked='checked'
+          [%- END -%]
+        [%- ELSE -%]
+          disabled='disabled'
+        [% END
+      %] />
+
+      <label for='talkpostfromremote'[% UNLESS remote.allowed %] class="disabled"[% END %]>
+        [% dw.img( 'id_user', '' ) %]
+        [% '/talkpost.bml.opt.loggedin' | ml %]
+      </label>
+      [% remote.ljuser %]
+
+      [%- IF remote.allowed -%]
+        [%- IF remote.screened -%] [%- '/talkpost.bml.opt.willscreen' | ml -%][%- END -%]
+      [%- ELSE -%]
+
+        [%- IF remote.banned -%]
+          [%- journal.is_community ?
+            '/talkpost.bml.opt.bannedfrom.comm' : '/talkpost.bml.opt.bannedfrom'
+            | ml( journal => journal.user ) -%]
+        [%- ELSE -%][%# you're not on the access list -%]
+          [%- journal.is_community ?
+            '/talkpost_do.bml.error.notamember' : '/talkpost_do.bml.error.notafriend'
+            | ml( user => journal.user ) -%]
+        [%- END -%]
+
+      [%- END -%]
+
+      [%- UNLESS remote.banned -%]
+        <input type='hidden' name='cookieuser' value='[% remote.user %]' id='cookieuser' />
+      [%- END -%]
+    </div>
+
+
+    [%- END -%]
+
+    [%# not-logged-in site user -%]
+    <div class="from-option" id="from-user-loggedout">
+      <input type='radio' name='usertype' value='user' data-more="from-user-more" id='talkpostfromlj'[% IF default_usertype == 'user' %] checked='checked'[% END %] />
+
+      <label for='talkpostfromlj'>
+        [% dw.img( 'id_user', '' ) %]
+        [% IF remote && ! remote.openid_identity %] Other [%- END %]
+        [% '/talkpost.bml.opt.siteuser' | ml( sitename => site.nameshort ) %]
+      </label>
+      [%- IF journal.screens_all -%]
+        [%- '/talkpost.bml.opt.willscreen' | ml -%]
+      [%- ELSIF journal.screens_non_access -%]
+        [%- '/talkpost.bml.opt.willscreenfriend' | ml -%]
+      [%- END -%]
+    </div>
+
+    [%# site user login form, always present but sometimes hidden -%]
+    <div class="from-login" id="from-user-more">
+      <div>
+        [%- form.textbox(
+          name = 'userpost'
+          id = 'username'
+          label = dw.ml('Username')
+          size = 13
+          maxlength = username_maxlength
+          value = ( comment.user || remote.user )
+          style = "background: url('${site.imgroot}/silk/identity/user.png') no-repeat; background-color: #fff; background-position: 0px 50%; padding-left: 18px; color: #00C; font-weight: bold;"
+        ) -%]
+      </div>
+
+      <div>
+        [%- form.password(
+          name = 'password'
+          id= 'password'
+          label = dw.ml('Password')
+          maxlength = 30
+          size = 18
+        ) -%]
+      </div>
+
+      <div>
+        [%- form.checkbox(
+          name = 'do_login'
+          id = 'logincheck'
+          label = dw.ml('/talkpost.bml.loginq')
+          selected = comment.do_login
+        ) -%]
+      </div>
+    </div>
+
+    [%- IF ! create_link && ! remote -%]
+      <span style='font-size: 8pt; font-style: italic;'>
+        [%- '/talkpost.bml.noaccount' | ml( aopts => "href='${site.root}/create'") -%]
+      </span>
+    [%- END -%]
+
+  [%- END -%][%# figuring out whether it's an edit or new reply. -%]
+</div>
+
+<div class='qr-meta'>
+  <div class='qr-icon'>
+    [%- IF remote.can_use_userpic_select -%]
+      <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
+    [%- ELSIF remote -%]
+      <a href="[% remote.icons_url %]">
+    [%- END -%]
+    [%- IF comment.current_icon -%]
+      [%- comment.current_icon.imgtag -%]
+    [%- ELSE -%]
+      [%- dw.img( "nouserpic_sitescheme", "" ) -%]
+    [%- END -%]
+    [%- IF remote.can_use_userpic_select -%]
+      </button>
+    [%- ELSIF remote -%]
+      </a>
+    [%- END -%]
+  </div>
+
+  [%- IF remote.icons.size > 0 -%]
+    <div class='qr-icon-controls'>
+      <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
+      [%- form.select(
+        name = 'prop_picture_keyword',
+        id = 'prop_picture_keyword',
+        selected = comment.current_icon_kw,
+        items = remote.icons
+      ) -%]
+
+      <input type="button" id="randomicon" value="Random" class="secondary" style="display: none;" />
+    </div>
+  [%- END -%]
+</div>
+
+
+[%# Subject, subjecticon, quote button %]
+
+<div class="qr-subject">
+  [%- form.textbox(
+    label = dw.ml( '/talkpost.bml.opt.subject2' )
+    labelclass = 'invisible'
+    size = 50
+    maxlength = 100
+    name = 'subject'
+    id = 'subject'
+    placeholder = dw.ml( '/talkpost.bml.opt.subject2' )
+    value = comment.subject
+  ) -%]
+
+  [%- form.hidden(
+    id = 'subjectIconField'
+    name = 'subjecticon'
+    value = comment.subjecticon
+  ) -%]
+
+  [%# The current subjecticon, as the button to open the menu. %]
+  [%- print_subjecticon_by_id(
+    comment.subjecticon,
+    "id='subjectIconImage' role='button' title='Click to change the subject icon'"
+  ) -%]
+
+  <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button secondary" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+</div>
+
+<div style="display: none;" id="subjectIconList">
+  <div class="subjecticon-grid">
+    [%- FOREACH id IN subjecticon_ids -%]
+      <div>
+        [%- print_subjecticon_by_id(
+          id,
+          "id='${id}' role='button'"
+        ) -%]
+      </div>
+    [%- END -%]
+  </div>
+</div>
+
+<div id='ljnohtmlsubj' class='ljdeem no-js'><span style='font-size: 8pt; font-style: italic;'>
+  [%- '/talkpost.bml.nosubjecthtml' | ml -%]
+</span></div>
+
+
+[%# Message body text %]
+
+<div class="qr-body">
+  [%- form.textarea(
+    label = dw.ml( '/talkpost.bml.opt.message2' )
+    labelclass = 'invisible'
+    rows = 10
+    cols = 80
+    wrap = 'soft'
+    name = 'body'
+    id = 'body'
+    value = comment.body
+  ) -%]
+</div>
+
+
+[%# Misc checkboxes, captcha, edit reason - after body, before post buttons %]
+
+<div id="talkform-misc">
+  [%- form.checkbox(
+    name = 'prop_opt_preformatted'
+    id = 'prop_opt_preformatted'
+    value = 1
+    selected = comment.preformatted
+    label = dw.ml('/talkpost.bml.opt.noautoformat')
+  ) -%]
+  [%- help_icon( 'autoformat' ) -%]
+
+  [%- IF can_checkspell -%]
+    [%- form.checkbox(
+      label = dw.ml('talk.spellcheck')
+      name = 'do_spellcheck'
+      id = 'spellcheck'
+      value = '1'
+    ) -%]
+  [%- END -%]
+
+  [%- IF remote.can_manage_community -%]
+    <br />
+    [%- form.checkbox(
+      name = 'prop_admin_post'
+      id = 'prop_admin_post'
+      value = 1
+      selected = comment.admin_post
+      label = 'Admin Post'
+    ) -%]
+  [%- END -%]
+
+  [%- IF remote.can_unscreen_parent -%]
+    <br />
+    [%- form.checkbox(
+      label = dw.ml('/talkpost.bml.opt.unscreenparent')
+      name = 'unscreen_parent'
+      id = 'unscreen_parent'
+      value = 1
+      selected = 0
+    ) -%]
+  [%- END -%]
+
+  [%- IF captcha -%]
+    <br />
+    [%- captcha.html -%]
+    [%- form.hidden(
+      name = 'captcha_type'
+      value = captcha.type
+    ) -%]
+  [%- END -%]
+
+  [%- IF comment.editid -%]
+    <br />
+    [%- form.textbox(
+      label = dw.ml('/talkpost.bml.opt.editreason')
+      name = 'editreason'
+      id = 'editreason'
+      value = comment.editreason
+      size = 75
+      maxlength = 255
+    ) -%]
+    <div id='nohtmledit' class='ljdeem no-js'><span style='font-size: 8pt; font-style: italic;'>[% '/talkpost.bml.noedithtml' | ml %]</span></div>
+  [%- END -%]
+</div>
+
+
+[%# post button controls and info notices. %]
+<div class="qr-footer">
+
+  [%- form.submit(
+    name = "submitpost"
+    value = comment.editid ? dw.ml('/talkpost.bml.opt.edit') : dw.ml('/talkpost.bml.opt.submit')
+    id = "submitpost"
+  ) -%]
+  &nbsp;
+  [%- form.submit(
+    name = "submitpreview"
+    value = dw.ml('talk.btn.preview')
+    id = "submitpview"
+    class = "secondary"
+  ) -%]
+  [%- form.hidden(
+    name = "previewplaceholder"
+    id = "previewplaceholder"
+    value = 1
+  ) -%]
+
+  [%- IF journal.is_iplogging -%]
+    <div class='de'>
+      [%- IF journal.is_iplogging == 'all' -%]
+        [% '/talkpost.bml.logyourip' | ml -%]
+      [%- ELSIF journal.is_iplogging == 'anon' -%]
+        [% '/talkpost.bml.loganonip' | ml -%]
+      [%- END -%]
+    </div>
+    [%- help_icon( 'iplogging' ) -%]
+  [%- END -%]
+
+  [%- IF journal.is_linkstripped -%]
+    <div class='de'>[%- '/talkpost.bml.linkstripped' | ml -%]</div>
+  [%- END %]
+
+</div>
+
+</form>
+</div></div>
+
+[%- ELSE -%][%# not in S2 foundation beta, use old table-based talkform -%]
+
 <form id="postform" name="postform" method="POST" action="[% form_url | url %]">
 [%- dw.form_auth -%]
 [%- hidden_form_elements -%]
@@ -28,7 +512,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <table summary='' class='talkform'>
 [%# First row: "From" fields %]
 
-<tr>
+<tr id='talkform-from'>
   <td align='right' valign='top'>
     [%- '/talkpost.bml.opt.from' | ml %]
   </td>
@@ -355,12 +839,12 @@ the same terms as Perl itself.  For a copy of the license, please reference
         ) -%]
 
         [%- IF remote.can_use_userpic_select -%]
-          <button type="button" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
+          <button type="button" class="secondary" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
               Browse
           </button>
         [%- END -%]
 
-        <input type='button' id='randomicon' class="js-only" style="display: none;" value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
+        <input type='button' id='randomicon' class="js-only secondary" style="display: none;" value='[%- '/talkpost.bml.userpic.random2' | ml -%]' />
       </div>
     [%- END -%]
 
@@ -375,7 +859,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
       ) -%]
       [%- help_icon( 'autoformat' ) -%]
 
-      <input type="button" id="comment-text-quote" value="Quote" class="js-only" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+      <input type="button" id="comment-text-quote" value="Quote" class="js-only secondary" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
 
       [%- IF remote.can_manage_community -%]
         [%- form.checkbox(
@@ -465,6 +949,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         name = "submitpreview"
         value = dw.ml('talk.btn.preview')
         id = "submitpview"
+        class = "secondary"
       ) -%]
       [%- form.hidden(
         name = "previewplaceholder"
@@ -499,6 +984,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
 </table>
 
 </form>
+
+[%- END -%][%# check for S2 foundation beta -%]
 
 [%- IF remote.can_use_userpic_select AND foundation_beta -%]
   [%- INCLUDE "components/icon-browser.tt" -%]


### PR DESCRIPTION
This is an omnibus monster PR, and mostly just exists to be a record of the various dependencies in here. The changes in it should be merged as a series of smaller PRs, as described below. 

## Split PRs for Easier Review

Since the mega-version is looking kind of impossible to review, I've split this into eight smaller PRs, each one chained against the last. They're categorized by an intersection of change-type and relative risk. 

1. <del>[Aug19 megamix 1: safe noops](https://github.com/dreamwidth/dw-free/pull/2575)</del> _(done)_
2. <del>[Aug19 megamix 2: middlin noops](https://github.com/dreamwidth/dw-free/pull/2579)</del> _(done)_
3. <del>[Aug19 megamix 3: safe bugfixes](https://github.com/dreamwidth/dw-free/pull/2580)</del> _(done)_
4. <del>[Aug19 megamix 4: safe frontend (next quick-reply design iteration)](https://github.com/dreamwidth/dw-free/pull/2581)</del> _(done)_
5. [Aug19 megamix 5: risky core (`s2foundation` beta)](https://github.com/nfagerlund/dw-free/pull/5) _(ready)_
    - Interlude: [A dw-nonfree PR that should be merged immediately after that one.](https://github.com/dreamwidth/dw-nonfree/pull/128)
6. [Aug19 megamix 6: safe, complex frontend](https://github.com/nfagerlund/dw-free/pull/6)
7. [Aug19 megamix 7: safe frontend bugfixes (talkform stuff)](https://github.com/nfagerlund/dw-free/pull/7)
8. [Aug19 megamix 8: risky noops](https://github.com/nfagerlund/dw-free/pull/8)

7 and 8 are both very low priority compared to the rest of these.

## Further Comments

### Demo

http://rr-thrice.hack.dreamwidth.net

My dev server is running all of this. Please kick the tires. Invite codes:

3. Invite code: 5GNA9R3SWM656AAAAAAN
4. Invite code: RJDSZBFADHS8KAAAAAAP
5. Invite code: CJY8TFKMDDEPQAAAAAAQ
6. Invite code: AQGBTBMRE6XRNAAAAAAR

I can post some screenshots later, too.

### Notable Stuff In Here 

- The next quick-reply design iteration.
- **Beta:** Foundation in S2 Pages. Makes site-scheme entry pages mobile-friendly, and enables new features in journal-styled S2 pages. 
- **Beta:** New-New Icon Browser everywhere. Well, more places. (Previously was only available on the beta new entry page.) 
- *Beta:** Make the talkform resemble the quick-reply. 
- Some fixes for misc bugs that didn't get out of my way fast enough. 