### PR TITLE
Fix drifting talkform in Drifting

### DIFF
--- a/styles/drifting/layout.s2
+++ b/styles/drifting/layout.s2
@@ -709,6 +709,11 @@ function Page::print_default_stylesheet()
         padding-bottom: 20px;
     }
 
+    /* Hack to keep the new-style talkform usable until we can rip the old float crud out of this layout */
+    #reply #qrformdiv {
+        clear: none;
+    }
+
     /* Entry
     ***************************************************************************/
     .entry {


### PR DESCRIPTION
In the s2foundation beta, where the talkform adopts some of the quick-reply's
styling, the form on the reply page gets pushed down below the sidebar. This
fixes that.

This layout is a great example of why everyone hates float-based layouts these
days. The fix is a kind of 😒 hack, but the alternative is basically open-heart
surgery on this thing so... *shrug*