### PR TITLE
Add password 'peppering'

### DIFF
--- a/bin/upgrading/d10-passwords.pl
+++ b/bin/upgrading/d10-passwords.pl
@@ -54,6 +54,12 @@ while (1) {
             or die "Failed to get password on $u->{user}($uid)!\n";
         $u->set_password( $password, force_bcrypt => 1 );
         $u->update_self( { dversion => 10 } );
+
+        # And nuke memcache, so we don't keep passwords
+        # floating around there
+        LJ::memcache_kill( $uid, "userid" );
+        $u->memc_delete('pw');
+
         print "UPGRADED $u->{user}($uid) MIGRATED\n";
     }
 }

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -2217,8 +2217,9 @@ EOC
 
 register_tablecreate( "password2", <<'EOC');
 CREATE TABLE password2 (
-    userid      INT UNSIGNED NOT NULL PRIMARY KEY,
-    bcrypt_hash VARCHAR(60) NOT NULL
+    userid   INT UNSIGNED NOT NULL PRIMARY KEY,
+    version  INT UNSIGNED NOT NULL,
+    password VARCHAR(255) NOT NULL
 )
 EOC
 

--- a/cgi-bin/DW/Auth/Password.pm
+++ b/cgi-bin/DW/Auth/Password.pm
@@ -1,0 +1,122 @@
+#!/usr/bin/perl
+#
+# DW::Auth::Password
+#
+# Library for centralizing password storage code, so that this never leaks
+# into other systems.
+#
+# TODO: We are recording a schema in the database in case we ever need to
+# change how we store passwords, but for now, this module only ever sets it
+# to 1 and never checks it.
+#
+# Authors:
+#     Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2020 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::Auth::Password;
+
+use strict;
+use v5.10;
+use Log::Log4perl;
+my $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+use Authen::Passphrase::Clear;
+use Authen::Passphrase::BlowfishCrypt;
+use Crypt::Mode::CBC;
+use MIME::Base64 qw/ encode_base64 decode_base64 /;
+
+sub check_password {
+    my ( $class, $u, $password ) = @_;
+
+    my $crypt =
+        $u->dversion <= 9
+        ? Authen::Passphrase::Clear->new( $u->password )
+        : Authen::Passphrase::BlowfishCrypt->from_crypt( $class->password_hash( $u ) );
+
+    return $crypt->match($password);
+}
+
+sub password_hash {
+    my ( $class, $u ) = @_;
+    return unless $u->is_person;
+
+    $log->logcroak('User password hash is unavailable.')
+        unless $u->dversion >= 10;
+
+    my $userid        = $u->userid;
+    my $dbh           = LJ::get_db_writer() or $log->logcroak("Couldn't get db master");
+    my $safe_password = decode_base64(
+        $dbh->selectrow_array( q{SELECT password FROM password2 WHERE userid = ?}, undef, $userid )
+    );
+
+    my $aes        = Crypt::Mode::CBC->new('AES');
+    my $pkey       = get_pepper_key( ord( substr( $safe_password, 0, 1 ) ) );
+    my $iv         = substr( $safe_password, 1, 16 );
+    my $ciphertext = substr( $safe_password, 17 );
+
+    return $aes->decrypt( $ciphertext, $pkey, $iv );
+}
+
+sub get_pepper_key {
+    my ( $class, $keyid ) = @_;
+
+    $keyid //= $LJ::PASSWORD_PEPPER_KEY_CURRENT_ID;
+
+    # Key is later encoded to a single byte, so if this doesn't fit, explode
+    # very early on (here)
+    $log->logcroak('Pepper key ID must be in the range 0..255')
+        if $keyid < 0 || $keyid > 255;
+
+    my $keyval = $LJ::PASSWORD_PEPPER_KEYS{$keyid};
+    return wantarray ? ( $keyid, $keyval ) : $keyval;
+}
+
+sub set_password {
+    my ( $class, $u, $password ) = @_;
+
+    # Step 1)
+    #
+    # Use bcrypt with a random salt to construct a hash that we can use to
+    # verify the password later. This step makes it so that we can never
+    # retrieve the password.
+    #
+    my $crypt = Authen::Passphrase::BlowfishCrypt->new(
+        cost        => $LJ::BCRYPT_COST,
+        salt_random => 1,
+        passphrase  => $password,
+    );
+
+    my $bcrypt_hash = $crypt->as_crypt;
+
+    # Step 2)
+    #
+    # Now encrypt the password. This is equivalent to applying 'pepper',
+    # which provides the property that if our database were to be
+    # breached, the password fields are entirely useless unless the
+    # attacker also was able to get access to the encryption key (which
+    # is not stored in the database).
+
+    # Perform the encryption with random IV.
+    my $aes = Crypt::Mode::CBC->new('AES');
+    my $iv  = pack( 'C*', map { rand(256) } 1 .. 16 );
+    my ( $pkeyid, $pkey ) = $class->get_pepper_key();
+    my $ciphertext = $aes->encrypt( $bcrypt_hash, $pkey, $iv );
+
+    # Safe password is base64'd and includes the IV.
+    my $safe_password = encode_base64( chr($pkeyid) . $iv . $ciphertext, '' );
+
+    # Replace into database.
+    my $dbh = LJ::get_db_writer()
+        or $log->logcroak('Failed to get database writer.');
+    $dbh->do( q{REPLACE INTO password2 (userid, version, password) VALUES (?, ?, ?)},
+        undef, $u->userid, 1, $safe_password )
+        or $log->logcroak('Failed to set password hash: ', $dbh->errstr);
+}
+
+1;

--- a/cgi-bin/DW/Auth/Password.pm
+++ b/cgi-bin/DW/Auth/Password.pm
@@ -37,7 +37,7 @@ sub check_password {
     my $crypt =
         $u->dversion <= 9
         ? Authen::Passphrase::Clear->new( $u->password )
-        : Authen::Passphrase::BlowfishCrypt->from_crypt( $class->password_hash( $u ) );
+        : Authen::Passphrase::BlowfishCrypt->from_crypt( $class->password_hash($u) );
 
     return $crypt->match($password);
 }
@@ -116,7 +116,7 @@ sub set_password {
         or $log->logcroak('Failed to get database writer.');
     $dbh->do( q{REPLACE INTO password2 (userid, version, password) VALUES (?, ?, ?)},
         undef, $u->userid, 1, $safe_password )
-        or $log->logcroak('Failed to set password hash: ', $dbh->errstr);
+        or $log->logcroak( 'Failed to set password hash: ', $dbh->errstr );
 }
 
 1;

--- a/cgi-bin/LJ/Global/Constants.pm
+++ b/cgi-bin/LJ/Global/Constants.pm
@@ -67,11 +67,12 @@ use constant CMAX_UPIC_DESCRIPTION => 300;
 #    7: clustered userpics, keyword limiting, and comment support
 #    8: clustered polls
 #    9: userpicmap3, with mapid
+#    10: password2, with password schema
 #
 # Dreamwidth installations should ALL be dversion >= 8.  We do not support anything
 # else and are ripping out code to support all previous dversions.
 #
-use constant MAX_DVERSION => 9;
+use constant MAX_DVERSION => 10;
 $LJ::MAX_DVERSION = MAX_DVERSION;
 
 1;

--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -352,6 +352,13 @@ no strict "vars";
 
     # Cost to set for bcrypt password hash calculations.
     $BCRYPT_COST = 12;
+
+    # Default pepper key -- ONLY SET IF DEV SERVER. If this is production,
+    # you MUST set a valid pepper key here!
+    if ($LJ::IS_DEV_SERVER) {
+        %PASSWORD_PEPPER_KEYS           = ( 1 => "A" x 32, );
+        $PASSWORD_PEPPER_KEY_CURRENT_ID = 1;
+    }
 }
 
 1;

--- a/cgi-bin/LJ/User/Login.pm
+++ b/cgi-bin/LJ/User/Login.pm
@@ -339,7 +339,8 @@ sub password {
         unless $u->dversion <= 9;
 
     my $dbh = LJ::get_db_writer() or die "Couldn't get db master";
-    return $dbh->selectrow_array( "SELECT password FROM password WHERE userid=?", undef, $u->userid );
+    return $dbh->selectrow_array( "SELECT password FROM password WHERE userid=?", undef,
+        $u->userid );
 }
 
 sub set_password {

--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -8,7 +8,7 @@ Class::Autouse
 Class::Data::Inheritable
 Class::Trigger
 Compress::Zlib
-Crypt::DH
+CryptX
 Danga::Socket
 Data::ObjectDriver
 Digest::HMAC_SHA1

--- a/t/auth-password.t
+++ b/t/auth-password.t
@@ -1,0 +1,58 @@
+# t/blobstore.t
+#
+# Test some DW::Auth::Password functionality.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2020 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+plan tests => 12;
+
+use DW::Auth::Password;
+use LJ::Test qw/ temp_user /;
+
+my $u = temp_user();
+
+# Test public APIs work
+ok( $u->dversion == 10,           'New user is on dversion 10.' );
+ok( $u->set_password('test'),     'Able to set password.' );
+ok( $u->check_password('test'),   'Password validates.' );
+ok( !$u->check_password('test?'), 'Password fails validation.' );
+
+# Looks like a bcrypt hash (not quite base64)
+my $hash1 = DW::Auth::Password->_password_hash($u);
+ok( $hash1 =~ m!^\$2a\$$LJ::BCRYPT_COST\$[a-zA-Z0-9./]+$!, ' Appropriate bcrypt hash.' );
+
+# Same password results in different hash
+ok( $u->set_password('test'),                         'Able to set password.' );
+ok( $hash1 ne DW::Auth::Password->_password_hash($u), 'Same password uses new hash.' );
+ok( $u->check_password('test'),                       'Password validates.' );
+ok( !$u->check_password('test?'),                     'Password fails validation.' );
+
+# Check pepper keys
+ok( DW::Auth::Password->_get_pepper_key eq 'A' x 32, 'Pepper key is right.' );
+eval { DW::Auth::Password->_get_pepper_key(100) };
+ok( $@, 'Invalid pepper key throws.' );
+
+# Check encrypt/decrypt works
+my $enc1 = DW::Auth::Password->_encrypt_password_hash($hash1);
+ok( DW::Auth::Password->_decrypt_password_hash($enc1) eq $hash1, 'Decryption works.' );
+
+# Encrypting again results in different ciphertexts
+ok( DW::Auth::Password->_encrypt_password_hash($hash1) ne $enc1,
+    'Encryption results in new ciphertext.' );
+
+1;

--- a/t/auth-password.t
+++ b/t/auth-password.t
@@ -19,7 +19,7 @@ use Test::More;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
-plan tests => 12;
+plan tests => 13;
 
 use DW::Auth::Password;
 use LJ::Test qw/ temp_user /;
@@ -34,7 +34,7 @@ ok( !$u->check_password('test?'), 'Password fails validation.' );
 
 # Looks like a bcrypt hash (not quite base64)
 my $hash1 = DW::Auth::Password->_password_hash($u);
-ok( $hash1 =~ m!^\$2a\$$LJ::BCRYPT_COST\$[a-zA-Z0-9./]+$!, ' Appropriate bcrypt hash.' );
+ok( $hash1 =~ m!^\$2a\$$LJ::BCRYPT_COST\$[a-zA-Z0-9./]+$!, 'Appropriate bcrypt hash.' );
 
 # Same password results in different hash
 ok( $u->set_password('test'),                         'Able to set password.' );


### PR DESCRIPTION
After discussion with a security engineering friend of mine, this is
take two at the secure password storage approach. Now, we are applying a
'pepper' on the web server, before we write to the database.

The advantage of this is that a database exfiltration does not result in
useful data (when it comes to passwords). In order to get useful data,
you need to get data off of the webserver memory/filesystem AND from the
database, which raises the bar.

The chosen peppering solution is symmetric encryption, which enables us
to do pepper rotation if we ever believe that our pepper key was
compromised somehow.

This also re-introduces @momijizukamori's schema/revision/version
column, so we can change how passwords are stored in the future.
Additionally this pulls most of the functionality out into
DW::Auth::Password which will let us isolate things better and ensure
that it's easy to audit credential management code.