### PR TITLE
(#2629) Fix error when commenting anonymous with browser-saved password

### DIFF
--- a/htdocs/js/jquery.talkform.js
+++ b/htdocs/js/jquery.talkform.js
@@ -6,7 +6,7 @@ jQuery(function($){
     var authForms = $('.from-login');
     var iconSelect = $('#prop_picture_keyword');
 
-    // Blank out any input children.
+    // Helpers for modifying every input in a sub-section of the form:
     jQuery.fn.extend({
         clearFormFields: function() {
             this.find('input').each(function(i, elm){
@@ -18,18 +18,33 @@ jQuery(function($){
                 }
             });
             return this;
+        },
+        disableFormFields: function() {
+            this.find('input').each(function(i, elm) {
+                elm.disabled = true;
+            });
+            return this;
+        },
+        enableFormFields: function() {
+            this.find('input').each(function(i, elm) {
+                elm.disabled = false;
+            });
+            return this;
         }
     });
 
     // Tidy up irrelevant controls when choosing who the comment is from
     fromOptions.change(function(e) {
-        // When a "from" option is selected, show its associated login form (if
-        // any), and blank out the values of any other login forms so we don't
-        // send contradictory info.
+        // If the backend gets a user/password value AND a usertype that doesn't
+        // need it, it considers that an error. So in addition to keeping
+        // irrelevant sections of the form out of the way, we blank+disable any
+        // other login forms to avoid sending contradictory info. (Disabling is
+        // necessary to keep browser password managers from sending an unwanted
+        // user/password at the last minute; browsers omit disabled fields.)
         var associatedLoginForm = document.getElementById( $(this).data('more') );
         authForms.hide();
-        $(associatedLoginForm).show();
-        authForms.not(associatedLoginForm).clearFormFields();
+        $(associatedLoginForm).show().enableFormFields();
+        authForms.not(associatedLoginForm).clearFormFields().disableFormFields();
 
         // Icon select menu is only available for logged-in user
         if (this.id === 'talkpostfromremote' || this.id === 'talkpostfromoidli') {


### PR DESCRIPTION
Fixes #2629 

I couldn't get stock Chrome to insert login info at the last minute as reported, so I suspect the user has Lastpass or something. So it takes a little bit more finagling in the web inspector to be able to reproduce this. But I did eventually confirm that:

- Without this patch, using the inspector to set values for user/pass _will_ cause errors when submitting an anonymous comment. 
- With this patch, you can go ahead and set those values with the inspector, but they won't cause an error because the backend will never receive them. 

So, this should fix the issue, whatever extension it is that's actually causing it. 