### PR TITLE
Styles: Fix pervasive sideways slop in "summertime" layout

### DIFF
--- a/styles/summertime/layout.s2
+++ b/styles/summertime/layout.s2
@@ -1508,6 +1508,7 @@ table.month td.day-has-entries p:hover { border: 1px solid; }
 #lj_controlstrip {
     border: none;
     padding: 4px;
+    box-sizing: border-box;
     }
 
 #lj_controlstrip select,


### PR DESCRIPTION
I noticed some sideways slop (MY NEMESIS) while I was trying to reproduce some cut tag behavior several people had described to me.

TBH I don't understand why this style wants 4px of padding on the control strip in the first place, but hey, whatever floats your boat. Easy enough to keep that and still fix the slop. 