### PR TITLE
Always display beta features in a consistent order

### DIFF
--- a/cgi-bin/DW/Controller/Misc.pm
+++ b/cgi-bin/DW/Controller/Misc.pm
@@ -72,7 +72,10 @@ sub beta_handler {
     my @current_features;
     if ( keys %LJ::BETA_FEATURES ) {
         my @all_features =
-            sort { $LJ::BETA_FEATURES{$b}->{start_time} <=> $LJ::BETA_FEATURES{$a}->{start_time} }
+            sort {
+                   ( $LJ::BETA_FEATURES{$b}->{start_time} <=> $LJ::BETA_FEATURES{$a}->{start_time} )
+                || ( $b cmp $a )
+            }
             keys %LJ::BETA_FEATURES;
         foreach my $feature (@all_features) {
             my $feature_handler = LJ::BetaFeatures->get_handler($feature);


### PR DESCRIPTION
The list of available features on /beta gets ordered at random on every visit,
which is disorienting. Whenever there's 2+ betas, it's real hard not to notice.

That's not the intended behavior, but the controller was only sorting betas by
their "start time", which we don't appear to actually use. So let's fall back to
sorting by the beta's ID when the start times are identical (i.e. first
comparison returns 0); arbitrary, but at least it won't jump around like that.