### PR TITLE
Fix misaligned site logo

### DIFF
--- a/htdocs/scss/skins/_nav.scss
+++ b/htdocs/scss/skins/_nav.scss
@@ -216,6 +216,7 @@ $nav-small-screen-header-height: 3em;
 
     #logo img {
         height: $nav-small-screen-header-height;
+        vertical-align: middle;
     }
 
     #content {


### PR DESCRIPTION
I commented out Foundation's default image CSS because it was inappropriate for
a world where we display entries and comments in the foundationized site skins.
But the site logo was relying on that default `vertical-align: middle` rule, and
floated up a centimeter or so once it was gone. Didn't break anything, but sure
looked gross.