### PR TITLE
jQ expects absolute protocol links, page prints relative protocol links

### DIFF
--- a/htdocs/talkscreen.bml
+++ b/htdocs/talkscreen.bml
@@ -69,12 +69,15 @@ _info?><?_code
             'unfreeze' => "silk/comments/unfreeze.png",
         };
 
+        my $imgprefix = $LJ::IMGPREFIX;
+        $imgprefix =~ s/^https?://;
+
         my %ret = (
             id       => $dtalkid,
             mode     => $mode,
             newalt   => $alttext,
-            oldimage => "$LJ::IMGPREFIX/$stockimg->{$mode}",
-            newimage => "$LJ::IMGPREFIX/$stockimg->{$newmode}",
+            oldimage => "$imgprefix/$stockimg->{$mode}",
+            newimage => "$imgprefix/$stockimg->{$newmode}",
             newurl   => "$LJ::SITEROOT/talkscreen?mode=$newmode&journal=$journal&talkid=$dtalkid",
             msg      => $message,
         );


### PR DESCRIPTION
At some point we told LJ::S2::Image_std to start printing relative protocol links, but the JSON generated by talkscreen.bml for use by jquery.commentmanage.js was still using links that included the protocol, which meant that `this.element.find('img[src="'+newData.oldimage+'"]')` would never get a match, and so whenever you clicked on an icon for freezing/unfreezing or screening/unscreening a comment, the icon link would be replaced by a text link instead of another icon link.

ANYWAY this is the fix. I tested it. Who knows whether it will unexpectedly cause a mismatch somewhere else.