### PR TITLE
Fix crossposter, maybe

### DIFF
--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -69,20 +69,14 @@ sub ljuser_display {
     my $display_class = $opts{no_ljuser_class} ? "" : " class='ljuser'";
     my $domain = $self->site->{domain} ? $self->site->{domain} : $self->site->{hostname};
 
-    my $ret = '';
-    $ret .= "<span style='white-space: nowrap;'$display_class>";
-    $ret .= "<a href='$profile_url'>"
-        unless $opts{no_link};
-    $ret .=
-"<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>";
-    $ret .= "</a><a href='$journal_url'>"
-        unless $opts{no_link};
-    $ret .= "<b>$user</b>";
-    $ret .= "</a>"
-        unless $opts{no_link};
-    $ret .= "</span>";
-
-    return $ret;
+    return
+          "<span style='white-space: nowrap;'$display_class>"
+        . ( $opts{no_link} ? '' : "<a href='$profile_url'>" )
+        . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
+        . ( $opts{no_link} ? '' : "</a><a href='$journal_url'>" )
+        . "<b>$user</b>"
+        . ( $opts{no_link} ? '' : "</a>" )
+        . "</span>";
 }
 
 1;

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -579,8 +579,10 @@ TOKEN:
                 if ( $opts->{preserve_lj_tags_for} ) {
                     $opencount{'lj-cut'}++;
                     $newdata .= qq{<lj-cut};
-                    $newdata .= qq{ text="$attr->{'text'}"}
-                        if $attr->{'text'};
+                    if ( $attr->{'text'} ) {
+                        my $etext = $link_text->();
+                        $newdata .= qq{ text="$etext"};
+                    }
                     $newdata .= '>';
                     next TOKEN;
                 }

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -532,13 +532,6 @@ TOKEN:
                 $ljcut_div = 0;
             }
 
-            # no cut URL, record the anchor, but then fall through
-            if ( 0 && $ljcut_div && !$cut ) {
-                $cutcount++;
-                $newdata .= "<a name=\"cutid$cutcount\"></a>";
-                $ljcut_div = 0;
-            }
-
             # Hack: Twitter uses @-syntax to refer to users, so we want to set
             # a flag that says we're in a space where we shouldn't embed.
             if ( $tag eq 'blockquote' && $attr->{class} eq 'twitter-tweet' ) {

--- a/cgi-bin/LJ/User/Display.pm
+++ b/cgi-bin/LJ/User/Display.pm
@@ -214,20 +214,15 @@ sub ljuser_display {
 
         my $lj_user = $opts->{no_ljuser_class} ? "" : " lj:user='$name'";
 
-        my $ret = '';
-        $ret .= "<span$lj_user style='white-space: nowrap;$strike'$display_class>";
-        $ret .= "<a href='$profile'>"
-            unless $opts->{no_link};
-        $ret .= "<img src='$imgurl' alt='[$type profile] ' width='$width' height='$height'";
-        $ret .= " style='vertical-align: text-bottom; border: 0; padding-right: 1px;' />";
-        $ret .= "</a><a href='$url' rel='nofollow'>"
-            unless $opts->{no_link};
-        $ret .= "<b>$name</b>";
-        $ret .= "</a>"
-            unless $opts->{no_link};
-        $ret .= "</span>";
-
-        return $ret;
+        return
+              "<span$lj_user style='white-space: nowrap;$strike'$display_class>"
+            . ( $opts->{no_link} ? '' : "<a href='$profile'>" )
+            . "<img src='$imgurl' alt='[$type profile] ' width='$width' height='$height'"
+            . " style='vertical-align: text-bottom; border: 0; padding-right: 1px;' />"
+            . ( $opts->{no_link} ? '' : "</a><a href='$url' rel='nofollow'>" )
+            . "<b>$name</b>"
+            . ( $opts->{no_link} ? '' : "</a>" )
+            . "</span>";
     }
     else {
         return "<b>????</b>";
@@ -637,20 +632,15 @@ sub ljuser {
         $profile = $profile_url ne '' ? $profile_url : $profile . $andfull;
         $url     = $journal_url ne '' ? $journal_url : $url;
 
-        my $ret = '';
-        $ret .= "<span$lj_user style='white-space: nowrap;$strike'$display_class>";
-        $ret .= "<a href='$profile'>"
-            unless $opts->{no_link};
-        $ret .= "<img src='$img/$fil' alt='[$alttext] ' width='$x' height='$y'";
-        $ret .= " style='vertical-align: text-bottom; border: 0; padding-right: 1px;' />";
-        $ret .= "</a><a href='$url'$link_color>"
-            unless $opts->{no_link};
-        $ret .= $ljusername;
-        $ret .= "</a>"
-            unless $opts->{no_link};
-        $ret .= "</span>";
-
-        return $ret;
+        return
+              "<span$lj_user style='white-space: nowrap;$strike'$display_class>"
+            . ( $opts->{no_link} ? '' : "<a href='$profile'>" )
+            . "<img src='$img/$fil' alt='[$alttext] ' width='$x' height='$y'"
+            . " style='vertical-align: text-bottom; border: 0; padding-right: 1px;' />"
+            . ( $opts->{no_link} ? '' : "</a><a href='$url'$link_color>" )
+            . $ljusername
+            . ( $opts->{no_link} ? '' : "</a>" )
+            . "</span>";
     };
 
     my $u = isu($user) ? $user : LJ::load_user($user);


### PR DESCRIPTION
Fixes #2606 

We discussed this approach briefly in the discord. Roughly: currently the crossposter has to know things about all of DW's formatting dialects and do Something to whip them into a format that will display as expected on LJ. This PR tries to simplify that a bit:

- Crossposts will now always get sent as `opt_preformatted`, and we'll process them ahead of time to render all of our autoformatting correctly, no matter what the original formatting dialect is. So if you try to edit a crosspost manually on LJ, it's not going to much resemble your original source — we'll have already turned markdown into HTML, or replaced line breaks with `<br>` tags, or what have you. 
- But we're keeping the existing behavior where we preserve cut tags, and the one where we translate `<user name="whoevs" site="DESTINATION.SITE">` into `<lj user="whoevs">` if DESTINATION.SITE matches the crosspost's target. (Works with `@mentions` now!)

More in the commit messages. 

## 🚨 THIS PR HAS NOT BEEN TESTED. 🚨

Because I don't have any good way to field-test the crossposter. I know it doesn't blow up normal site display stuff, but beyond that I'm at the mercy of my kind reviewers here. So please stare hard. 😬