### PR TITLE
Fix backwards cut-tag expansion

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -569,11 +569,8 @@ TOKEN:
 
                     # include empty span and div to be filled in on page
                     # load if javascript is enabled
-                    # Note: cuttag_container is a hack, to guard against Firefox bug
-                    # where toggling an element's display is glitchy in the presence
-                    # of certain CSS pseudo-elements (:first-letter, others?)
                     $newdata .=
-"<span class=\"cuttag_container\"><span style=\"display: none;\" id=\"span-cuttag_"
+                          "<span style=\"display: none;\" id=\"span-cuttag_"
                         . $journal . "_"
                         . $ditemid . "_"
                         . $cutcount
@@ -585,7 +582,7 @@ TOKEN:
                         . $ditemid . "_"
                         . $cutcount
                         . "\" aria-live=\"assertive\">";
-                    $newdata .= "</div></span>";
+                    $newdata .= "</div>";
                     $newdata .= "</div>" if $tag eq "div";
 
                     unless ( $opts->{'cutpreview'} ) {

--- a/styles/goldleaf/layout.s2
+++ b/styles/goldleaf/layout.s2
@@ -1377,7 +1377,7 @@ a, a:link, a:visited, a:active, a:hover{
     text-align:$*entry_comment_text_align;
 }
 
-.cuttag_container img{
+.cuttag-action img{
     vertical-align:bottom;
 }
 

--- a/t/cleaner-ljtags.t
+++ b/t/cleaner-ljtags.t
@@ -66,25 +66,25 @@ is(
 # old lj-cut
 is(
     $clean->("And a cut:<lj-cut>foooooooooooooo</lj-cut>"),
-"And a cut:<span class=\"cuttag_container\"><span style=\"display: none;\" id=\"span-cuttag___1\" class=\"cuttag\"></span><b>(&nbsp;<a href=\"$fullurl#cutid1\">Read more...</a>&nbsp;)</b><div style=\"display: none;\" id=\"div-cuttag___1\" aria-live=\"assertive\"></div></span>",
+"And a cut:<span style=\"display: none;\" id=\"span-cuttag___1\" class=\"cuttag\"></span><b>(&nbsp;<a href=\"$fullurl#cutid1\">Read more...</a>&nbsp;)</b><div style=\"display: none;\" id=\"div-cuttag___1\" aria-live=\"assertive\"></div>",
     "old lj-cut"
 );
 is(
     $clean->("And a cut:<lj-cut text='foo'>foooooooooooooo</lj-cut>"),
-"And a cut:<span class=\"cuttag_container\"><span style=\"display: none;\" id=\"span-cuttag___1\" class=\"cuttag\"></span><b>(&nbsp;<a href=\"$fullurl#cutid1\">foo</a>&nbsp;)</b><div style=\"display: none;\" id=\"div-cuttag___1\" aria-live=\"assertive\"></div></span>",
+"And a cut:<span style=\"display: none;\" id=\"span-cuttag___1\" class=\"cuttag\"></span><b>(&nbsp;<a href=\"$fullurl#cutid1\">foo</a>&nbsp;)</b><div style=\"display: none;\" id=\"div-cuttag___1\" aria-live=\"assertive\"></div>",
     "old lj-cut w/ text"
 );
 
 # new lj-cut
 is(
     $clean->(qq{New cut: <div class="ljcut">baaaaaaaaaarrrrr</div>}),
-qq{New cut: <div><span class="cuttag_container"><span style="display: none;" id="span-cuttag___1" class="cuttag"></span><b>(&nbsp;<a href="http://lj.example/full.html#cutid1">Read more...</a>&nbsp;)</b><div style="display: none;" id="div-cuttag___1" aria-live="assertive"></div></span></div>},
+qq{New cut: <div><span style="display: none;" id="span-cuttag___1" class="cuttag"></span><b>(&nbsp;<a href="http://lj.example/full.html#cutid1">Read more...</a>&nbsp;)</b><div style="display: none;" id="div-cuttag___1" aria-live="assertive"></div></div>},
     "new lj-cut w/ div"
 );
 
 is(
     $clean->(qq{New cut: <div class="ljcut" text="This is my div cut">baaaaaaaaaarrrrr</div>}),
-qq{New cut: <div><span class="cuttag_container"><span style="display: none;" id="span-cuttag___1" class="cuttag"></span><b>(&nbsp;<a href="http://lj.example/full.html#cutid1">This is my div cut</a>&nbsp;)</b><div style="display: none;" id="div-cuttag___1" aria-live="assertive"></div></span></div>},
+qq{New cut: <div><span style="display: none;" id="span-cuttag___1" class="cuttag"></span><b>(&nbsp;<a href="http://lj.example/full.html#cutid1">This is my div cut</a>&nbsp;)</b><div style="display: none;" id="div-cuttag___1" aria-live="assertive"></div></div>},
     "new lj-cut w/ div w/ text"
 );
 
@@ -93,7 +93,7 @@ is(
     $clean->(
 qq{Nested: <div class="ljcut" text="Nested">baaaaaaaaaa<div style="background: red">I AM RED</div>arrrrrr</div>}
     ),
-qq{Nested: <div><span class="cuttag_container"><span style="display: none;" id="span-cuttag___1" class="cuttag"></span><b>(&nbsp;<a href="http://lj.example/full.html#cutid1">Nested</a>&nbsp;)</b><div style="display: none;" id="div-cuttag___1" aria-live="assertive"></div></span></div>},
+qq{Nested: <div><span style="display: none;" id="span-cuttag___1" class="cuttag"></span><b>(&nbsp;<a href="http://lj.example/full.html#cutid1">Nested</a>&nbsp;)</b><div style="display: none;" id="div-cuttag___1" aria-live="assertive"></div></div>},
     "nested div cuts"
 );
 is(


### PR DESCRIPTION
Some users have been seeing cut-tags on last-N pages (recent, reading, etc.) expand _backwards._ That is: the content BELOW the cut tag stays in place, everything ABOVE the cut gets pushed upwards, and you find yourself looking at the END of the cut text rather than the beginning. So, basically the opposite of what anyone could possibly want. 

I haven't been able to reproduce this on Chrome yet, but I DID manage to isolate the necessary conditions on Firefox. Basically, when a child of a `display: inline` element gets its `display` property switched between `none` and `block`, it causes the scroll anchor to get re-set in a really maladaptive way. This is probably a Firefox bug, but it turns out we wouldn't be hitting that bug if it weren't for a workaround we did in 2010 for a _different_ Firefox bug, which appears to be long since fixed. If we remove the hack, the current problem goes away. Hashtag #or-you-live-long-enough-to-become-the-villain.

(There are other things that can interrupt this bug's chain too, which is why we weren't seeing that behavior on every layout or with every entry that includes a multi-page cut. Posts using markdown were exempt, and layouts that set `overflow-x` or certain other properties on entry containers were also exempt.)

To check it out yourself: 

- In `about:config`, switch `layout.css.scroll-anchoring.highlight` to `true`. This will highlight the current scroll anchoring node with a purple box. Gets annoying REAL quick. 
- Testcase at <http://www.sedumphotos.net/nfagerlund/testcases/re-anchoring.html>. Scroll down, note that the anchor node is correctly set to one of the paragraphs near the top of the viewport, then click the button. Anchor node should switch to the "big mood" element below the button. 
- This is what happens immediately _before_ the cut tag text gets rendered. Then, with the anchor set nice and low, the cut content is free to push everything upwards. 