### PR TITLE
Site skin tweaks to support fixes in Tropospherical skins

### DIFF
--- a/htdocs/scss/skins/_form-elements.scss
+++ b/htdocs/scss/skins/_form-elements.scss
@@ -4,8 +4,35 @@
 
 // make .submit act the same as a .button
 .submit {
-    @extend .button;
- }
+  @include button-base;
+  @include button-size;
+  @include button-style;
+
+  @include single-transition(background-color);
+
+  &.secondary { @include button-style($bg:$secondary-button-bg-color, $bg-hover:$secondary-button-bg-hover, $border-color:$secondary-button-border-color); }
+  &.large  { @include button-size($padding:$button-lrg); }
+  &.small  { @include button-size($padding:$button-sml); }
+  &.tiny   { @include button-size($padding:$button-tny); }
+  &.expand { @include button-size($full-width:true); }
+  &.left-align  { text-align: left; text-indent: rem-calc(12); }
+  &.right-align { text-align: right; padding-right: rem-calc(12); }
+
+  &.radius { @include button-style($bg:false, $radius:true); }
+  &.round  { @include button-style($bg:false, $radius:$button-round); }
+  &.disabled, &[disabled] { @include button-style($bg:$button-bg-color, $disabled:true, $bg-hover:$button-bg-hover, $border-color:$button-border-color);
+    &.secondary { @include button-style($bg:$secondary-button-bg-color, $disabled:true, $bg-hover:$secondary-button-bg-hover, $border-color:$secondary-button-border-color); }
+    &.success { @include button-style($bg:$success-button-bg-color, $disabled:true, $bg-hover:$success-button-bg-hover, $border-color:$success-button-border-color); }
+    &.alert { @include button-style($bg:$alert-button-bg-color, $disabled:true, $bg-hover:$alert-button-bg-hover, $border-color:$alert-button-border-color); }
+    &.warning { @include button-style($bg:$warning-button-bg-color, $disabled:true, $bg-hover:$warning-button-bg-hover, $border-color:$warning-button-border-color); }
+    &.info { @include button-style($bg:$info-button-bg-color, $disabled:true, $bg-hover:$info-button-bg-hover, $border-color:$info-button-border-color); }
+  }
+
+  @media #{$medium-up} {
+    @include button-base($style:false, $display:inline-block);
+    @include button-size($padding:false, $full-width:false);
+  }
+}
 
 // add the userhead in front of .user-textbox, etc
 input.journaltype-textbox {

--- a/htdocs/scss/skins/_nav.scss
+++ b/htdocs/scss/skins/_nav.scss
@@ -299,13 +299,12 @@ $nav-small-screen-header-height: 3em;
             right: 0;
         }
 
-        /* Adds background color to menu nav when we hover over the dropdown it contains.
-        Because submit extends button, the css for this selector in _top-bar.scss is too specific,
-        and we override the expected bg (from a different selector). This just re-overrides.
-        Ugly but it's what we need!
+        /* Make top-level nav items match the color of their sub-menu when open.
+        /  Without this, it looks like you're hovering on both the top-level item
+        /  AND whichever sub-item you're actually hovering on.
         */
         @media #{$topbar-media-query} {
-            .top-bar-section li:hover:not(.has-form) a:not(.button):not(.submit) {
+            .top-bar-section li:hover:not(.has-form) a:not(.button):not(:hover) {
                 background: $topbar-dropdown-link-bg;
             }
         }


### PR DESCRIPTION
Fixes #2653 (partially; the other part is in https://github.com/dreamwidth/dw-nonfree/pull/136.)

The `.submit` thing was making the problems unfixable by scrambling the specificity order of all the relevant CSS rules. The top-level hover hack is a minor tweak; things look fine without it (after the nonfree fixes), but it makes new tropo match old tropo the rest of the way. 