### PR TITLE
Beta icon browser improvements (keyboard & general)

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1785,12 +1785,7 @@ sub icon_dropdown {
 
     my $ret = "";
     if ( $res{pickw_count} ) {
-        $ret .= BML::ml(
-            '/talkpost.bml.label.picturetouse2',
-            {
-                aopts => "href='" . $remote->allpics_base . "'"
-            }
-        ) . " ";
+        $ret .= BML::ml('/talkpost.bml.label.picturetouse2') . " ";
 
         my @pics;
         foreach my $i ( 1 ... $res{pickw_count} ) {

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -140,7 +140,7 @@ IconBrowser.prototype = {
         $(document).off('keydown.icon-browser');
     },
     registerListeners: function() {
-        $(document).on('keydown.icon-browser', this.selectByEnter.bind(this));
+        $(document).on('keydown.icon-browser', this.keyboardNav.bind(this));
 
         if ( this.listenersRegistered ) return;
 
@@ -164,16 +164,14 @@ IconBrowser.prototype = {
     focusSearch: function() {
         $('#js-icon-browser-search').focus();
     },
-    selectByEnter: function(e) {
-        // enter
-        if (e.keyCode && e.keyCode === 13) {
-            var $originalTarget = $(e.originalTarget);
-            if ($originalTarget.hasClass("keyword")) {
-                $originalTarget.click();
-            } else if ($originalTarget.is("a")) {
-                return;
-            }
-            this.updateOwner.call(this, e);
+    keyboardNav: function(e) {
+        if ( $(e.target).is('#js-icon-browser-search') ) return;
+
+        if ( e.key === 'Enter' || (! e.key && e.keyCode === 13) ) {
+            $(e.target).trigger('click');
+        } else if ( e.key === '/' || (! e.key && e.keyCode === 191) ) {
+            e.preventDefault();
+            $("#js-icon-browser-search").focus();
         }
     },
     selectByClick: function(e) {
@@ -285,6 +283,13 @@ IconBrowser.prototype = {
         this.modal.foundation('reveal', 'close');
     },
     filter: function(e) {
+        if (this.selectedKeyword) {
+            if ( e.key === 'Enter' || (! e.key && e.keyCode === 13) ) {
+                this.updateOwner.call(this, e);
+                return;
+            }
+        }
+
         var val = $(e.target).val().toLocaleUpperCase();
 
         if ( ! this.contentElement ) {

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -44,6 +44,11 @@ function IconBrowser($el, options) {
             if ( Math.abs( $(window).scrollTop() - scrollPositionDogear ) > 500 ) {
                 $(window).scrollTop(scrollPositionDogear);
             }
+
+            // the browser blew away the user's tab-through position, so restore
+            // it on the icon menu, since that's what they just indirectly set a
+            // value for.
+            $el.focus();
         });
 }
 

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -249,9 +249,6 @@ IconBrowser.prototype = {
             .addClass("active");
     },
     updateOwner: function(e) {
-        // hackety hack -- being triggered on both 'close' and 'close.fndtn.reveal'; just want once
-        if (e.namespace === "") return;
-
         if (this.selectedKeyword) {
             this.element
                 .val(this.selectedKeyword)

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -94,9 +94,10 @@ IconBrowser.prototype = {
                     var $img = $("<img />").attr( {
                             src: icon.url,
                             alt: icon.alt,
-                            height:
-                            icon.height,
+                            height: icon.height,
                             width: icon.width,
+                            role: "button",
+                            tabindex: "0",
                             "class": "th" } )
                         .wrap("<a>").parent()
                         .wrap("<div class='icon-browser-icon-image'></div>").parent();
@@ -107,7 +108,7 @@ IconBrowser.prototype = {
                         $.each(icon.keywords, function(i, kw) {
                             iconBrowser.kwToIcon[kw] = idstring;
                             $keywords
-                                .append( $("<a class='keyword radius' data-kw='" + kw + "'></a>").text(kw) )
+                                .append( $("<a class='keyword radius' role='button' tabindex='0' data-kw='" + kw + "'></a>").text(kw) )
                                 .append(document.createTextNode(" "));
 
                         });
@@ -174,6 +175,10 @@ IconBrowser.prototype = {
     selectByClick: function(e) {
         e.stopPropagation();
         e.preventDefault();
+
+        // Some browsers don't focus buttons or role=buttons on click, and we
+        // want predictable behavior when people combine click + tab/enter.
+        e.target.focus();
 
         // If this is the second click, treat it as confirmation:
         if ( $(e.target).hasClass("active") ) {

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -36,6 +36,8 @@ function IconBrowser($el, options) {
             if (e.namespace === "") return;
 
             scrollPositionDogear = $(window).scrollTop();
+            iconBrowser.modal.removeAttr('tabindex'); // WHY does foundation.reveal set this.
+            iconBrowser.focusSearch();
         })
         .on('closed.fndtn.reveal', modalSelector, function(e) {
             // hackety hack -- being triggered on both 'closed' and 'closed.fndtn.reveal'; just want one
@@ -64,7 +66,8 @@ IconBrowser.prototype = {
             iconBrowser.resetFilter();
             iconBrowser.initializeKeyword();
         } else {
-            iconBrowser.modal.find(":input[type=search]").prop("disabled", true);
+            var searchField = $("#js-icon-browser-search");
+            searchField.prop("disabled", true);
 
             var url = Site.currentJournalBase ? "/" + Site.currentJournal + "/__rpc_userpicselect" : "/__rpc_userpicselect";
             $.getJSON(url).then(function(data) {
@@ -126,9 +129,7 @@ IconBrowser.prototype = {
                         .attr( "id", idstring );
                 });
 
-                iconBrowser.modal.find(":input[type=search]")
-                    .prop("disabled", false)
-                    .focus();
+                searchField.prop("disabled", false);
 
                 iconBrowser.initializeKeyword();
             });
@@ -159,6 +160,9 @@ IconBrowser.prototype = {
             .on('closed.fndtn.reveal', '#' + this.modalId, this.deregisterListeners.bind(this));
 
         this.listenersRegistered = true;
+    },
+    focusSearch: function() {
+        $('#js-icon-browser-search').focus();
     },
     selectByEnter: function(e) {
         // enter

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -145,8 +145,8 @@ IconBrowser.prototype = {
         if ( this.listenersRegistered ) return;
 
         $("#js-icon-browser-content")
-            .on("click", this.selectByClick.bind(this))
-            .on("dblclick", this.selectByDoubleClick.bind(this));
+            .on("click", ".icon-browser-item", this.selectByClick.bind(this))
+            .on("dblclick", ".icon-browser-item", this.selectByDoubleClick.bind(this));
 
         this.modal
             .find(".keyword-menu")
@@ -252,11 +252,16 @@ IconBrowser.prototype = {
             .find(".th, a[data-kw='" + iconBrowser.selectedKeyword + "']")
                 .addClass("active");
 
-        // keyword menu
+        // update keyword menus, move inline menu and select button
         if ( replaceKwMenu ) {
-            var $keywords = $container.find(".keywords");
-            iconBrowser.modal.find(".keyword-menu .keywords")
-                .replaceWith($keywords.clone());
+            var $currentKeywords = $container.find(".keywords");
+            var $oldKeywords = iconBrowser.modal.find(".keyword-menu")
+                .find(".keywords");
+            $currentKeywords.clone().replaceAll($oldKeywords);
+            // adopt inline menu as sibling:
+            $container.after( $('#inline-keyword-menu') );
+            // adopt select button as child:
+            $container.append( $('#icon-browser-select-button-wrapper') );
         } else {
             iconBrowser.modal.find(".keyword-menu .active")
                 .removeClass("active");

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -223,7 +223,17 @@ IconBrowser.prototype = {
         var iconBrowser = this;
 
         $("#" + iconBrowser.selectedId).find(".th, a").removeClass("active");
-        if ( $container.length == 0 ) return;
+
+        if ( ! $container || $container.length === 0 ) {
+            // more like DON'Tselect.
+            iconBrowser.selectedKeyword = undefined;
+            iconBrowser.selectedId = undefined;
+            // move keyword menu and select button back to their original spots
+            $("#js-icon-browser-content").before(
+                iconBrowser.modal.find("#inline-keyword-menu, #icon-browser-select-button-wrapper")
+            )
+            return;
+        }
 
         // select keyword
         if ( keyword != null ) {
@@ -271,44 +281,35 @@ IconBrowser.prototype = {
         this.modal.foundation('reveal', 'close');
     },
     filter: function(e) {
-        console.log("filter");
         var val = $(e.target).val().toLocaleUpperCase();
 
-        if ( ! this.originalElement ) {
-            this.originalElement = $("#js-icon-browser-content");
-            this.originalElementContainer = this.originalElement.parent();
-            this.originalElement.detach();
-        } else {
-            $("#js-icon-browser-content").remove();
+        if ( ! this.contentElement ) {
+            this.contentElement = $("#js-icon-browser-content");
         }
 
-
-        var $filtered = this.originalElement.clone(true);
-        $filtered
+        this.contentElement
             .find("li").each(function(i, item) {
-                console.log("item", item, $(this).data("keywords"), val);
                 if ( $(this).data("keywords").indexOf(val) == -1
                     && $(this).data("comment").indexOf(val) == -1
                     && $(this).data("alt").indexOf(val) == -1 ) {
 
-                    $(this).remove();
+                    $(this).css('display', 'none');
+                } else {
+                    $(this).css('display', ''); // Reason we aren't using .show() is bc it forcibly sets 'display: block'.
                 }
-            }).end()
-        .appendTo(this.originalElementContainer);
+            });
 
         var $visible = $("#js-icon-browser-content li:visible");
-        if ( $visible.length == 1 )
+        if ( $visible.length == 1 ) {
             this.doSelect($visible, null, true);
+        } else if ( ! $visible.is('#' + this.selectedId) ) {
+            // The previously selected icon doesn't match the filter anymore, so deselect it.
+            this.doSelect(null, null, true);
+        }
     },
     resetFilter: function() {
         $("#js-icon-browser-search").val("");
-        if ( this.originalElement ) {
-            $("#js-icon-browser-content").detach();
-            this.originalElementContainer.append(this.originalElement);
-        }
-
-        this.originalElement = null;
-        this.originalElementContainer = null;
+        $("#js-icon-browser-content li").show();
     }
 };
 

--- a/htdocs/scss/components/icon-browser.scss
+++ b/htdocs/scss/components/icon-browser.scss
@@ -125,7 +125,7 @@
         line-height: 1.5;
         transition-duration: 300ms;
         transition-timing-function: ease-out;
-        transition-property: color, background-color, border-width, margin-top, margin-bottom, margin-right;
+        transition-property: color, background-color;
 
         &.active {
             // Journal styles don't know about ".active" controls so they don't

--- a/htdocs/scss/components/icon-browser.scss
+++ b/htdocs/scss/components/icon-browser.scss
@@ -79,17 +79,18 @@
             flex-direction: row-reverse;
             flex-wrap: wrap;
             align-items: center;
-            justify-content: space-between;
+            justify-content: space-around;
         }
 
         & > * {
-            display: inline-block; // for no-flex browsers
-            // fake row-gap:
+            // for no-flex browsers
+            display: inline-block;
             margin-right: 2em;
-            &:last-child {
+
+            @supports (display: flex) {
                 margin-right: 0;
             }
-            // Consistent spacing
+
             margin-bottom: 1rem;
         }
     }
@@ -97,19 +98,6 @@
     p.icon-browser-help {
         font-size: smaller;
         margin-bottom: 1rem;
-    }
-
-    .keyword-menu {
-        // Slow yr roll, jumpy!
-        min-height: 2.5em;
-        @media #{$small-only} {
-            min-height: 4.2em;
-        }
-        label.left {
-            float: left;
-            margin-top: calc(.3em + 1px); // match keyword padding + margin + border
-            line-height: 1.5;
-        }
     }
 
     .keyword, .icon-browser-options a {
@@ -143,9 +131,59 @@
         font-size: smaller;
     }
 
+    // Keyword menus: the inline one is the modern one, and the legacy one is
+    // for old browsers that can't handle display: grid, because there's no way
+    // to make it work inline without tearing my hair out.
+    #inline-keyword-menu { // when no icon selected, or redundant bc meta text = yes
+        display: none;
+    }
+
+    #legacy-keyword-menu {
+        min-height: 4em;
+
+        @supports (display: grid) {
+            display: none;
+        }
+
+        label.left {
+            float: left;
+            margin-right: .5rem;
+        }
+    }
+
+    #icon-browser-select-button-wrapper {
+        display: none; // when no icon selected
+    }
+
+    #js-icon-browser-select {
+        margin-top: .5rem;
+        margin-bottom: .5rem;
+    }
+
+    .icon-browser-content #icon-browser-select-button-wrapper {
+        display: block;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+
     &.no-meta {
         .icon-browser-item-meta {
             display: none;
+        }
+
+        @supports (display: grid) { // no inline menu for old browsers
+            .icon-browser-content #inline-keyword-menu {
+                display: block;
+                grid-column: 1 / -1;
+
+                .keywords {
+                    display: flex;
+                    justify-content: center;
+                    flex-wrap: wrap;
+                    margin-bottom: .5rem;
+                }
+            }
         }
     }
 
@@ -158,8 +196,10 @@
     .js-icon-browser-icon-grid {
         list-style: none;
         padding: 0;
+        padding-bottom: 3rem;
         margin: 0;
         display: grid;
+        grid-auto-flow: row dense;
         grid-template-columns: repeat(auto-fill, 110px);
         grid-column-gap: 1rem;
         grid-row-gap: 1rem;

--- a/htdocs/scss/components/icon-browser.scss
+++ b/htdocs/scss/components/icon-browser.scss
@@ -76,7 +76,7 @@
         // @supports will hide this from IE11, which thinks it can flex but kinda can't.
         @supports (display: flex) {
             display: flex;
-            flex-direction: row;
+            flex-direction: row-reverse;
             flex-wrap: wrap;
             align-items: center;
             justify-content: space-between;
@@ -112,7 +112,7 @@
         }
     }
 
-    .keyword {
+    .keyword, .icon-browser-options a {
         display: inline-block;
         max-width: 100%;
         cursor: pointer;
@@ -127,7 +127,7 @@
         transition-timing-function: ease-out;
         transition-property: color, background-color;
 
-        &.active {
+        &.active, &.inactive-toggle {
             // Journal styles don't know about ".active" controls so they don't
             // do the inverted colors thing you see in site skins. But border
             // thickness will do in a pinch.
@@ -135,11 +135,6 @@
             margin: calc(.2em - 2px); // absorb extra border size
             margin-left: 0;
         }
-    }
-
-    a.inactive-toggle {
-        color: inherit;
-        text-decoration: none;
     }
 
     .icon-browser-item-meta {

--- a/htdocs/talkpost.bml.text
+++ b/htdocs/talkpost.bml.text
@@ -25,7 +25,7 @@
 
 .error.noreply_suspended=This entry is suspended.  You can't reply to it.
 
-.label.picturetouse2=<a [[aopts]]>Icon</a> to use:
+.label.picturetouse2=Icon to use:
 
 .linkstripped=Links will be displayed as unclickable URLs to help prevent spam.
 

--- a/views/components/icon-browser.tt
+++ b/views/components/icon-browser.tt
@@ -36,27 +36,23 @@ the same terms as Perl itself.  For a copy of the license, please reference
                     </div>
                 </div>
 
-                <button id='js-icon-browser-select'>Select</button>
-
                 <label class='invisible' for='js-icon-browser-search'>Search</label>
                 <input type='search' id='js-icon-browser-search' placeholder='Search' />
             </div>
         </div>
 
-        <div class="row">
-            <div class="columns">
-                <p class="icon-browser-help">Tap icon to select, tap again to confirm.</p>
-            </div>
+        <div id="legacy-keyword-menu" class="keyword-menu">
+            <label class="left">Keywords of selected icon:</label>
+            <div class='keywords'></div>
         </div>
 
-        <div class="row">
-            <div class="columns keyword-menu">
-                <label class="left">Keywords of selected icon:</label>
-                <div class='keywords'></div>
-            </div>
+        <div id="inline-keyword-menu" class="keyword-menu">
+            <div class='keywords'></div>
         </div>
 
-        <hr />
+        <div id='icon-browser-select-button-wrapper'>
+            <button id='js-icon-browser-select'>Select</button>
+        </div>
 
         <div id="js-icon-browser-content" class="icon-browser-content">
             <span class="icon-browser-status">Loading...</span>

--- a/views/components/icon-browser.tt
+++ b/views/components/icon-browser.tt
@@ -24,20 +24,22 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
         <div class="row">
             <div class="columns top-controls">
-                <label class='invisible' for='js-icon-browser-search'>Search</label>
-                <input type='search' id='js-icon-browser-search' placeholder='Search' />
-                <button id='js-icon-browser-select'>Select</button>
                 <div class="display-toggles">
-                    <div class='icon-browser-meta-toggle' id='js-icon-browser-meta-toggle'>
-                        <a href="#" data-action="text">Meta text</a> /
-                        <a href="#" data-action="no-text">No meta text</a>
+                    <div class='icon-browser-options icon-browser-meta-toggle' id='js-icon-browser-meta-toggle'>
+                        <a href="#" role="button" data-action="text">Text</a> /
+                        <a href="#" role="button" data-action="no-text">No text</a>
                     </div>
 
-                    <div class='icon-browser-size-toggle' id='js-icon-browser-size-toggle'>
-                        <a href="#" data-action="small">Small images</a> /
-                        <a href="#" data-action="large">Large images</a>
+                    <div class='icon-browser-options icon-browser-size-toggle' id='js-icon-browser-size-toggle'>
+                        <a href="#" role="button" data-action="small">Small</a> /
+                        <a href="#" role="button" data-action="large">Large</a>
                     </div>
                 </div>
+
+                <button id='js-icon-browser-select'>Select</button>
+
+                <label class='invisible' for='js-icon-browser-search'>Search</label>
+                <input type='search' id='js-icon-browser-search' placeholder='Search' />
             </div>
         </div>
 

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -42,7 +42,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
   [%- IF remote.icons.size > 0 -%]
     <div class='qr-icon-controls'>
-      <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
+      <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' -%]</label>
       [%- form.select(
           name = 'prop_picture_keyword',
           id = 'prop_picture_keyword',

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -332,7 +332,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
   [%- IF remote.icons.size > 0 -%]
     <div class='qr-icon-controls'>
-      <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
+      <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' -%]</label>
       [%- form.select(
         name = 'prop_picture_keyword',
         id = 'prop_picture_keyword',
@@ -836,7 +836,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
     [%- IF remote AND remote.icons.size > 0 -%]
       <div id="userpics">
-        [%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) %]
+        [%- '/talkpost.bml.label.picturetouse2' %]
         [% form.select(
           name = 'prop_picture_keyword'
           id = 'prop_picture_keyword'


### PR DESCRIPTION
Fixes #2640 and then some.

This is split into semantic commits for review. Code's live on rr-thrice.hack.dreamwidth.net if you have an account or openID login there. 

Have some screens:

<img src="https://user-images.githubusercontent.com/484309/80856983-71304200-8c03-11ea-9e24-460947fe013e.png" alt="Screenshot<em>2020-05-01 sheworks4themoney RIP, butthead(1)" title="" height="280" /> <img src="https://user-images.githubusercontent.com/484309/80856988-755c5f80-8c03-11ea-9708-37b24f91fa0d.png" alt="Screenshot<em>2020-05-01 sheworks4themoney Recent Entries(4)" title="" height="280" />
<img src="https://user-images.githubusercontent.com/484309/80856986-742b3280-8c03-11ea-85fe-c49e87f22fac.png" alt="Screenshot</em>2020-05-01 sheworks4themoney RIP, butthead" title="" height="280" />
<img src="https://user-images.githubusercontent.com/484309/80856989-75f4f600-8c03-11ea-8946-2a9b694506b8.png" alt="Screenshot</em>2020-05-01 sheworks4themoney Recent Entries(2)" title="" height="280" />
<img src="https://user-images.githubusercontent.com/484309/80856990-768d8c80-8c03-11ea-8829-2542dbc92598.png" alt="Screenshot<em>2020-05-01 sheworks4themoney Recent Entries(1)" title="" height="280" />
<img src="https://user-images.githubusercontent.com/484309/80856991-77262300-8c03-11ea-9cf5-57e9b4643f84.png" alt="Screenshot</em>2020-05-01 sheworks4themoney Recent Entries" title="" height="280" />

And here's a shot from Camino 2.1.2, the most antique browser I have ready to hand on my laptop:

<img height="280" alt="Screen Shot 2020-05-01 at May 1, 11 32PM" src="https://user-images.githubusercontent.com/484309/80857067-059aa480-8c04-11ea-997d-a95e43b58292.png">
