### PR TITLE
Finish removing spellcheck from non-legacy pages  🔪

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -169,7 +169,7 @@ sub new_handler {
         if defined $usejournal && !$vars->{usejournal};
 
     if ( $r->did_post ) {
-        my $mode_preview    = $post->{"action:preview"}    ? 1 : 0;
+        my $mode_preview = $post->{"action:preview"} ? 1 : 0;
 
         $errors->add( undef, 'bml.badinput.body1' )
             unless LJ::text_in($post);
@@ -499,8 +499,8 @@ sub _edit {
         $post->remove('poster_remote');
         $post->remove('usejournal');
 
-        my $mode_preview    = $post->{"action:preview"}    ? 1 : 0;
-        my $mode_delete     = $post->{"action:delete"}     ? 1 : 0;
+        my $mode_preview = $post->{"action:preview"} ? 1 : 0;
+        my $mode_delete  = $post->{"action:delete"}  ? 1 : 0;
 
         $errors->add( undef, 'bml.badinput.body1' )
             unless LJ::text_in($post);

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -118,7 +118,6 @@ sub new_handler {
     my $errors   = DW::FormErrors->new;
     my $warnings = DW::FormErrors->new;
     my $post     = $r->did_post ? $r->post_args : undef;
-    my %spellcheck;
 
     # figure out times
     my $datetime;
@@ -171,7 +170,6 @@ sub new_handler {
 
     if ( $r->did_post ) {
         my $mode_preview    = $post->{"action:preview"}    ? 1 : 0;
-        my $mode_spellcheck = $post->{"action:spellcheck"} ? 1 : 0;
 
         $errors->add( undef, 'bml.badinput.body1' )
             unless LJ::text_in($post);
@@ -184,19 +182,6 @@ sub new_handler {
         if ($mode_preview) {
 
             # do nothing
-        }
-        elsif ($mode_spellcheck) {
-            if ($LJ::SPELLER) {
-                my $spellchecker = LJ::SpellCheck->new(
-                    {
-                        spellcommand => $LJ::SPELLER,
-                        class        => "searchhighlight",
-                    }
-                );
-                my $event = $post->{event};
-                $spellcheck{results}        = $spellchecker->check_html( \$event, 1 );
-                $spellcheck{did_spellcheck} = 1;
-            }
         }
         elsif ( $okay_formauth && $post->{showform} )
         {    # some other form posted content to us, which the user will want to edit further
@@ -255,8 +240,6 @@ sub new_handler {
 # this is an error in the user-submitted data, so regenerate the form with the error message and previous values
     $vars->{errors}   = $errors;
     $vars->{warnings} = $warnings;
-
-    $vars->{spellcheck} = \%spellcheck;
 
     # prepopulate if we haven't been through this form already
     $vars->{formdata} = $post || _prepopulate($get);
@@ -432,7 +415,7 @@ sub _init {
     # TODO:
     #             # JavaScript sets this value, so we know that the time we get is correct
     #             # but always trust the time if we've been through the form already
-    #             my $date_diff = ($opts->{'mode'} eq "edit" || $opts->{'spellcheck_html'}) ? 1 : 0;
+    #             my $date_diff = ($opts->{'mode'} eq "edit") ? 1 : 0;
 
     $vars = {
         remote => $u,
@@ -465,8 +448,6 @@ sub _init {
 
         displaydate       => \%displaydate,
         displaydate_check => $displaydate_check,
-
-        can_spellcheck => $LJ::SPELLER,
 
         panels        => $panels,
         formwidth     => $formwidth && $formwidth eq "P" ? "narrow" : "wide",
@@ -509,7 +490,6 @@ sub _edit {
     my $errors   = DW::FormErrors->new;
     my $warnings = DW::FormErrors->new;
     my $post;
-    my %spellcheck;
 
     if ( $r->did_post ) {
         $post = $r->post_args;
@@ -520,7 +500,6 @@ sub _edit {
         $post->remove('usejournal');
 
         my $mode_preview    = $post->{"action:preview"}    ? 1 : 0;
-        my $mode_spellcheck = $post->{"action:spellcheck"} ? 1 : 0;
         my $mode_delete     = $post->{"action:delete"}     ? 1 : 0;
 
         $errors->add( undef, 'bml.badinput.body1' )
@@ -533,19 +512,6 @@ sub _edit {
         if ($mode_preview) {
 
             # do nothing
-        }
-        elsif ($mode_spellcheck) {
-            if ($LJ::SPELLER) {
-                my $spellchecker = LJ::SpellCheck->new(
-                    {
-                        spellcommand => $LJ::SPELLER,
-                        class        => "searchhighlight",
-                    }
-                );
-                my $event = $post->{event};
-                $spellcheck{results}        = $spellchecker->check_html( \$event, 1 );
-                $spellcheck{did_spellcheck} = 1;
-            }
         }
         elsif ($okay_formauth) {
             $errors->add_string( undef, $LJ::MSG_READONLY_USER )
@@ -639,8 +605,6 @@ sub _edit {
 # this is an error in the user-submitted data, so regenerate the form with the error message and previous values
     $vars->{errors}   = $errors;
     $vars->{warnings} = $warnings;
-
-    $vars->{spellcheck} = \%spellcheck;
 
     $vars->{formdata} = $post || _backend_to_form($entry_obj);
 

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -943,7 +943,6 @@ sub create_qr_div {
         {
             form_url             => LJ::create_url( '/talkpost_do', host => $LJ::DOMAIN_WEB ),
             hidden_form_elements => $hidden_form_elements,
-            can_checkspell       => $LJ::SPELLER ? 1 : 0,
             post_disabled        => $post_disabled,
             post_button_class    => $post_disabled ? 'ui-state-disabled' : '',
 

--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -188,7 +188,7 @@ var postForm = (function($) {
             } else {
                 $custom_edit_button.hide();
             }
-        });
+        }).triggerHandler("change", true);
 
         // update the list of people who can see the entry
         function updatePostingMembers(e, useCached) {
@@ -314,7 +314,8 @@ var postForm = (function($) {
                 $security.append(opts.join(""));
 
                 // select the minsecurity value and disable the values with lesser security
-                $security.val(rank[oldval] >= rank[data.ret['minsecurity']] ? oldval : data.ret['minsecurity']);
+                var minsecrank = rank[data.ret['minsecurity']] || 0;
+                $security.val(rank[oldval] >= minsecrank ? oldval : data.ret['minsecurity']);
                 if ( data.ret['minsecurity'] == 'access' ) {
                     $security.find("option[value='public']").prop("disabled", true);
                 } else if ( data.ret['minsecurity'] == 'private' ) {

--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -89,7 +89,6 @@ var postForm = (function($) {
             $("input[name='action:post']").attr("data-reveal-id", "js-post-entry-login");
 
             $("#js-post-entry-login").find("input[type=submit]").click(handleLoginModal);
-            $form.hashpassword();
         }
     };
 

--- a/htdocs/js/pages/entry/new.js
+++ b/htdocs/js/pages/entry/new.js
@@ -55,10 +55,6 @@ var postForm = (function($) {
             e.preventDefault();
         }
 
-        function handleSpellcheck(e) {
-            $(this.form).data( "skipchecks", "spellcheck" );
-        }
-
         function handleDelete(e) {
             $(this.form).data( "skipchecks", "delete" );
 
@@ -87,7 +83,6 @@ var postForm = (function($) {
         }
 
         $("#js-preview-button").click(openPreview);
-        $("#js-spellcheck-button").click(handleSpellcheck);
         $("#js-delete-button").click(handleDelete);
 
         if ( ! hasRemote() ) {
@@ -183,7 +178,6 @@ var postForm = (function($) {
                 .after($custom_edit_button);
 
         // show the custom groups modal
-        var rememberInitialValue = !opts.spellcheck;
         $security_select.change( function(e, init) {
             var $this = $(this);
 
@@ -195,7 +189,7 @@ var postForm = (function($) {
             } else {
                 $custom_edit_button.hide();
             }
-        }).triggerHandler("change", rememberInitialValue);
+        });
 
         // update the list of people who can see the entry
         function updatePostingMembers(e, useCached) {
@@ -671,7 +665,7 @@ var postForm = (function($) {
         initCommunitySection(entryForm);
 
         initCurrents(entryForm, formData.moodpics);
-        initSecurity(entryForm, formData.security, { spellcheck: formData.did_spellcheck, edit: formData.edit } );
+        initSecurity(entryForm, formData.security, { edit: formData.edit } );
         initJournal(entryForm);
         initIcons(entryForm, formData.iconBrowser);
         initSlug(entryForm, $("#js-entrytime-date"));

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -98,8 +98,6 @@ postFormInitData.strings = {
   "delete_xposts_confirm": [%- "entryform.delete.xposts.confirm" | ml | js  -%]
 };
 
-postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false" %];
-
 [%- IF remote && remote.can_use_userpic_select -%]
     postFormInitData.iconBrowser = {
         "metatext": [%- icon_browser.metatext ? "true" : "false" -%],
@@ -116,19 +114,6 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
     [%- FOREACH warning IN warnings.get_all -%]
         <div class="alert-box">[%- warning.message -%]</div>
     [%- END -%]
-[%- END -%]
-
-[%- IF spellcheck.did_spellcheck -%]
-    <h2>[% 'entryform.spellchecked' | ml %]</h2>
-    [%-
-    IF spellcheck.results;
-         spellcheck.results;
-    ELSE;
-        'entryform.spellcheck.noerrors' | ml;
-    END -%]
-
-    [%# indicate where the spellcheck bit ends, and the entry form begins #%]
-    <h2>[% 'entryform.form' | ml %]</h2>
 [%- END -%]
 
 <form method="POST" id="js-post-entry" action="[% action.url %]" class="
@@ -289,15 +274,6 @@ postFormInitData.did_spellcheck = [% spellcheck.did_spellcheck ? "true" : "false
                                      class = "secondary button"
                                      )
                     -%]</li>
-
-                    [%- IF can_spellcheck %]
-                    <li>[% form.submit( value = dw.ml('entryform.spellcheck')
-                                     name = "action:spellcheck"
-                                     id = "js-spellcheck-button"
-                                     class = "secondary button"
-                                     );
-                    %]</li>
-                    [%- END -%]
                 </ul>
             </div>
         </div></div>


### PR DESCRIPTION
This pulls spellcheck elements off of the beta Create Entries page and cleans up one remaining setup check from the rendering of journal/quickreply.tt.

I think spellcheck should stay intact on update.bml and editjournal.bml until we launch those into the sun. If we agree that should be the case, this closes #2481. 

I also discovered that the entry/new.js script was calling an undefined hashpassword function when the user was posting while logged out, so I removed that call as well.