### PR TITLE
fix bug in converted faqbrowse

### DIFF
--- a/cgi-bin/DW/Controller/Support/Faq.pm
+++ b/cgi-bin/DW/Controller/Support/Faq.pm
@@ -341,7 +341,7 @@ sub faqbrowse_handler {
             'answer'          => $answer,
             'summary'         => $summary,
             'display_summary' => $display_summary,
-            'display_answer'  => $display_summary,
+            'display_answer'  => $display_answer,
             'lastmodwho'      => $lastmodwho,
             'lastmodtime'     => $f->lastmodtime
         };

--- a/cgi-bin/DW/Controller/Support/Faq.pm
+++ b/cgi-bin/DW/Controller/Support/Faq.pm
@@ -231,7 +231,6 @@ sub faqbrowse_handler {
                 undef, $faqcatarg );
             die $dbr->errstr if $dbr->err;
         }
-        warn $catname;
         $title =
             LJ::Lang::ml( '/support/faqbrowse.tt.title_cat', { catname => LJ::ehtml($catname) } );
         @faqs = sort { $a->sortorder <=> $b->sortorder }
@@ -439,7 +438,6 @@ sub faqsearch_handler {
 
         my @clean_results;
         foreach my $f (@results) {
-            warn $f;
             my $dq = $f->question_html;
             $dq =~ s/(\Q$q\E)/$term->($1) /ige;
             my $ueq   = LJ::eurl($q);

--- a/cgi-bin/DW/Controller/Support/Faq.pm
+++ b/cgi-bin/DW/Controller/Support/Faq.pm
@@ -179,7 +179,7 @@ sub faqbrowse_handler {
     }
 
     # get faqid and redirect to faq.bml if none
-    my $faqidarg = $GET->{'faqid'} + 0;
+    my $faqidarg = $GET->{'faqid'} ? $GET->{'faqid'} + 0 : 0;
 
     # FIXME: disallow both faqid and faqcat (or ignore one)
     my $faqcatarg = $GET->{'faqcat'};
@@ -308,6 +308,7 @@ sub faqbrowse_handler {
 
         if ($qterm) {
             $question =~ s/(\Q$qterm\E)/$term->($1)/ige;
+            $summary //= '';    # no undefined string warnings
 
             # don't highlight terms in URLs or HTML tags
             # FIXME: if the search term is present in a tag, should still


### PR DESCRIPTION
I missed this bug in my testing because it only shows up when the affected FAQ doesn't have a summary. In that particular case, the answer doesn't display, because display_answer was assigned the value of display_summary.

I also removed a few more warnings seen in production logs that I missed in #2693. 

The display_answer fix is live in production; the warnings fixes are not.