### PR TITLE
Remove extra .columns div in faqsearch

### DIFF
--- a/views/support/faqsearch.tt
+++ b/views/support/faqsearch.tt
@@ -7,27 +7,25 @@
 
 <p>[% '.info' | ml %]</p>
 <form method='GET'>
-    <div class="columns">
-        <div class="row">
-            <div class="columns large-3 text-right">[% '.label.term' | ml %]:</div>
-            <div class="columns large-6">
-                [%- form.textbox( size = 30, value = q, name = 'q') -%]
-            </div>
-            <div class="columns large-3">
-                [%- form.submit( 'value' = dw.ml('.button.search')) -%]
-            </div>
+    <div class="row">
+        <div class="columns large-3 text-right">[% '.label.term' | ml %]:</div>
+        <div class="columns large-6">
+            [%- form.textbox( size = 30, value = q, name = 'q') -%]
         </div>
+        <div class="columns large-3">
+            [%- form.submit( 'value' = dw.ml('.button.search')) -%]
+        </div>
+    </div>
 
-        <div class="row">
-            <div class="columns large-3 text-right">
-                [% '.label.lang' | ml %]
-            </div>
-            <div class="columns large-3">
-                [%- form.select( name = 'lang', selected = sel, items = langs) -%]
-            </div>
-            <div class="columns large-6">
-                [% '.example' | ml %]
-            </div>
+    <div class="row">
+        <div class="columns large-3 text-right">
+            [% '.label.lang' | ml %]
+        </div>
+        <div class="columns large-3">
+            [%- form.select( name = 'lang', selected = sel, items = langs) -%]
+        </div>
+        <div class="columns large-6">
+            [% '.example' | ml %]
         </div>
     </div>
 </form>


### PR DESCRIPTION
Since Foundation uses floats to fake up its row/column grid layout thing, it can
launch itself into the Minus World if you do anything mildly unexpected with the
nesting.

Said nesting is supposed to go `.row > (.columns) * N`, and then a columns
container can contain other rows if it wants. This page's nesting was going
`.row > .columns > (form) > .columns > .row`. Some browsers just make a pained
expression and render it fine, but Safari totally splodes.

My hack server doesn't have anything in its faq, so I can't really test it over there, but you can test this fix on prod by going into your web inspector, right-clicking the `<div class="columns">` that's right inside the `<form method="GET">`, choosing Edit -> HTML, and then deleting both the closing and opening tag of _only that div._