### PR TITLE
Nerf an OP `#content ul li` rule in _page-layout-hacks.scss

### DIFF
--- a/htdocs/scss/components/autocompletewithunknown.scss
+++ b/htdocs/scss/components/autocompletewithunknown.scss
@@ -30,7 +30,6 @@ $half-form-spacing: $form-spacing / 2;
 
     .token.new {
         border-style: dashed;
-        margin-left: 0 !important;
     }
 
     .token .token-remove {

--- a/htdocs/scss/pages/entry/new.scss
+++ b/htdocs/scss/pages/entry/new.scss
@@ -146,7 +146,7 @@
             display: flex;
             flex-grow: 1;
             & > li {
-                margin-bottom: 0 !important; // override generic #content ul li rule
+                margin-bottom: 0;
             }
         }
         .entry-quick-metadata {

--- a/htdocs/scss/skins/_entry-styles.scss
+++ b/htdocs/scss/skins/_entry-styles.scss
@@ -109,8 +109,7 @@ ul.text-links {
   margin: 0;
   display: inline;
 
-  // Need an ID to match specificity of a default #content ul li rule.
-  #content & li {
+  li {
     display: inline;
     list-style: none;
     margin-left: 0;
@@ -189,8 +188,7 @@ ul.text-links {
     margin: 0;
     list-style: none;
 
-    // Need an ID to match specificity of a default #content ul li rule.
-    #content & li {
+    li {
       margin-left: 0;
     }
   }
@@ -204,8 +202,7 @@ ul.text-links {
     display: inline;
     margin-left: 0;
 
-    // Need an ID to match specificity of a default #content ul li rule.
-    #content & li {
+    li {
       display: inline;
       margin-left: 0;
     }
@@ -433,7 +430,7 @@ ul.entry-management-links {
     font-weight: bold;
   }
 
-  #content & .comment .reply, // reply action link; need ID to override defaults
+  .comment .reply, // reply action link
   .entry .footer {
     display: none;
   }

--- a/htdocs/scss/skins/_icons-page.scss
+++ b/htdocs/scss/skins/_icons-page.scss
@@ -34,8 +34,7 @@
     font-size: .9rem;
     padding: .2rem 1rem;
 
-    // need one ID to fight a default #content li rule
-    ul, #content & li {
+    ul, li {
       list-style: none;
       display: inline;
       margin: 0;

--- a/htdocs/scss/skins/_page-layout-hacks.scss
+++ b/htdocs/scss/skins/_page-layout-hacks.scss
@@ -10,21 +10,24 @@
     padding-top: 1px;  /*to ensure margin*/
 }
 
-#content ul li {
+// We want default margins for lists inside #content, but an ID selector is too
+// powerful for a constantly-overridden default. An attribute selector has the
+// same specificity as a class, so it's easy to override.
+[id="content"] li {
     margin-left: 2em;
     margin-bottom: 0.75em;
 }
 
-// don't add the bottom spacing for success links
-#content ul.successlinks li {
+// Case in point: override bottom spacing for success links
+ul.successlinks li {
     margin-bottom: 0;
 }
 
-#content ul ul {
+[id="content"] li ul, [id="content"] li ol {
     margin-top: 0.75em;
 }
 
-#content dl dd {
+[id="content"] dd {
     margin-left: 1.5em;
 }
 


### PR DESCRIPTION
The tags field on the new entry page currently looks like this: 

<img src="https://user-images.githubusercontent.com/484309/71287888-5c22d880-231e-11ea-82d9-0761d77202e5.png" width="350">

But it's _supposed_ to look like this: 

<img src="https://user-images.githubusercontent.com/484309/71287920-7361c600-231e-11ea-945c-9a1e54e22e8d.png" width="350">

The problem is a default list style that uses an ID selector. I was going to just add yet another hack to work around it (there were several already, see diff), but it's gonna keep biting us, so let's just fix it instead.

-----

The fix: `#content` and `[id="content"]` target the same element, but the former can only be overridden by rules that contain at least one `#id` (or by `!important`). The latter can be overridden by any class, so specific components will always defeat it.