### PR TITLE
Prevent infinite loop in htmlcleaner

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1352,8 +1352,8 @@ TOKEN:
     }
 
     # If crossposting, explicitly close cuts to keep the crosspost footer visible.
-    if ($preserve_lj_tags_for) {
-        while ( $opencount{'lj-cut'} ) {
+    if ( $preserve_lj_tags_for && $opencount{'lj-cut'} ) {
+        while ( $opencount{'lj-cut'} > 0 ) {
             $newdata .= "</lj-cut>";
             $opencount{'lj-cut'}--;
         }


### PR DESCRIPTION
N.B.: @alierak discovered this and did some kind of hotfix for it, so he should get the commit credit if he wants it. I'm just tossing this up here to make sure it doesn't get forgotten. 

If the user's raw text has more closing `</cut>`s than it had opening `<cut>`s
(resulting in a negative `opencount{'lj-cut'}`), don't keep adding closing
`</cut>`s until the end of time.