### PR TITLE
Tweak `@mention` scanning regexps to fix end-of-sentence bug

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1902,7 +1902,7 @@ sub convert_user_mentions {
 
     # First pass is just to look for an edge case where an unescaped
     # username that needs to be converted is the first item in the string.
-    $$ref =~ s!^(\@([\w\d_-]+)(?:\.([\w\d\.]+))?)(?=$|\W)!$usertag->($1, $2, $3)!mge;
+    $$ref =~ s!^(\@([\w\-]+)(?:\.([\w\-\.]*[\w\-]))?)(?=$|\W)!$usertag->($1, $2, $3)!mge;
 
     # Second pass is to look for all other occurrences of unescaped usernames.
     # If we find an escaped username, remove the escape sequence and continue.
@@ -1910,7 +1910,7 @@ sub convert_user_mentions {
     # sequences here, to avoid parsing edge cases like '\\@foo' incorrectly
     # (note that's two user-supplied backslashes).  That's why the (\\.) case is
     # actually (\\.) and not (\\\@).
-    $$ref =~ s!(\\.)|(?<=[^\w/])(\@([\w\d_-]+)(?:\.([\w\d\.]+))?)(?=$|\W)!
+    $$ref =~ s!(\\.)|(?<=[^\w/])(\@([\w\-]+)(?:\.([\w\-\.]*[\w\-]))?)(?=$|\W)!
         defined($1) ? ( $1 eq '\@' ? '@' : $1 ) : $usertag->($2, $3, $4)
         !mge;
 }

--- a/t/cleaner-markdown.t
+++ b/t/cleaner-markdown.t
@@ -17,7 +17,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 25;
+use Test::More tests => 28;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::CleanHTML;
@@ -82,6 +82,27 @@ is(
     $clean->("[link from \@system]($url)"),
     qq{<p><a href="$url">link from $lju_sys_no_link</a></p>},
     'user tag in href not converted, but user tag in link text converted (using de-linked form) []'
+);
+
+# user tags at ends of sentences
+is(
+    $clean->('hi @system.'),
+    "<p>hi $lju_sys.</p>",
+    "bare usertag before period is converted, keeping period"
+);
+my $ao3_user = DW::External::User->new( user => 'system', site => 'ao3' );
+my $lju_ao3  = $ao3_user->ljuser_display;
+is(
+    $clean->('hi @system.ao3.'),
+    qq{<p>hi $lju_ao3.</p>},
+    "shortcut sitename usertag before period is converted, keeping period"
+);
+my $gh_user = DW::External::User->new( user => 'system', site => 'github.com' );
+my $lju_gh  = $gh_user->ljuser_display;
+is(
+    $clean->('hi @system.github.com.'),
+    qq{<p>hi $lju_gh.</p>},
+    "full sitename usertag before period is converted, keeping period"
 );
 
 # HTML within Markdown is passed through, but Markdown can build new tags around it and user tags get processed

--- a/t/cleaner-markdown.t
+++ b/t/cleaner-markdown.t
@@ -105,6 +105,10 @@ is(
     "full sitename usertag before period is converted, keeping period"
 );
 
+# TODO: add a test to properly handle @user.hyphenated-sitename.com.
+# This SHOULD work fine, but testing it isn't practical until DW::External::Site
+# includes at least ONE site with a hyphenated hostname.
+
 # HTML within Markdown is passed through, but Markdown can build new tags around it and user tags get processed
 is(
     $clean->(qq{<a href="$url">link from \@system</a>}),


### PR DESCRIPTION
Prior to this patch, `@mentions` went Bad if they occurred before a
sentence-ending period -- mentions that used a shortcut site name (like `.ao3`)
just exploded, and other mentions would work but swallowed the sentence-ending
period.

This tweaks the regexps a bit:

- Cleanup: `\w` implies both `\d` and `_`, so they're not needed.
- Cleanup: `-` has special meaning depending on where it occurs within the
character class square brackets, so it's better to always escape it.
- Cleanup: hostnames can have hyphens.
- Bug fix: Final character of the matched @mention must not be a period.