### PR TITLE
[#2681] Don't break mapid -> pic lookups just because keyword is empty

### DIFF
--- a/cgi-bin/LJ/User/Icons.pm
+++ b/cgi-bin/LJ/User/Icons.pm
@@ -714,12 +714,13 @@ sub get_userpic_info {
                     $info->{mapkw}->{$mapid} = $kw;
                 }
             }
-            next if $skip_kw;
 
             next unless $info->{pic}->{$id};
-            $info->{kw}->{$kw}       = $info->{pic}->{$id};
             $info->{mapid}->{$mapid} = $info->{pic}->{$id} if $mapped_icons && $id;
-            $minfokw{$kw}            = int($id);
+
+            next if $skip_kw;
+            $info->{kw}->{$kw} = $info->{pic}->{$id};
+            $minfokw{$kw} = int($id);
         }
         $kwstr = join( '', map { pack( "Z*N", $_, $minfokw{$_} ) } keys %minfokw );
         if ($mapped_icons) {


### PR DESCRIPTION
Fixes #2681 

This misplaced "next" statement was bailing out before mapid housekeeping
finished, making it so userpics without keywords were never shown in comments.
(Although their keywords would appear in hovertext on the default icon. Since we
finished SOME of the mapid housekeeping before being interrupted,
get_keyword_from_mapid worked fine, even though get_picid_from_mapid didn't.)