### PR TITLE
Feature: bcrypted passwords

### DIFF
--- a/bin/renameuser.pl
+++ b/bin/renameuser.pl
@@ -66,10 +66,6 @@ unless ( $args{force} ) {
         print "   " . $acct[1]->email_raw . "\n";
         exit 1;
     }
-    unless ( $acct[0]->password eq $acct[1]->password ) {
-        print "Passwords don't match.\n";
-        exit 1;
-    }
     unless ( $acct[0]->{'status'} eq "A" || $acct[1]->{'status'} eq "A" ) {
         print "At least one account isn't verified.\n";
         exit 1;

--- a/bin/upgrading/d10-passwords.pl
+++ b/bin/upgrading/d10-passwords.pl
@@ -1,0 +1,59 @@
+#!/usr/bin/perl
+#
+# d10-passwords.pl
+#
+# Migration tool to migrate users to dversion 10, with bcrypted passwords.
+#
+# Authors:
+#     Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2020 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+#
+use v5.10;
+use strict;
+BEGIN { require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+my $dbh = LJ::get_db_writer();
+
+while (1) {
+    sleep(1);
+    print "FINDING_USERS\n";
+
+    # Get 1000 users at a time to do the migration.
+    my $sth = $dbh->prepare(q{SELECT userid FROM user WHERE dversion = 9 LIMIT 1000});
+    $sth->execute;
+    die $sth->errstr if $sth->err;
+
+    # Iterate each user, load, update, save
+    while ( my ($uid) = $sth->fetchrow_array ) {
+        my $u = LJ::load_userid($uid)
+            or die "Invalid userid: $uid\n";
+
+        # If this is not a person, there's nothing to do, so just upgrade their dversion
+        # and move on.
+        unless ( $u->is_person ) {
+            $u->update_self( { dversion => 10 } );
+            print "UPGRADED $u->{user}($uid) NOT_PERSON\n";
+            continue;
+        }
+
+        # If they're expunged, we also just auto-upgrade.
+        if ( $u->is_expunged ) {
+            $u->update_self( { dversion => 10 } );
+            print "UPGRADED $u->{user}($uid) EXPUNGED\n";
+            continue;
+        }
+
+        # Valid user, get their password, set it, move on.
+        my $password = $u->password
+            or die "Failed to get password on $u->{user}($uid)!\n";
+        $u->set_password( $password, force_bcrypt => 1 );
+        $u->update_self( { dversion => 10 } );
+        print "UPGRADED $u->{user}($uid) MIGRATED\n";
+    }
+}

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -2215,12 +2215,10 @@ CREATE TABLE password (
 )
 EOC
 
-register_tablecreate( "password_bcrypt", <<'EOC');
-CREATE TABLE password_bcrypt (
-    userid           INT UNSIGNED NOT NULL PRIMARY KEY,
-    bcrypt_cost      SMALLINT UNSIGNED NOT NULL,
-    bcrypt_salt      CHAR(22) NOT NULL,
-    bcrypt_hash      CHAR(31) NOT NULL
+register_tablecreate( "password2", <<'EOC');
+CREATE TABLE password2 (
+    userid      INT UNSIGNED NOT NULL PRIMARY KEY,
+    bcrypt_hash VARCHAR(60) NOT NULL
 )
 EOC
 

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -2215,6 +2215,15 @@ CREATE TABLE password (
 )
 EOC
 
+register_tablecreate( "password_bcrypt", <<'EOC');
+CREATE TABLE password_bcrypt (
+    userid           INT UNSIGNED NOT NULL PRIMARY KEY,
+    bcrypt_cost      SMALLINT UNSIGNED NOT NULL,
+    bcrypt_salt      CHAR(22) NOT NULL,
+    bcrypt_hash      CHAR(31) NOT NULL
+)
+EOC
+
 register_tablecreate( "email", <<'EOC');
 CREATE TABLE email (
     userid    INT UNSIGNED NOT NULL PRIMARY KEY,

--- a/cgi-bin/DW/Auth.pm
+++ b/cgi-bin/DW/Auth.pm
@@ -4,6 +4,11 @@
 #
 # Alternate authentication styles
 #
+# BIG NOTE: These authentication mechanisms break as soon as we move to storing
+# bcrypted passwords, which are not compatible with schemes like digest auth that
+# require us to be able to reverse the user's password. Do we care? Do we need to
+# generate app passwords?
+#
 # Authors:
 #      Andrea Nall <anall@andreanall.com>
 #      Afuna <coder.dw@afunamatata.com>

--- a/cgi-bin/DW/Auth.pm
+++ b/cgi-bin/DW/Auth.pm
@@ -195,25 +195,24 @@ sub _auth_basic {
     };
 
     unless ( $r->header_in("Authorization") ) {
-       return $decline->();
+        return $decline->();
     }
 
     my $header = $r->header_in("Authorization");
 
-    my ($authname, $val) = split( ' ', $header );
+    my ( $authname, $val ) = split( ' ', $header );
 
     # sanity checks
-    unless ( $authname eq 'Basic')
-    {
+    unless ( $authname eq 'Basic' ) {
         return $decline->();
     }
     $val =~ s/=$//;    # strip base64 newline char
     my $decoded = MIME::Base64::decode_base64($val);
 
-    my ($username, $password) = split(":", $decoded, 2);
+    my ( $username, $password ) = split( ":", $decoded, 2 );
 
     # the username
-    my $user = LJ::canonical_username( $username );
+    my $user = LJ::canonical_username($username);
     my $u    = LJ::load_user($user);
 
     return $decline->() unless $u;
@@ -223,7 +222,7 @@ sub _auth_basic {
     return $decline->() unless $u->password;
 
     return $decline->()
-        unless $u->check_password( $password );
+        unless $u->check_password($password);
 
     return ( $u, undef );
 }

--- a/cgi-bin/DW/Controller/ChangeEmail.pm
+++ b/cgi-bin/DW/Controller/ChangeEmail.pm
@@ -89,7 +89,9 @@ sub changeemail_handler {
             push @errors, LJ::Lang::ml('/changeemail.tt.error.nospace');
         }
 
-        if ( !$remote->is_identity && ( !defined $password || $password ne $remote->password ) ) {
+        if ( !$remote->is_identity
+            && ( !defined $password || !$remote->check_password($password) ) )
+        {
             push @errors, LJ::Lang::ml('/changeemail.tt.error.invalidpassword');
         }
 

--- a/cgi-bin/DW/Controller/Create.pm
+++ b/cgi-bin/DW/Controller/Create.pm
@@ -326,6 +326,8 @@ sub create_handler {
         email_checkbox => $email_checkbox,
 
         username_maxlength => $LJ::USERNAME_MAXLENGTH,
+        password_minlength => $LJ::PASSWORD_MINLENGTH,
+        password_maxlength => $LJ::PASSWORD_MAXLENGTH,
     };
 
     if ( $code_valid && $rate_ok ) {

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -265,6 +265,8 @@ sub new_handler {
 
     $vars->{action} = { url => LJ::create_url( undef, keep_args => 1 ), };
 
+    $vars->{password_maxlength} = $LJ::PASSWORD_MAXLENGTH;
+
     return DW::Template->render_template( 'entry/form.tt', $vars );
 }
 

--- a/cgi-bin/DW/Controller/MassPrivacy.pm
+++ b/cgi-bin/DW/Controller/MassPrivacy.pm
@@ -191,18 +191,19 @@ sub editprivacy_handler {
     my @days   = map { $_, $_ } ( 1 .. 31 );
     my @months = map { $_, LJ::Lang::month_long_ml($_) } ( 1 .. 12 );
     my $vars   = {
-        mode          => $mode,
-        POST          => $POST,
-        more_public   => $more_public,
-        day_list      => \@days,
-        month_list    => \@months,
-        security_list => \@security,
-        security      => \%security,
-        errors        => $errors,
-        s_dt          => $s_dt,
-        e_dt          => $e_dt,
-        posts         => $posts,
-        u             => $u,
+        mode               => $mode,
+        POST               => $POST,
+        more_public        => $more_public,
+        day_list           => \@days,
+        month_list         => \@months,
+        security_list      => \@security,
+        security           => \%security,
+        errors             => $errors,
+        s_dt               => $s_dt,
+        e_dt               => $e_dt,
+        posts              => $posts,
+        u                  => $u,
+        password_maxlength => $LJ::PASSWORD_MAXLENGTH,
     };
 
     return DW::Template->render_template( 'editprivacy.tt', $vars );

--- a/cgi-bin/DW/Controller/Settings.pm
+++ b/cgi-bin/DW/Controller/Settings.pm
@@ -381,6 +381,9 @@ sub changepassword_handler {
 
         formdata => $post || { user => $remote ? $remote->user : "" },
         errors   => $errors,
+
+        username_maxlength => $LJ::USERNAME_MAXLENGTH,
+        password_maxlength => $LJ::PASSWORD_MAXLENGTH,
     };
     return DW::Template->render_template( 'settings/changepassword.tt', $vars );
 }

--- a/cgi-bin/DW/User/Rename.pm
+++ b/cgi-bin/DW/User/Rename.pm
@@ -329,7 +329,6 @@ sub _are_same_person {
 # may be able to do this more elegantly once we are able to associate accounts
 # right now: two valid accounts, same email address, same password, and at least one must be validated
     return 0 unless $p1->has_same_email_as($p2);
-    return 0 unless $p1->password eq $p2->password;
     return 0 unless $p1->is_validated || $p2->is_validated;
 
     return 1;

--- a/cgi-bin/LJ/Auth.pm
+++ b/cgi-bin/LJ/Auth.pm
@@ -171,7 +171,7 @@ sub auth_okay {
     };
 
     ## LJ default authorization:
-    return 1 if $password eq $u->password;
+    return 1 if $u->check_password($password);
     return $bad_login->();
 }
 

--- a/cgi-bin/LJ/Console/Command/ResetPassword.pm
+++ b/cgi-bin/LJ/Console/Command/ResetPassword.pm
@@ -46,8 +46,7 @@ sub execute {
         unless $u;
 
     my $newpass = LJ::rand_chars(8);
-    my $oldpass = Digest::MD5::md5_hex( $u->password . "change" );
-    my $rval    = $u->infohistory_add( 'passwordreset', $oldpass );
+    my $rval    = $u->infohistory_add( 'passwordreset', 'reset' );
     return $self->error("Failed to insert old password into infohistory.")
         unless $rval;
 

--- a/cgi-bin/LJ/CreatePage.pm
+++ b/cgi-bin/LJ/CreatePage.pm
@@ -62,7 +62,7 @@ sub verify_username {
                     # brute-force possibly going on
                 }
                 else {
-                    if ( $u->password eq $post->{password1} ) {
+                    if ( $u->check_password( $post->{password1} ) ) {
 
                         # okay either they double-clicked the submit button
                         # or somebody entered an account name that already exists
@@ -96,7 +96,6 @@ sub verify_password {
     my ( $password, $username, $email, $name );
     my $u = $opts{u};
     if ( LJ::isu($u) ) {
-        $password = $u->password;
         $username = $u->user;
         $email    = $u->email_raw;
         $name     = $u->name_raw;

--- a/cgi-bin/LJ/CreatePage.pm
+++ b/cgi-bin/LJ/CreatePage.pm
@@ -110,13 +110,13 @@ sub verify_password {
     return LJ::Lang::ml('widget.createaccount.error.password.blank')
         unless $password;
 
-    # at least 6 characters
+    # at least a few characters
     return LJ::Lang::ml('widget.createaccount.error.password.tooshort')
-        if length $password < 6;
+        if length $password < $LJ::PASSWORD_MINLENGTH;
 
-    # no more than 30 characters
+    # no more than X characters
     return LJ::Lang::ml('widget.createaccount.error.password.toolong')
-        if length $password > 30;
+        if length $password > $LJ::PASSWORD_MAXLENGTH;
 
     # only ascii characters
     return LJ::Lang::ml('widget.createaccount.error.password.asciionly')

--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -346,6 +346,10 @@ no strict "vars";
     # of database fields to match. And perhaps other stuff.
     $USERNAME_MAXLENGTH = 25;
 
+    # Password size requirements
+    $PASSWORD_MINLENGTH = 6;
+    $PASSWORD_MAXLENGTH = 72;
+
     # Cost to set for bcrypt password hash calculations.
     $BCRYPT_COST = 12;
 }

--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -342,8 +342,12 @@ no strict "vars";
     # Selective screening limit. No user can have more than this.
     $LJ::SEL_SCREEN_LIMIT ||= 500;
 
-# maximum length of a username (NB do not change without changing width of database fields to match. And perhaps other stuff.
+    # Maximum length of a username (NB do not change without changing width
+    # of database fields to match. And perhaps other stuff.
     $USERNAME_MAXLENGTH = 25;
+
+    # Cost to set for bcrypt password hash calculations.
+    $BCRYPT_COST = 12;
 }
 
 1;

--- a/cgi-bin/LJ/Setting/EmailPosting.pm
+++ b/cgi-bin/LJ/Setting/EmailPosting.pm
@@ -183,7 +183,7 @@ sub save {
             'setting.emailposting.error.pin.invalidaccount',
             { sitename => $LJ::SITENAMESHORT }
         )
-    ) if $pin_val eq $u->password || $pin_val eq $u->user;
+    ) if $pin_val eq $u->user;
 
     $u->set_prop( emailpost_pin => $pin_val );
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1617,6 +1617,7 @@ sub talkform {
         create_link          => '',
         subjecticon_ids      => \@subjecticon_ids,
         username_maxlength   => $LJ::USERNAME_MAXLENGTH,
+        password_maxlength   => $LJ::PASSWORD_MAXLENGTH,
 
         foundation_beta => LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" )
             && $LJ::ACTIVE_RES_GROUP

--- a/cgi-bin/LJ/User/Login.pm
+++ b/cgi-bin/LJ/User/Login.pm
@@ -378,7 +378,7 @@ sub set_password {
     my $dbh = LJ::get_db_writer()
         or croak('Unable to get db master.');
 
-    if ( $u->dversion <= 9 && ! $opts{force_bcrypt} ) {
+    if ( $u->dversion <= 9 && !$opts{force_bcrypt} ) {
 
         # Old style: Write raw password to the database and store it in the user
         # object. This is quite dumb, but it was the late 90s when this was written?

--- a/cgi-bin/LJ/Widget/Login.pm
+++ b/cgi-bin/LJ/Widget/Login.pm
@@ -96,7 +96,7 @@ sub render_body {
             . LJ::Lang::ml('/login.bml.login.password')
             . "</label>\n";
         $ret .=
-"<input type='password' id='lj_loginwidget_password' name='password' class='lj_login_password text' size='20' maxlength='30' tabindex='12' /><a href='$LJ::SITEROOT/lostinfo' class='small-link' tabindex='16'>"
+"<input type='password' id='lj_loginwidget_password' name='password' class='lj_login_password text' size='20' maxlength='$LJ::PASSWORD_MAXLENGTH' tabindex='12' /><a href='$LJ::SITEROOT/lostinfo' class='small-link' tabindex='16'>"
             . LJ::Lang::ml('/login.bml.login.forget2')
             . "</a>\n";
         $ret .= "</fieldset>\n";

--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -7,6 +7,7 @@ Class::Data::Inheritable
 Class::Trigger
 Compress::Zlib
 Crypt::DH
+Crypt::Eksblowfish::Bcrypt
 Danga::Socket
 Data::ObjectDriver
 Digest::HMAC_SHA1
@@ -30,6 +31,7 @@ MIME::Lite
 MIME::Words
 Mail::GnuPG
 Math::BigInt::GMP
+Math::Random::Secure
 MogileFS::Client@1.17
 Moose
 Mozilla::CA

--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -1,3 +1,5 @@
+Authen::Passphrase::Clear
+Authen::Passphrase::BlowfishCrypt
 Business::CreditCard
 CGI::Cookie
 Cache::Memcached
@@ -7,7 +9,6 @@ Class::Data::Inheritable
 Class::Trigger
 Compress::Zlib
 Crypt::DH
-Crypt::Eksblowfish::Bcrypt
 Danga::Socket
 Data::ObjectDriver
 Digest::HMAC_SHA1
@@ -31,7 +32,6 @@ MIME::Lite
 MIME::Words
 Mail::GnuPG
 Math::BigInt::GMP
-Math::Random::Secure
 MogileFS::Client@1.17
 Moose
 Mozilla::CA

--- a/htdocs/admin/impersonate.bml
+++ b/htdocs/admin/impersonate.bml
@@ -39,7 +39,7 @@ body<=
         push @errors, BML::ml( '.error.invaliduser', { user => LJ::ehtml( $POST{username} ) } ) unless $u;
 
         my $password = $POST{password};
-        push @errors, $ML{'.error.invalidpassword'} unless $password && $password eq $remote->password;
+        push @errors, $ML{'.error.invalidpassword'} unless $password && $remote->check_password( $password );
 
         my $reason = LJ::ehtml( LJ::trim( $POST{reason} ) );
         push @errors, $ML{'.error.emptyreason'} unless $reason;

--- a/htdocs/lostinfo.bml
+++ b/htdocs/lostinfo.bml
@@ -107,8 +107,7 @@ body<=
             return $err->( $ML{'.error.syndicated'} );
         }
 
-        if ( $u->is_community && ! length $u->password ) {
-            # community with no password
+        if ( $u->is_community ) {
             return $err->( $ML{'.error.commnopassword'} );
         }
 

--- a/htdocs/manage/emailpost.bml
+++ b/htdocs/manage/emailpost.bml
@@ -284,7 +284,7 @@ body<=
             unless $pin =~ /^([a-z0-9]){4,20}$/i or $pin eq '';
 
         push @errors, BML::ml('.error.invalidpinaccount', {'sitename' => $LJ::SITENAMESHORT})
-            if $pin eq $u->password or $pin eq $u->user;
+            if $pin eq $u->user;
 
         # Check email, add flags if needed.
         my %allowed;

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -180,7 +180,7 @@ _c?>
         $auth .= "<p class='pkg'>\n";
         $auth .= "<label for='altlogin_password' class='left'>$ML{'.password'}</label>\n";
         $auth .= LJ::html_text({ 'type' => 'password', 'id' => 'altlogin_password', 'class' => 'text',
-                'name' => 'password', 'tabindex' => '6', 'size' => '15', 'maxlength' => '30' }) . "\n";
+                'name' => 'password', 'tabindex' => '6', 'size' => '15', 'maxlength' => $LJ::PASSWORD_MAXLENGTH }) . "\n";
         # posted with a user, but no password
         if ($did_post && $auth_missing) {
             $auth .= "<br /><?inerr $ML{'.error.nopass'} inerr?>";

--- a/views/create/account.tt
+++ b/views/create/account.tt
@@ -90,7 +90,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         label = dw.ml( '.field.password' )
         name  = 'password1'
 
-        maxlength = 31
+        maxlength = password_maxlength + 1
 
         "aria-required" = "true"
     ) -%]
@@ -106,7 +106,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         label = dw.ml( '.field.confirmpassword' )
         name  = 'password2'
 
-        maxlength = 31
+        maxlength = password_maxlength + 1
 
         "aria-required" = "true"
     ) -%]
@@ -172,5 +172,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
 </form>
 
 [%- BLOCK tooltip text="" id="" -%]
-<div class="tooltip tip-right" id="hint-[%- id -%]"><div class='nub'></div> [%- text | ml -%]</div>
+<div class="tooltip tip-right" id="hint-[%- id -%]">
+    <div class='nub'></div>
+    [%- text | ml( password_minlength = password_minlength, password_maxlength = password_maxlength ) -%]
+</div>
 [%- END -%]

--- a/views/create/account.tt.text
+++ b/views/create/account.tt.text
@@ -26,7 +26,7 @@
 
 .tip.email=We need your email address to send you important information. We'll never give your email address to anyone else.
 
-.tip.password=Choose a secure password that's between 6 and 30 characters long with at least 4 unique characters and one non-letter character (digit or symbol). Passwords can't be based on your account name, your real name, or your email address for security reasons.
+.tip.password=Choose a secure password that's between [[password_minlength]] and [[password_maxlength]] characters long with at least 4 unique characters and one non-letter character (digit or symbol). Passwords can't be based on your account name, your real name, or your email address for security reasons.
 
 .tip.username=Use lower-case letters (a-z), digits (0-9), and underscores (_), and choose a name between 2 and 25 characters long. You can't start or end your account name with an underscore, nor have two consecutive underscores.
 

--- a/views/editprivacy.tt
+++ b/views/editprivacy.tt
@@ -115,7 +115,7 @@
             [% IF more_public %]
             <div class="row">
             	<div class="columns medium-6 end">
-                [% form.password( name = 'password', size='20,' maxlength='30', 'label'= "Password Required") %]
+                [% form.password(name='password', size='20', maxlength=password_maxlength, label="Password Required") %]
                 </div>
                 </div>
             [% END %]

--- a/views/entry/login.tt
+++ b/views/entry/login.tt
@@ -32,6 +32,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         type = "password"
         name = "password"
         size = "20"
+        maxlength = password_maxlength
         "aria-required" = "true"
     ) -%]
     <input class="button expand" type="submit" name="login" value="[% '.onetime.button.post' | ml %]" aria-describedby="one-time" />

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -287,7 +287,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
           name = 'password'
           id= 'password'
           label = dw.ml('Password')
-          maxlength = 30
+          maxlength = password_maxlength
           size = 18
         ) -%]
       </div>
@@ -760,7 +760,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
               name = 'password'
               id= 'password'
               label = dw.ml('Password')
-              maxlength = 30
+              maxlength = password_maxlength
               size = 18
             ) -%]
           </div>

--- a/views/login.tt
+++ b/views/login.tt
@@ -22,7 +22,7 @@ reference 'perldoc perlartistic' or 'perldoc perlgpl'.
       </fieldset>
       <fieldset class="pkg nostyle"> 
         <label for="lj_login_password" class="left">[% '.login.password' | ml %]</label> 
-        <input type="password" id="lj_login_password" name="password" class="lj_login_password text" size="20" maxlength="30" tabindex="12" aria-required="true" />
+        <input type="password" id="lj_login_password" name="password" class="lj_login_password text" size="20" maxlength="[% password_maxlength %]" tabindex="12" aria-required="true" />
       </fieldset>
       <input type="hidden" name="returnto" value="[% returnto %]"/>
       <fieldset class="pkg nostyle"> 

--- a/views/settings/changepassword.tt
+++ b/views/settings/changepassword.tt
@@ -34,14 +34,14 @@ the same terms as Perl itself.  For a copy of the license, please reference
             [%- form.textbox(
                     label = dw.ml( '.header.username' )
                     name = 'user'
-                    maxlength = 25
+                    maxlength = username_maxlength
             ) -%]
         </div></div>
         <div class="row"><div class="columns">
             [%- form.password(
                 label = dw.ml( ".currentpassword" )
                 name = "password"
-                maxlength = "30"
+                maxlength = password_maxlength
             ) -%]
         </div></div>
     [%- END -%]
@@ -50,7 +50,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.password(
             label = dw.ml( ".newpassword" )
             name = "newpass1"
-            maxlength = "31"
+            maxlength = password_maxlength + 1
         ) -%]
     </div></div>
 
@@ -58,7 +58,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- form.password(
             label = dw.ml( ".newpasswordagain" )
             name = "newpass2"
-            maxlength = "31"
+            maxlength = password_maxlength + 1
         ) -%]
     </div></div>
 

--- a/views/settings/changepassword.tt.text
+++ b/views/settings/changepassword.tt.text
@@ -29,8 +29,6 @@ Regards,
 
 .error.changetestaccount=You can't change the test account's password.
 
-.error.characterlimit=Passwords are limited to a maximum of 30 characters.
-
 .error.emailchanged=You've changed your email address since you requested this password reset. You'll need to <a href="[[url]]">request another reset link</a> in order to change your password.
 
 .error.identity=OpenID accounts don't have passwords.


### PR DESCRIPTION
This implements using properly bcrypted passwords with unique salts, per
best practices. This change has a couple of sharp edges:

1) ATOM posting and digest-auth will break. Unclear how impactful this
is or what we should consider doing (if anything) about it.

2) Renames used to verify that the accounts being merged shared a
password. We think that having validated email accounts that match is
good enough, though.

3) Probably some bugs, I've only tested that I can still log in/out,
haven't gone wild testing every flow.

The implementation leverages our dversion system so that users can be on
the 'old style' passwords and we can upgrade them when we are confident
and ready to roll.