### PR TITLE
Escape data attributes in _html_option

### DIFF
--- a/cgi-bin/LJ/HTMLControls.pm
+++ b/cgi-bin/LJ/HTMLControls.pm
@@ -265,6 +265,9 @@ sub _html_option {
     my %item_data      = $item->{data} ? %{ $item->{data} } : ();
     foreach ( keys %item_data ) {
         my $val = $item_data{$_} // '';
+        if ($ehtml) {
+            $val = ehtml($val);
+        }
         $data_attribute .= " data-$_='$val'";
     }
 


### PR DESCRIPTION
Fixes #2631 

Looks like this was just forgotten when the feature was added. Only got noticed
when we started setting data attributes in the userpic menu to wrangle the icon
preview in reply forms.

I'm using the same $ehtml argument that sets escaping for values and text, since
I can't conceive of a situation where we'd want the one escaped but not the
other.