### PR TITLE
Fix failing comment-create.t

### DIFF
--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -102,10 +102,10 @@ sub talkpost_do_handler {
     # expects this, but it might also be irrelevant. Who knows.
     $r->note( 'journalid', $journalu->userid ) if $r;
 
-    my $entry = LJ::Entry->new( $journalu, ditemid => $POST->{itemid} + 0 );
-    unless ($entry) {
+    unless ( $POST->{itemid} ) {
         return error_ml('talk.error.noentry');
     }
+    my $entry   = LJ::Entry->new( $journalu, ditemid => $POST->{itemid} + 0 );
     my $talkurl = $entry->url;
 
     # validate the challenge/response value (anti-spammer)

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -256,11 +256,11 @@ sub addcomment {
         bad_journal => 206,    # authenticate() takes care of this
         bad_poster  => 100,    # authenticate() takes care of this
         bad_args    => 202,
+        no_entry    => 200,
 
         too_many_comments => 412,
 
         init_comment => 158,
-        frozen       => 158,
         post_comment => 158,
     }->{ $comment_err->{code} }
         if $comment_err;

--- a/t/comment-create.t
+++ b/t/comment-create.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 6;
+use Test::More tests => 8;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Test qw( temp_user );
@@ -61,6 +61,27 @@ my $pu = temp_user();
         extra_args => undef
     );
 
+    ok( !$c, "No comment created: missing ditemid, no entry to reply to" );
+    is( $err_ref->{code}, "no_entry" );
+}
+
+{
+    my $err_ref;
+    my $c = LJ::Comment->create(
+        err_ref => \$err_ref,
+
+        journal => $ju,
+        poster  => $pu,
+
+        ditemid => '111',    # < 256, guaranteed premium fake but never mind that
+
+        extra_args => undef
+    );
+
+    # Fails before ever calling prepare-and-validate
     ok( !$c, "No comment created: invalid args" );
     is( $err_ref->{code}, "bad_args" );
 }
+
+# LJ::Talk::prepare_and_validate_comment has its own tests, so don't test for
+# anything that would fail during that in here.


### PR DESCRIPTION
Thank you to @kareila for catching this! My bad. 

- First problem: Legit!! I forgot to add an early exit to LJ::Comment::create
when it's called without a ditemid. Previously, this would blow up slightly
later during LJ::Talk::Post::init and then create would return a generic error,
but because LJ::Entry::new explodes without it, we need to handle it earlier.
Could result in uninformative errors in both LJ::Comment::create and the Talk
controller.

- Second problem: Annoying. The test is looking for specific error codes, which
means if you give it input that's illegal in MULTIPLE ways, you're really
testing the ORDER in which it checks things, which I struggle to believe anyone
actually cares about. Well, oh well.