### PR TITLE
Enable Foundation in S2 pages (Aug19 megamix 5: risky core)

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -195,7 +195,7 @@ sub make_journal {
 
         # used if we're using our jquery library
         LJ::need_res(
-            { group => "jquery" }, qw(
+            { group => "all" }, qw(
                 js/md5.js
                 js/login-jquery.js
                 )
@@ -203,7 +203,7 @@ sub make_journal {
     }
 
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.widget.js
             js/jquery/jquery.ui.tooltip.js
@@ -1870,7 +1870,7 @@ sub use_journalstyle_entry_page {
 sub tracking_popup_js {
     return LJ::is_enabled('esn_ajax')
         ? (
-        { group => 'jquery' }, qw(
+        { group => 'all' }, qw(
             js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.widget.js
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -176,11 +176,21 @@ sub make_journal {
     # like print_stylesheet() won't run, which don't have an method invocant
     return $page if $page && ref $page ne 'HASH';
 
-    LJ::set_active_resource_group('jquery');
+    if ( LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" ) ) {
+        LJ::set_active_resource_group('foundation');
+
+        # Minimal Foundation component support if we're not in site scheme
+        unless ( $ctx->[S2::SCRATCH]->{siteviews_enabled} ) {
+            LJ::need_res( { priority => $LJ::LIB_RES_PRIORITY, group => 'foundation' },
+                "stc/css/foundation/foundation_minimal.css" );
+        }
+    }
+    else {
+        LJ::set_active_resource_group('jquery');
+    }
 
     # Control strip
-    my $show_control_strip = LJ::Hooks::run_hook('show_control_strip');
-    if ($show_control_strip) {
+    if ( $page->{show_control_strip} ) {
         LJ::Hooks::run_hook('control_strip_stylesheet_link');
 
         # used if we're using our jquery library
@@ -219,15 +229,15 @@ sub make_journal {
 
     # this will cause double-JS and likely cause issues if called during siteviews
     # as this is done once the page is out of S2's control.
-    $page->{head_content} .= LJ::res_includes()
-        unless $ctx->[S2::SCRATCH]->{siteviews_enabled};
+    unless ( $ctx->[S2::SCRATCH]->{siteviews_enabled} || $view eq "res" ) {
+        $page->{head_content} .= LJ::res_includes_head();    # CSS
+
+        $page->{head_content} .= get_script_tags($page)
+            if $LJ::ACTIVE_RES_GROUP eq "jquery";    # Foundation puts scripts at end of body
+    }
 
     $page->{head_content} .= $extra_js;
     $page->{head_content} .= LJ::PageStats->new->render_head('journal');
-
-    # inject the control strip JS, but only after any libraries have been injected
-    $page->{head_content} .= LJ::control_strip_js_inject( user => $u->user )
-        if $show_control_strip;
 
     s2_run( $apache_r, $ctx, $opts, $entry, $page );
 
@@ -374,6 +384,19 @@ sub make_link {
         $append = "&";
     }
     return $url;
+}
+
+# Uses the res_includes system to return the appropriate JavaScript tags
+# for the current page. This should be called once per page at most, and never
+# called for siteviews pages.
+sub get_script_tags {
+    my ($page) = @_;
+    my $ret = LJ::res_includes_body();
+    $ret .= LJ::control_strip_js_inject( user => $page->{_u}->user )
+        if $page->{show_control_strip};
+    $ret .= '<script>$(document).foundation();</script>'
+        if $LJ::ACTIVE_RES_GROUP eq "foundation";
+    return $ret;
 }
 
 # <LJFUNC>
@@ -2438,6 +2461,7 @@ sub Page {
         'views_order'         => [ 'recent', 'archive', 'read', 'tags', 'memories', 'userinfo' ],
         'global_title'        => LJ::ehtml( $u->{'journaltitle'} || $u->{'name'} ),
         'global_subtitle'     => LJ::ehtml( $u->{'journalsubtitle'} ),
+        'show_control_strip'  => LJ::Hooks::run_hook('show_control_strip'),
         'head_content'        => '',
         'data_link'           => {},
         'data_links_order'    => [],
@@ -4002,6 +4026,13 @@ sub Comment__print_unhide_link {
     );
 }
 
+sub Page__print_script_tags {
+    my ( $ctx, $this ) = @_;
+    if ( $LJ::ACTIVE_RES_GROUP eq "foundation" ) {
+        $S2::pout->( LJ::S2::get_script_tags($this) );
+    }
+}
+
 sub Page__print_trusted {
     my ( $ctx, $this, $key ) = @_;
 
@@ -4978,9 +5009,15 @@ sub string__css_keyword_list {
 }
 
 sub Siteviews__need_res {
-    my ( $ctx, $this, $res ) = @_;
+    my ( $ctx, $this, $opts, $res ) = @_;
     die "Siteviews doesn't work standalone" unless $ctx->[S2::SCRATCH]->{siteviews_enabled};
-    LJ::need_res($res);
+    if ( ref($opts) ne 'HASH' ) {
+        $res = $opts;
+        LJ::need_res($res);
+    }
+    else {
+        LJ::need_res( $opts, $res );
+    }
 }
 
 sub Siteviews__start_capture {

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -413,7 +413,7 @@ sub EntryPage {
     }
 
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.core.js
             js/jquery/jquery.ui.tooltip.js
             js/jquery.ajaxtip.js

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1891,14 +1891,14 @@ sub init_s2journal_js {
 
     # load for everywhere you can reply (ReplyPage, lastn, AND entries)
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery.replyforms.js
             )
     );
 
     # load for quick reply (every view except ReplyPage)
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.core.js
             stc/jquery/jquery.ui.core.css
             js/jquery/jquery.ui.widget.js
@@ -1910,7 +1910,7 @@ sub init_s2journal_js {
 
     # load only for ReplyPage
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery.talkform.js
             stc/css/components/talkform.css
             )
@@ -1922,14 +1922,14 @@ sub init_s2journal_js {
     # if we're using the site skin, don't override the jquery-ui theme,
     # as that's already included
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             stc/jquery/jquery.ui.theme.smoothness.css
             )
     ) unless $opts{siteskin};
 
     # load for ajax cuttag - again, only needed on lastn-type pages
     LJ::need_res(
-        { group => "jquery" }, qw(
+        { group => "all" }, qw(
             js/jquery/jquery.ui.widget.js
             js/jquery.cuttag-ajax.js
             )
@@ -1950,12 +1950,12 @@ sub init_s2journal_shortcut_js {
 
     my $connect_string = "";
 
-    LJ::need_res( { group => "jquery" }, "js/shortcuts.js" );
-    LJ::need_res( { group => "jquery" }, "js/jquery.shortcuts.nextentry.js" );
+    LJ::need_res( { group => "all" }, "js/shortcuts.js" );
+    LJ::need_res( { group => "all" }, "js/jquery.shortcuts.nextentry.js" );
 
     $p->{'head_content'} .= "  <script type='text/javascript'>\n  var dw_shortcuts = {\n";
     if ( $remote->prop("opt_shortcuts") ) {
-        LJ::need_res( { group => "jquery" }, "js/mousetrap.js" );
+        LJ::need_res( { group => "all" }, "js/mousetrap.js" );
         $p->{'head_content'} .= "    keyboard: {\n";
 
         my $nextKey = $remote->prop("opt_shortcuts_next");
@@ -1965,7 +1965,7 @@ sub init_s2journal_shortcut_js {
         $connect_string = ",";
     }
     if ( $remote->prop("opt_shortcuts_touch") ) {
-        LJ::need_res( { group => "jquery" }, "js/jquery.touchSwipe.js" );
+        LJ::need_res( { group => "all" }, "js/jquery.touchSwipe.js" );
         my $nextTouch = $remote->prop("opt_shortcuts_touch_next");
         my $prevTouch = $remote->prop("opt_shortcuts_touch_prev");
         $p->{'head_content'} .=

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1615,6 +1615,10 @@ sub talkform {
         subjecticon_ids      => \@subjecticon_ids,
         username_maxlength   => $LJ::USERNAME_MAXLENGTH,
 
+        foundation_beta => LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" )
+            && $LJ::ACTIVE_RES_GROUP
+            && $LJ::ACTIVE_RES_GROUP eq "foundation",
+
         public_entry     => $entry->security eq 'public',
         default_usertype => $default_usertype,
 
@@ -1825,11 +1829,22 @@ sub init_iconbrowser_js {
 
     # There are three separate implementations of the icon browser.
 
-    # The New-New Icon Browser: Depends on Foundation CSS/JS. Used on: New entry
-    # page (if in "updatepage" beta). Omitted here.
+    # The New-New Icon Browser: Depends on Foundation CSS/JS (either site skin
+    # or minimal version). Used on: New entry page (if in "updatepage" beta),
+    # quickreply and talkform on journal pages (if in "s2foundation" beta).
+    LJ::need_res(
+        { group => 'foundation' },
+
+        'js/foundation/foundation/foundation.js',
+        'js/foundation/foundation/foundation.reveal.js',
+        'js/components/jquery.icon-browser.js',
+        'stc/css/components/block-grid.css',
+        'stc/css/components/icon-browser.css',
+    );
 
     # The Old-New Icon Browser: Depends on jQuery. Used on: Quick-reply and
-    # talkform on journal pages, talkform on talkpost_do.bml, preview page.
+    # talkform on journal pages (if NOT in "s2foundation" beta), talkform on
+    # talkpost_do.bml (always), preview page (always).
     LJ::need_res(
         { group => 'jquery' },
 

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -933,6 +933,9 @@ sub create_qr_div {
 
             current_icon_kw => $userpic_kw,
             current_icon    => LJ::Userpic->new_from_keyword( $remote, $userpic_kw ),
+            foundation_beta => LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" )
+                && $LJ::ACTIVE_RES_GROUP
+                && $LJ::ACTIVE_RES_GROUP eq "foundation",
 
             remote => {
                 ljuser => $remote->ljuser_display,

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -4569,7 +4569,7 @@ sub statusvis_message_js {
     $statusvis_full = "memorial" if $u->is_memorial;
     $statusvis_full = "readonly" if $u->is_readonly;
 
-    LJ::need_res("js/statusvis_message.js");
+    LJ::need_res( { group => 'all' }, "js/statusvis_message.js" );
     return
           "<script>Site.StatusvisMessage=\""
         . LJ::Lang::ml("statusvis_message.$statusvis_full")

--- a/etc/config-local.pl
+++ b/etc/config-local.pl
@@ -160,10 +160,9 @@
 #            start_time => 0,
 #            end_time => "Inf",
 #        },
-#        "s2comments" => {
+#        "s2foundation" => {
 #            start_time => 0,
 #            end_time => "Inf",
-#            sitewide => 1,
 #        },
 #    );
 

--- a/htdocs/js/jquery.replyforms.js
+++ b/htdocs/js/jquery.replyforms.js
@@ -48,6 +48,19 @@ jQuery(function($) {
     // Random icon re-roll button (hidden until random is selected once)
     $("#randomicon").on("click", randomIcon);
 
+
+    // New-new icon browser, if available
+    if ( $.fn.iconBrowser ) {
+        iconSelect.iconBrowser({
+            triggerSelector: "#lj_userpicselect",
+            modalId: "js-icon-browser",
+            preferences: {
+                "metatext": $('#lj_userpicselect').data('iconbrowserMetatext'),
+                "smallicons": $('#lj_userpicselect').data('iconbrowserSmallicons')
+            }
+        });
+    }
+
     iconSelect.on("change", function(e) {
         var selection = $(this).find("option:selected");
         if (selection.attr('id') === 'random') {

--- a/htdocs/scss/foundation/foundation_minimal.scss
+++ b/htdocs/scss/foundation/foundation_minimal.scss
@@ -1,0 +1,21 @@
+// The minimum of Foundation functionality, to enable shared components in
+// journal styled pages. Do not include both this and foundation.scss; choose
+// ONE.
+
+// The goal of this is to basically act like _base.scss, except we DO want to
+// print the meta.foundation.* classes from _global. For any other styles, we
+// rely on what the components bring with them.
+
+// import the settings we want to work with
+@import "foundation/settings";
+
+$include-html-classes: false;
+
+// import global
+@import "foundation/components/global";
+
+$include-html-classes: true;
+
+// import components we use in journal-styled pages
+@import "foundation/components/reveal";
+@import "foundation/components/thumbs";

--- a/styles/core2.s2
+++ b/styles/core2.s2
@@ -590,6 +590,9 @@ class Page
     "Extra tags supplied by the server to go in the <head> section of the output HTML document. Layouts
     should include this in the head section if they are writing HTML.";
 
+    var readonly bool show_control_strip
+    "Whether the control strip will be shown on the current page.";
+
     var readonly string stylesheet_url
     "The URL to use in a link element for the server-supported external stylesheet to put stuff in it)";
 
@@ -725,6 +728,9 @@ class Page
 
     function print_theme_stylesheet
     "Prints theme-specific CSS. Should be overwritten by themes that include CSS not part of the layout's default stylesheet.";
+
+    function builtin print_script_tags
+    "Prints the JavaScript tags that this page requires. Used in Page::print_wrapper_end. Do not override this.";
 
     function builtin print_trusted(string key)
     "Prints a trusted string by key.";
@@ -4019,6 +4025,7 @@ function Page::print_wrapper_start(string{} opts)
 function Page::print_wrapper_end()
 "This function concludes the wrapper to the page.  Overriding this function is NOT RECOMMENDED. Overriding this function could prevent sitewide improvements to styles, accessibility, or other functionality from operating in your layout."
 {
+    $this->print_script_tags();
     """</body>""";
 }
 

--- a/styles/siteviews/layout.s2
+++ b/styles/siteviews/layout.s2
@@ -5,6 +5,7 @@ layerinfo is_internal = "1";
 
 class Siteviews {
     function builtin need_res(string res);
+    function builtin need_res(string{} opts, string res);
     function builtin start_capture();
     function builtin end_capture() : string;
 
@@ -40,7 +41,7 @@ function Page::print_title() {
 
 function Page::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/layout.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/siteviews/layout.css" );
 }
 
 function Page::print_theme_stylesheet() {}
@@ -100,7 +101,7 @@ function IconsPage::print_title() {
 
 function IconsPage::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/allpics.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/allpics.css" );
 }
 
 function IconsPage::print_body() {
@@ -189,13 +190,13 @@ set comment_time_format = "short_24";
 
 function EntryPage::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/entrypage.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/entrypage.css" );
 
 }
 
 function ReplyPage::print_default_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/replypage.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/replypage.css" );
 
 }
 

--- a/styles/siteviews/themes.s2
+++ b/styles/siteviews/themes.s2
@@ -14,7 +14,7 @@ layerinfo redist_uniq = "siteviews/celerity";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/celerity.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/siteviews/celerity.css" );
 }
 
 #NEWLAYER: siteviews/gradation-horizontal
@@ -24,7 +24,7 @@ layerinfo redist_uniq = "siteviews/gradation-horizontal";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/gradation.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/siteviews/gradation.css" );
 }
 
 #NEWLAYER: siteviews/gradation-vertical
@@ -34,7 +34,7 @@ layerinfo redist_uniq = "siteviews/gradation-vertical";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/gradation.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/siteviews/gradation.css" );
 }
 
 
@@ -45,5 +45,5 @@ layerinfo redist_uniq = "siteviews/lynx";
 
 function Page::print_theme_stylesheet() {
     # Do not actually *print* any stylesheets here, but you can $*SITEVIEWS->need_res(...); here to pull in anything.
-    $*SITEVIEWS->need_res( "stc/siteviews/lynx.css" );
+    $*SITEVIEWS->need_res( {"group" => "jquery"}, "stc/siteviews/lynx.css" );
 }

--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -19,6 +19,22 @@
 
 .betafeature.updatepage.title=New Create Entries Page
 
+.betafeature.s2foundation.cantadd=Sorry, your account is not eligible to test this feature.
+
+.betafeature.s2foundation.off<<
+<p>Activate several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up some bugs.</p>
+
+<p>TODO: post a link for reporting bugs.</p>
+.
+
+.betafeature.s2foundation.on<<
+<p>You are currently testing several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up some bugs.</p>
+
+<p>TODO: post a link for reporting bugs.</p>
+.
+
+.betafeature.s2foundation.title=Updated journal page components
+
 .nofeatures=There are no features currently available for beta testing.
 
 .staytuned.newscomm=Stay tuned to [[news]] for upcoming testing opportunities. Thank you.

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -113,3 +113,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 </form></div>
 </div>
+
+[%- IF remote.can_use_userpic_select AND foundation_beta -%]
+  [%- INCLUDE "components/icon-browser.tt" -%]
+[%- END -%]

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -499,3 +499,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 </table>
 
 </form>
+
+[%- IF remote.can_use_userpic_select AND foundation_beta -%]
+  [%- INCLUDE "components/icon-browser.tt" -%]
+[%- END -%]


### PR DESCRIPTION
This is a subset of #2574.
Fixes #2570 (as best as it looks like we can, without cutting a core3)
Functional basis for #2427
Functional basis for #2411

These commits are:

- Front-end code, but it's Perl and S2 front-end, not CSS/JS/markup.
- **Sorta high risk.**
    - Yeah, this doesn't mess with the database or core logic, but it does futz with the weirder corners of a code path that basically EVERY journal page MUST pass through, and it uses some subsystems that seemed to be poorly understood when I was asking questions about them.
    - The functional changes are all behind a new beta flag. So the most critical thing is to make sure nothing new and bad can possibly happen when the beta is OFF. I feel pretty confident about that. 

Bits I want advice on:

- What would you like on that beta feature text?
- Does the implementation of the beta switch match what you want? I followed what the `updatepage` beta does, which is different from what the instructions on the wiki say.