### PR TITLE
Markup type switching, in comment forms and beta create entries

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -2309,3 +2309,21 @@ general /go.bml.link.to.journal
 general talk.error.nosuchjournal
 general talk.spellcheck
 general /talkform.tt.opt.noautoformat
+
+general /views/entry/success.tt.edit.edited
+general /views/entry/success.tt.edit.edited.comm
+general /views/entry/success.tt.edit.delete
+general /views/entry/success.tt.edit.delete.comm
+general /views/entry/success.tt.edit.links
+general /views/entry/success.tt.edit.links.editentry
+general /views/entry/success.tt.edit.links.manageentries
+general /views/entry/success.tt.edit.links.viewentries
+general /views/entry/success.tt.edit.links.viewentries.comm
+general /views/entry/success.tt.edit.links.viewentry
+general /views/entry/success.tt.new.links
+general /views/entry/success.tt.new.links.backdated
+general /views/entry/success.tt.new.links.edit
+general /views/entry/success.tt.new.links.memories
+general /views/entry/success.tt.new.links.myentries
+general /views/entry/success.tt.new.links.tags
+general /views/entry/success.tt.new.links.view

--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -2308,3 +2308,4 @@ general /go.bml.link.to.journal
 
 general talk.error.nosuchjournal
 general talk.spellcheck
+general /talkform.tt.opt.noautoformat

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2045,6 +2045,10 @@ lynx.nav.siteopts=Browse Options
 
 lynx.nav.update=Post Entry
 
+markup.helplink.url=FAQ_URL
+
+markup.helplink.alttext=More info about formatting
+
 menunav.create=Create
 
 menunav.create.createaccount=Create Account

--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -94,6 +94,14 @@ userproplist.comm_theme:
   multihomed: 0
   prettyname: Community theme
 
+userproplist.comment_editor:
+  cldversion: 4
+  datatype: char
+  des: The last-used comment markup format; new replies default to this.
+  indexed: 0
+  multihomed: 0
+  prettyname: Last-used comment markup format
+
 userproplist.control_strip_display:
   cldversion: 4
   datatype: num
@@ -325,6 +333,14 @@ userproplist.entry_editor:
   indexed: 0
   multihomed: 0
   prettyname: Default entry editor
+
+userproplist.entry_editor2:
+  cldversion: 4
+  datatype: char
+  des: The last-used markup format for posting entries. New entries default to this.
+  indexed: 0
+  multihomed: 0
+  prettyname: Last-used entry markup format.
 
 userproplist.entryform_width:
   cldversion: 4

--- a/cgi-bin/DW/Controller/Editor.pm
+++ b/cgi-bin/DW/Controller/Editor.pm
@@ -15,6 +15,7 @@
 package DW::Controller::Editor;
 
 use strict;
+use v5.10;
 use LJ::JSON;
 use DW::Controller;
 use DW::Routing;
@@ -60,10 +61,12 @@ sub default_editor_handler {
     my ( $ok, $rv ) = controller( form_auth => 1 );
     return $rv unless $ok;
 
-    my $r      = $rv->{r};
-    my $POST   = $r->post_args;
+    my $r = $rv->{r};
+    return error_ml('/default_editor.tt.error.nopost') unless $r->did_post;
     my $remote = $rv->{remote};
     return error_ml('/default_editor.tt.error.nouser') unless $remote;
+
+    my $POST = $r->post_args;
 
     my $type       = $POST->{type};
     my $new_editor = $POST->{new_editor};

--- a/cgi-bin/DW/Controller/Editor.pm
+++ b/cgi-bin/DW/Controller/Editor.pm
@@ -1,0 +1,119 @@
+# DW::Controller::Editor
+#
+# Single-purpose routes for setting the editor userprops, which determine the
+# default formatting type when writing new entries/comments/etc in the web UI.
+#
+# Authors:
+#   Nick Fagerlund <nick.fagerlund@gmail.com>
+#
+# Copyright (c) 2020 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+package DW::Controller::Editor;
+
+use strict;
+use LJ::JSON;
+use DW::Controller;
+use DW::Routing;
+use DW::Template;
+use DW::Formats;
+use Carp;
+
+DW::Routing->register_string( "/default_editor", \&default_editor_handler, app => 1 );
+
+DW::Routing->register_rpc(
+    "default_editor", \&default_editor_rpc_handler,
+    format  => 'json',
+    methods => { POST => 1 },
+);
+
+# Returns (1, "format_id") on success, (0, "error") on error.
+sub default_editor_helper {
+    my ( $remote, $type, $new_editor ) = @_;
+    my $userprop;
+
+    my $err = sub { return ( 0, $_[0] ); };
+
+    return $err->('nouser') unless $remote;
+
+    $new_editor = DW::Formats::validate($new_editor);
+
+    if ( $type eq 'comment' ) {
+        $userprop = 'comment_editor';
+    }
+    elsif ( $type eq 'entry' ) {
+        $userprop = 'entry_editor2';
+    }
+    else {
+        return $err->('unknowntype');
+    }
+
+    $remote->set_prop( $userprop, $new_editor );
+    return ( 1, $new_editor );
+}
+
+# zero-javascript version
+sub default_editor_handler {
+    my ( $ok, $rv ) = controller( form_auth => 1 );
+    return $rv unless $ok;
+
+    my $r      = $rv->{r};
+    my $POST   = $r->post_args;
+    my $remote = $rv->{remote};
+    return error_ml('/default_editor.tt.error.nouser') unless $remote;
+
+    my $type       = $POST->{type};
+    my $new_editor = $POST->{new_editor};
+    my $exit_text  = $POST->{exit_text};
+    my $exit_url   = $POST->{exit_url};
+
+    my ( $set_ok, $set_result ) = default_editor_helper( $remote, $type, $new_editor );
+
+    unless ($set_ok) {
+        return error_ml( "/default_editor.tt.error.$set_result", { type => $type } );
+    }
+
+    return DW::Template->render_template(
+        'default_editor.tt',
+        {
+            title      => ".title.$type",
+            type       => $type,
+            new_format => DW::Formats::display_name($set_result),
+            exit_text  => $exit_text,
+            exit_url   => $exit_url,
+        }
+    );
+}
+
+sub default_editor_rpc_handler {
+    my $r    = DW::Request->get;
+    my $POST = $r->post_args;
+
+    # make sure we have a user of some sort
+    my $remote = LJ::get_remote();
+    return DW::RPC->err('Unable to load user for call.') unless $remote;
+
+    my $type       = $POST->{type};
+    my $new_editor = $POST->{new_editor};
+
+    my ( $set_ok, $set_result ) = default_editor_helper( $remote, $type, $new_editor );
+
+    return DW::RPC->err( LJ::Lang::ml( "/default_editor.tt.error.$set_result", { type => $type } ) )
+        unless $set_ok;
+
+    return DW::RPC->out(
+        success    => 1,
+        new_editor => $set_result,
+        message    => LJ::ehtml(
+            LJ::Lang::ml(
+                '/default_editor.tt.success',
+                { type => $type, new_format => DW::Formats::display_name($set_result) }
+            )
+        )
+    );
+}
+
+1;

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1087,7 +1087,10 @@ sub _get_extradata {
 
     # Figure out whether we should offer to update their default formatting.
     my $remote = LJ::get_remote();
-    if ($remote && DW::Formats::is_active( $form_req->{props}->{editor} ) && $form_req->{props}->{editor} ne $remote->entry_editor2 ) {
+    if (   $remote
+        && DW::Formats::is_active( $form_req->{props}->{editor} )
+        && $form_req->{props}->{editor} ne $remote->entry_editor2 )
+    {
         $extradata->{format} = $DW::Formats::formats{ $form_req->{props}->{editor} };
     }
 

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -588,7 +588,7 @@ sub _edit {
 
                 my %edit_res = _do_edit(
                     $ditemid, $form_req,
-                    { remote => $remote, journal => $journal },
+                    { poster => $remote, journal => $journal },
                     warnings => $warnings,
                 );
                 return $edit_res{render} if $edit_res{status} eq "ok";
@@ -1117,17 +1117,18 @@ sub _do_post {
         $warnings->add_string( undef, LJ::auto_linkify( LJ::ehtml( $res->{message} ) ) )
             if $res->{message};
 
-        my $u  = $auth->{poster};
-        my $ju = $auth->{journal} || $auth->{poster};
+        my $u       = $auth->{poster};
+        my $journal = $auth->{journal};
 
         # we updated successfully! Now tell the user
         my $poststatus = {
-            ml_string => $ju->is_community ? ".new.community" : ".new.journal",
-            url       => $ju->journal_base . "/",
+            status    => 'posted',
+            ml_string => $journal->is_community ? ".new.community" : ".new.journal",
+            url       => $journal->journal_base . "/",
         };
 
         # bunch of helpful links
-        my $juser        = $ju->user;
+        my $juser        = $journal->user;
         my $ditemid      = $res->{itemid} * 256 + $res->{anum};
         my $itemlink     = $res->{url};
         my $edititemlink = "$LJ::SITEROOT/entry/$juser/$ditemid/edit";
@@ -1135,46 +1136,50 @@ sub _do_post {
         my @links = (
             {
                 url       => $itemlink,
-                ml_string => ".new.links.view"
-            }
+                ml_string => ".links.viewentry"
+            },
+            {
+                url       => $edititemlink,
+                ml_string => ".links.editentry"
+            },
+            {
+                url       => "$LJ::SITEROOT/edittags?journal=$juser&itemid=$ditemid",
+                ml_string => ".links.tags"
+            },
         );
+
+        push @links,
+            {
+            url       => $journal->journal_base . "?poster=" . $auth->{poster}->user,
+            ml_string => ".links.myentries"
+            }
+            if $journal->is_community;
 
         push @links,
             (
             {
-                url       => $edititemlink,
-                ml_string => ".new.links.edit"
-            },
-            {
                 url       => "$LJ::SITEROOT/tools/memadd?journal=$juser&itemid=$ditemid",
-                ml_string => ".new.links.memories"
+                ml_string => ".links.memories"
             },
             {
-                url       => "$LJ::SITEROOT/edittags?journal=$juser&itemid=$ditemid",
-                ml_string => ".new.links.tags"
-            },
-            );
-
-        push @links,
-            {
-            url       => $ju->journal_base . "?poster=" . $auth->{poster}->user,
-            ml_string => ".new.links.myentries"
+                url       => "$LJ::SITEROOT/editjournal",
+                ml_string => '.links.manageentries',
             }
-            if $ju->is_community;
+            );
 
         # crosspost!
         my @crossposts = _queue_crosspost(
             $form_req,
             remote  => $u,
-            journal => $ju,
+            journal => $journal,
             deleted => 0,
             editurl => $edititemlink,
             ditemid => $ditemid,
         );
 
         # set sticky
-        if ( $form_req->{sticky_entry} && $u->can_manage($ju) ) {
-            my $added_sticky = $ju->sticky_entry_new($ditemid);
+        if ( $form_req->{sticky_entry} && $u->can_manage($journal) ) {
+            my $added_sticky = $journal->sticky_entry_new($ditemid);
             $warnings->add( '', '.sticky.max', { limit => $u->count_max_stickies } )
                 unless $added_sticky;
         }
@@ -1186,8 +1191,8 @@ sub _do_post {
                 warnings     => $warnings,       # warnings about the entry or your account
                 crossposts   => \@crossposts,    # crosspost status list
                 links        => \@links,
-                links_header => ".new.links",
-                extradata => _get_extradata( $form_req, $ju ),
+                links_header => ".links",
+                extradata => _get_extradata( $form_req, $journal ),
             }
         );
     }
@@ -1200,7 +1205,7 @@ sub _save_editted_entry {
 
     my $req = {
         ver        => $LJ::PROTOCOL_VER,
-        username   => $auth->{remote} ? $auth->{remote}->user : undef,
+        username   => $auth->{poster} ? $auth->{poster}->user : undef,
         usejournal => $auth->{journal} ? $auth->{journal}->user : undef,
         xpost  => '0',             # don't crosspost by default; we handle this ourselves later
         itemid => $ditemid >> 8,
@@ -1214,7 +1219,7 @@ sub _save_editted_entry {
         \$err,
         {
             noauth => 1,
-            u      => $auth->{remote},
+            u      => $auth->{poster},
         }
     );
 
@@ -1228,7 +1233,7 @@ sub _do_edit {
     my $res = _save_editted_entry( $ditemid, $form_req, $auth );
     return %$res if $res->{errors};
 
-    my $remote  = $auth->{remote};
+    my $remote  = $auth->{poster};
     my $journal = $auth->{journal};
 
     my $deleted = $form_req->{event} ? 0 : 1;
@@ -1249,9 +1254,10 @@ sub _do_edit {
         if $res->{message};
 
     # bunch of helpful links:
-    my $juser     = $journal->user;
-    my $entry_url = $res->{url};
-    my $edit_url  = "$LJ::SITEROOT/entry/$juser/$ditemid/edit";
+    my $juser         = $journal->user;
+    my $comm_modifier = $journal->is_community ? '.comm' : '';
+    my $entry_url     = $res->{url};
+    my $edit_url      = "$LJ::SITEROOT/entry/$juser/$ditemid/edit";
 
     my $is_sticky_entry = $journal->sticky_entries_lookup->{$ditemid};
     if ( $remote->can_manage($journal) ) {
@@ -1266,39 +1272,64 @@ sub _do_edit {
     }
 
     if ($deleted) {
-        $poststatus_ml = ".edit.delete";
+        $poststatus_ml = ".edit.delete2$comm_modifier";
 
         $journal->sticky_entry_remove($ditemid)
             if $is_sticky_entry && $remote->can_manage($journal);
+
+        push @links,
+            {
+            url       => $journal->journal_base . "?poster=" . $auth->{poster}->user,
+            ml_string => ".links.myentries"
+            }
+            if $journal->is_community;
+
+        push @links,
+            {
+            url       => "$LJ::SITEROOT/editjournal",
+            ml_string => '.links.manageentries',
+            };
+
     }
     else {
-        $poststatus_ml = ".edit.edited";
+        $poststatus_ml = ".edit.edited2$comm_modifier";
+
+        push @links,
+            (
+            {
+                url       => $entry_url,
+                ml_string => ".links.viewentry",
+            },
+            {
+                url       => $edit_url,
+                ml_string => ".links.editentry",
+            },
+            {
+                url       => "$LJ::SITEROOT/edittags?journal=$juser&itemid=$ditemid",
+                ml_string => ".links.tags"
+            },
+            );
 
         push @links,
             {
-            url       => $entry_url,
-            ml_string => ".edit.links.viewentry",
-            };
+            url       => $journal->journal_base . "?poster=" . $auth->{poster}->user,
+            ml_string => ".links.myentries"
+            }
+            if $journal->is_community;
 
         push @links,
+            (
             {
-            url       => $edit_url,
-            ml_string => ".edit.links.editentry",
-            };
+                url       => "$LJ::SITEROOT/tools/memadd?journal=$juser&itemid=$ditemid",
+                ml_string => ".links.memories"
+            },
+            {
+                url       => "$LJ::SITEROOT/editjournal",
+                ml_string => '.links.manageentries',
+            }
+            );
 
     }
-
-    push @links,
-        (
-        {
-            url       => $journal->journal_base,
-            ml_string => '.edit.links.viewentries',
-        },
-        {
-            url       => "$LJ::SITEROOT/editjournal",
-            ml_string => '.edit.links.manageentries',
-        }
-        );
 
     my @crossposts = _queue_crosspost(
         $form_req,
@@ -1309,7 +1340,12 @@ sub _do_edit {
         editurl => $edit_url,
     );
 
-    my $poststatus = { ml_string => $poststatus_ml };
+    my $poststatus = {
+        status    => $deleted ? 'deleted' : 'edited',
+        ml_string => $poststatus_ml,
+        url       => $journal->journal_base . "/",
+    };
+
     $render_ret = DW::Template->render_template(
         'entry/success.tt',
         {
@@ -1317,7 +1353,7 @@ sub _do_edit {
             warnings     => $warnings,       # warnings about the entry or your account
             crossposts   => \@crossposts,    # crosspost status list
             links        => \@links,
-            links_header => '.edit.links',
+            links_header => '.links',
             extradata => _get_extradata( $form_req, $journal ),
         }
     );

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -24,6 +24,7 @@ use DW::Controller;
 use DW::Routing;
 use DW::Template;
 use DW::FormErrors;
+use DW::Formats;
 
 use Hash::MultiValue;
 use HTTP::Status qw( :constants );
@@ -260,6 +261,15 @@ sub new_handler {
 
     # prepopulate if we haven't been through this form already
     $vars->{formdata} = $post || _prepopulate($get);
+
+    # Had to wait for formdata before figuring out the editors list -- if we
+    # have a WIP form submission with errors, we want to reuse what the user
+    # already chose.
+    $vars->{editors} = DW::Formats::select_items(
+        current   => $vars->{formdata}->{editor},
+        preferred => $remote ? $remote->prop('entry_editor2') : '',
+    );
+    $vars->{formdata}->{editor} = $vars->{editors}->{selected};
 
     $vars->{editable} = { map { $_ => 1 } @modules };
 
@@ -644,6 +654,17 @@ sub _edit {
 
     $vars->{formdata} = $post || _backend_to_form($entry_obj);
 
+    # Now that we have {formdata}->{editor}, we can get the list of available
+    # editors.
+    $vars->{editors} = DW::Formats::select_items(
+        current   => $vars->{formdata}->{editor},
+        preferred => $remote->prop('entry_editor2'),
+    );
+
+    # The template helper uses "formdata" to set the default values for fields,
+    # so we'll update it in place with what DW::Formats thinks we should use.
+    $vars->{formdata}->{editor} = $vars->{editors}->{selected};
+
     my %editable = map { $_ => 1 } @modules;
     $vars->{editable} = \%editable;
 
@@ -740,11 +761,9 @@ sub _form_to_backend {
     $props->{picture_keyword} = $post->{icon}    if defined $post->{icon};
     $props->{opt_backdated} = $post->{entrytime_outoforder} ? 1 : 0;
 
-    # FIXME
+    # This form always uses the editor prop instead of opt_preformatted.
     $props->{opt_preformatted} = 0;
-
-    #     $req->{"prop_opt_preformatted"} ||= $POST->{'switched_rte_on'} ? 1 :
-    #         $POST->{event_format} && $POST->{event_format} eq "preformatted" ? 1 : 0;
+    $props->{editor}           = DW::Formats::validate( $post->{editor} );
 
     # old implementation of comments
     # FIXME: remove this before taking the page out of beta
@@ -856,6 +875,34 @@ sub _backend_to_form {
 
     # direct translation of prop values to the form
 
+    my $event = $entry->event_raw;
+
+    # Look up formatting for newer entries...
+    my $editor = $entry->prop('editor');
+
+    # ...or, figure out formatting when editing old entries.
+    # TODO: This duplicates some logic from LJ::CleanHTML for guessing an editor
+    # value for old posts. Would be nice to centralize it in the Entry class,
+    # except that if we're detecting old-style !markdown, we DO want to also
+    # mutate the body text, which makes it hairy.
+    unless ($editor) {
+        if ( $event =~ s/^\s*!markdown\s*\r?\n//s ) {
+            $editor = 'markdown0';
+        }
+        elsif ( $entry->prop('opt_preformatted') ) {
+            $editor = 'html_raw0';
+        }
+        elsif ( $entry->prop('import_source') ) {
+            $editor = 'html_casual0';
+        }
+        elsif ( $entry->logtime_mysql lt '2019-05' ) {
+            $editor = 'html_casual0';
+        }
+        else {
+            $editor = 'html_casual1';    # For accurate state when editing posts.
+        }
+    }
+
     my %formprops = map { $_ => $entry->prop( $form_to_props{$_} ) } keys %form_to_props;
 
     # some properties aren't in the hash above, so go through them manually
@@ -876,8 +923,13 @@ sub _backend_to_form {
 
         flags_adminpost => $entry->prop("admin_post"),
 
-        # FIXME:
-        # ...       => $entry->prop( "opt_preformatted" )
+        # At this point we know enough to get the full list of editors (and
+        # selection state) for the dropdown, but because of how the template
+        # variables are laid out, we shouldn't really do that from here. (This
+        # function's whole return value becomes 'formdata' in the template
+        # vars.) So we'll pass this along, and the caller (currently just _edit)
+        # will use it to get the list for the dropdown.
+        editor => DW::Formats::validate($editor),
 
         # FIXME: remove before taking the page out of beta
         opt_screening      => $entry->prop("opt_screening"),
@@ -901,8 +953,7 @@ sub _backend_to_form {
     }
 
     # allow editing of embedded content
-    my $event = $entry->event_raw;
-    my $ju    = $entry->journal;
+    my $ju = $entry->journal;
     LJ::EmbedModule->parse_module_embed( $ju, \$event, edit => 1 );
 
     return {
@@ -1284,19 +1335,9 @@ sub _persist_props {
 
     # FIXME:
     #
-    #                 # persist the default value of the disable auto-formatting option
-    #                 $u->disable_auto_formatting( $POST{event_format} ? 1 : 0 );
-    #
     #                 # Clear out a draft
     #                 $remote->set_prop('entry_draft', '')
     #                     if $remote;
-    #
-    #                 # Store what editor they last used
-    #                 unless (!$remote || $remote->prop('entry_editor') =~ /^always_/) {
-    #                      $POST{'switched_rte_on'} ?
-    #                          $remote->set_prop('entry_editor', 'rich') :
-    #                          $remote->set_prop('entry_editor', 'plain');
-    #                  }
 
 }
 
@@ -1408,8 +1449,7 @@ sub preview_handler {
     # the cleaner won't eat
     LJ::EmbedModule->parse_module_embed( $u, \$event, preview => 1 );
 
-    # TODO: get prop_editor from the form (not currently being set)
-    my $editor = undef;
+    my $editor = $form_req->{props}->{editor};
 
     # clean content normally
     LJ::CleanHTML::clean_event(

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -1085,6 +1085,12 @@ sub _get_extradata {
         $extradata->{security_ml} = "post.security.public";
     }
 
+    # Figure out whether we should offer to update their default formatting.
+    my $remote = LJ::get_remote();
+    if ($remote && DW::Formats::is_active( $form_req->{props}->{editor} ) && $form_req->{props}->{editor} ne $remote->entry_editor2 ) {
+        $extradata->{format} = $DW::Formats::formats{ $form_req->{props}->{editor} };
+    }
+
     return $extradata;
 }
 
@@ -1192,6 +1198,7 @@ sub _do_post {
                 crossposts   => \@crossposts,    # crosspost status list
                 links        => \@links,
                 links_header => ".links",
+                entry_url    => $itemlink,
                 extradata => _get_extradata( $form_req, $journal ),
             }
         );
@@ -1354,6 +1361,7 @@ sub _do_edit {
             crossposts   => \@crossposts,    # crosspost status list
             links        => \@links,
             links_header => '.links',
+            entry_url    => $entry_url,
             extradata => _get_extradata( $form_req, $journal ),
         }
     );

--- a/cgi-bin/DW/Controller/RPC/CutExpander.pm
+++ b/cgi-bin/DW/Controller/RPC/CutExpander.pm
@@ -91,7 +91,6 @@ sub load_cuttext {
         ditemid             => $ditemid,
         suspend_msg         => $suspend_msg,
         unsuspend_supportid => $suspend_msg ? $entry_obj->prop('unsuspend_supportid') : 0,
-        preformatted        => $entry_obj->prop("opt_preformatted"),
         cut_retrieve        => $cutid,
     };
 

--- a/cgi-bin/DW/Controller/RPC/Misc.pm
+++ b/cgi-bin/DW/Controller/RPC/Misc.pm
@@ -322,6 +322,7 @@ sub addcomment_handler {
         body                 => $post->{body},
         subject              => $post->{subject},
         prop_picture_keyword => $post->{prop_picture_keyword},
+        prop_editor          => $post->{prop_editor},
 
         useragent => "rpc-addcomment",
     };

--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -204,6 +204,7 @@ sub talkpost_do_handler {
                 preformat       => $POST->{'prop_opt_preformatted'},
                 admin_post      => $POST->{'prop_admin_post'},
                 picture_keyword => $POST->{'prop_picture_keyword'},
+                editor          => $POST->{'prop_editor'},
             };
         }
 
@@ -640,8 +641,7 @@ sub preview_comment_args {
             anon_comment => LJ::Talk::treat_as_anon( $comment->{u}, $comment->{entry}->journal ),
             preformatted => $comment->{preformat},
             admin_post   => $comment->{admin_post},
-
-            # editor       => $comment->{editor}, # not wired through yet
+            editor       => $comment->{editor},
         }
     );
 

--- a/cgi-bin/DW/EmailPost/Base.pm
+++ b/cgi-bin/DW/EmailPost/Base.pm
@@ -15,6 +15,7 @@ use strict;
 
 require 'ljlib.pl';
 use LJ::Emailpost::Web;
+use DW::Formats;
 
 use Encode;
 use MIME::Words      ();
@@ -334,6 +335,24 @@ sub _clean_body_and_subject {
     $self->{subject} = $subject;
 
     return 1;
+}
+
+# Convert special email format keywords to the real format IDs used by
+# DW::Formats and LJ::CleanHTML.
+sub _choose_editor {
+    my ( $self, $format ) = @_;
+    $format = lc($format);
+
+    # Support email-only short names for the active formats:
+    $format = 'markdown_latest'    if $format eq 'markdown';
+    $format = 'html_casual_latest' if $format eq 'html';
+
+    $format = DW::Formats::validate($format);
+
+    # If validate returns '', use an email-specific default.
+    $format = DW::Formats::validate('markdown_latest') unless $format;
+
+    return $format;
 }
 
 # By default, returns first plain text entity from email message.

--- a/cgi-bin/DW/EmailPost/Comment.pm
+++ b/cgi-bin/DW/EmailPost/Comment.pm
@@ -108,9 +108,9 @@ sub _process {
         body                 => $self->{body},
         subject              => $self->{subject},
         prop_picture_keyword => $self->{props}->{picture_keyword},
+        prop_editor          => "markdown",
 
         useragent => "emailpost",
-        editor    => "markdown",
     };
 
     # post!

--- a/cgi-bin/DW/EmailPost/Comment.pm
+++ b/cgi-bin/DW/EmailPost/Comment.pm
@@ -108,7 +108,7 @@ sub _process {
         body                 => $self->{body},
         subject              => $self->{subject},
         prop_picture_keyword => $self->{props}->{picture_keyword},
-        prop_editor          => "markdown",
+        prop_editor          => $self->{props}->{editor},
 
         useragent => "emailpost",
     };
@@ -148,6 +148,8 @@ sub _set_props {
     my $props = {};
     $props->{picture_keyword} = $post_headers{userpic}
         || $post_headers{icon};
+    $props->{editor} = $self->_choose_editor( $post_headers{format} );
+
     $self->{props} = $props;
 
     return 1;

--- a/cgi-bin/DW/EmailPost/Entry.pm
+++ b/cgi-bin/DW/EmailPost/Entry.pm
@@ -188,6 +188,7 @@ sub _set_props {
     }
     $props->{current_music}    = $post_headers{music};
     $props->{current_location} = $post_headers{location};
+    $props->{editor}           = $self->_choose_editor( $post_headers{format} );
     $props->{opt_nocomments}   = 1
         if $post_headers{comments} =~ /off/i
         || $u->{emailpost_comments} =~ /off/i;

--- a/cgi-bin/DW/Formats.pm
+++ b/cgi-bin/DW/Formats.pm
@@ -1,0 +1,149 @@
+#!/usr/bin/perl
+#
+# DW::Formats
+#
+# A helper package for getting info about DW's supported markup formats. Each of
+# these named formats represents a specific set of expected formatting
+# behaviors, and each entry and comment is assigned a specific format. By
+# remembering the expected formats of archived content, we can always display it
+# as originally intended despite changing our markup behaviors over time.
+#
+# When adding a new format, you must also:
+# - Implement its markup transformations in LJ::CleanHTML. We're deliberately
+#   sacrificing some convenience in this package to keep CleanHTML more legible.
+# - If it replaces an existing format, update @active_formats, %format_upgrades,
+#   and $default_format accordingly.
+#
+# Authors:
+#      Nick Fagerlund <nick.fagerlund@gmail.com>
+#
+# Copyright (c) 2020 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+package DW::Formats;
+
+use strict;
+
+our @active_formats = qw( html_casual1 markdown0 html_raw0 );
+our $default_format = 'html_casual1';
+
+# obsolete version => newest version:
+our %format_upgrades = ( html_casual0 => 'html_casual1', );
+
+our %formats = (
+    html_casual0 => {
+        id   => 'html_casual0',
+        name => "Casual HTML (legacy 0)",
+        description =>
+"Text with normal line breaks, plus HTML tags for formatting. Doesn't support \@mentions.",
+    },
+    html_casual1 => {
+        id   => 'html_casual1',
+        name => "Casual HTML",
+        description =>
+            "Text with normal line breaks, plus \@mentions and HTML tags for formatting.",
+    },
+    html_raw0 => {
+        id   => 'html_raw0',
+        name => "Raw HTML",
+        description =>
+"Pre-formatted HTML. Doesn't automatically detect paragraph breaks, and doesn't support \@mentions.",
+    },
+    html_extra_raw => {
+        id   => 'html_extra_raw',
+        name => "Raw HTML (external source)",
+        description =>
+"Pre-formatted HTML from a feed or some other external source. Doesn't support special Dreamwidth tags like &lt;user&gt;.",
+    },
+    markdown0 => {
+        id   => 'markdown0',
+        name => "Markdown",
+        description =>
+"Markdown, a lightweight text format that makes paragraphs from normal line breaks and provides shortcuts for the most common HTML tags. Supports \@mentions, and supports real HTML tags for more complex formatting.",
+    },
+);
+
+# Legacy aliases:
+$formats{markdown} = $formats{markdown0};
+
+# Builds items that can be passed to an LJ::html_select for picking a format,
+# plus the format that should be initially selected.
+# Args: opts hash like (current => "format", preferred => "format").
+# Returns: Hashref like {selected => "format", items => [...]}. (Unfortunately,
+# LJ::html_select doesn't support just setting selected=true on one of the items,
+# so we need to return an extra value.)
+sub select_items {
+    my %opts = @_;
+
+    # Canonicalize em
+    my $current   = validate( $opts{current} );
+    my $preferred = validate( $opts{preferred} );
+
+    my @formats  = @active_formats;
+    my $selected = $default_format;
+
+    # Use the content's existing format if possible, then fall back to the
+    # user's preference (IF it's active or has an active replacement), then the
+    # site default.
+    if ($current) {
+        push( @formats, $current ) unless grep( $_ eq $current, @formats );
+        $selected = $current;
+    }
+    elsif ( $preferred && is_active($preferred) ) {
+        $selected = $preferred;
+    }
+    elsif ( $preferred && is_active( upgrade($preferred) ) ) {
+        $selected = upgrade($preferred);
+    }
+
+    return {
+        selected => $selected,
+        items =>
+            [ map { { value => $formats{$_}->{id}, text => $formats{$_}->{name}, } } @formats ],
+    };
+}
+
+# Return the canonical version of the provided format ID if valid, empty string if not.
+sub validate {
+    my $format = $_[0];
+    if ( $formats{$format} ) {
+        return $formats{$format}->{id};
+    }
+    else {
+        return '';
+    }
+}
+
+sub is_active {
+    my $format = $_[0];
+    if ( grep( $_ eq $format, @active_formats ) ) {
+        return 1;
+    }
+    return 0;
+}
+
+sub display_name {
+    my $format = $_[0];
+    if ( $formats{$format} ) {
+        return $formats{$format}->{name};
+    }
+    return "Unknown markup format";
+}
+
+# If the provided format ID was replaced by a newer format, return the newest ID
+# in its lineage.
+sub upgrade {
+    my $format = validate( $_[0] );
+    return $format_upgrades{$format} || $format;
+}
+
+# Convenience aliases for email posts -- these should never be entered into the
+# database as an editor prop value, but email posts pass these to validate() as
+# a way of asking which format a user currently means if they just said 'html'
+# or 'markdown'. (Why not just use 'html' and 'markdown' as the "current"
+# aliases? Because 'markdown' is already in use by old email comments.)
+$formats{markdown_latest}    = $formats{ upgrade('markdown0') };
+$formats{html_casual_latest} = $formats{ upgrade('html_casual1') };

--- a/cgi-bin/LJ/Comment.pm
+++ b/cgi-bin/LJ/Comment.pm
@@ -866,8 +866,9 @@ sub body_html {
     $opts->{nocss}        = $opts->{anon_comment};
     $opts->{editor}       = $self->prop('editor');
     $opts->{is_imported}  = defined $self->prop('import_source') ? 1 : 0;
-    $opts->{journal}      = $self->journal->user;
-    $opts->{ditemid}      = $self->entry->ditemid;
+    $opts->{datepost} = $self->{datepost};       # for format guessing
+    $opts->{journal}  = $self->journal->user;
+    $opts->{ditemid}  = $self->entry->ditemid;
 
     my $body = $self->body_raw;
     LJ::CleanHTML::clean_comment( \$body, $opts ) if $body;

--- a/cgi-bin/LJ/Comment.pm
+++ b/cgi-bin/LJ/Comment.pm
@@ -176,8 +176,8 @@ sub create {
         "bad_args", __PACKAGE__ . "->create: Unsupported params: " . join " " => keys %opts
     ) if %opts;
 
-    # Move props values to the talk_opts hash.
-    # Because prepare_and_validate_comment needs this.
+    # Move props values to the talk_opts hash so it resembles the reply form
+    # fields, since that's what prepare_and_validate_comment expects.
     foreach my $key ( keys %{ $talk_opts{props} } ) {
         my $talk_key = "prop_$key";
 

--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -893,16 +893,22 @@ sub subject_text {
 #    undef:   loads the opt_preformatted key and uses that for formatting options
 #    1:       treats entry as preformatted (no breaks applied)
 #    0:       treats entry as normal (newlines convert to HTML breaks)
-#    hashref: passed to LJ::CleanHTML::clean_event verbatim
+#    hashref: extra arguments to LJ::CleanHTML::clean_event
 sub event_html {
     my ( $self, $opts ) = @_;
 
+    $self->_load_props unless $self->{_loaded_props};
+
     if ( !defined $opts ) {
-        $self->_load_props unless $self->{_loaded_props};
-        $opts = { preformatted => $self->{props}{opt_preformatted} };
+        $opts = {};
     }
     elsif ( !ref $opts ) {
         $opts = { preformatted => $opts };
+    }
+
+    # Caller can override preformatted (but: plz don't.)
+    if ( !defined $opts->{preformatted} ) {
+        $opts->{preformatted} = $self->prop('opt_preformatted');
     }
 
     my $remote      = LJ::get_remote();
@@ -913,7 +919,8 @@ sub event_html {
     $opts->{ditemid}             = $self->{ditemid};
     $opts->{is_syndicated}       = $self->{u}->is_syndicated;
     $opts->{is_imported}         = defined $self->{props}{import_source};
-    $opts->{editor}              = $self->{props}{editor};
+    $opts->{editor}              = $self->prop('editor');
+    $opts->{logtime_mysql} = $self->logtime_mysql;    # for format guessing
 
     $self->_load_text unless $self->{_loaded_text};
     my $event = $self->{event};

--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -2877,4 +2877,31 @@ sub currents_table {
     return $ret;
 }
 
+# Same, but stop it with the tables
+sub currents_div {
+    my (%current) = @_;
+    my $ret = '';
+    return $ret unless %current;
+
+    $ret .= "<div class='currents'>\n";
+    $ret .= "<div class='metadata bottom-metadata'>\n";
+    $ret .= "<ul>\n";
+
+    foreach ( sort keys %current ) {
+        next unless $current{$_};
+
+        my $curkey  = "talk.curname_" . $_;
+        my $curname = LJ::Lang::ml($curkey);
+        $curname = "<b>Current $_:</b>" unless $curname;
+
+        $ret .= "<li><span class='metadata-label'>$curname</span> ";
+        $ret .= "<span class='metadata-item'>$current{$_}</span></li>\n";
+    }
+    $ret .= "</ul>\n";
+    $ret .= "</div>\n";
+    $ret .= "</div>\n";
+
+    return $ret;
+}
+
 1;

--- a/cgi-bin/LJ/Event/NewUserpic.pm
+++ b/cgi-bin/LJ/Event/NewUserpic.pm
@@ -52,7 +52,6 @@ sub _clean_field {
     LJ::CleanHTML::clean(
         \$field,
         {
-            wordlength => 40,
             addbreaks  => 0,
             tablecheck => 1,
             mode       => "deny",

--- a/cgi-bin/LJ/Feed.pm
+++ b/cgi-bin/LJ/Feed.pm
@@ -229,7 +229,6 @@ ENTRY:
             LJ::CleanHTML::clean_event(
                 \$event,
                 {
-                    wordlength       => 0,
                     preformatted     => $logprops{$itemid}->{opt_preformatted},
                     cuturl           => $u->{opt_synlevel} eq 'cut' ? $entry_url : "",
                     to_external_site => 1,

--- a/cgi-bin/LJ/Global/Img.pm
+++ b/cgi-bin/LJ/Global/Img.pm
@@ -209,8 +209,8 @@ $img{key} = {
 
 $img{help} = {
     src    => '/silk/site/help.png',
-    width  => 14,
-    height => 14,
+    width  => 16,
+    height => 16,
     alt    => 'img.help',
 };
 

--- a/cgi-bin/LJ/Poll.pm
+++ b/cgi-bin/LJ/Poll.pm
@@ -166,12 +166,11 @@ sub clean_poll {
     LJ::CleanHTML::clean(
         $ref,
         {
-            'wordlength' => 40,
-            'addbreaks'  => 0,
-            'eat'        => $poll_eat,
-            'mode'       => 'deny',
-            'allow'      => $poll_allow,
-            'remove'     => $poll_remove,
+            'addbreaks' => 0,
+            'eat'       => $poll_eat,
+            'mode'      => 'deny',
+            'allow'     => $poll_allow,
+            'remove'    => $poll_remove,
         }
     );
     LJ::text_out($ref);

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -247,7 +247,10 @@ sub addcomment {
         body    => $req->{body},
         subject => $req->{subject},
 
-        props => { picture_keyword => $req->{prop_picture_keyword} },
+        props => {
+            picture_keyword => $req->{prop_picture_keyword},
+            editor          => $req->{prop_editor},
+        },
 
         err_ref => \$comment_err,
     );
@@ -269,7 +272,6 @@ sub addcomment {
 
     my %props = ();
     $props{useragent} = $req->{useragent} if $req->{useragent};
-    $props{editor}    = $req->{editor}    if $req->{editor};
     $comment->set_props(%props);
 
     # OK

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -2199,18 +2199,11 @@ sub Entry_from_entryobj {
         && $remote->id != $journalid ? ( style => 'mine' ) : ();
     my $style_args = LJ::viewing_style_args( %$get, %opt_stylemine );
 
-    my $suspend_msg = $entry_obj && $entry_obj->should_show_suspend_msg_to($remote) ? 1 : 0;
-
     # Configuration for cleaning the entry text: cuts and such
     my $cut_disable    = $opts->{cut_disable};
     my $cleanhtml_opts = {
         cuturl => $entry_obj->url( style_opts => LJ::viewing_style_opts( %$get, %opt_stylemine ) ),
-        ljcut_disable       => $cut_disable,
-        journal             => $journal->username,
-        ditemid             => $ditemid,
-        suspend_msg         => $suspend_msg,
-        unsuspend_supportid => $suspend_msg ? $entry_obj->prop('unsuspend_supportid') : 0,
-        preformatted        => $entry_obj->prop("opt_preformatted"),
+        ljcut_disable => $cut_disable,
     };
 
     # reading pages might need to display image placeholders

--- a/cgi-bin/LJ/S2/EntryPage.pm
+++ b/cgi-bin/LJ/S2/EntryPage.pm
@@ -146,7 +146,9 @@ sub EntryPage {
                     preformatted => $com->{props}->{opt_preformatted},
                     anon_comment => $anon_comment,
                     nocss        => $anon_comment,
-                    editor       => $com->{props}->{editor}
+                    editor       => $com->{props}->{editor},
+                    datepost     => $com->{datepost},                    # for format guessing
+                    is_imported => defined $com->{props}->{import_source} ? 1 : 0,
                 }
             );
 

--- a/cgi-bin/LJ/S2/IconsPage.pm
+++ b/cgi-bin/LJ/S2/IconsPage.pm
@@ -121,7 +121,6 @@ sub IconsPage {
             LJ::CleanHTML::clean(
                 \$eh_comment,
                 {
-                    'wordlength' => 40,
                     'addbreaks'  => 0,
                     'tablecheck' => 1,
                     'mode'       => 'deny',
@@ -134,7 +133,6 @@ sub IconsPage {
             LJ::CleanHTML::clean(
                 \$eh_description,
                 {
-                    'wordlength' => 40,
                     'addbreaks'  => 0,
                     'tablecheck' => 1,
                     'mode'       => 'deny',

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -115,6 +115,7 @@ sub ReplyPage {
         $comment_values{subjecticon}           = $comment->prop('subjecticon');
         $comment_values{prop_opt_preformatted} = $comment->prop('opt_preformatted');
         $comment_values{prop_picture_keyword}  = $comment->userpic_kw;
+        $comment_values{prop_editor}           = $comment->prop('editor');
     }
 
     if ($replytoid) {

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -199,10 +199,12 @@ sub ReplyPage {
         LJ::CleanHTML::clean_comment(
             \$parpost->{'body'},
             {
-                preformatted => $parpost->{props}->{opt_preformatted},
+                preformatted => $parentcomment->prop('opt_preformatted'),
                 anon_comment => $anon_comment,
                 nocss        => $anon_comment,
-                editor       => $parpost->{props}->{editor},
+                editor       => $parentcomment->prop('editor'),
+                datepost     => $parentcomment->{datepost},                 # for format guessing
+                is_imported => defined $parentcomment->prop('import_source') ? 1 : 0,
             }
         );
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -24,6 +24,7 @@ use Carp qw/ croak /;
 
 use DW::Captcha;
 use DW::EmailPost::Comment;
+use DW::Formats;
 use LJ::Comment;
 use LJ::Event::JournalNewComment;
 use LJ::Event::JournalNewComment::Edited;
@@ -1464,6 +1465,12 @@ sub talkform {
         $basesubject = "Re: $basesubject";
     }
 
+    # hashref with "selected" and "items" keys
+    my $editors = DW::Formats::select_items(
+        current   => $form->{prop_editor},
+        preferred => $remote ? $remote->prop('comment_editor') : '',
+    );
+
     my $screening = LJ::Talk::screening_level( $journalu, $opts->{ditemid} >> 8 ) // '';
 
     # Variables for talkform.tt (most of them, at least)
@@ -1473,6 +1480,7 @@ sub talkform {
         errors               => $opts->{errors},
         create_link          => '',
         subjecticon_ids      => \@subjecticon_ids,
+        editors              => $editors,
         username_maxlength   => $LJ::USERNAME_MAXLENGTH,
         password_maxlength   => $LJ::PASSWORD_MAXLENGTH,
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2404,6 +2404,7 @@ sub enter_comment {
 
     $talkprop{admin_post}         = $comment->{admin_post} ? 1 : 0;
     $talkprop{'opt_preformatted'} = $comment->{preformat}  ? 1 : 0;
+    $talkprop{'editor'}           = $comment->{editor};
 
     my $site_user_comment = $comment->{u} && $comment->{u}->is_person;
     if ( $journalu->opt_logcommentips eq "A"
@@ -2885,18 +2886,20 @@ sub prepare_and_validate_comment {
         posterid => $parpost->{posterid},
     };
     my $comment = {
-        u               => $commenter,
-        parent          => $parent,
-        entry           => $entry,
-        subject         => $subject,
-        body            => $body,
-        unknown8bit     => 0,
-        subjecticon     => $subjecticon,
+        u           => $commenter,
+        parent      => $parent,
+        entry       => $entry,
+        subject     => $subject,
+        body        => $body,
+        unknown8bit => 0,
+        subjecticon => $subjecticon,
+
+        # TODO need a more organized way to carry approved props forward.
+        editor          => DW::Formats::validate( $content->{'prop_editor'} ),
         preformat       => $content->{'prop_opt_preformatted'},
         admin_post      => $content->{'prop_admin_post'},
         picture_keyword => $content->{'prop_picture_keyword'},
 
-        # TODO need a more organized way to carry approved props forward.
         state      => $state,
         editid     => $content->{editid},
         editreason => $content->{editreason},
@@ -3043,7 +3046,8 @@ sub post_comment {
     if (@LJ::MEMCACHE_SERVERS) {
 
         # avoid warnings FIXME this should be done elsewhere
-        foreach my $field (qw(body subject subjecticon preformat admin_post picture_keyword)) {
+        foreach my $field (qw(body subject subjecticon preformat editor admin_post picture_keyword))
+        {
             $comment->{$field} = '' if not defined $comment->{$field};
         }
         my $md5_b64 = Digest::MD5::md5_base64(
@@ -3052,7 +3056,7 @@ sub post_comment {
                 (
                     $comment->{body},        $comment->{subject},
                     $comment->{subjecticon}, $comment->{preformat},
-                    $comment->{picture_keyword}
+                    $comment->{editor},      $comment->{picture_keyword}
                 )
             )
         );
@@ -3119,6 +3123,7 @@ sub edit_comment {
         subjecticon      => $comment->{subjecticon},
         opt_preformatted => $comment->{preformat} ? 1 : 0,
         admin_post       => $comment->{admin_post} ? 1 : 0,
+        editor           => $comment->{editor},
         edit_reason      => $comment->{editreason},
     );
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1883,11 +1883,12 @@ sub init_s2journal_js {
             )
     ) unless $opts{siteskin};
 
-    # load for ajax cuttag - only needed on lastn-type pages
+    # load for ajax cuttag and ajax quickreply - only needed on lastn-type pages
     LJ::need_res(
         { group => "all" }, qw(
             js/jquery/jquery.ui.widget.js
             js/jquery.cuttag-ajax.js
+            js/jquery.default-editor.js
             )
     ) if $opts{lastn};
 }

--- a/cgi-bin/LJ/User/Journal.pm
+++ b/cgi-bin/LJ/User/Journal.pm
@@ -477,13 +477,13 @@ sub _editor_props {
 # getter/setter
 sub comment_editor {
     my ( $u, $new_editor ) = @_;
-    return _editor_props($u, 'comment_editor', $new_editor);
+    return _editor_props( $u, 'comment_editor', $new_editor );
 }
 
 # getter/setter
 sub entry_editor2 {
     my ( $u, $new_editor ) = @_;
-    return _editor_props($u, 'entry_editor2', $new_editor);
+    return _editor_props( $u, 'entry_editor2', $new_editor );
 }
 
 # getter/setter

--- a/cgi-bin/LJ/User/Journal.pm
+++ b/cgi-bin/LJ/User/Journal.pm
@@ -19,6 +19,7 @@ use Carp;
 use Storable;
 use LJ::Global::Constants;
 use LJ::Keywords;
+use DW::Formats;
 
 ########################################################################
 ### 13. Community-Related Functions and Authas
@@ -444,6 +445,45 @@ sub entryform_width {
     else {
         return 'F';
     }
+}
+
+# don't call this directly, only use the wrapper functions below.
+sub _editor_props {
+    my ( $u, $propname, $new_editor ) = @_;
+
+    if ( defined $new_editor ) {
+        $new_editor = DW::Formats::validate($new_editor);
+        $u->set_prop( $propname => $new_editor );
+        return $new_editor;
+    }
+
+    my $editor_default = DW::Formats::validate( $u->raw_prop($propname) );
+
+    if ( !$editor_default ) {
+        return $DW::Formats::default_format;
+    }
+
+    if (  !DW::Formats::is_active($editor_default)
+        && DW::Formats::is_active( DW::Formats::upgrade($editor_default) ) )
+    {
+        # Silently upgrade to new version.
+        $editor_default = DW::Formats::upgrade($editor_default);
+        $u->set_prop( $propname => $editor_default );
+    }
+
+    return $editor_default;
+}
+
+# getter/setter
+sub comment_editor {
+    my ( $u, $new_editor ) = @_;
+    return _editor_props($u, 'comment_editor', $new_editor);
+}
+
+# getter/setter
+sub entry_editor2 {
+    my ( $u, $new_editor ) = @_;
+    return _editor_props($u, 'entry_editor2', $new_editor);
 }
 
 # getter/setter

--- a/cgi-bin/LJ/User/Permissions.pm
+++ b/cgi-bin/LJ/User/Permissions.pm
@@ -1049,7 +1049,7 @@ sub prop {
             map { $_ => 1 }
                 qw(opt_sharebday opt_showbday opt_showlocation opt_showmutualfriends
                 view_control_strip show_control_strip opt_ctxpopup opt_embedplaceholders
-                esn_inbox_default_expand)
+                esn_inbox_default_expand comment_editor entry_editor2)
         }->{$prop}
         )
     {

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -22,6 +22,7 @@ use POSIX;
 use DW::Auth::Challenge;
 use DW::External::Site;
 use DW::Request;
+use DW::Formats;
 use LJ::Global::Constants;
 use LJ::Event;
 use LJ::Subscription::Pending;
@@ -933,6 +934,9 @@ sub create_qr_div {
     # For userpic selector
     my @icons = icon_keyword_menu($remote);
 
+    # hashref with "selected" and "items" keys
+    my $editors = DW::Formats::select_items( preferred => $remote->prop('comment_editor'), );
+
     # FIXME: This is incoherent on reading/network pages. (But it's only
     # noticeable when viewing the reading/network page of someone who wouldn't
     # allow you to comment.) -NF
@@ -952,12 +956,14 @@ sub create_qr_div {
 
             current_icon_kw => $userpic_kw,
             current_icon    => LJ::Userpic->new_from_keyword( $remote, $userpic_kw ),
+
+            editors => $editors,
+
             foundation_beta => LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" ),
 
             remote => {
-                ljuser => $remote->ljuser_display,
-                user   => $remote->user,
-
+                ljuser                 => $remote->ljuser_display,
+                user                   => $remote->user,
                 icons_url              => $remote->allpics_base,
                 icons                  => \@icons,
                 can_use_userpic_select => $remote->can_use_userpic_select && ( scalar(@icons) > 0 ),

--- a/htdocs/js/jquery.ajaxtip.js
+++ b/htdocs/js/jquery.ajaxtip.js
@@ -55,6 +55,17 @@ $.widget("dw.ajaxtip", $.ui.tooltip, {
         // this is only a confirmation message. We can fade away quickly
         window.setTimeout( function() { self.close(); }, 1500 );
     },
+    sticky: function(msg) {
+        var self = this;
+        self.option("content", msg);
+        self.open();
+        $.each(self.tooltips, function(id, element) {
+            // auto-close handlers on the tooltip itself:
+            self._off($('#' + id), "mouseleave focusout");
+            // auto-close handlers on the trigger element:
+            element.off("mouseleave focusout");
+        });
+    },
     abort: function () {
         var self = this;
         if ( self.requests.length ) {

--- a/htdocs/js/jquery.default-editor.js
+++ b/htdocs/js/jquery.default-editor.js
@@ -1,0 +1,31 @@
+(function($) {
+    $(document).on('submit', 'form#default_editor', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var $form = $(this);
+        var $submit = $form.find('input[type="submit"]');
+
+        var request = $.ajax({
+            method: 'POST',
+            type: 'POST', // until we upgrade jquery ≥ 1.9
+            url: $.endpoint($form.data('rpcEndpoint')),
+            data: $form.serialize(),
+            dataType: 'json',
+            success: function(data) {
+                if (data.success) {
+                    $form.replaceWith('<span class="success">' + data.message + '</span>');
+                } else {
+                    $form.replaceWith('<span class="failure">' + data.error + '</span>');
+                }
+            },
+            error: function(jqXHR, errorText) {
+                $form.after('<span class="failure">Sorry, an error occurred: ' + errorText + '. Please try again.</span>');
+                $(document).off('submit', 'form#default_editor'); // fall back to no-JS behavior.
+            },
+        });
+
+        $submit.throbber(request);
+    });
+
+})(jQuery);

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -179,9 +179,14 @@ jQuery(function($) {
                                     // for the 0 -> 1 case, when the link starts out hidden
                                     $readLink.parent().show();
 
-                                    $readLink
-                                        .ajaxtip() // init
-                                        .ajaxtip("success", data.message); // success message
+                                    $readLink.ajaxtip(); // init
+                                    if (data.extra) {
+                                        // success message plus extra actions
+                                        $readLink.ajaxtip("sticky", data.message + ' ' + data.extra);
+                                    } else {
+                                        // plain success message
+                                        $readLink.ajaxtip("success", data.message);
+                                    }
 
                                     var commentText = '';
                                     if ( data.count == 1 ) {

--- a/htdocs/manage/emailpost.bml
+++ b/htdocs/manage/emailpost.bml
@@ -182,6 +182,7 @@ body<=
                     $from
                     $subject
                     <b>post-icon:</b> $ML{'.help.headers.options.userpic.example'}<br />
+                    <b>post-format:</b> $ML{'.help.headers.options.format.example'}<br />
                     <b>post-tags:</b> $ML{'.help.headers.options.tags.example'}<br />
                     <b>post-mood:</b> $ML{'.help.headers.options.mood.example'}<br />
                     <b>post-music:</b> $ML{'.help.headers.options.music.example'}<br />

--- a/htdocs/manage/emailpost.bml.text
+++ b/htdocs/manage/emailpost.bml.text
@@ -51,6 +51,8 @@
 
 .help.headers.options.comments.example=("[[off]]" or "[[noemail]]")
 
+.help.headers.options.format.example=("markdown" or "html"; defaults to "markdown")
+
 .help.headers.options.header=Journal entry options
 
 .help.headers.options.location.example=Paris, France
@@ -61,7 +63,7 @@
 
 .help.headers.options.tags.example=greyhounds, potato, wool
 
-.help.headers.options.text=Most journal-specific features can be set via "post-headers" in the body of your message. The post-headers should be at the top of your message, separated by a blank line. All post-headers are completely optional and simply override your journal defaults.
+.help.headers.options.text=Most journal-specific features can be set via "post-headers" in the body of your message. The post-headers should be at the top of your message, separated by a blank line. All post-headers are completely optional and simply override your journal defaults. The <strong>post-icon</strong> and <strong>post-format</strong> headers can also be used when replying to comments by email.
 
 .help.headers.options.userpic.example=icon keywords
 

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -183,9 +183,12 @@
             flex-grow: 1;
             flex-shrink: 1;
         }
-        #comment-text-quote {
-            margin-left: 5px;
-        }
+    }
+
+    .qr-markup {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-end;
     }
 
     .qr-body {

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -189,6 +189,10 @@
         display: flex;
         justify-content: space-between;
         align-items: flex-end;
+
+        & > div {
+            display: inline-block;
+        }
     }
 
     .qr-body {
@@ -223,4 +227,3 @@
         position: absolute;
     }
 }
-

--- a/htdocs/scss/pages/entry/new.scss
+++ b/htdocs/scss/pages/entry/new.scss
@@ -200,6 +200,16 @@
     }
 }
 
+.markup-container {
+    display: flex;
+    align-items: center;
+
+    img { // help icon
+        margin-bottom: 1rem;
+        margin-left: 1rem;
+    }
+}
+
 .inactive-component {
     display: none;
 }

--- a/htdocs/scss/pages/entry/new.scss
+++ b/htdocs/scss/pages/entry/new.scss
@@ -207,6 +207,16 @@
     img { // help icon
         margin-bottom: 1rem;
         margin-left: 1rem;
+        vertical-align: middle;
+    }
+
+    & > * {
+        display: inline-block;
+        width: auto;
+    }
+
+    select#editor {
+        flex-grow: 1;
     }
 }
 

--- a/t/cleaner-event.t
+++ b/t/cleaner-event.t
@@ -17,7 +17,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 49;
+use Test::More tests => 42;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::CleanHTML;
@@ -301,43 +301,5 @@ qq{&lt;select ... &gt;&lt;option ... &gt;hello&lt;/option&gt;&lt;option ... &gt;
     is( $orig_post, $clean_post,
         "Full text of entry, with mismatched HTML tags within and with-out the cut" );
 }
-
-note("expected wordbreak behavior");
-
-$orig_post  = qq{wordbreak};
-$clean_post = qq{word<wbr />brea<wbr />k};
-$clean->( { wordlength => 4 } );
-is( $orig_post, $clean_post, "Word break tags inserted where requested" );
-
-$orig_post  = qq{insert a word<wbr>break};
-$clean_post = qq{insert a word<wbr>break};
-$clean->();
-is( $orig_post, $clean_post, "Existing word break tags unchanged" );
-
-$orig_post  = qq{word-break};
-$clean_post = qq{word-<wbr />break};
-$clean->( { wordlength => 8 } );
-is( $orig_post, $clean_post, "Word break tag prefers punctuation points" );
-
-$orig_post  = qq{&quot;entity&quot; test};
-$clean_post = qq{&quot;entity&quot; test};
-$clean->( { wordlength => 8 } );
-is( $orig_post, $clean_post, "Word break handling of HTML entities OK" );
-
-$orig_post  = qq{multi-character-string test};
-$clean_post = qq{multi-character-<wbr />string test};
-$clean->( { wordlength => 20 } );
-is( $orig_post, $clean_post, "Choose last punctuation in string" );
-
-$orig_post  = qq{"This_is_a_test_of_the_emergency_word_break_system."};
-$clean_post = qq{"This_is_a_test_of_the_emergency_word_br<wbr />eak_system."};
-$clean->( { wordlength => 40 } );
-is( $orig_post, $clean_post, "Don't choose first character in string" );
-
-$orig_post = qq{"Auto-linkify: http://www.dreamwidth.org/file/edit"};
-$clean_post =
-qq{"Auto-linkify: <a href="http://www.dreamwidth.org/file/edit">http://www.dreamwidth.org/file/edit</a>"};
-$clean->( { wordlength => 40 } );
-is( $orig_post, $clean_post, "Don't mutilate URL entity markers" );
 
 1;

--- a/t/cleaner-markdown.t
+++ b/t/cleaner-markdown.t
@@ -29,7 +29,7 @@ my $url             = 'https://medium.com/@username/title-of-page';
 my $clean = sub {
     my ( $text, %opts ) = @_;
     unless (%opts) {
-        %opts = ( wordlength => 80, editor => 'markdown' );
+        %opts = ( editor => 'markdown' );
     }
     LJ::CleanHTML::clean_event( \$text, \%opts );
     chomp $text;
@@ -72,7 +72,7 @@ is(
 
 # plain URL containing user tag, with autolinks enabled
 is(
-    $clean->( $url, editor => undef, preformatted => 0, noautolinks => 0, wordlength => 80 ),
+    $clean->( $url, editor => undef, preformatted => 0, noautolinks => 0 ),
 '<a href="https://medium.com/@username/title-of-page">https://medium.com/@username/title-of-page</a>',
     'user tag in auto-linked URL not converted'
 );

--- a/t/cleaner-markdown.t
+++ b/t/cleaner-markdown.t
@@ -17,7 +17,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 28;
+use Test::More tests => 27;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::CleanHTML;
@@ -137,17 +137,16 @@ is( $clean->( '@system', editor => 'markdown' ),
 is( $clean->( '<pre>@system</pre>', editor => 'markdown' ),
     "<pre>\@system</pre>", 'user tag in pre unconverted and unmarkeddown (markdown)' );
 
+# Local content from before ~May 2019 doesn't expect user conversion either.
+is( $clean->( '@system', logtime_mysql => '2018-10-10', editor => undef ),
+    '@system', 'old content - user tag in plain text unconverted (undef editor)' );
+
 # imported content obeys the same rules, except isn't considered local content
 # so doesn't convert users
 check_doesnt_use_markdown( 'imported content w/o editor set', is_imported => 1, editor => undef );
 check_uses_markdown( 'imported content w/editor set', is_imported => 1, editor => 'markdown' );
 is( $clean->( '@system', is_imported => 1, editor => undef ),
     '@system', 'imported content - user tag in plain text unconverted (undef editor)' );
-is( $clean->( '@system', is_imported => 1, editor => 'markdown' ),
-    '<p>@system</p>', 'imported content - user tag in plain text unconverted (markdown)' );
-is( $clean->( '<pre>@system</pre>', is_imported => 1, editor => 'markdown' ),
-    "<pre>\@system</pre>",
-    'imported content - user tag in pre unconverted and unmarkeddown (markdown)' );
 
 # syndicated content is always post-processed (even if we get it from another DW/LJ)
 # so it can't have any editor settings

--- a/t/formats.t
+++ b/t/formats.t
@@ -1,0 +1,92 @@
+# t/formats.t
+#
+# Test resolution and validation of available text formats. This just tests
+# which ones get chosen under which circumstances; the actual display behavior
+# of them is handled in the HTML cleaner tests.
+#
+# Authors:
+#      Nick Fagerlund <nick.fagerlund@gmail.com>
+#
+# Copyright (c) 2017-2019 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use warnings;
+
+use Test::More tests => 16;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+use DW::Formats;
+
+note("Format ID validation/canonicalization tests");
+
+is( DW::Formats::validate('html_casual1'), 'html_casual1', "Normal validation." );
+
+is( DW::Formats::validate('markdown'),
+    'markdown0', "Uses canonical name for legacy markdown format value." );
+
+is( DW::Formats::validate('nuthin'), '',
+    "Returns empty string when validating unknown format ID." );
+
+note("HTML select items tests");
+
+my $select = DW::Formats::select_items();
+is( $select->{selected}, $DW::Formats::default_format,
+    "Without args, default format is selected." );
+is(
+    scalar @{ $select->{items} },
+    scalar @DW::Formats::active_formats,
+    "Without args, only active formats are offered."
+);
+
+$select = DW::Formats::select_items( preferred => 'invalid' );
+is( $select->{selected}, $DW::Formats::default_format,
+    "w/ invalid preference, default format is selected." );
+is(
+    scalar @{ $select->{items} },
+    scalar @DW::Formats::active_formats,
+    "w/ invalid preference, only active formats are offered."
+);
+
+$select = DW::Formats::select_items( preferred => 'html_casual0' );
+is( $select->{selected}, $DW::Formats::default_format,
+    "w/ obsolete preference, default format is selected." );
+is(
+    scalar @{ $select->{items} },
+    scalar @DW::Formats::active_formats,
+    "w/ obsolete preference, only active formats are offered."
+);
+
+$select = DW::Formats::select_items( preferred => 'markdown0' );
+is( $select->{selected}, 'markdown0', "w/ active preference, preference is selected." );
+
+$select = DW::Formats::select_items( current => 'invalid', preferred => 'markdown0' );
+is( $select->{selected}, 'markdown0',
+    "w/ invalid current format and active preference, preference is selected." );
+is(
+    scalar @{ $select->{items} },
+    scalar @DW::Formats::active_formats,
+    "w/ invalid current format, only active formats are offered."
+);
+
+$select = DW::Formats::select_items( current => 'html_casual1', preferred => 'markdown0' );
+is( $select->{selected}, 'html_casual1',
+    "w/ active current format and active preference, current is selected." );
+is(
+    scalar @{ $select->{items} },
+    scalar @DW::Formats::active_formats,
+    "w/ active current format, only active formats are offered."
+);
+
+$select = DW::Formats::select_items( current => 'html_casual0', preferred => 'markdown0' );
+is( $select->{selected}, 'html_casual0',
+    "w/ obsolete current format and active preference, current is selected." );
+is(
+    scalar @{ $select->{items} },
+    1 + scalar @DW::Formats::active_formats,
+    "w/ obsolete current format, that obsolete format is added to the list."
+);

--- a/t/post.t
+++ b/t/post.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 104;
+use Test::More tests => 108;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Test qw( temp_user temp_comm );
@@ -266,6 +266,7 @@ my $postdecoded_bare = {
 
     props => {
         taglist => "",
+        editor  => '',
 
         opt_nocomments => 0,
         opt_noemail    => 0,
@@ -539,6 +540,36 @@ note("Post - with tags, nothing fancy");
         { map { $_ => 1 } qw( bar baz foo ) },
         "tag list as parsed array (order doesn't matter)"
     );
+}
+
+note("Post - setting non-default editor format");
+{
+    my ( $req, $res, $u ) = post_with( editor => 'markdown0', );
+    is_deeply(
+        $req,
+        {
+            %$postdecoded_bare, props => { %{ $postdecoded_bare->{props} }, editor => 'markdown0' }
+        },
+        "decoded entry form with metadata"
+    );
+
+    my $entry = LJ::Entry->new( $u, jitemid => $res->{itemid} );
+    is( $entry->prop("editor"), "markdown0", "specified format in saved editor prop" );
+}
+
+note("Post - setting invalid editor format");
+{
+    my ( $req, $res, $u ) = post_with( editor => 'morkdawn0', );
+    is_deeply(
+        $req,
+        {
+            %$postdecoded_bare, props => { %{ $postdecoded_bare->{props} }, editor => '' }
+        },
+        "decoded entry form with metadata"
+    );
+
+    my $entry = LJ::Entry->new( $u, jitemid => $res->{itemid} );
+    is( $entry->prop("editor"), undef, "undef in saved editor prop" );
 }
 
 note("Logged in - post (community)");

--- a/views/default_editor.tt
+++ b/views/default_editor.tt
@@ -1,0 +1,19 @@
+[%# Success page after changing your default entry or comment markup format.
+
+Authors:
+    Nick Fagerlund <nick.fagerlund@gmail.com>
+
+Copyright (c) 2020 by Dreamwidth Studios, LLC.
+
+This program is free software; you may redistribute it and/or modify it under
+the same terms as Perl itself.  For a copy of the license, please reference
+'perldoc perlartistic' or 'perldoc perlgpl'.
+-%]
+
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%- sections.title = dw.ml(title) -%]
+
+[% ".success" | ml(type => type, new_format => new_format) %]
+
+<ul><li><a href="[% exit_url %]">[% exit_text %]</a></li></ul>

--- a/views/default_editor.tt.text
+++ b/views/default_editor.tt.text
@@ -1,5 +1,7 @@
 ;; -*- coding: utf-8 -*-
 
+.error.nopost=This page doesn't do anything on its own; you're only supposed to land here after submitting a form.
+
 .error.nouser=Can only set default editor for logged-in users.
 
 .error.unknowntype=Don't know how to set default editor for [[type]]!

--- a/views/default_editor.tt.text
+++ b/views/default_editor.tt.text
@@ -1,0 +1,13 @@
+;; -*- coding: utf-8 -*-
+
+.error.nouser=Can only set default editor for logged-in users.
+
+.error.unknowntype=Don't know how to set default editor for [[type]]!
+
+.title.comment=Changed default comment formatting
+
+.title.entry=Changed default entry formatting
+
+.form.label=Set as default
+
+.success=Successfully changed your default [[type]] formatting to [[new_format]].

--- a/views/default_editor_form.tt
+++ b/views/default_editor_form.tt
@@ -10,7 +10,11 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 -%]
 
-<form id="default_editor" method="POST" action="[%site.root%]/default_editor" data-rpc-endpoint="default_editor">
+[% dw.need_res( { group => "foundation" },
+    "js/jquery.default-editor.js"
+) %]
+
+<form id="default_editor" method="POST" action="[%site.root%]/default_editor" data-rpc-endpoint="default_editor" style="position: relative;">
 [%- dw.form_auth -%]
 [%- form.hidden( name = "type", value = type ) -%]
 [%- form.hidden( name = "new_editor", value = format.id ) -%]

--- a/views/default_editor_form.tt
+++ b/views/default_editor_form.tt
@@ -1,0 +1,22 @@
+[%# Form fragment for changing your default entry or comment markup format.
+
+Authors:
+    Nick Fagerlund <nick.fagerlund@gmail.com>
+
+Copyright (c) 2020 by Dreamwidth Studios, LLC.
+
+This program is free software; you may redistribute it and/or modify it under
+the same terms as Perl itself.  For a copy of the license, please reference
+'perldoc perlartistic' or 'perldoc perlgpl'.
+-%]
+
+<form id="default_editor" method="POST" action="[%site.root%]/default_editor" data-rpc-endpoint="default_editor">
+[%- dw.form_auth -%]
+[%- form.hidden( name = "type", value = type ) -%]
+[%- form.hidden( name = "new_editor", value = format.id ) -%]
+[%- form.hidden( name = "exit_text", value = exit_text ) -%]
+[%- form.hidden( name = "exit_url", value = exit_url ) -%]
+
+The [% type %] was posted using [% format.name %] formatting.
+[% form.submit( value = dw.ml("/default_editor.tt.form.label")) %]
+</form>

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -189,6 +189,29 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
         </div></div>
 
         <div class="row"><div class="columns">
+            <div class='markup-container'>
+                [%- form.select(
+                  label = 'Formatting type'
+                  labelclass = 'invisible'
+                  name = 'editor'
+                  id = 'editor'
+                  select = editors.selected
+                  items = editors.items
+                ) -%]
+
+                <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1">[%-
+                  dw.img('help', '',
+                    {
+                      alt   => dw.ml('markup.helplink.alttext'),
+                      title => dw.ml('markup.helplink.alttext'),
+                      style => 'box-sizing: content-box;'
+                    }
+                  )
+                -%]</a>
+            </div>
+        </div></div>
+
+        <div class="row"><div class="columns">
             <div class='event-container'>
                 [%- form.textarea( label = dw.ml(".event.label")
                     name = "event"

--- a/views/entry/preview.tt
+++ b/views/entry/preview.tt
@@ -12,50 +12,73 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
 
-[%- dw.need_res( "stc/talkpage.css" ) -%]
-
 [%- sections.windowtitle = '.title' | ml( sitenameshort = site.nameshort ) -%]
 
-[%- IF journal -%]
-    <table summary=''><tr valign='middle'>
-    [%- IF icon -%]
-        <td>[% icon %]</td>
-    [%- END -%]
+<div class="entry-wrapper entry-wrapper-odd journal-type-P [%- IF icon -%]has[%- ELSE -%]no[%- END -%]-userpic  [%- IF subject -%]has[%- ELSE -%]no[%- END -%]-subject">
+    <div class="separator separator-before">
+        <div class="inner">
+        </div>
+    </div>
 
-    <td>
-        [%- postername = poster.name | html -%]
+    <div class="entry" id="entry-4857">
+        <div class="inner">
+            [%- IF journal -%]
+                <div class="header">
+                    <div class="inner">
+                        <div class="userpic">
+                            [%- IF icon -%]
+                                [% icon %]
+                            [%- END -%]
+                        </div>
 
-        [%- IF journal.is_community -%]
-            [%- "talk.somebodywrote_comm" | ml( realname = postername
-                                                userlink = poster.ljuser_display
-                                                commlink = journal.ljuser_display )
-            -%]
-        [%- ELSE -%]
-            [%- "talk.somebodywrote" | ml(  realname = postername
-                                            userlink = poster.ljuser_display )
-            -%]
-        [%- END -%]
+                        <div class="poster-info">
+                            <span class="poster entry-poster ">[%- postername = poster.name | html -%]
+                                [%- IF journal.is_community -%]
+                                    [%- "talk.somebodywrote_comm" | ml( realname = postername
+                                                                        userlink = poster.ljuser_display
+                                                                        commlink = journal.ljuser_display )
+                                    -%]
+                                [%- ELSE -%]
+                                    [%- "talk.somebodywrote" | ml(  realname = postername
+                                                                    userlink = poster.ljuser_display )
+                                    -%]
+                                [%- END -%]
+                            </span>
+                            <span class='datetime'>@ [% displaydate %]</span>
+                        </div>
+                    </div>
+                </div>
 
-        <br /><span class='time'>@ [% displaydate %]</span>
-    </td>
+                [%- currents -%]
+            [%- END -%]
 
-    </tr></table>
-[%- END -%]
+            <div>
+                <div class="contents usercontent">
+                    <div class="inner">
+                        [%- IF security -%]
+                            <span class="access-filter">
+                                <img src="[% site.imgroot %][% security.src %]" alt="[% security.alt%]" width="[% security.width %]" height="[% security.height %]" align="absmiddle" />
+                            </span>
+                        [%- END -%]
 
-<div id='entry' class='usercontent' style='margin-left: 30px'>
-    [%- currents -%]
+                        <h3 class="entry-title">
+                            <a title="testing editor prop">[% subject %]</a>
+                        </h3>
 
-    [%- IF security -%]
-        <img src="[% site.imgroot %][% security.src %]" alt="[% security.alt%]" width="[% security.width %]" height="[% security.height %]" align="absmiddle" />
-    [%- END -%]
+                        <div class="entry-content">
+                            [%- event -%]
+                        </div>
+                    </div>
+                </div>
+            </div>
 
-    <div id='entrysubj'>[% subject %]</div>
-    [%- IF security OR subject -%]<br />[%- END -%]
-
-    [%- event -%]
+            <div class="footer">
+                <div class="inner">
+                    <div class='alert-box'>
+                        <p>[% '.entry.preview_warn_text' | ml %]</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
-
-<br clear='all' /><hr width='100%' size='2' align='center' />
-
-<div class='highlight-box'><p>[% '.entry.preview_warn_text' | ml %]</p></div>
-

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -29,7 +29,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%- END -%]
 [%- END -%]
 
-[%- IF poststatus.ml_string != ".edit.delete" -%]
+[%- IF poststatus.status != "deleted" -%]
 
     <p>[% extradata.security_ml | ml( filters => extradata.filters ) %]</p>
     <p>[% ".extradata.subj" | ml %]

--- a/views/entry/success.tt
+++ b/views/entry/success.tt
@@ -31,6 +31,15 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- IF poststatus.status != "deleted" -%]
 
+    [%- IF extradata.format -%]
+        <p>[% INCLUDE default_editor_form.tt
+            type = "entry"
+            format = extradata.format
+            exit_text = dw.ml(".links.viewentry")
+            exit_url = entry_url
+        %]</p>
+    [%- END -%]
+
     <p>[% extradata.security_ml | ml( filters => extradata.filters ) %]</p>
     <p>[% ".extradata.subj" | ml %]
         [% IF extradata.subject.length %]

--- a/views/entry/success.tt.text
+++ b/views/entry/success.tt.text
@@ -1,24 +1,26 @@
-.edit.delete=Journal entry was deleted.
+.edit.delete2=Journal entry was deleted. <a href="[[url]]">View your updated journal</a>.
 
-.edit.delete.comm=Community entry was deleted.
+.edit.delete2.comm=Community entry was deleted. <a href="[[url]]">View your updated community</a>.
 
 .edit.deletespam=Additionally, the entry was marked as spam.  Thank you for your report.
 
-.edit.edited=Journal entry was edited.
+.edit.edited2=Your edit was successful. <a href="[[url]]">View your updated journal</a>.
 
-.edit.edited.comm=Community entry was edited.
+.edit.edited2.comm=Your edit was successful. <a href="[[url]]">View your updated community</a>.
 
-.edit.links=From here you can:
+.links=From here you can:
 
-.edit.links.editentry=Edit this entry again
+.links.viewentry=View this entry
 
-.edit.links.manageentries=Manage your journal entries
+.links.editentry=Edit this entry
 
-.edit.links.viewentries=View your journal entries
+.links.tags=Edit this entry's tags
 
-.edit.links.viewentries.comm=View community
+.links.myentries=View all my entries in this community
 
-.edit.links.viewentry=View this entry
+.links.memories=Add this entry to your memories
+
+.links.manageentries=Manage your journal entries
 
 .extradata.subj=The entry was posted with the following subject: 
 
@@ -27,19 +29,5 @@
 .new.community=Your update was successful. <a href="[[url]]">View your updated community</a>.
 
 .new.journal=Your update was successful. <a href="[[url]]">View your updated journal</a>.
-
-.new.links=Now that you've posted, you can:
-
-.new.links.backdated=View all entries from the same date
-
-.new.links.edit=Edit the entry
-
-.new.links.memories=Add the entry to your memories
-
-.new.links.myentries=View all my entries in this community
-
-.new.links.tags=Edit this entry's tags
-
-.new.links.view=View the entry
 
 .sticky.max=This entry was not made sticky because you've reached your limit of [[limit]] for sticky entries.

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -67,7 +67,35 @@ the same terms as Perl itself.  For a copy of the license, please reference
         placeholder = dw.ml( '/journal/talkform.tt.opt.subject2' )
   ) -%]
 
-  <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+</div>
+
+[%# Markup controls %]
+
+<div class="qr-markup">
+  <div class="qr-markup-type">
+    [%- form.select(
+      label = 'Formatting type'
+      labelclass = 'invisible'
+      name = 'prop_editor'
+      id = 'prop_editor'
+      selected = editors.selected
+      items = editors.items
+    ) -%]
+
+    <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1">[%-
+      dw.img('help', '',
+        {
+          alt   => dw.ml('markup.helplink.alttext'),
+          title => dw.ml('markup.helplink.alttext'),
+          style => 'vertical-align: middle;'
+        }
+      )
+    -%]</a>
+  </div>
+
+  <div class="qr-markup-controls">
+    <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+  </div>
 </div>
 
 <div class="qr-body">

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -372,8 +372,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
     comment.subjecticon,
     "id='subjectIconImage' role='button' class='js-only' style='display: none;' title='Click to change the subject icon'"
   ) -%]
-
-  <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
 </div>
 
 <div style="display: none;" id="subjectIconList">
@@ -392,6 +390,36 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <div id='ljnohtmlsubj' class='ljdeem no-js'><span style='font-size: 8pt; font-style: italic;'>
   [%- '.nosubjecthtml' | ml -%]
 </span></div>
+
+[%# Markup controls %]
+
+<div class="qr-markup">
+  <div class="qr-markup-type">
+    [%- form.select(
+      label = 'Formatting type'
+      labelclass = 'invisible'
+      name = 'prop_editor'
+      id = 'prop_editor'
+      selected = editors.selected
+      items = editors.items
+    ) -%]
+
+    <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1">[%-
+      dw.img('help', '',
+        {
+          alt   => dw.ml('markup.helplink.alttext'),
+          title => dw.ml('markup.helplink.alttext'),
+          style => 'vertical-align: middle;'
+        }
+      )
+    -%]</a>
+  </div>
+
+  <div class="qr-markup-controls">
+    <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+  </div>
+</div>
+
 
 
 [%# Message body text %]
@@ -413,15 +441,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%# Misc checkboxes, captcha, edit reason - after body, before post buttons %]
 
 <div id="talkform-misc">
-  [%- form.checkbox(
-    name = 'prop_opt_preformatted'
-    id = 'prop_opt_preformatted'
-    value = 1
-    selected = comment.preformatted
-    label = dw.ml('.opt.noautoformat')
-  ) -%]
-  [%- help_icon( 'autoformat' ) -%]
-
   [%- IF remote.can_unscreen_parent -%]
     <br />
     [%- form.checkbox(
@@ -858,14 +877,24 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 
     <div id="misc_controls">
-      [%- form.checkbox(
-        name = 'prop_opt_preformatted'
-        id = 'prop_opt_preformatted'
-        value = 1
-        selected = comment.preformatted
-        label = dw.ml('.opt.noautoformat')
+      [%- form.select(
+        label = 'Formatting type'
+        labelclass = 'invisible'
+        name = 'prop_editor'
+        id = 'prop_editor'
+        selected = editors.selected
+        items = editors.items
       ) -%]
-      [%- help_icon( 'autoformat' ) -%]
+
+      <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1">[%-
+        dw.img('help', '',
+          {
+            alt   => dw.ml('markup.helplink.alttext'),
+            title => dw.ml('markup.helplink.alttext'),
+            style => 'vertical-align: middle;'
+          }
+        )
+      -%]</a>
 
       <input type="button" id="comment-text-quote" value="Quote" class="js-only" style="display: none;" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
 

--- a/views/journal/talkform.tt.text
+++ b/views/journal/talkform.tt.text
@@ -47,8 +47,6 @@
 
 .opt.noanonpost.nonpublic=You can't comment anonymously on a protected entry.
 
-.opt.noautoformat=Don't auto-format
-
 .opt.noopenidpost=You must <a [[aopts1]]>set</a> and <a [[aopts2]]>confirm</a> your email address before you can comment.
 
 .opt.openid=OpenID


### PR DESCRIPTION
Fixes #2573 
Fixes #2608 

### Notable 🚨 s: 
 
- Two new userprops.
- Imposes new semantics on an existing entry prop and comment prop.
- Imposes new names for things that never used to have a name before. (DW's default HTML-with-auto-linebreaks format is now "casual HTML".)
- Changes design of comment forms again. 
- Requires a post-deploy string update on prod for a help/faq link. 
    - (Requires said faq page to be written, which I can help with.)
- Affects implementation of new RTE.

-----

### The dirt

Mostly copied from one of the earlier commits in here: 

This PR introduces "named markup formats" as a central interface for dealing with user-entered text.

Each unit of user-provided body text (entry and comment bodies) can include, as metadata, the name of the markup format it uses. There's already a space reserved for this: both entries and comments include an `editor` prop, originally intended for exactly this.

We'll use these named formats for two purposes:

- **Picking the correct formatting options for the HTML cleaner.** DW stores source text raw, and then formats it on display; the saved "editor" value will be a clear signal of exactly what the user expected to have happen when they wrote the post, so we can freely change our markup behaviors in the present day (adding `@mentions`, changing Markdown processors, etc.) without worrying about wreaking havoc on archived content. Formats are versioned, and any significant change to markup behavior is now expected to result in a new format name.

- **Picking the correct format-dependent states and behaviors for the create entries form and the comment forms.** In the initial implementation, this only affects the selection state of the markup format drop-down. In the future, it will affect the output of formatting helper buttons for plain-text formats, and will control whether to display the plain-text or rich text editor. In the event of a future migration from one rich text editor to another, named formats will allow us to treat the old one and the new one as separate entities; we won't need to ensure the new editor can accommodate text created by the old one, and can even keep both editors operational for some time during the transition.

The initial set of formats is a codification of the formats DW **already uses.** It's just that they didn't have names before, and were selected by emergent interactions between the `opt_preformatted` prop, the imported/syndicated status, Secret Glyphs (`!markdown`), and the editor prop (only supported in comment-by-email).

### Likely future work after this PR

- Simple markup helper buttons (bold, link, etc.) for plaintext editing modes. 
- Integrate formats into the new entries API (which isn't merged yet). 
- User profile bios get format selector. (Needs an additional prop somewhere, probably a singleton userprop?)
- Inbox messaging gets format selector? ......maybe, theoretically, but I'm not touching that until Momiji finishes converting the inbox off BML. 

-----

### Screenz

<details><summary>Here's some pictures.</summary>

QR on journal page: 

![Screenshot_2020-06-03 sheworks4themoney Recent Entries](https://user-images.githubusercontent.com/484309/83684366-c57c6800-a59b-11ea-9c4f-b97376c203c9.png)

![Screenshot_2020-06-03 sheworks4themoney Recent Entries(1)](https://user-images.githubusercontent.com/484309/83684386-cb724900-a59b-11ea-9b68-0675851d051c.png)

New talkform on siteskin: 

![Screenshot_2020-06-03 sheworks4themoney (no subject) (Reply)](https://user-images.githubusercontent.com/484309/83684414-d2995700-a59b-11ea-8e8a-2fe131048658.png)

![Screenshot_2020-06-03 sheworks4themoney (no subject) (Reply)(1)](https://user-images.githubusercontent.com/484309/83684416-d331ed80-a59b-11ea-8db0-a724c1cf8232.png)

Old talkform, why not. 

![Screenshot_2020-06-03 sheworks4themoney (no subject) (Reply)(2)](https://user-images.githubusercontent.com/484309/83684431-d927ce80-a59b-11ea-9339-cfce49efec74.png)

Beta create entries: 

![Screenshot_2020-06-03 Create Entries](https://user-images.githubusercontent.com/484309/83684468-ec3a9e80-a59b-11ea-81e9-74112d0af71c.png)

![Screenshot_2020-06-03 Create Entries(1)](https://user-images.githubusercontent.com/484309/83684470-ecd33500-a59b-11ea-8093-c7787de4d34b.png)

</details>