### PR TITLE
The Squish, Part 3

### DIFF
--- a/htdocs/js/jquery.imageshrink.js
+++ b/htdocs/js/jquery.imageshrink.js
@@ -1,5 +1,97 @@
-$(document).on('click', '.entry-content img, .comment-content img', function(e){
-    if ( ! $(e.target).is('a img, .poll-response img') ) {
-        $(e.target).toggleClass('expanded');
+// Helper for shrinking images in entry/comment content. The actual Squish is
+// pure CSS; this just handles adding and removing classes to support:
+// - Zooming (on click)
+// - Exempting decorative markup from Squish (should be pure CSS, but can't yet)
+// - Hiding zoom cursors for images that won't zoom
+jQuery(function($) {
+
+    // First: Basic click-to-zoom. (.imageshrink-expanded on/off)
+    $(document).on('click', '.entry-content img, .comment-content img', function(e) {
+        var $that = $(e.target);
+        if ( ! $that.is('a img, .poll-response img, .imageshrink-actualsize') ) {
+            $that.toggleClass('imageshrink-expanded');
+        }
+    });
+
+    // Second: Exempt codes from the squish. (.imageshrink-exempt on/off)
+    // Only shrink casual pics; leave artisanal HTML alone. Can't predict
+    // everything, but 99% of the time that's a <div style="..."> or a table.
+    function protectTheCodes(container) {
+        // Expanded cut tags have style='display: block', but aren't decorations.
+        // Feeds (.journal-type-Y) always make a mess, so no mercy.
+        var exemptImages = container.querySelectorAll(
+            '.journal-type-P .entry-content div[style]:not(.cuttag-open) img, ' +
+            '.journal-type-P .entry-content table img, ' +
+            '.journal-type-C .entry-content div[style]:not(.cuttag-open) img, ' +
+            '.journal-type-C .entry-content table img, ' +
+            '.comment-content div[style] img, ' +
+            '.comment-content table img'
+        );
+        for (var i = 0; i < exemptImages.length; i++) {
+            exemptImages[i].classList.add('imageshrink-exempt');
+        }
     }
+
+    // Check the whole document to start with.
+    protectTheCodes(document);
+
+    // Third: Don't show zoom cursors for non-zooming images (.imageshrink-actualsize on/off)
+
+    // Dummied out observeImages function, to simplify browser support in (Fourth).
+    var observeImages = function(img) {return;};
+
+    if (typeof ResizeObserver === 'function') {
+        var zoomCursorCleaner = new ResizeObserver(function(resizeList, observer) {
+            resizeList.forEach(function(entry) {
+                var img = entry.target;
+                if (img.tagName !== 'IMG') { return; }
+
+                // Zoomed images don't count.
+                if ( ! img.classList.contains('imageshrink-expanded')
+                    && img.width === img.naturalWidth
+                    && img.height === img.naturalHeight
+                ) {
+                    img.classList.add('imageshrink-actualsize');
+                } else {
+                    img.classList.remove('imageshrink-actualsize');
+                }
+            });
+        });
+
+        // And now the real version:
+        observeImages = function(container) {
+            let images = container.querySelectorAll('.entry-content img, .comment-content img');
+            // Anything with ResizeObserver definitely has NodeList.forEach.
+            images.forEach(function(img) {
+                zoomCursorCleaner.observe(img);
+            });
+        }
+
+        // Check the whole document to start with.
+        observeImages(document);
+    }
+
+    // Fourth: Repeat (Second) and (Third) when adding images to the page.
+    // (Via cut tags, comment expansion, or image placeholders.)
+    if (typeof MutationObserver === 'function') {
+        var imageUpdater = new MutationObserver(function(mutationList, observer) {
+            mutationList.forEach(function(mutation) {
+                if (mutation.addedNodes.length > 0) {
+                    protectTheCodes(mutation.target);
+                    observeImages(mutation.target);
+                }
+            });
+        });
+
+        var opts = {childList: true, subtree: true};
+        var entries = document.getElementById('entries');
+        var comments = document.getElementById('comments');
+        if (entries) {
+            imageUpdater.observe(entries, opts);
+        }
+        if (comments) {
+            imageUpdater.observe(comments, opts);
+        }
+    }
+
 });

--- a/htdocs/js/jquery.imageshrink.js
+++ b/htdocs/js/jquery.imageshrink.js
@@ -38,7 +38,7 @@ jQuery(function($) {
     // Third: Don't show zoom cursors for non-zooming images (.imageshrink-actualsize on/off)
 
     // Dummied out observeImages function, to simplify browser support in (Fourth).
-    var observeImages = function(img) {return;};
+    var observeImages = function(container) {return;};
 
     if (typeof ResizeObserver === 'function') {
         var zoomCursorCleaner = new ResizeObserver(function(resizeList, observer) {

--- a/htdocs/scss/components/imageshrink.scss
+++ b/htdocs/scss/components/imageshrink.scss
@@ -1,36 +1,51 @@
-/* Constrain image dimensions.
-    Job 1: Don't trash the layout sideways.
-    Job 2: Limit height to fit inside the viewport. Having to scroll to see a
+/* Constrain size of casually posted images.
+    1: Don't trash the layout sideways.
+    2: Limit height to fit inside the viewport. Having to scroll to see a
       portrait of someone is nonsense.
-    Job 3: Defend the native aspect ratio.
-    Job 4: Respect the width/height HTML attributes for scaling down OR up
+    3: Defend the native aspect ratio.
+    4: Respect the width/height HTML attributes for scaling down OR up
       (within the limits of the container), but if they conflict with the aspect
       ratio, treat them as maximums and let the aspect ratio win.
-    Job 5: Let the user expand an individual image to max size by clicking.
+    5: Let the user expand an individual image to max size by clicking.
+      (js/jquery.imageshrink.js)
+    6: Use a zoom-in/zoom-out cursor to show when users can zoom.
+    7: Undo zoom cursor for images that are actual size in their unexpanded
+      state (.imageshrink-actualsize; relies on JS for comparing effective and
+      natural dimensions).
+    8: NONE of the above applies to images inside tables or inline-styled divs.
+      (.imageshrink-exempt; relies on JS for heavy lifting.)
+
+      FIXME: Someday in the distant future, part 8 should be pure CSS, using
+      selectors kind of like this:
+      img:not(.journal-type-P .entry-content div[style]:not(.cuttag-open) img)
+      Unfortunately that's a CSS Selectors Level 4 thing, and as of 2020 only
+      Safari supports it (and that's just the earlier iteration; I didn't try
+      the one that skips .cuttag-open like that). Oh well.
 */
+
 @supports (object-fit: contain) {
   .entry-content, .comment-content {
-    img {
+    img:not(.imageshrink-exempt) {
       cursor: zoom-in;
       height: auto;
       max-width: 100%;
       max-height: 95vh;
       object-fit: contain;
       object-position: left;
-    }
 
-    img.expanded {
-      cursor: zoom-out;
-      height: auto;
-      width: auto;
-      max-width: unset;
-      max-height: unset;
-      object-fit: unset;
-      object-position: unset;
+      &.imageshrink-expanded {
+        cursor: zoom-out;
+        height: auto;
+        width: auto;
+        max-width: unset;
+        max-height: unset;
+        object-fit: unset;
+        object-position: unset;
+      }
     }
+  }
 
-    a img, .poll-response img {
-      cursor: unset;
-    }
+  a img, .poll-response img, img.imageshrink-actualsize {
+    cursor: unset !important;
   }
 }

--- a/htdocs/scss/foundation/components/_global.scss
+++ b/htdocs/scss/foundation/components/_global.scss
@@ -515,9 +515,9 @@ $cursor-text-value: text !default;
   a:hover { cursor: $cursor-pointer-value; }
 
     // Grid Defaults to get images and embeds to work properly
-    img { max-width: 100%; height: auto; }
+//     img { max-width: 100%; height: auto; }
 
-    img { -ms-interpolation-mode: bicubic; }
+//     img { -ms-interpolation-mode: bicubic; }
 
     #map_canvas,
     .map_canvas,
@@ -548,10 +548,10 @@ $cursor-text-value: text !default;
     .antialiased { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
 
     // Get rid of gap under images by making them display: inline-block; by default
-    img {
-      display: inline-block;
-      vertical-align: middle;
-    }
+//     img {
+//       display: inline-block;
+//       vertical-align: middle;
+//     }
 
     //
     // Global resets for forms


### PR DESCRIPTION
Fixes #2650
Fixes #2611
 
Shoutout to Alyndra, @rshatch, and AlexSeanchai for helping test and refine this.

We currently constrain the size of images in entry and comment content. But the
REASON we do this is so that people can casually post medium-sized images
and not stress about annoying their friends and readers; the beginning and end
of it is to make it easier to post on DW.

There's another set of user behaviors that's basically the OPPOSITE of casually
posting a medium image, where people express themselves by doing weird intricate
HTML shit no modern site would allow. It's part of DW's fandom-centric culture,
so we'd rather not interfere with it or make it harder.

This commit uses some extra javascript to try and guess which images are part of
a complex hunk of decorative / narrative markup, and changes the CSS to leave
said images alone (under the assumption that the author knows what they're
trying to accomplish and doesn't need any "help").

And while I'm at it, it also removes the "zoom in" cursor from images that are
already actual size and thus don't need to zoom. (That part uses an ultra-modern
API with stringent browser requirements, because 1. it's kind of just a vanity
thing, and 2. it has to update on window resize, but any tangible performance
cost is unacceptable, so if we can't do it for nearly-free then we shouldn't do
it at all. Native ResizeObserver is nearly-free, polyfills ain't.)