### PR TITLE
Catch some remaining MD5 gunk

### DIFF
--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -192,14 +192,6 @@ sub make_journal {
     # Control strip
     if ( $page->{show_control_strip} ) {
         LJ::Hooks::run_hook('control_strip_stylesheet_link');
-
-        # used if we're using our jquery library
-        LJ::need_res(
-            { group => "all" }, qw(
-                js/md5.js
-                js/login-jquery.js
-                )
-        );
     }
 
     LJ::need_res(

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -549,6 +549,7 @@ head<=
                     js/entry.js
                     js/poll.js
                     js/browserdetect.js
+                    js/md5.js
                     js/xpost.js
                     ));
 

--- a/schemes/common.tt
+++ b/schemes/common.tt
@@ -31,11 +31,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [% END %]
 
     [%- # block.need_res below includes files for the individual pages
-        # this need_res is for the sake of the login form on the theme
-        dw.need_res( "js/md5.js" );
-        dw.need_res( { group => 'jquery' }
-                    "js/md5.js"
-        );
         dw.need_res( { group => "foundation" },
                     "js/foundation/foundation/foundation.reveal.js"
                     "js/skins/jquery.focus-on-reveal.js"


### PR DESCRIPTION
- One attempt to require a missing JS file (breaks journal pages due to 404)
- Stop requiring MD5 library in places that don't use it
- Guarantee MD5 library is available for the two places that actually still call
  the `MD5()` function (xpost.js and jquery.crosspost.js)