### PR TITLE
require minimum version 0.015 of Params::Classify

### DIFF
--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -46,6 +46,7 @@ Net::OpenID::Server
 Net::SMTPS
 Net::SSL@2.85
 Net::Subnet
+Params::Classify@0.015
 Paws::S3
 Perl::Tidy@20190601
 Proc::ProcessTable


### PR DESCRIPTION
An older version of this module prevented Apache from starting in some environments. It's not explicitly called in our code, but it's included by Authen::Passphrase::BlowfishCrypt, which DW::Auth::Password uses.