### PR TITLE
[#2587] Add click-to-zoom for images in entry/comment content

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -208,6 +208,9 @@ sub make_journal {
             stc/jquery/jquery.ui.dialog.css
             stc/jquery/jquery.ui.theme.smoothness.css
 
+            js/jquery.imageshrink.js
+            stc/css/components/imageshrink.css
+
             js/jquery.poll.js
             js/journals/jquery.tag-nav.js
 

--- a/htdocs/js/jquery.imageshrink.js
+++ b/htdocs/js/jquery.imageshrink.js
@@ -1,0 +1,5 @@
+$(document).on('click', '.entry-content img, .comment-content img', function(e){
+    if ( ! $(e.target).is('a img, .poll-response img') ) {
+        $(e.target).toggleClass('expanded');
+    }
+});

--- a/htdocs/scss/components/imageshrink.scss
+++ b/htdocs/scss/components/imageshrink.scss
@@ -1,0 +1,36 @@
+/* Constrain image dimensions.
+    Job 1: Don't trash the layout sideways.
+    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+      portrait of someone is nonsense.
+    Job 3: Defend the native aspect ratio.
+    Job 4: Respect the width/height HTML attributes for scaling down OR up
+      (within the limits of the container), but if they conflict with the aspect
+      ratio, treat them as maximums and let the aspect ratio win.
+    Job 5: Let the user expand an individual image to max size by clicking.
+*/
+@supports (object-fit: contain) {
+  .entry-content, .comment-content {
+    img {
+      cursor: zoom-in;
+      height: auto;
+      max-width: 100%;
+      max-height: 95vh;
+      object-fit: contain;
+      object-position: left;
+    }
+
+    img.expanded {
+      cursor: zoom-out;
+      height: auto;
+      width: auto;
+      max-width: unset;
+      max-height: unset;
+      object-fit: unset;
+      object-position: unset;
+    }
+
+    a img, .poll-response img {
+      cursor: unset;
+    }
+  }
+}

--- a/styles/abstractia/layout.s2
+++ b/styles/abstractia/layout.s2
@@ -1227,22 +1227,6 @@ q {
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 .entry .tag,.footer .multiform-checkbox {
     width: 98%;
     margin: .667em 0 0;

--- a/styles/bases/layout.s2
+++ b/styles/bases/layout.s2
@@ -564,22 +564,6 @@ ul ul {list-style: circle;}
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 /* ====================== HEADER ======================= */
 
 #header {

--- a/styles/blanket/layout.s2
+++ b/styles/blanket/layout.s2
@@ -682,22 +682,6 @@ h3.entry-title a {
     list-style-position: inside;
     }
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 .metadata {
     margin: 2em 0 0;
     }

--- a/styles/brittle/layout.s2
+++ b/styles/brittle/layout.s2
@@ -573,22 +573,6 @@ li.page-separator { display: none; }
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 .entry .header {
     padding: 0;
     margin: 0 0 10px 0;

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -594,22 +594,6 @@ h2#pagetitle {
     list-style-position: inside;
     }
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 .metadata ul {
     display: inline;
     list-style: none;

--- a/styles/drifting/layout.s2
+++ b/styles/drifting/layout.s2
@@ -738,22 +738,6 @@ function Page::print_default_stylesheet()
         list-style-position: inside;
         }
 
-    /* Constrain image dimensions.
-        Job 1: Don't trash the layout sideways.
-        Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-          portrait of someone is nonsense.
-        Job 3: Defend the native aspect ratio.
-        Job 4: Respect the width/height HTML attributes for scaling down OR up
-          (within the limits of the container), but if they conflict with the aspect
-          ratio, treat them as maximums and let the aspect ratio win. */
-    .entry-content img, .comment-content img {
-        height: auto;
-        max-width: 100%;
-        max-height: 95vh;
-        object-fit: contain;
-        object-position: left;
-    }
-
     .entry .subject {
         padding: 3px;
         border: 1px solid $*color_entry_border;

--- a/styles/easyread/layout.s2
+++ b/styles/easyread/layout.s2
@@ -614,22 +614,6 @@ h2.module-header a {
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 /* Set height to keep spacing */
 /* Use standard H3 font size */
 .no-subject .entry .entry-title {

--- a/styles/goldleaf/layout.s2
+++ b/styles/goldleaf/layout.s2
@@ -1385,22 +1385,6 @@ a, a:link, a:visited, a:active, a:hover{
     list-style-position: inside;
 }
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 .metadata ul {
     display: inline;
     list-style: none;

--- a/styles/negatives/layout.s2
+++ b/styles/negatives/layout.s2
@@ -584,23 +584,6 @@ function Page::print_default_stylesheet()
         list-style-position: inside;
         }
 
-    /* Constrain image dimensions.
-        Job 1: Don't trash the layout sideways.
-        Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-          portrait of someone is nonsense.
-        Job 3: Defend the native aspect ratio.
-        Job 4: Respect the width/height HTML attributes for scaling down OR up
-          (within the limits of the container), but if they conflict with the aspect
-          ratio, treat them as maximums and let the aspect ratio win. */
-    .entry-content img, .comment-content img {
-        height: auto;
-        max-width: 100%;
-        max-height: 95vh;
-        object-fit: contain;
-        object-position: left;
-    }
-
-
     .entry .footer,
     .comment .footer {
         clear: both;

--- a/styles/skittlishdreams/layout.s2
+++ b/styles/skittlishdreams/layout.s2
@@ -963,22 +963,6 @@ body { $page_background $page_font margin: 0; padding: 0; }
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 .page-recent .security-public.restrictions-none.journal-type-P.has-userpic.no-subject .entry-content,
 .page-day .security-public.restrictions-none.journal-type-P.has-userpic.no-subject .entry-content {
     padding-top: 20px;

--- a/styles/venture/layout.s2
+++ b/styles/venture/layout.s2
@@ -1702,22 +1702,6 @@ $display_topnav_css
     padding: 0 0 0 2em;
     }
 
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win. */
-.entry-content img, .comment-content img {
-    height: auto;
-    max-width: 100%;
-    max-height: 95vh;
-    object-fit: contain;
-    object-position: left;
-}
-
 .entry ol { list-style: decimal-leading-zero; }
 
 .entry .footer {


### PR DESCRIPTION
Previously, we added CSS that limits image sizes, to avoid reading page blowouts
when people post large images. This works as expected most of the time, but:

- It sometimes shrinks images it shouldn't, like vertical comic strips.
- Sometimes you just want to see the full size and don't mind a temporary blowout.

This commit handles those cases by adding a click-to-zoom behavior for images in
entry/comment contents. On desktop, a special cursor indicates when you can use
it. The new behavior only targets images that aren't inside links (since those
already have a click behavior), and has a special exemption for poll bar graphs.

This also moves the shrink CSS into a global fragment that gets pulled in with
need_res, so we don't need to maintain it in every layout.