### PR TITLE
Fix change_journal_type console command

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -267,7 +267,7 @@ email.emailreset.body<<
 The email address for your [[sitename]] account '[[user]]' has
 been reset. To validate the change, please go to this address:
 
-     [[siteroot]]/confirm/[[auth]]
+     [[siteroot]]confirm/[[auth]]
 
 Regards,
 [[sitename]] Team
@@ -279,7 +279,7 @@ email.emailreset.body_withpasswd<<
 The email address for your [[sitename]] account '[[user]]' has
 been reset. To validate the change, please go to this address:
 
-     [[siteroot]]/confirm/[[auth]]
+     [[siteroot]]confirm/[[auth]]
 
 Additionally, the password for this account has been reset to:
 
@@ -287,7 +287,7 @@ Additionally, the password for this account has been reset to:
 
 Please change it immediately by going to:
 
-     [[siteroot]]/changepassword
+     [[siteroot]]changepassword
 
 Regards,  
 [[sitename]] Team

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -275,6 +275,26 @@ Regards,
 [[siteroot]]
 .
 
+email.emailreset.body_withpasswd<<
+The email address for your [[sitename]] account '[[user]]' has
+been reset. To validate the change, please go to this address:
+
+     [[siteroot]]confirm/[[auth]]
+
+Additionally, the password for this account has been reset to:
+
+     [[newpass]]
+
+Please change it immediately by going to:
+
+     [[siteroot]]changepassword
+
+Regards,  
+[[sitename]] Team
+
+[[siteroot]]
+.
+
 email.emailreset.error=Unable to update user record for [[user]]
 
 email.emailreset.subject=Email Address Reset

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -267,7 +267,7 @@ email.emailreset.body<<
 The email address for your [[sitename]] account '[[user]]' has
 been reset. To validate the change, please go to this address:
 
-     [[siteroot]]confirm/[[auth]]
+     [[siteroot]]/confirm/[[auth]]
 
 Regards,
 [[sitename]] Team
@@ -279,7 +279,7 @@ email.emailreset.body_withpasswd<<
 The email address for your [[sitename]] account '[[user]]' has
 been reset. To validate the change, please go to this address:
 
-     [[siteroot]]confirm/[[auth]]
+     [[siteroot]]/confirm/[[auth]]
 
 Additionally, the password for this account has been reset to:
 
@@ -287,7 +287,7 @@ Additionally, the password for this account has been reset to:
 
 Please change it immediately by going to:
 
-     [[siteroot]]changepassword
+     [[siteroot]]/changepassword
 
 Regards,  
 [[sitename]] Team

--- a/cgi-bin/LJ/Console/Command/ChangeJournalType.pm
+++ b/cgi-bin/LJ/Console/Command/ChangeJournalType.pm
@@ -83,6 +83,15 @@ sub execute {
 
     #############################
 
+    if ( $type eq "community" ) {
+
+        # make sure the journal to be converted does not administer other communities
+        my $admin_of_count = scalar( $u->communities_managed_list ) || 0;
+        return $self->error(
+"Account administers $admin_of_count other communities, must remove maintainership first."
+        ) if $admin_of_count;
+    }
+
     if ( $type eq "person" ) {
 
         # going to a personal journal. do they have any entries posted by other users?

--- a/cgi-bin/LJ/User/Message.pm
+++ b/cgi-bin/LJ/User/Message.pm
@@ -183,6 +183,13 @@ sub reset_email {
 
     $update_opts ||= { status => 'T' };
     $update_opts->{email} = $newemail;
+
+    # this is no longer done using update_self
+    my $changepass = delete $update_opts->{password};
+    if ( defined $changepass ) {
+        $u->set_password($changepass);
+    }
+
     $u->update_self($update_opts)
         or return $errsub->( LJ::Lang::ml( "email.emailreset.error", { user => $u->user } ) );
 
@@ -198,13 +205,26 @@ sub reset_email {
                 from    => $LJ::ADMIN_EMAIL,
                 subject => LJ::Lang::ml("email.emailreset.subject"),
                 body    => LJ::Lang::ml(
-                    "email.emailreset.body",
-                    {
-                        user     => $u->user,
-                        sitename => $LJ::SITENAME,
-                        siteroot => "$LJ::SITEROOT/",
-                        auth     => $auth
-                    }
+                    $changepass
+                    ? (
+                        "email.emailreset.body_withpasswd",
+                        {
+                            user     => $u->user,
+                            newpass  => $changepass,
+                            sitename => $LJ::SITENAME,
+                            siteroot => "$LJ::SITEROOT/",
+                            auth     => $auth
+                        }
+                        )
+                    : (
+                        "email.emailreset.body",
+                        {
+                            user     => $u->user,
+                            sitename => $LJ::SITENAME,
+                            siteroot => "$LJ::SITEROOT/",
+                            auth     => $auth
+                        }
+                    )
                 ),
             }
         );

--- a/t/console-changejournaltype.t
+++ b/t/console-changejournaltype.t
@@ -18,15 +18,13 @@
 use strict;
 use warnings;
 
-use Test::More;
-plan skip_all => "Console command is currently broken -- password issues!";
-
-#use Test::More tests => 7;
+use Test::More tests => 7;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Console;
 use LJ::Test qw (temp_user temp_comm);
 local $LJ::T_NO_COMMAND_PRINT = 1;
+local $LJ::T_SUPPRESS_EMAIL   = 1;
 
 my $u  = temp_user();
 my $u2 = temp_user();

--- a/t/console-changejournaltype.t
+++ b/t/console-changejournaltype.t
@@ -18,7 +18,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 8;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Console;
@@ -28,6 +28,7 @@ local $LJ::T_SUPPRESS_EMAIL   = 1;
 
 my $u  = temp_user();
 my $u2 = temp_user();
+$u->update_self(  { status => 'A' } );
 $u2->update_self( { status => 'A' } );
 $u2 = LJ::load_user( $u2->user );
 
@@ -54,6 +55,14 @@ foreach my $to (qw(person community)) {
 
 ### NOW CHECK WITH PRIVS
 $u->grant_priv("changejournaltype");
+
+{
+    # test community maintainer case
+    LJ::set_rel( $comm, $u2, 'A' );
+    is( $run->("change_journal_type $owner community $u->{user}"),
+        "error: Account administers 1 other communities, must remove maintainership first." );
+    LJ::clear_rel( $comm, $u2, 'A' );
+}
 
 my $types = { 'community' => 'C', 'person' => 'P' };
 


### PR DESCRIPTION
This command had been temporarily disabled because when changing a community journal to a personal journal, the old behavior was to copy both the email and password of the named community admin over to the converted journal. But the previously used method for accessing that password was recently removed in favor of better password practices, so we needed a different solution for that aspect of the change.

The modifications here are copied in part from the `reset_password` console command, which uses LJ::rand_chars to generate a random string and assigns that as the value of the new password, then communicates it directly to the user via email with the expectation that it will immediately be changed.

The actions taken by the change_journal_type console command are executed by the `reset_email` user method, which sends a message asking the user to confirm the new email address for the journal. For the case where we are also changing the password, the message sent now asks the user to both confirm the email and change the password. In the case of converting to a community, the password is silently reset to the empty string.

While I was in here, I also took care of #2350 and cleaned up the test suite a bit.