### PR TITLE
Align external user icons the same way as site user icons

### DIFF
--- a/cgi-bin/DW/External/User.pm
+++ b/cgi-bin/DW/External/User.pm
@@ -72,7 +72,7 @@ sub ljuser_display {
     return
           "<span style='white-space: nowrap;'$display_class>"
         . ( $opts{no_link} ? '' : "<a href='$profile_url'>" )
-        . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
+        . "<img src='$badge_image->{url}' alt='[$domain profile] ' style='vertical-align: text-bottom; border: 0; padding-right: 1px;' width='$badge_image->{width}' height='$badge_image->{height}'/>"
         . ( $opts{no_link} ? '' : "</a><a href='$journal_url'>" )
         . "<b>$user</b>"
         . ( $opts{no_link} ? '' : "</a>" )


### PR DESCRIPTION
The function that builds DW site user links is over in LJ/User/Display.pm, and
it sets `vertical-align: text-bottom` in the inline style for the icon. For
consistency, external user links should do the same thing.

Scroll down about a screenful on https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align to see a comparison of all the different vertical-align values with an image whose ratio to the surrounding text roughly matches our user icons. 