### PR TITLE
Add local TaskQueue

### DIFF
--- a/cgi-bin/DW/Task/ESN/FilterSubs.pm
+++ b/cgi-bin/DW/Task/ESN/FilterSubs.pm
@@ -74,7 +74,7 @@ sub work {
 
     $0 = 'esn-filter-subs [bored]';
 
-    DW::TaskQueue->get->send( LJ::ESN->tasks_of_unique_matching_subs( $evt, @subs ) );
+    DW::TaskQueue->send( LJ::ESN->tasks_of_unique_matching_subs( $evt, @subs ) );
     return DW::Task::COMPLETED;
 }
 

--- a/cgi-bin/DW/Task/ESN/FindSubsByCluster.pm
+++ b/cgi-bin/DW/Task/ESN/FindSubsByCluster.pm
@@ -42,7 +42,7 @@ sub work {
 
     # fast path:  job from phase2 to phase4, skipping filtering.
     if ( @subs <= $LJ::ESN::MAX_FILTER_SET ) {
-        DW::TaskQueue->get->send( LJ::ESN->tasks_of_unique_matching_subs( $evt, @subs ) );
+        DW::TaskQueue->send( LJ::ESN->tasks_of_unique_matching_subs( $evt, @subs ) );
         return DW::Task::COMPLETED;
     }
 
@@ -96,7 +96,7 @@ sub work {
         push @subjobs, DW::Task::ESN::FilterSubs->new( $e_params, $sublist, $cid );
     }
 
-    DW::TaskQueue->get->send(@subjobs);
+    DW::TaskQueue->send(@subjobs);
     return DW::Task::COMPLETED;
 }
 

--- a/cgi-bin/DW/TaskQueue.pm
+++ b/cgi-bin/DW/TaskQueue.pm
@@ -7,7 +7,7 @@
 # Authors:
 #     Mark Smith <mark@dreamwidth.org>
 #
-# Copyright (c) 2019 by Dreamwidth Studios, LLC.
+# Copyright (c) 2019-2020 by Dreamwidth Studios, LLC.
 #
 # This program is free software; you may redistribute it and/or modify it under
 # the same terms as Perl itself.  For a copy of the license, please reference
@@ -21,154 +21,47 @@ use v5.10;
 use Log::Log4perl;
 my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
-# use Coro;
-use MIME::Base64;
-use Paws;
-use Paws::Credential::InstanceProfile;
-use Storable qw/ nfreeze thaw /;
-use Time::HiRes qw/ time /;
-use UUID::Tiny qw/ :std /;
-
-use DW::Task;
-
-use constant LARGE_MESSAGE_CUTOFF => 255_000;
-use constant MAX_BATCH_SIZE       => 10;
+use DW::TaskQueue::SQS;
+use DW::TaskQueue::LocalDisk;
 
 my $_queue;
 
 sub get {
     my $class = $_[0];
-    return $_queue //= $class->init(%LJ::SQS);
+
+    return $_queue if defined $_queue;
+
+    # Determine what kind of queue object to build, depending on if we're
+    # running locally or not
+    if ( exists $LJ::SQS{region} ) {
+        return $_queue = DW::TaskQueue::SQS->init(%LJ::SQS);
+    }
+
+    # If we're a dev server, allow the local mode (not allowed in production,
+    # it's really crappy)
+    if ($LJ::IS_DEV_SERVER) {
+        return $_queue = DW::TaskQueue::LocalDisk->init();
+    }
+
+    $log->logcroak('Unable to instantiate any DW::TaskQueue modules.');
 }
 
-sub init {
-    my ( $class, %args ) = @_;
+sub send {
+    my ( $class, @args ) = @_;
 
-    foreach my $required (qw/ region prefix /) {
-        $log->logcroak( 'SQS configuration must include config: ', $required )
-            unless exists $args{$required};
-    }
-
-    $log->logcroak('Prefix does not match required regex: [a-zA-Z0-9_-]+$.')
-        if defined $args{prefix} && $args{prefix} !~ /^[a-zA-Z0-9_-]+$/;
-
-    my $credentials = Paws::Credential::InstanceProfile->new;
-    if ( defined $args{access_key} && defined $args{secret_key} ) {
-        $log->warn('Using INSECURE AWS configuration!');
-        $credentials = Paws::Credential::Local->new(
-            access_key => $args{access_key},
-            secret_key => $args{secret_key},
-        );
-    }
-
-    my $paws = Paws->new(
-        config => {
-            credentials => $credentials,
-            region      => $args{region},
-        },
-    ) or $log->logcroak('Failed to initialize Paws object.');
-    my $sqs = $paws->service('SQS')
-        or $log->logcroak('Failed to initialize Paws::SQS object.');
-
-    $log->debug("Initializing taskqueue for SQS");
-    my $self = {
-        sqs    => $sqs,
-        prefix => $args{prefix},
-        queues => {},
-    };
-    return bless $self, $class;
+    $class->get->send(@args);
 }
 
-sub _get_queue_for_task {
-    my ( $self, $task, %opts ) = @_;
+sub receive {
+    my ( $class, @args ) = @_;
 
-    my ( $dlq_name, $dlq_url );
-    my $queue_name = lc( ref $task || $task );
-    unless ( $opts{dlq} ) {
-        $queue_name =~ s/::/-/g;
-        $queue_name = $self->{prefix} . $queue_name;
+    $class->get->receive(@args);
+}
 
-        $dlq_name = $queue_name . '-dlq';
-        $dlq_url  = $self->_get_queue_for_task( $dlq_name, dlq => { $task->queue_attributes } );
-    }
+sub completed {
+    my ( $class, @args ) = @_;
 
-    # Cache hit?
-    return ( $queue_name, $self->{queues}->{$queue_name} )
-        if exists $self->{queues}->{$queue_name};
-
-    # Fetch queue attributes
-    my $queue_attrs = $opts{dlq} // { $task->queue_attributes( dlq => $dlq_name ) };
-
-    # Fall back to SQS
-    my $res = eval { $self->{sqs}->GetQueueUrl( QueueName => $queue_name ) };
-    if ( $@ && $@->isa('Paws::Exception') ) {
-        $log->warn("Failed to get queue $queue_name, creating.");
-
-        # Fall back to creating the queue
-        $res = eval {
-            $self->{sqs}->CreateQueue(
-                QueueName  => $queue_name,
-                Attributes => $queue_attrs,
-            );
-        };
-        if ( $@ && $@->isa('Paws::Exception') ) {
-            $log->error( "Failed to create queue $queue_name: " . $@->message );
-            return;
-        }
-
-        # Get URL from SQS
-        $res = eval { $self->{sqs}->GetQueueUrl( QueueName => $queue_name ) };
-        if ( $@ && $@->isa('Paws::Exception') ) {
-            $log->error( "Failed to get queue $queue_name after creating: " . $@->message );
-            return;
-        }
-    }
-
-    my $queue_url = $res->QueueUrl;
-
-    # This is possibly racy, but hopefully attributes don't change much, and
-    # also that we don't run N versions of the code in prod at the same time...
-    # but it beats forgetting to update SQS and/or having to do it by hand
-    # all the time
-    my $res = eval {
-        $self->{sqs}->GetQueueAttributes(
-            QueueUrl       => $queue_url,
-            AttributeNames => [ keys %$queue_attrs ],
-        );
-    };
-    if ( $@ && $@->isa('Paws::Exception') ) {
-        $log->warn( 'Failed to get queue attributes for ', $queue_name, ': ', $@->message );
-        next;
-    }
-
-    $log->debug( 'Checking queue attributes for ', $queue_name, '...' );
-    foreach my $attr ( sort keys %$queue_attrs ) {
-
-        # Coerce to strings for easy comparisons
-        my $val_local = "" . $queue_attrs->{$attr};
-        my $val_prod  = "" . $res->Attributes->{$attr};
-        next if $val_local eq $val_prod;
-
-        $log->info(
-            sprintf(
-                'Changing attribute %s of queue %s from %s to %s.',
-                $attr, $queue_name, $val_prod, $val_local
-            )
-        );
-        eval {
-            $self->{sqs}->SetQueueAttributes(
-                QueueUrl   => $queue_url,
-                Attributes => { $attr => $val_local }
-            );
-        };
-        if ( $@ && $@->isa('Paws::Exception') ) {
-            $log->warn( 'Failed to set queue attributes for ', $queue_name, ': ', $@->message );
-            next;
-        }
-    }
-
-    # Stick it in the queue
-    return ( $queue_name, $self->{queues}->{$queue_name} = $queue_url );
+    $class->get->completed(@args);
 }
 
 sub dispatch {
@@ -179,20 +72,20 @@ sub dispatch {
 
     # This is a shim function that inspects the tasks being sent and dispatches
     # them to the appropriate task queueing system.
-    my ( @schwartz_jobs, @sqs_tasks );
+    my ( @schwartz_jobs, @tsq_tasks );
     foreach my $task (@tasks) {
         if ( $task->isa('TheSchwartz::Job') ) {
             push @schwartz_jobs, $task;
         }
         elsif ( $task->isa('DW::Task') ) {
-            push @sqs_tasks, $task;
+            push @tsq_tasks, $task;
         }
         elsif ( $task->isa('LJ::Event') ) {
 
-            # Do the SQS check, because these tasks could go either way, and we
+            # Do the TSQ check, because these tasks could go either way, and we
             # want to be able to ramp up the traffic slowly.
             if ( $LJ::ESN_OVER_SQS && rand() < $LJ::ESN_OVER_SQS ) {
-                push @sqs_tasks, $task->fire_task;
+                push @tsq_tasks, $task->fire_task;
             }
             else {
                 push @schwartz_jobs, $task->fire_job;
@@ -218,195 +111,15 @@ sub dispatch {
         }
     }
 
-    # Dispatch to SQS
-    if (@sqs_tasks) {
-        $log->debug( 'Inserting ' . scalar(@sqs_tasks) . ' tasks into SQS.' );
-        $rv &&= $self->send(@sqs_tasks);
+    # Dispatch to TaskQueue
+    if (@tsq_tasks) {
+        $log->debug( 'Inserting ' . scalar(@tsq_tasks) . ' tasks into TaskQueue.' );
+        $rv &&= $self->send(@tsq_tasks);
     }
 
     # Returns the "worse" of the return values. If either are falsey, we will
     # return a false value.
     return $rv;
-}
-
-# Send a group of tasks to SQS. Returns 1 if all succeeded or undef if there was one
-# or more failures. TODO: might be nice to make it so callers can determine which messages
-# succeeded, maybe?
-sub send {
-    my ( $self, @tasks ) = @_;
-    return undef unless @tasks;
-
-    $self = $self->get unless ref $self;
-
-    my ( $queue_name, $queue_url ) = $self->_get_queue_for_task( $tasks[0] )
-        or return undef;
-
-    my $tags = [ 'queue:' . $queue_name ];
-    DW::Stats::increment( 'dw.taskqueue.action.send_attempt', scalar(@tasks), $tags );
-
-    # Send batches of messages, limited by count or size
-    my @messages;
-    my ( $sent_bytes, $ctr ) = ( 0, 0 );
-
-    my $send = sub {
-        $log->debug( 'Sending ', scalar(@messages), ' messages: ', $sent_bytes,
-            ' bytes to queue: ', $queue_name );
-        my $res =
-            eval { $self->{sqs}->SendMessageBatch( QueueUrl => $queue_url, Entries => \@messages ) };
-        if ( $@ && $@->isa('Paws::Exception') ) {
-            $log->error( 'Failed to send SQS message batch: ', $@->message );
-            DW::Stats::increment( 'dw.taskqueue.action.send_error', scalar(@messages), $tags );
-            return undef;
-        }
-        else {
-            $log->debug( 'Successfully sent ', scalar(@messages), ' messages.' );
-            DW::Stats::increment( 'dw.taskqueue.action.send_ok', scalar(@messages), $tags );
-            DW::Stats::increment( 'dw.taskqueue.sent_messages',  scalar(@messages), $tags );
-        }
-
-        @messages   = ();
-        $sent_bytes = 0;
-        return 1;
-    };
-
-    foreach my $task (@tasks) {
-        my $body = $self->_offload_large_message_if_necessary($task);
-
-        # If this message would put us over the cap, we need to send the previous batch
-        # before appending it
-        if (
-            @messages
-            && ( $sent_bytes + length $body > LARGE_MESSAGE_CUTOFF
-                || scalar @messages == MAX_BATCH_SIZE )
-            )
-        {
-            $send->() or return undef;
-        }
-
-        # Safe to append this messages
-        $sent_bytes += length $body;
-        push @messages, { Id => 'id-' . $ctr++, MessageBody => $body };
-    }
-
-    # If there are any messages left send them
-    if (@messages) {
-        $send->() or return undef;
-    }
-
-    # If any messages had failed, we would have early returned elsewhere when a
-    # call to $send failed
-    return 1;
-}
-
-sub _offload_large_message_if_necessary {
-    my ( $self, $message ) = @_;
-
-    $message = encode_base64( nfreeze($message) );
-    return $message if length $message < LARGE_MESSAGE_CUTOFF;
-
-    my $uuid = create_uuid_as_string(UUID_V4);
-    my $rv   = DW::BlobStore->store( tasks => $uuid, \$message );
-    unless ($rv) {
-        $log->error('Failed to offload task to BlobStore!');
-        DW::Stats::increment( 'dw.taskqueue.action.send_offload_error', 1 );
-        return undef;
-    }
-
-    DW::Stats::increment( 'dw.taskqueue.action.send_offload_ok', 1 );
-    return 'offloaded:' . $uuid;
-}
-
-sub _reload_large_message_if_necessary {
-    my ( $self, $message ) = @_;
-
-    my $uuid = $1
-        if $message =~ /^offloaded:(.+?)$/;
-    return $message unless $uuid;
-
-    my $rv = DW::BlobStore->retrieve( tasks => $uuid );
-    unless ($rv) {
-        $log->error( 'Failed to reload task from BlobStore: ' . $uuid );
-        DW::Stats::increment( 'dw.taskqueue.action.send_reload_error', 1 );
-        return undef;
-    }
-
-    DW::Stats::increment( 'dw.taskqueue.action.send_reload_ok', 1 );
-    return $$rv;
-}
-
-sub receive {
-    my ( $self, $class, $count ) = @_;
-    $count ||= 10;
-
-    $self = $self->get unless ref $self;
-
-    my ( $queue_name, $queue_url ) = $self->_get_queue_for_task($class)
-        or return undef;
-
-    my $tags = [ 'queue:' . $queue_name ];
-    DW::Stats::increment( 'dw.taskqueue.action.receive_attempt', 1, $tags );
-
-    my $res = eval {
-        $self->{sqs}->ReceiveMessage(
-            QueueUrl            => $queue_url,
-            MaxNumberOfMessages => $count,
-            WaitTimeSeconds     => 10
-        );
-    };
-    if ( $@ && $@->isa('Paws::Exception') ) {
-        $log->warn( 'Failed to retrieve SQS messages: ' . $@->message );
-        DW::Stats::increment( 'dw.taskqueue.action.receive_error', 1, $tags );
-        return undef;
-    }
-
-    my $messages = $res->Messages;
-    unless ( $messages && ref $messages eq 'ARRAY' && length @$messages >= 1 ) {
-        DW::Stats::increment( 'dw.taskqueue.action.receive_empty', 1, $tags );
-        return undef;
-    }
-
-    DW::Stats::increment( 'dw.taskqueue.action.receive_ok', 1, $tags );
-    DW::Stats::increment( 'dw.taskqueue.received_messages', scalar(@$messages), $tags );
-    $messages = [
-        map {
-            [
-                $_->ReceiptHandle,
-                thaw( decode_base64( $self->_reload_large_message_if_necessary( $_->Body ) ) )
-            ]
-        } @$messages
-    ];
-    return $messages;
-}
-
-sub completed {
-    my ( $self, $class, @handles ) = @_;
-    return unless @handles;
-
-    $self = $self->get unless ref $self;
-
-    my ( $queue_name, $queue_url ) = $self->_get_queue_for_task($class)
-        or return undef;
-
-    my $tags = [ 'queue:' . $queue_name ];
-    DW::Stats::increment( 'dw.taskqueue.action.completed_attempt', 1, $tags );
-
-    my $res = eval {
-        my $idx = 0;
-        $self->{sqs}->DeleteMessageBatch(
-            QueueUrl => $queue_url,
-            Entries  => [ map { { Id => $idx++, ReceiptHandle => $_ } } @handles ]
-        );
-    };
-    if ( $@ && $@->isa('Paws::Exception') ) {
-        $log->warn( 'Failed to delete message batch: ', $@->message );
-        DW::Stats::increment( 'dw.taskqueue.action.completed_error', 1, $tags );
-        return undef;
-    }
-
-    # TODO: We could return information about which messages failed to complete,
-    # and then do something else with them, but not sure what to do yet.
-    DW::Stats::increment( 'dw.taskqueue.action.completed_ok', 1, $tags );
-    DW::Stats::increment( 'dw.taskqueue.completed_messages', scalar(@handles), $tags );
 }
 
 sub start_work {
@@ -420,10 +133,6 @@ sub start_work {
 
     my $start_time    = time();
     my $messages_done = 0;
-
-    # Turn on coroutines for MySQL so that our database handles will
-    # activate the scheduler for us
-    # $LJ::ENABLE_CORO_MYSQL = 1;
 
     while (1) {
         my $recv_start_time = time();
@@ -463,12 +172,10 @@ sub start_work {
             )
         );
 
-        my ( @completed, @failed );
-        my ( $work_start_time, $work_end_time, @coros );
+        my ( @completed,       @failed );
+        my ( $work_start_time, $work_end_time );
         foreach my $message_pair (@$messages) {
             my ( $handle, $message ) = @$message_pair;
-
-            #push @coros, async {
 
             # Record earliest start time of any coroutine
             my $local_start_time = time();
@@ -507,12 +214,7 @@ sub start_work {
                 $log->warn( sprintf( '[%s] Message "%s" failed', $class, $handle ) );
                 push @failed, $handle;
             }
-
-            #};
         }
-
-        # Wait for all coroutines to have finished and exited
-        #$_->join foreach @coros;
 
         $log->debug(
             sprintf(
@@ -535,74 +237,5 @@ sub start_work {
         );
     }
 }
-
-sub _queue_name_from_url {
-    my $queue_url = $_[0];
-    return $1 if $queue_url =~ m|/([^/]+)$|;
-    return;
-}
-
-sub queue_attributes {
-    my ( $self, $queue ) = @_;
-
-    my @queues;
-    if ($queue) {
-        my ( $_queue_name, $queue_url ) = $self->_get_queue_for_task($queue);
-        unless ($queue_url) {
-            $log->error( 'Failed to fetch URL for queue: ', $queue );
-            return;
-        }
-        push @queues, $queue_url;
-    }
-    else {
-        my $res = eval { $self->{sqs}->ListQueues( QueueNamePrefix => $self->{prefix}, ) };
-        if ( $@ && $@->isa('Paws::Exception') ) {
-            $log->warn( 'Failed to list queues: ', $@->message );
-            return;
-        }
-
-        @queues = @{ $res->QueueUrls || [] };
-    }
-
-    return {} unless @queues;
-
-    my $rv = {};
-    foreach my $queue_url (@queues) {
-        my $res = eval {
-            $self->{sqs}->GetQueueAttributes(
-                QueueUrl       => $queue_url,
-                AttributeNames => ['ApproximateNumberOfMessages']
-            );
-        };
-        if ( $@ && $@->isa('Paws::Exception') ) {
-            $log->warn( 'Failed to get queue attributes for ', $queue_url, ': ', $@->message );
-            next;
-        }
-
-        $rv->{ _queue_name_from_url($queue_url) } = $res->Attributes;
-    }
-    return $rv;
-}
-
-################################################################################
-#
-# Paws::Credential::Local
-#
-# Implements the Paws::Credential role for passing in the access credentials
-# directly. You would think this would be a default package supplied
-# by the library...
-#
-
-package Paws::Credential::Local;
-
-use Moose;
-
-has access_key    => ( is => 'ro' );
-has secret_key    => ( is => 'ro' );
-has session_token => ( is => 'ro', default => sub { undef } );
-
-with 'Paws::Credential';
-
-no Moose;
 
 1;

--- a/cgi-bin/DW/TaskQueue/LocalDisk.pm
+++ b/cgi-bin/DW/TaskQueue/LocalDisk.pm
@@ -1,0 +1,117 @@
+#!/usr/bin/perl
+#
+# DW::TaskQueue::LocalDisk
+#
+# Library for queueing and executing jobs via local disk. This is in no way
+# production quality code, only use it in development.
+#
+# Authors:
+#     Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2020 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::TaskQueue::LocalDisk;
+
+use strict;
+use v5.10;
+use Log::Log4perl;
+my $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+use MIME::Base64 qw/ encode_base64 decode_base64 /;
+use Storable qw/ nfreeze thaw /;
+use Time::HiRes qw/ time /;
+use UUID::Tiny qw/ :std /;
+
+use DW::Task;
+
+sub init {
+    my $class = $_[0];
+
+    $log->debug("Initializing taskqueue for LocalDisk");
+
+    mkdir("$LJ::HOME/var/taskqueue") unless -d "$LJ::HOME/var/taskqueue";
+
+    my $self = { path => "$LJ::HOME/var/taskqueue", queues => {} };
+    return bless $self, $class;
+}
+
+sub _queue_dir {
+    my ( $self, $task ) = @_;
+
+    my $queue_name = lc( ref $task || $task );
+    $queue_name =~ s/::/-/g;
+
+    my $dir = $self->{path} . '/' . $queue_name;
+    mkdir($dir) unless -d $dir;
+
+    return $dir;
+}
+
+sub send {
+    my ( $self, @tasks ) = @_;
+    return undef unless @tasks;
+
+    my $dir = $self->_queue_dir( $tasks[0] );
+
+    # Send batches of messages, limited by count or size
+    my @messages;
+    my ( $sent_bytes, $ctr ) = ( 0, 0 );
+
+    foreach my $task (@tasks) {
+
+        # Pickle the message and write to a file with a random name
+        my $uuid = create_uuid_as_string(UUID_V4);
+        open FILE, ">$dir/$uuid"
+            or $log->logcroak('Failed to open message file!');
+        print FILE encode_base64( nfreeze($task) );
+        close FILE;
+    }
+
+    return 1;
+}
+
+sub receive {
+    my ( $self, $class, $count ) = @_;
+    $count ||= 10;
+
+    my $dir = $self->_queue_dir($class);
+
+    # To emulate SQS, we will wait for messages for 10 seconds
+    my @tasks;
+    my $abort_after = time() + 10;
+    while (time() < $abort_after) {
+        opendir DIR, $dir or $log->logcroak('Failed to open directory!');
+        @tasks = grep { /^[0-9a-f]/ && -f "$dir/$_" } readdir DIR;
+        closedir DIR;
+
+        last if @tasks;
+    }
+
+    my $thaw_task = sub {
+        local $/ = undef;
+        open FILE, "<$dir/$_[0]" or $log->logcroak('Unable to open file.');
+        my $task = thaw( decode_base64(<FILE>) );
+        close FILE;
+        return $task;
+    };
+
+    return [ map { [ $_, $thaw_task->($_) ] } @tasks ];
+}
+
+sub completed {
+    my ( $self, $class, @handles ) = @_;
+    return unless @handles;
+
+    my $dir = $self->_queue_dir($class);
+
+    foreach my $handle (@handles) {
+        unlink "$dir/$handle";
+    }
+}
+
+1;

--- a/cgi-bin/DW/TaskQueue/LocalDisk.pm
+++ b/cgi-bin/DW/TaskQueue/LocalDisk.pm
@@ -84,7 +84,7 @@ sub receive {
     # To emulate SQS, we will wait for messages for 10 seconds
     my @tasks;
     my $abort_after = time() + 10;
-    while (time() < $abort_after) {
+    while ( time() < $abort_after ) {
         opendir DIR, $dir or $log->logcroak('Failed to open directory!');
         @tasks = grep { /^[0-9a-f]/ && -f "$dir/$_" } readdir DIR;
         closedir DIR;

--- a/cgi-bin/DW/TaskQueue/SQS.pm
+++ b/cgi-bin/DW/TaskQueue/SQS.pm
@@ -1,0 +1,415 @@
+#!/usr/bin/perl
+#
+# DW::TaskQueue::SQS
+#
+# Library for queueing and executing jobs via Amazon SQS.
+#
+# Authors:
+#     Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2019-2020 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::TaskQueue::SQS;
+
+use strict;
+use v5.10;
+use Log::Log4perl;
+my $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+use MIME::Base64 qw/ encode_base64 decode_base64 /;
+use Paws;
+use Paws::Credential::InstanceProfile;
+use Storable qw/ nfreeze thaw /;
+use Time::HiRes qw/ time /;
+use UUID::Tiny qw/ :std /;
+
+use DW::Task;
+
+use constant LARGE_MESSAGE_CUTOFF => 255_000;
+use constant MAX_BATCH_SIZE       => 10;
+
+sub init {
+    my ( $class, %args ) = @_;
+
+    foreach my $required (qw/ region prefix /) {
+        $log->logcroak( 'SQS configuration must include config: ', $required )
+            unless exists $args{$required};
+    }
+
+    $log->logcroak('Prefix does not match required regex: [a-zA-Z0-9_-]+$.')
+        if defined $args{prefix} && $args{prefix} !~ /^[a-zA-Z0-9_-]+$/;
+
+    my $credentials = Paws::Credential::InstanceProfile->new;
+    if ( defined $args{access_key} && defined $args{secret_key} ) {
+        $log->warn('Using INSECURE AWS configuration!');
+        $credentials = Paws::Credential::Local->new(
+            access_key => $args{access_key},
+            secret_key => $args{secret_key},
+        );
+    }
+
+    my $paws = Paws->new(
+        config => {
+            credentials => $credentials,
+            region      => $args{region},
+        },
+    ) or $log->logcroak('Failed to initialize Paws object.');
+    my $sqs = $paws->service('SQS')
+        or $log->logcroak('Failed to initialize Paws::SQS object.');
+
+    $log->debug("Initializing taskqueue for SQS");
+    my $self = {
+        sqs    => $sqs,
+        prefix => $args{prefix},
+        queues => {},
+    };
+    return bless $self, $class;
+}
+
+sub _get_queue_for_task {
+    my ( $self, $task, %opts ) = @_;
+
+    my ( $dlq_name, $dlq_url );
+    my $queue_name = lc( ref $task || $task );
+    unless ( $opts{dlq} ) {
+        $queue_name =~ s/::/-/g;
+        $queue_name = $self->{prefix} . $queue_name;
+
+        $dlq_name = $queue_name . '-dlq';
+        $dlq_url  = $self->_get_queue_for_task( $dlq_name, dlq => { $task->queue_attributes } );
+    }
+
+    # Cache hit?
+    return ( $queue_name, $self->{queues}->{$queue_name} )
+        if exists $self->{queues}->{$queue_name};
+
+    # Fetch queue attributes
+    my $queue_attrs = $opts{dlq} // { $task->queue_attributes( dlq => $dlq_name ) };
+
+    # Fall back to SQS
+    my $res = eval { $self->{sqs}->GetQueueUrl( QueueName => $queue_name ) };
+    if ( $@ && $@->isa('Paws::Exception') ) {
+        $log->warn("Failed to get queue $queue_name, creating.");
+
+        # Fall back to creating the queue
+        $res = eval {
+            $self->{sqs}->CreateQueue(
+                QueueName  => $queue_name,
+                Attributes => $queue_attrs,
+            );
+        };
+        if ( $@ && $@->isa('Paws::Exception') ) {
+            $log->error( "Failed to create queue $queue_name: " . $@->message );
+            return;
+        }
+
+        # Get URL from SQS
+        $res = eval { $self->{sqs}->GetQueueUrl( QueueName => $queue_name ) };
+        if ( $@ && $@->isa('Paws::Exception') ) {
+            $log->error( "Failed to get queue $queue_name after creating: " . $@->message );
+            return;
+        }
+    }
+
+    my $queue_url = $res->QueueUrl;
+
+    # This is possibly racy, but hopefully attributes don't change much, and
+    # also that we don't run N versions of the code in prod at the same time...
+    # but it beats forgetting to update SQS and/or having to do it by hand
+    # all the time
+    my $res = eval {
+        $self->{sqs}->GetQueueAttributes(
+            QueueUrl       => $queue_url,
+            AttributeNames => [ keys %$queue_attrs ],
+        );
+    };
+    if ( $@ && $@->isa('Paws::Exception') ) {
+        $log->warn( 'Failed to get queue attributes for ', $queue_name, ': ', $@->message );
+        next;
+    }
+
+    $log->debug( 'Checking queue attributes for ', $queue_name, '...' );
+    foreach my $attr ( sort keys %$queue_attrs ) {
+
+        # Coerce to strings for easy comparisons
+        my $val_local = "" . $queue_attrs->{$attr};
+        my $val_prod  = "" . $res->Attributes->{$attr};
+        next if $val_local eq $val_prod;
+
+        $log->info(
+            sprintf(
+                'Changing attribute %s of queue %s from %s to %s.',
+                $attr, $queue_name, $val_prod, $val_local
+            )
+        );
+        eval {
+            $self->{sqs}->SetQueueAttributes(
+                QueueUrl   => $queue_url,
+                Attributes => { $attr => $val_local }
+            );
+        };
+        if ( $@ && $@->isa('Paws::Exception') ) {
+            $log->warn( 'Failed to set queue attributes for ', $queue_name, ': ', $@->message );
+            next;
+        }
+    }
+
+    # Stick it in the queue
+    return ( $queue_name, $self->{queues}->{$queue_name} = $queue_url );
+}
+
+# Send a group of tasks to SQS. Returns 1 if all succeeded or undef if there was one
+# or more failures. TODO: might be nice to make it so callers can determine which messages
+# succeeded, maybe?
+sub send {
+    my ( $self, @tasks ) = @_;
+    return undef unless @tasks;
+
+    $self = $self->get unless ref $self;
+
+    my ( $queue_name, $queue_url ) = $self->_get_queue_for_task( $tasks[0] )
+        or return undef;
+
+    my $tags = [ 'queue:' . $queue_name ];
+    DW::Stats::increment( 'dw.taskqueue.action.send_attempt', scalar(@tasks), $tags );
+
+    # Send batches of messages, limited by count or size
+    my @messages;
+    my ( $sent_bytes, $ctr ) = ( 0, 0 );
+
+    my $send = sub {
+        $log->debug( 'Sending ', scalar(@messages), ' messages: ', $sent_bytes,
+            ' bytes to queue: ', $queue_name );
+        my $res =
+            eval { $self->{sqs}->SendMessageBatch( QueueUrl => $queue_url, Entries => \@messages ) };
+        if ( $@ && $@->isa('Paws::Exception') ) {
+            $log->error( 'Failed to send SQS message batch: ', $@->message );
+            DW::Stats::increment( 'dw.taskqueue.action.send_error', scalar(@messages), $tags );
+            return undef;
+        }
+        else {
+            $log->debug( 'Successfully sent ', scalar(@messages), ' messages.' );
+            DW::Stats::increment( 'dw.taskqueue.action.send_ok', scalar(@messages), $tags );
+            DW::Stats::increment( 'dw.taskqueue.sent_messages',  scalar(@messages), $tags );
+        }
+
+        @messages   = ();
+        $sent_bytes = 0;
+        return 1;
+    };
+
+    foreach my $task (@tasks) {
+        my $body = $self->_offload_large_message_if_necessary($task);
+
+        # If this message would put us over the cap, we need to send the previous batch
+        # before appending it
+        if (
+            @messages
+            && ( $sent_bytes + length $body > LARGE_MESSAGE_CUTOFF
+                || scalar @messages == MAX_BATCH_SIZE )
+            )
+        {
+            $send->() or return undef;
+        }
+
+        # Safe to append this messages
+        $sent_bytes += length $body;
+        push @messages, { Id => 'id-' . $ctr++, MessageBody => $body };
+    }
+
+    # If there are any messages left send them
+    if (@messages) {
+        $send->() or return undef;
+    }
+
+    # If any messages had failed, we would have early returned elsewhere when a
+    # call to $send failed
+    return 1;
+}
+
+sub _offload_large_message_if_necessary {
+    my ( $self, $message ) = @_;
+
+    $message = encode_base64( nfreeze($message) );
+    return $message if length $message < LARGE_MESSAGE_CUTOFF;
+
+    my $uuid = create_uuid_as_string(UUID_V4);
+    my $rv   = DW::BlobStore->store( tasks => $uuid, \$message );
+    unless ($rv) {
+        $log->error('Failed to offload task to BlobStore!');
+        DW::Stats::increment( 'dw.taskqueue.action.send_offload_error', 1 );
+        return undef;
+    }
+
+    DW::Stats::increment( 'dw.taskqueue.action.send_offload_ok', 1 );
+    return 'offloaded:' . $uuid;
+}
+
+sub _reload_large_message_if_necessary {
+    my ( $self, $message ) = @_;
+
+    my $uuid = $1
+        if $message =~ /^offloaded:(.+?)$/;
+    return $message unless $uuid;
+
+    my $rv = DW::BlobStore->retrieve( tasks => $uuid );
+    unless ($rv) {
+        $log->error( 'Failed to reload task from BlobStore: ' . $uuid );
+        DW::Stats::increment( 'dw.taskqueue.action.send_reload_error', 1 );
+        return undef;
+    }
+
+    DW::Stats::increment( 'dw.taskqueue.action.send_reload_ok', 1 );
+    return $$rv;
+}
+
+sub receive {
+    my ( $self, $class, $count ) = @_;
+    $count ||= 10;
+
+    $self = $self->get unless ref $self;
+
+    my ( $queue_name, $queue_url ) = $self->_get_queue_for_task($class)
+        or return undef;
+
+    my $tags = [ 'queue:' . $queue_name ];
+    DW::Stats::increment( 'dw.taskqueue.action.receive_attempt', 1, $tags );
+
+    my $res = eval {
+        $self->{sqs}->ReceiveMessage(
+            QueueUrl            => $queue_url,
+            MaxNumberOfMessages => $count,
+            WaitTimeSeconds     => 10
+        );
+    };
+    if ( $@ && $@->isa('Paws::Exception') ) {
+        $log->warn( 'Failed to retrieve SQS messages: ' . $@->message );
+        DW::Stats::increment( 'dw.taskqueue.action.receive_error', 1, $tags );
+        return undef;
+    }
+
+    my $messages = $res->Messages;
+    unless ( $messages && ref $messages eq 'ARRAY' && length @$messages >= 1 ) {
+        DW::Stats::increment( 'dw.taskqueue.action.receive_empty', 1, $tags );
+        return undef;
+    }
+
+    DW::Stats::increment( 'dw.taskqueue.action.receive_ok', 1, $tags );
+    DW::Stats::increment( 'dw.taskqueue.received_messages', scalar(@$messages), $tags );
+    $messages = [
+        map {
+            [
+                $_->ReceiptHandle,
+                thaw( decode_base64( $self->_reload_large_message_if_necessary( $_->Body ) ) )
+            ]
+        } @$messages
+    ];
+    return $messages;
+}
+
+sub completed {
+    my ( $self, $class, @handles ) = @_;
+    return unless @handles;
+
+    $self = $self->get unless ref $self;
+
+    my ( $queue_name, $queue_url ) = $self->_get_queue_for_task($class)
+        or return undef;
+
+    my $tags = [ 'queue:' . $queue_name ];
+    DW::Stats::increment( 'dw.taskqueue.action.completed_attempt', 1, $tags );
+
+    my $res = eval {
+        my $idx = 0;
+        $self->{sqs}->DeleteMessageBatch(
+            QueueUrl => $queue_url,
+            Entries  => [ map { { Id => $idx++, ReceiptHandle => $_ } } @handles ]
+        );
+    };
+    if ( $@ && $@->isa('Paws::Exception') ) {
+        $log->warn( 'Failed to delete message batch: ', $@->message );
+        DW::Stats::increment( 'dw.taskqueue.action.completed_error', 1, $tags );
+        return undef;
+    }
+
+    # TODO: We could return information about which messages failed to complete,
+    # and then do something else with them, but not sure what to do yet.
+    DW::Stats::increment( 'dw.taskqueue.action.completed_ok', 1, $tags );
+    DW::Stats::increment( 'dw.taskqueue.completed_messages', scalar(@handles), $tags );
+}
+
+sub _queue_name_from_url {
+    my $queue_url = $_[0];
+    return $1 if $queue_url =~ m|/([^/]+)$|;
+    return;
+}
+
+sub queue_attributes {
+    my ( $self, $queue ) = @_;
+
+    my @queues;
+    if ($queue) {
+        my ( $_queue_name, $queue_url ) = $self->_get_queue_for_task($queue);
+        unless ($queue_url) {
+            $log->error( 'Failed to fetch URL for queue: ', $queue );
+            return;
+        }
+        push @queues, $queue_url;
+    }
+    else {
+        my $res = eval { $self->{sqs}->ListQueues( QueueNamePrefix => $self->{prefix}, ) };
+        if ( $@ && $@->isa('Paws::Exception') ) {
+            $log->warn( 'Failed to list queues: ', $@->message );
+            return;
+        }
+
+        @queues = @{ $res->QueueUrls || [] };
+    }
+
+    return {} unless @queues;
+
+    my $rv = {};
+    foreach my $queue_url (@queues) {
+        my $res = eval {
+            $self->{sqs}->GetQueueAttributes(
+                QueueUrl       => $queue_url,
+                AttributeNames => ['ApproximateNumberOfMessages']
+            );
+        };
+        if ( $@ && $@->isa('Paws::Exception') ) {
+            $log->warn( 'Failed to get queue attributes for ', $queue_url, ': ', $@->message );
+            next;
+        }
+
+        $rv->{ _queue_name_from_url($queue_url) } = $res->Attributes;
+    }
+    return $rv;
+}
+
+################################################################################
+#
+# Paws::Credential::Local
+#
+# Implements the Paws::Credential role for passing in the access credentials
+# directly. You would think this would be a default package supplied
+# by the library...
+#
+
+package Paws::Credential::Local;
+
+use Moose;
+
+has access_key    => ( is => 'ro' );
+has secret_key    => ( is => 'ro' );
+has session_token => ( is => 'ro', default => sub { undef } );
+
+with 'Paws::Credential';
+
+no Moose;
+
+1;


### PR DESCRIPTION
This makes TaskQueue behave like BlobStore and use abstract backends.
The primary one is DW::TaskQueue::SQS but there is now also a new one
DW::TaskQueue::LocalDisk that is invoked if you're a development server
and haven't set up SQS.

This should allow developers to use the task system without having to
think about it too hard, but you'll still have to run workers like
production if you want to use them. TODO: make it synchronous?