### PR TITLE
[#1841] include priv packages on /admin/priv page

### DIFF
--- a/cgi-bin/LJ/Console/Command/PrivPackage.pm
+++ b/cgi-bin/LJ/Console/Command/PrivPackage.pm
@@ -62,7 +62,7 @@ sub execute {
         if $dbh->err;
 
     # canonical package name is "#" plus whatever is in the db
-    $cpkg = "#$cpkg";
+    $cpkg = defined $cpkg ? "#$cpkg" : undef;
 
     # list created packages, or contents of one
     if ( $cmd eq 'list' ) {

--- a/views/admin/priv/viewuser.tt
+++ b/views/admin/priv/viewuser.tt
@@ -93,6 +93,13 @@
 
         [% form.textbox( label = dw.ml( '.label.arg' ), name = 'arg',
                          size = 20, maxlength = 40 ) %]
+    [%- IF pkgmenu.size > 2; # not counting empty top selection -%]
+  </p>
+  <p>
+        [% form.select( label = dw.ml( '.label.pkgmenu' ),
+                        name = 'grantpkg', items = pkgmenu ) %]
+    [%- END -%]
+
   [%- ELSE -%]
         [% '.txt.noadmin' | ml %]
   [%- END -%]

--- a/views/admin/priv/viewuser.tt.text
+++ b/views/admin/priv/viewuser.tt.text
@@ -22,6 +22,8 @@
 
 .label.arg=Arg:
 
+.label.pkgmenu=Or grant the package of privileges:
+
 .label.privmenu=Grant [[user]] privilege: 
 
 .success.grant=Privilege '[[privcode]]' granted.


### PR DESCRIPTION
When granting privileges to a particular user, in addition to the existing dropdown of privileges, I added a second dropdown list of defined priv packages. I decided I liked the look of it better, and it was easier to implement than if I'd smashed the two sets of options into one menu as I had originally proposed. (It was also easier to implement than if I'd tried to do this before encapsulating the logic for granting privileges in the controller.)

This is just for ease of use when granting packages. All other package operations, such as seeing which privileges are included in a package, still require use of the priv_package console command.

Fixes #1841.