### PR TITLE
[#2536] Fix background color for "fancy-select" menus on Windows

### DIFF
--- a/htdocs/scss/components/fancy-select.scss
+++ b/htdocs/scss/components/fancy-select.scss
@@ -18,7 +18,6 @@ $regular-select-height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1))
         top: 0;
         left: 0;
         border: none;
-        background: none;
         outline: none;
         opacity: 0;
         -webkit-appearance: none;


### PR DESCRIPTION
Fixes #2536 

The background color of a `select` element is inherited by the menu it opens
when activated.

On most platform/browser combos, setting the background to "none" seems to make
both the menus and their text use the platform default styling, but in Chrome
and Edge on Windows, it unsets the background and doesn't affect the style of
the text. On dark themes like Gradation, that makes the menu white-on-white.

Since the select is invisible anyway via `opacity: 0`, I don't see any downside
to leaving out the `background: none` rule.

### The important screens

Win10, Chrome, pre-patch (courtesy ily): Note white-on-white. 

![screen](https://user-images.githubusercontent.com/484309/60378454-99de1e80-99d7-11e9-8477-41b1bcda24f7.png)

Win10, Edge, pre-patch: Similarly bad. 

![Screenshot (5)](https://user-images.githubusercontent.com/484309/66792478-c138f880-eead-11e9-9652-2731558a221a.png)

Win10, Edge, post-patch: Fixed! 

![Screenshot (4)](https://user-images.githubusercontent.com/484309/66792309-ef6a0880-eeac-11e9-9b7e-7e609ea85478.png)

### The fyi screens

Mac, Firefox, Tropo, with `background: none` (before this patch): Note platform default grey and rounded style. 

<img width="287" alt="Screen Shot 2019-10-14 at Oct 14, 5 51PM" src="https://user-images.githubusercontent.com/484309/66792183-6fdc3980-eeac-11e9-9dac-57c60da254e9.png">

Mac, Firefox, Tropo, after this patch: Note sharper corners and white bg. (Same as the other selects on the create entries page.)

<img width="285" alt="Screen Shot 2019-10-14 at Oct 14, 5 51PM 1" src="https://user-images.githubusercontent.com/484309/66792184-7074d000-eeac-11e9-8476-0a33ad3ad822.png">

Win10, Firefox, pre-patch: Note that it doesn't look whacked like Chrome/Edge.

![Screenshot (2)](https://user-images.githubusercontent.com/484309/66792311-f0029f00-eeac-11e9-850e-9d8cf695692a.png)

Win10, Firefox, post-patch: Still looks fine, but now looks like other selects on page.

![Screenshot (3)](https://user-images.githubusercontent.com/484309/66792308-ef6a0880-eeac-11e9-8d81-85342cd815ec.png)