### PR TITLE
change default journal style on new installations

### DIFF
--- a/etc/config.pl.example
+++ b/etc/config.pl.example
@@ -452,8 +452,8 @@
     # by default, give users a style
     $DEFAULT_STYLE = {
         'core' => 'core2',
-        'layout' => 'negatives/layout',
-        'theme' => 'negatives/black',
+        'layout' => 'ciel/layout',
+        'theme' => 'ciel/indil',
     };
 
     # Setup support email address to not accept new emails.  Basically if an


### PR DESCRIPTION
I couldn't find an issue open for this but I know we've talked about it on Discord: the default journal style for over a decade has been 'negatives/black', which isn't TR-based and doesn't support the newer features present in most other journal styles.

This changes the default style defined in config.pl.example to 'ciel/indil' which I picked because it wasn't nonfree and seemed pleasantly neutral. I also didn't want to pick the same default style that we have been using in production ('practicality/neutralgood') because I thought that might be too much of the same thing across different sites.

This will only affect future installations that don't have an existing config.pl file.