### PR TITLE
[#2427] Site skins: Add equivalent styles for legacy markup (.action-box)

### DIFF
--- a/htdocs/scss/skins/_compatibility-styles.scss
+++ b/htdocs/scss/skins/_compatibility-styles.scss
@@ -1,0 +1,20 @@
+// Style translations for widgets that sometimes show up in pages written for
+// the old non-Foundation site skins. These rules should mostly use @extend
+// rules to style these widgets in terms of existing classes from the modern
+// site skins.
+
+.action-box {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    margin-top: 20px;
+
+    .inner {
+        @extend .panel;
+        @extend .callout;
+        display: block;
+        padding: 5px;
+        text-align: center;
+    }
+}

--- a/htdocs/scss/skins/_global-styles.scss
+++ b/htdocs/scss/skins/_global-styles.scss
@@ -6,4 +6,4 @@ Should only @import other stylesheets
 $include-html-classes: true;
 @import "foundation/foundation";
 
-@import "skins/skin-colors", "skins/community-menu";
+@import "skins/skin-colors", "skins/community-menu", "skins/compatibility-styles";


### PR DESCRIPTION
I'm putting this in its own file because I'm expecting we'll eventually find
more classes like this in pages like the inbox or whatever. And .action-box
isn't specific to the entry/reply pages.

This was originally part of the big S2 Foundationizing PR chain, but it's independent and useful for something else that's going on atm, so I'm extracting it as a separate thing. 