### PR TITLE
Prevent infinite loop in htmlcleaner, belt + suspenders version

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1105,7 +1105,7 @@ TOKEN:
                 # state variable which is stashed across tokens.
             }
             elsif ( $tag eq "lj-cut" ) {
-                if ( $opts->{preserve_lj_tags_for} ) {
+                if ( $opts->{preserve_lj_tags_for} && $opencount{'lj-cut'} ) {
                     $opencount{'lj-cut'}--;
                     $newdata .= "</lj-cut>";
                 }

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1352,8 +1352,8 @@ TOKEN:
     }
 
     # If crossposting, explicitly close cuts to keep the crosspost footer visible.
-    if ($preserve_lj_tags_for) {
-        while ( $opencount{'lj-cut'} ) {
+    if ( $preserve_lj_tags_for && $opencount{'lj-cut'} ) {
+        while ( $opencount{'lj-cut'} > 0 ) {
             $newdata .= "</lj-cut>";
             $opencount{'lj-cut'}--;
         }


### PR DESCRIPTION
One pull request combining both @nfagerlund's fix and @alierak's fix, because why not both.

(I'm merely the git-wielding monkey in this merge scenario.)