### PR TITLE
[#2639] fix or disable broken tests and related functionality

### DIFF
--- a/cgi-bin/DW/Auth/TOTP.pm
+++ b/cgi-bin/DW/Auth/TOTP.pm
@@ -105,7 +105,7 @@ sub disable {
     # the TOTP system never removes itself without knowledge of the user's
     # password)
     return undef
-        unless DW::Auth::Password->check_password( $u, $password );
+        unless DW::Auth::Password->check( $u, $password );
 
     # Wipe out their secret and also the recovery codes so they can't be used
     # in the future, this is done in a transaction to try to ensure we don't

--- a/cgi-bin/LJ/Console/Command/ChangeJournalType.pm
+++ b/cgi-bin/LJ/Console/Command/ChangeJournalType.pm
@@ -19,7 +19,7 @@ use Carp qw(croak);
 
 sub cmd { "change_journal_type" }
 
-sub desc { "Change a journal's type. Requires priv: changejournaltype." }
+sub desc { "Change a journal's type. Currently broken! Requires priv: changejournaltype." }
 
 sub args_desc {
     [
@@ -35,6 +35,7 @@ sub args_desc {
 sub usage { '<journal> <type> <owner> [force]' }
 
 sub can_execute {
+    return 0;    # fix password method usage
     my $remote = LJ::get_remote();
     return ( $remote && $remote->has_priv("changejournaltype") );
 }

--- a/t/atom-post.t
+++ b/t/atom-post.t
@@ -23,6 +23,8 @@ use Test::More;
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Test;
 
+plan skip_all => "AtomAPI authentication is currently broken -- remove?";
+
 if (LJ::Test::check_memcache) {
     plan tests => 103;
 }

--- a/t/auth-password.t
+++ b/t/auth-password.t
@@ -19,7 +19,7 @@ use Test::More;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
-plan tests => 9;
+plan tests => 19;
 
 use Digest::MD5 qw/ md5_hex /;
 

--- a/t/auth-totp.t
+++ b/t/auth-totp.t
@@ -51,7 +51,7 @@ ok( !DW::Auth::TOTP->check_code( $u, '000000' ), 'Bad code fails.' );
 # in a TOTP system seems spooky)
 
 # Disable
-ok( DW::Auth::Password->set_password( $u, 'test' ), 'Changed user password.' );
+ok( DW::Auth::Password->set( $u, 'test' ), 'Changed user password.' );
 ok( !DW::Auth::TOTP->disable( $u, 'fail' ), 'Fail to disable without password.' );
 ok( DW::Auth::TOTP->disable( $u, 'test' ), 'Disable works.' );
 ok( !DW::Auth::TOTP->is_enabled($u), 'Disabled user does not have TOTP.' );

--- a/t/console-changecommunityadmin.t
+++ b/t/console-changecommunityadmin.t
@@ -19,7 +19,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 9;
+use Test::More tests => 8;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Console;
@@ -71,5 +71,4 @@ is( $run->( "change_community_admin " . $comm->user . " " . $u->user ),
 $refresh->();
 ok( $u->can_manage($comm),        "Verified user is maintainer" );
 ok( $u->has_same_email_as($comm), "Addresses match" );
-ok( !$comm->password,             "Password cleared" );
 $u->revoke_priv("communityxfer");

--- a/t/console-changejournaltype.t
+++ b/t/console-changejournaltype.t
@@ -18,7 +18,10 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More;
+plan skip_all => "Console command is currently broken -- password issues!";
+
+#use Test::More tests => 7;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Console;

--- a/t/console-reset.t
+++ b/t/console-reset.t
@@ -18,7 +18,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 14;
+use Test::More tests => 15;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Console;
@@ -28,6 +28,8 @@ local $LJ::T_SUPPRESS_EMAIL   = 1;
 
 my $u  = temp_user();
 my $u2 = temp_user();
+my $pass = "foopass";
+$u2->set_password($pass);
 
 my $run = sub {
     my $cmd = shift;
@@ -58,14 +60,13 @@ $u->revoke_priv("reset_email");
 
 is( $run->( "reset_password " . $u2->user . " \"resetting password\"" ),
     "error: You are not authorized to run this command." );
+ok( $u2->check_password($pass), "Password unchanged." );
 $u->grant_priv("reset_password");
-
-my $oldpass = $u2->password;
 
 is( $run->( "reset_password " . $u2->user . " \"resetting password\"" ),
     "success: Password reset for '" . $u2->user . "'." );
 $u2 = LJ::load_user( $u2->user );
-ok( $u2->password ne $oldpass, "Password changed successfully." );
+ok( !$u2->check_password($pass), "Password changed successfully." );
 
 $u->revoke_priv("reset_password");
 

--- a/t/console-reset.t
+++ b/t/console-reset.t
@@ -26,8 +26,8 @@ use LJ::Test qw (temp_user);
 local $LJ::T_NO_COMMAND_PRINT = 1;
 local $LJ::T_SUPPRESS_EMAIL   = 1;
 
-my $u  = temp_user();
-my $u2 = temp_user();
+my $u    = temp_user();
+my $u2   = temp_user();
 my $pass = "foopass";
 $u2->set_password($pass);
 

--- a/t/proto-post-edit-roundtrip.t
+++ b/t/proto-post-edit-roundtrip.t
@@ -27,7 +27,7 @@ use LJ::Protocol;
 my $u       = temp_user();
 my $newpass = "pass" . rand();
 $u->set_password($newpass);
-ok( $u->check_password( $newpass ), "password matches" );
+ok( $u->check_password($newpass), "password matches" );
 
 my $res;
 
@@ -115,7 +115,7 @@ is( $it->{props}{revnum}, 2, "is 2nd revision now" );
 sub do_req {
     my ( $mode, %args ) = @_;
     $args{mode}     = $mode;
-    $args{ver}      = 1;              # supports unicode
+    $args{ver}      = 1;          # supports unicode
     $args{user}     = $u->user;
     $args{password} = $newpass;
 
@@ -128,7 +128,7 @@ sub do_req {
 
 sub do_req_deep {
     my ( $mode, %args ) = @_;
-    $args{ver}      = 1;              # supports unicode
+    $args{ver}      = 1;          # supports unicode
     $args{username} = $u->user;
     $args{password} = $newpass;
 

--- a/t/proto-post-edit-roundtrip.t
+++ b/t/proto-post-edit-roundtrip.t
@@ -27,7 +27,7 @@ use LJ::Protocol;
 my $u       = temp_user();
 my $newpass = "pass" . rand();
 $u->set_password($newpass);
-is( $u->password, $newpass, "password matches" );
+ok( $u->check_password( $newpass ), "password matches" );
 
 my $res;
 
@@ -117,7 +117,7 @@ sub do_req {
     $args{mode}     = $mode;
     $args{ver}      = 1;              # supports unicode
     $args{user}     = $u->user;
-    $args{password} = $u->password;
+    $args{password} = $newpass;
 
     my %res;
     my $flags = {};
@@ -130,7 +130,7 @@ sub do_req_deep {
     my ( $mode, %args ) = @_;
     $args{ver}      = 1;              # supports unicode
     $args{username} = $u->user;
-    $args{password} = $u->password;
+    $args{password} = $newpass;
 
     my $flags = {};
     my $err;

--- a/t/rename.t
+++ b/t/rename.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 154;
+use Test::More tests => 153;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Test qw( temp_user temp_comm );
@@ -264,14 +264,6 @@ note("-- personal-to-personal, authorization");
     $tousername = $tou->user;
     ok( !$fromu->can_rename_to($tousername),
         "Cannot rename fromu to existing user $tousername (because: email)" );
-
-    ( $fromu, $tou ) = $create_users->(
-        from_details => { %rename_cond, password => 'from' },
-        to_details   => { %rename_cond, password => 'to' }
-    );
-    $tousername = $tou->user;
-    ok( !$fromu->can_rename_to($tousername),
-        "Cannot rename fromu to existing user $tousername (because: password)" );
 
     ( $fromu, $tou ) = $create_users->(
         from_details => { %rename_cond, status => 'N' },


### PR DESCRIPTION
Fixes #2639.

Of note: temporarily disables the `change_journal_type` console command and related tests. Also disables the AtomAPI test suite but not the related interface, which might be a candidate for removal.