### PR TITLE
quick-reply: quick fix for temporary resize bug

### DIFF
--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -116,6 +116,7 @@ $icon-control-height: 2.2em;
         }
         #body {
             width: 100%;
+            flex-shrink: 0;
         }
     }
 


### PR DESCRIPTION
Under some conditions, you can't resize the quick-reply textarea to be larger
anymore. It's a weird flexbox interaction I missed last time.

This is already a non-issue in a pending quick-reply PR because it separates the
body container and the subject container, but this band-aid will fix it until
then.