### PR TITLE
Return to original thread view after commenting/editing

### DIFF
--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -109,8 +109,7 @@ DW::Routing->register_string( '/talkpost_do', \&talkpost_do_handler, app => 1 );
 # - viewing_thread
 #     The filtered thread view (`?thread=12345`) they were in when they hit the
 #     "reply" link, and which they should be returned to once they finish posting.
-#     Currently only populated by the quick-reply. Consumed by Talk controller to
-#     build the return link.
+#     Consumed by Talk controller to build the return link.
 # - style/format/s2id/fallback
 #     The "viewing style" options (`?style=light`) that were in effect when they
 #     hit the "reply" link, which should be re-instated once they finish

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -3904,11 +3904,11 @@ sub Comment__expand_link {
         my $remote = LJ::get_remote();
 
         $onclick =
-" onClick=\"Expander.make(this,'$this->{expand_url}','$this->{talkid}', true); return false;\"";
+" onClick=\"Expander.make(this,'$this->{js_expand_url}','$this->{talkid}', true); return false;\"";
     }
     else {
         $onclick =
-" onClick=\"Expander.make(this,'$this->{expand_url}','$this->{talkid}'); return false;\"";
+" onClick=\"Expander.make(this,'$this->{js_expand_url}','$this->{talkid}'); return false;\"";
     }
     return "<a href='$this->{expand_url}'$title$class$onclick>$text</a>";
 }

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -176,7 +176,6 @@ sub ReplyPage {
         $parpost->{'body'}    = $tt->{$re_talkid}->[1];
         $parpost->{'props'} =
             LJ::load_talk_props2( $u, [$re_talkid] )->{$re_talkid} || {};
-        $parpost->{'dtid'} = $dtalkid;
 
         if ( $parpost->{'props'}->{'unknown8bit'} ) {
             LJ::item_toutf8( $u, \$parpost->{'subject'}, \$parpost->{'body'}, {} );
@@ -285,7 +284,6 @@ sub ReplyForm__print {
     my $u       = $form->{'_u'};
     my $parpost = $form->{'_parpost'};
     my $parent  = $parpost ? $parpost->{'jtalkid'} : 0;
-    my $dtid    = $parpost ? $parpost->{dtid} : 0;
 
     my $post_vars = DW::Request->get->post_args;
     $post_vars = $form->{_values}
@@ -297,7 +295,6 @@ sub ReplyForm__print {
                 'journalu'   => $u,
                 'parpost'    => $parpost,
                 'replyto'    => $parent,
-                'dtid'       => $dtid,                                  # unused in talkform, btw.
                 'ditemid'    => $form->{'_ditemid'},
                 'styleopts'  => $form->{_styleopts},
                 'form'       => $post_vars,

--- a/cgi-bin/LJ/S2/ReplyPage.pm
+++ b/cgi-bin/LJ/S2/ReplyPage.pm
@@ -269,6 +269,7 @@ sub ReplyPage {
         '_parpost'   => $parpost,
         '_values'    => \%comment_values,
         '_styleopts' => $p->{_styleopts},
+        '_thread'    => $get->{thread} || 0,
     };
 
     $p->{'isedit'} = $editid ? 1 : 0;
@@ -297,6 +298,7 @@ sub ReplyForm__print {
                 'replyto'    => $parent,
                 'ditemid'    => $form->{'_ditemid'},
                 'styleopts'  => $form->{_styleopts},
+                'thread'     => $form->{_thread},
                 'form'       => $post_vars,
                 'do_captcha' => LJ::Talk::Post::require_captcha_test(
                     $remote, $u, $post_vars->{body}, $form->{'_ditemid'}

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1407,6 +1407,7 @@ sub talkform {
     # replyto:     jtalkid of the parent comment (or 0 if replying to entry)
     # dtid:        dtalkid of the parent comment (or 0) -- useless, but preserved
     # ditemid:     target entry's ditemid
+    # styleopts:   the style options (`?style=light`) at reply time, as a hashref
     # form:        optional full form hashref. Empty if reply page was opened via
     #              direct link instead of partial form submission.
     # do_captcha:  optional toggle for creating a captcha challenge

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1405,7 +1405,6 @@ sub talkform {
     # journalu:    required journal user object
     # parpost:     parent comment hashref. Only keys we use are state and subject.
     # replyto:     jtalkid of the parent comment (or 0 if replying to entry)
-    # dtid:        dtalkid of the parent comment (or 0) -- useless, but preserved
     # ditemid:     target entry's ditemid
     # styleopts:   the style options (`?style=light`) at reply time, as a hashref
     # form:        optional full form hashref. Empty if reply page was opened via
@@ -1619,9 +1618,6 @@ sub talkform {
     }
 
     my $styleopts = $opts->{styleopts} || LJ::viewing_style_opts(%$form);
-    my $stylemineuri =
-        %{$styleopts} ? LJ::viewing_style_args( %{$styleopts} ) . "&" : "";
-    my $basepath = $entry->url . "?" . $stylemineuri;
 
     # hidden values
     $template_args->{'hidden_form_elements'} .= LJ::html_hidden(
@@ -1629,14 +1625,8 @@ sub talkform {
         "parenttalkid" => ( $opts->{replyto} + 0 ),
         "itemid"       => $opts->{ditemid},
         "journal"      => $journalu->{'user'},
-        "basepath"     => $basepath,
-        "dtid"         => $opts->{dtid},
-
-        # ^ display version of replyto/parenttalkid. Nothing actually uses this
-        # in the talkform or after the form is submitted. It's important for JS
-        # in the quickreply, but vestigial here.
-        "editid" => $editid,
-        "chrp1"  => generate_chrp1( $journalu->{userid}, $opts->{ditemid} ),
+        "editid"       => $editid,
+        "chrp1"        => generate_chrp1( $journalu->{userid}, $opts->{ditemid} ),
         %$styleopts,
     );
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1621,12 +1621,13 @@ sub talkform {
 
     # hidden values
     $template_args->{'hidden_form_elements'} .= LJ::html_hidden(
-        "replyto"      => $opts->{replyto},
-        "parenttalkid" => ( $opts->{replyto} + 0 ),
-        "itemid"       => $opts->{ditemid},
-        "journal"      => $journalu->{'user'},
-        "editid"       => $editid,
-        "chrp1"        => generate_chrp1( $journalu->{userid}, $opts->{ditemid} ),
+        replyto        => $opts->{replyto},
+        parenttalkid   => ( $opts->{replyto} + 0 ),
+        itemid         => $opts->{ditemid},
+        journal        => $journalu->{user},
+        editid         => $editid,
+        viewing_thread => $opts->{form}->{viewing_thread} || 0,
+        chrp1          => generate_chrp1( $journalu->{userid}, $opts->{ditemid} ),
         %$styleopts,
     );
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -3006,6 +3006,7 @@ sub post_comment {
     my $item     = $comment->{entry};
     my $journalu = $item->journal;
     my $parent   = $comment->{parent};
+    my $itemid   = $item->jitemid;
 
     my $parent_state = $parent->{state} || "";
 
@@ -3014,7 +3015,7 @@ sub post_comment {
 
      # if parent comment is screened and we got this far, the user has the permission to unscreen it
      # in this case the parent comment needs to be unscreened and the comment posted as normal
-        LJ::Talk::unscreen_comment( $journalu, $item->jitemid, $parent->{talkid} );
+        LJ::Talk::unscreen_comment( $journalu, $itemid, $parent->{talkid} );
         $parent->{state} = 'A';
     }
     elsif ( $parent_state eq 'S' ) {
@@ -3050,7 +3051,7 @@ sub post_comment {
         );
         $memkey = [
             $journalu->{userid},
-            "tdup:$journalu->{userid}:$item->jitemid-$parent->{talkid}-$posterid-$md5_b64"
+            "tdup:$journalu->{userid}:$itemid-$parent->{talkid}-$posterid-$md5_b64"
         ];
         $jtalkid = LJ::MemCache::get($memkey);
     }
@@ -3085,7 +3086,7 @@ sub post_comment {
         ]
     );
 
-    LJ::Hooks::run_hooks( 'new_comment', $journalu->{userid}, $item->jitemid, $jtalkid )
+    LJ::Hooks::run_hooks( 'new_comment', $journalu->{userid}, $itemid, $jtalkid )
         ;    # This hook is never registered by anything in -free or -nonfree. -NF
 
     return ( 1, $jtalkid );

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1407,6 +1407,7 @@ sub talkform {
     # replyto:     jtalkid of the parent comment (or 0 if replying to entry)
     # ditemid:     target entry's ditemid
     # styleopts:   the style options (`?style=light`) at reply time, as a hashref
+    # thread:      thread being viewed at reply time (`?thread=12345`), as a dtalkid
     # form:        optional full form hashref. Empty if reply page was opened via
     #              direct link instead of partial form submission.
     # do_captcha:  optional toggle for creating a captcha challenge
@@ -1626,7 +1627,7 @@ sub talkform {
         itemid         => $opts->{ditemid},
         journal        => $journalu->{user},
         editid         => $editid,
-        viewing_thread => $opts->{form}->{viewing_thread} || 0,
+        viewing_thread => $opts->{form}->{viewing_thread} || $opts->{thread} || 0,
         chrp1          => generate_chrp1( $journalu->{userid}, $opts->{ditemid} ),
         %$styleopts,
     );


### PR DESCRIPTION
Fixes #2717

- The quick-reply has always (?) had a hidden `viewing_thread` field that keeps a record of which thread you were viewing when you hit "reply", and we try to redirect you there after posting. 
- The talkform has never had that, so if you used "more options", you'd redirect to the main entry page when done. Same for editing comments or opening a reply link in a new tab (or with no JS). 
- The old previewform, however, used to just copy over every form field it didn't recognize into a hidden input. So if you previewed FROM the quick-reply, you'd get the quick-reply behavior! 

So: the return-to-thread after preview behavior broke because I replaced the previewform with the talkform, which didn't know how to deal with the `viewing_thread` field and doesn't duplicate whatever random garbage you huck at it.

The fourth commit in this PR fixes the reported bug.

The first three commits are cleanups and docs. 

The fifth and sixth commits enable return-to-thread for edit links and reply links, which have never supported that before, but really why shouldn't they. 