### PR TITLE
Update text strings for s2foundation beta

### DIFF
--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -22,15 +22,15 @@
 .betafeature.s2foundation.cantadd=Sorry, your account is not eligible to test this feature.
 
 .betafeature.s2foundation.off<<
-<p>Activate several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up some bugs.</p>
+<p>Activate several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up new bugs.</p>
 
-<p>TODO: post a link for reporting bugs.</p>
+<p>To report bugs with these updated components, leave a comment in <?ljuser dw_beta ljuser?>.</p>
 .
 
 .betafeature.s2foundation.on<<
-<p>You are currently testing several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up some bugs.</p>
+<p>You are currently testing several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up new bugs.</p>
 
-<p>TODO: post a link for reporting bugs.</p>
+<p>To report bugs with these updated components, leave a comment in <?ljuser dw_beta ljuser?>.</p>
 .
 
 .betafeature.s2foundation.title=Updated journal page components


### PR DESCRIPTION
As discussed in https://github.com/dreamwidth/dw-free/pull/2586: to reduce complexity, this text just says to check in at dw_beta rather than linking to a specific post. 