### PR TITLE
Markdown/HTMLCleaner fixes

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1408,11 +1408,15 @@ sub preview_handler {
     # the cleaner won't eat
     LJ::EmbedModule->parse_module_embed( $u, \$event, preview => 1 );
 
+    # TODO: get prop_editor from the form (not currently being set)
+    my $editor = undef;
+
     # clean content normally
     LJ::CleanHTML::clean_event(
         \$event,
         {
             preformatted => $form_req->{props}->{opt_preformatted},
+            editor       => $editor,
         }
     );
 

--- a/cgi-bin/DW/Controller/RPC/CutExpander.pm
+++ b/cgi-bin/DW/Controller/RPC/CutExpander.pm
@@ -84,10 +84,6 @@ sub load_cuttext {
     my $journalid = $entry_obj->journalid;
     my $journal   = LJ::load_userid($journalid);
 
-    #load and prepare text of entry
-    my $text = LJ::CleanHTML::quote_html( $entry_obj->event_raw, $get->{nohtml} );
-    LJ::item_toutf8( $journal, \$subject, \$text ) if $entry_obj->props->{unknown8bit};
-
     my $suspend_msg    = $entry_obj && $entry_obj->should_show_suspend_msg_to($remote) ? 1 : 0;
     my $cleanhtml_opts = {
         cuturl              => $entry_obj->url,
@@ -99,7 +95,8 @@ sub load_cuttext {
         cut_retrieve        => $cutid,
     };
 
-    LJ::CleanHTML::clean_event( \$text, $cleanhtml_opts );
+    #load and prepare text of entry
+    my $text = LJ::CleanHTML::quote_html( $entry_obj->event_html($cleanhtml_opts), $get->{nohtml} );
 
     LJ::expand_embedded( $journal, $jitemid, $remote, \$text );
 

--- a/cgi-bin/DW/Entry/Moderated.pm
+++ b/cgi-bin/DW/Entry/Moderated.pm
@@ -113,6 +113,7 @@ sub event {
         \$event,
         {
             preformatted => $raw_data->{props}->{opt_preformatted},
+            editor       => $raw_data->{props}->{editor},
             cutpreview   => 1,
             cuturl       => '#',
         }

--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,10 +69,20 @@ sub ljuser_display {
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
 
-    return
-          "<span style='white-space: nowrap;'$display_class><a href='$profile_url'>"
-        . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
-        . "</a><a href='$journal_url'><b>$user</b></a></span>";
+    my $ret = '';
+    $ret .= "<span style='white-space: nowrap;'$display_class>";
+    $ret .= "<a href='$profile_url'>"
+        unless $opts{no_link};
+    $ret .=
+"<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>";
+    $ret .= "</a><a href='$journal_url'>"
+        unless $opts{no_link};
+    $ret .= "<b>$user</b>";
+    $ret .= "</a>"
+        unless $opts{no_link};
+    $ret .= "</span>";
+
+    return $ret;
 }
 
 1;

--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -913,12 +913,6 @@ sub event_html {
     $self->_load_text unless $self->{_loaded_text};
     my $event = $self->{event};
 
-    # Old-style: if the entry has a special prefix then remove it and also turn on
-    # markdown formatting.
-    if ( $event =~ s/^\s*!markdown\s*\r?\n//s ) {
-        $opts->{editor} = 'markdown';
-    }
-
     LJ::CleanHTML::clean_event( \$event, $opts );
 
     LJ::expand_embedded( $self->{u}, $self->ditemid, LJ::User->remote, \$event,

--- a/cgi-bin/LJ/Feed.pm
+++ b/cgi-bin/LJ/Feed.pm
@@ -233,6 +233,7 @@ ENTRY:
                     preformatted     => $logprops{$itemid}->{opt_preformatted},
                     cuturl           => $u->{opt_synlevel} eq 'cut' ? $entry_url : "",
                     to_external_site => 1,
+                    editor           => $logprops{$itemid}->{editor},
                 }
             );
 

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -1652,7 +1652,10 @@ sub postevent {
     # warn the user of any bad markup errors
     my $clean_event = $event;
     my $errref;
-    LJ::CleanHTML::clean_event( \$clean_event, { errref => \$errref } );
+
+    # TODO: accept editor prop and thread it through to the cleaner.
+    my $editor = undef;
+    LJ::CleanHTML::clean_event( \$clean_event, { errref => \$errref, editor => $editor } );
     $res->{message} = translate(
         $u, $errref,
         {
@@ -2024,6 +2027,7 @@ sub editevent {
     }
 
     ## handle meta-data (properties)
+    # FIXME: Hey... I think this just throws the changed props away???? -NF
     my %props_byname = ();
     foreach my $key ( keys %{ $req->{'props'} } ) {
         ## changing to something else?
@@ -2168,7 +2172,11 @@ sub editevent {
 
     my $clean_event = $event;
     my $errref;
-    LJ::CleanHTML::clean_event( \$clean_event, { errref => \$errref } );
+
+    # TODO: get editor prop from the new props (or current, if unchanged) and
+    # thread it through to the cleaner.
+    my $editor = undef;
+    LJ::CleanHTML::clean_event( \$clean_event, { errref => \$errref, editor => $editor } );
     $add_message->(
         translate(
             $u, $errref,

--- a/cgi-bin/LJ/Sendmail.pm
+++ b/cgi-bin/LJ/Sendmail.pm
@@ -330,10 +330,7 @@ sub format_mail {
 
     # use markdown to format from text to HTML
     my $html = $text;
-    my $opts = {};
-    LJ::CleanHTML::clean_as_markdown( \$html, $opts );
-
-    # run this cleaner to convert any user tags that turn up post-markdown
+    my $opts = { editor => 'markdown' };
     LJ::CleanHTML::clean_event( \$html, $opts );
 
 # use plaintext as-is, but look for "[links like these](url)", and change them to "links like these (url)"

--- a/cgi-bin/LJ/User/Display.pm
+++ b/cgi-bin/LJ/User/Display.pm
@@ -213,12 +213,21 @@ sub ljuser_display {
             : "$LJ::SITEROOT/profile?userid=" . $u->userid . "&amp;t=I$andfull";
 
         my $lj_user = $opts->{no_ljuser_class} ? "" : " lj:user='$name'";
-        return
-              "<span$lj_user style='white-space: nowrap;$strike'$display_class><a href='$profile'>"
-            . "<img src='$imgurl' alt='[$type profile] ' width='$width' height='$height'"
-            . " style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a>"
-            . "<a href='$url' rel='nofollow'><b>$name</b></a></span>";
 
+        my $ret = '';
+        $ret .= "<span$lj_user style='white-space: nowrap;$strike'$display_class>";
+        $ret .= "<a href='$profile'>"
+            unless $opts->{no_link};
+        $ret .= "<img src='$imgurl' alt='[$type profile] ' width='$width' height='$height'";
+        $ret .= " style='vertical-align: text-bottom; border: 0; padding-right: 1px;' />";
+        $ret .= "</a><a href='$url' rel='nofollow'>"
+            unless $opts->{no_link};
+        $ret .= "<b>$name</b>";
+        $ret .= "</a>"
+            unless $opts->{no_link};
+        $ret .= "</span>";
+
+        return $ret;
     }
     else {
         return "<b>????</b>";
@@ -628,11 +637,20 @@ sub ljuser {
         $profile = $profile_url ne '' ? $profile_url : $profile . $andfull;
         $url     = $journal_url ne '' ? $journal_url : $url;
 
-        return
-              "<span$lj_user style='white-space: nowrap;$strike'$display_class>"
-            . "<a href='$profile'><img src='$img/$fil' alt='[$alttext] ' width='$x' height='$y'"
-            . " style='vertical-align: text-bottom; border: 0; padding-right: 1px;' /></a>"
-            . "<a href='$url'$link_color>$ljusername</a></span>";
+        my $ret = '';
+        $ret .= "<span$lj_user style='white-space: nowrap;$strike'$display_class>";
+        $ret .= "<a href='$profile'>"
+            unless $opts->{no_link};
+        $ret .= "<img src='$img/$fil' alt='[$alttext] ' width='$x' height='$y'";
+        $ret .= " style='vertical-align: text-bottom; border: 0; padding-right: 1px;' />";
+        $ret .= "</a><a href='$url'$link_color>"
+            unless $opts->{no_link};
+        $ret .= $ljusername;
+        $ret .= "</a>"
+            unless $opts->{no_link};
+        $ret .= "</span>";
+
+        return $ret;
     };
 
     my $u = isu($user) ? $user : LJ::load_user($user);

--- a/t/cleaner-markdown.t
+++ b/t/cleaner-markdown.t
@@ -22,8 +22,9 @@ use Test::More tests => 19;
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::CleanHTML;
 
-my $lju_sys = LJ::ljuser('system');
-my $url     = 'https://medium.com/@username/title-of-page';
+my $lju_sys         = LJ::ljuser('system');
+my $lju_sys_no_link = LJ::ljuser( 'system', { no_link => 1 } );
+my $url             = 'https://medium.com/@username/title-of-page';
 
 my $clean = sub {
     my ( $text, %opts ) = @_;
@@ -56,14 +57,14 @@ is(
 # linked URL containing user tag
 is(
     $clean->("[link from \@system]($url)"),
-    qq{<p><a href="$url">link from $lju_sys</a></p>},
-    'user tag in href not converted, but user tag in link text converted []'
+    qq{<p><a href="$url">link from $lju_sys_no_link</a></p>},
+    'user tag in href not converted, but user tag in link text converted (using de-linked form) []'
 );
 
-# same as standard HTML, we don't apply markdown to HTML
+# HTML within Markdown is passed through undigested, but Markdown can build new tags around it.
 is(
     $clean->(qq{<a href="$url">link from \@system</a>}),
-    qq{<a href="$url">link from \@system</a>},
+    qq{<p><a href="$url">link from $lju_sys_no_link</a></p>},
     'content is unconverted'
 );
 


### PR DESCRIPTION
This fixes most of the problems from #2601.

- Switches MD processing back to document-at-once mode. Markdown might look simple, but it's such a complex language that we can't expect an HTML tokenizer to reliably give us a valid chunk of Markdown. 
- Moves the `!markdown` check into `clean_event`, so it can hit everything that needs it (but not hit comments). 
- Preserves the desired @-mentions behavior as codified in the tests (with one exception, where the codified behavior didn't quite make sense — see `qq{<a href="$url">link from \@system</a>}`). 
- Handles a bit of a sideline question about how user tags within links should work. (Link-in-link is illegal.) 
- Adds some more contexts where @-mentions aren't processed. (code spans and pre blocks.)
- Makes reading/recent and cuttag-expander go through the same formatting route as the entry page does -- instead of (manually get raw, manually call clean_event), it's (call centralized thing that gets raw and cleans it). ...I think this is harmless deduplication, but you should double-check. 
- Threads editor prop through in a bunch of places that were missing it.
- Catches up some oddball uses of markdown (Sendmail). 

AFAICT, that should handle all of the new crop of Markdown bugs! EXCEPT for the following:

### Not addressed by this PR:

Crossposter's hosed. DW/External/XPostProtocol/LJXMLRPC.pm -- Right now it'll just explode, because it calls a function that got removed. 

That module has a bunch of code copy-pasted from CleanHTML, and it Seems Bad. It _looks_ like the right move would be somewhere in the neighborhood of: 

- Modify `clean()` to take an option that means "turn lj tags into their old-style LJ form and otherwise leave them undigested." Looks like these tags are all nicely isolated in their own conditionals, and you could handle the `@user` case by modifying `user_link_html`. 
- Thread that option through `clean_event`.
- Delete all that code from crossposter and just have it call `clean_event` with the special "transform and retain LJ tags" option.

BUT! IDK enough about the constraints the crossposter is operating under, so someone else should probably do it. 

I guess the quick dirty fix would be to just call Text::Markdown directly and forget about `@mentions`, passing them through to LJ undigested. That'd be a regression, but maybe not a critical one, and it might buy time to work on a less dirty fix if you're in a hurry to ship. 