### PR TITLE
Replace opt-in s2foundation beta with opt-out nos2foundation beta

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -2520,6 +2520,10 @@ general /views/beta.tt.betafeature.httpseverywhere.cantadd
 general /views/beta.tt.betafeature.httpseverywhere.on
 general /views/beta.tt.betafeature.httpseverywhere.off
 general /views/beta.tt.betafeature.httpseverywhere.title
+general /views/beta.tt.betafeature.s2foundation.cantadd
+general /views/beta.tt.betafeature.s2foundation.off
+general /views/beta.tt.betafeature.s2foundation.on
+general /views/beta.tt.betafeature.s2foundation.title
 
 general email.newacct5.body
 

--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -294,7 +294,7 @@ sub talkpost_do_handler {
     # $LJ::ACTIVE_RES_GROUP, definitely do that. In the meantime, this needs to
     # happen before LJ::Talk::talkform gets called or things might break. -NF
     my $real_remote = LJ::get_remote();
-    if ( LJ::BetaFeatures->user_in_beta( $real_remote => "s2foundation" ) ) {
+    if ( !LJ::BetaFeatures->user_in_beta( $real_remote => "nos2foundation" ) ) {
         LJ::set_active_resource_group("foundation");
     }
     else {

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -176,7 +176,7 @@ sub make_journal {
     # like print_stylesheet() won't run, which don't have an method invocant
     return $page if $page && ref $page ne 'HASH';
 
-    if ( LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" ) ) {
+    if ( !LJ::BetaFeatures->user_in_beta( $remote => "nos2foundation" ) ) {
         LJ::set_active_resource_group('foundation');
 
         # Minimal Foundation component support if we're not in site scheme

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1485,7 +1485,7 @@ sub talkform {
         username_maxlength   => $LJ::USERNAME_MAXLENGTH,
         password_maxlength   => $LJ::PASSWORD_MAXLENGTH,
 
-        foundation_beta => LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" ),
+        foundation_beta => !LJ::BetaFeatures->user_in_beta( $remote => "nos2foundation" ),
 
         public_entry     => $entry->security eq 'public',
         default_usertype => 'user',
@@ -1751,8 +1751,7 @@ sub init_iconbrowser_js {
 
     # The New-New Icon Browser: Depends on Foundation CSS/JS (either site skin
     # or minimal version). Used on: Create entry page (if in "updatepage" beta),
-    # quickreply and talkform on journal pages and on talkpost_do (if in
-    # "s2foundation" beta).
+    # quickreply and talkform on journal pages and on talkpost_do.
     LJ::need_res(
         { group => 'foundation' },
 

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -958,7 +958,7 @@ sub create_qr_div {
 
             editors => $editors,
 
-            foundation_beta => LJ::BetaFeatures->user_in_beta( $remote => "s2foundation" ),
+            foundation_beta => !LJ::BetaFeatures->user_in_beta( $remote => "nos2foundation" ),
 
             remote => {
                 ljuser                 => $remote->ljuser_display,
@@ -2867,18 +2867,15 @@ sub js_dumper {
 #     - "all" - always included, regardless of the current resource group.
 #     - "fragment" - no idea, tbh. Something involving the template system.
 #
-# LIMITATIONS: Lazy resolution basically doesn't work with S2 pages, so they
-# need to know all of their CSS/JS files BEFORE we start rendering markup. In
-# particular, watch out for this when using .tt components that call need_res.
+# LIMITATIONS: Lazy resolution doesn't work reliably with non-"siteviews" S2
+# pages (they can sometimes do JS, but not CSS), so they should know all of
+# their CSS/JS files BEFORE we start rendering markup. In particular, watch out
+# for this when using .tt components that call need_res.
 #     Why? To lazy resolve, you need to call res_includes AFTER the inner
 # content is fully built, which means building the outer frame of the page last.
 # That's easy for site pages, but since journal styles can override the entire
 # HTML document, there's not really any protected "outer" part of the page that
 # core2 can defer.
-# Exceptions to this:
-#     - The "siteviews" layout can lazy-resolve just fine.
-#     - If the "s2foundation" beta is active, S2 pages can lazy-resolve JS (but
-#       not CSS).
 # -NF
 
 # optional first argument: hashref with options

--- a/etc/config-local.pl.example
+++ b/etc/config-local.pl.example
@@ -160,7 +160,7 @@
 #            start_time => 0,
 #            end_time => "Inf",
 #        },
-#        "s2foundation" => {
+#        "nos2foundation" => {
 #            start_time => 0,
 #            end_time => "Inf",
 #        },

--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -31,21 +31,23 @@
 
 .betafeature.updatepage.title=New Create Entries Page
 
-.betafeature.s2foundation.cantadd=Sorry, your account is not eligible to test this feature.
+.betafeature.nos2foundation.cantadd=Sorry, your account is not eligible to test this feature.
 
-.betafeature.s2foundation.off<<
-<p>Activate several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up new bugs.</p>
+.betafeature.nos2foundation.off<<
+<p>We recently updated several important components on journal pages; this includes a mobile-friendly cleanup of the site-styled comment pages, a refresh of the "more options" reply form, and a new version of the icon browser.</p>
 
-<p>To report bugs with these updated components, leave a comment in <?ljuser dw_beta ljuser?>.</p>
+<p>These changes were already beta tested, but enabling them for everyone might reveal bugs we haven't seen before. If any updated components are so broken that you can't use them, you can set this beta to "ON" to temporarily disable the updates while we work on a fix.</p>
+
+<p><strong>If you disable the updates to work around a bug, please report the bug by leaving a comment in <?ljuser dw_beta ljuser?>.</strong> The option to disable these updates is only temporary, and we will remove it once we feel confident that we've fixed all major bugs.</p>
 .
 
-.betafeature.s2foundation.on<<
-<p>You are currently testing several updated components on journal pages, including a new version of the icon browser for paid users and a mobile-friendly cleanup of the site-styled comment pages. The underlying components are already well-tested, but introducing them into a new environment might turn up new bugs.</p>
+.betafeature.nos2foundation.on<<
+<p>You have temporarily disabled several updated components on journal pages (mobile-friendly site-styled comment pages, refreshed "more options" comment form, and new icon browser).</p>
 
-<p>To report bugs with these updated components, leave a comment in <?ljuser dw_beta ljuser?>.</p>
+<p><strong>If you disabled these updates to work around a bug, please make sure you have reported it by leaving a comment in <?ljuser dw_beta ljuser?>.</strong> The option to disable these updates is only temporary, and we will remove it once we feel confident that we've fixed all major bugs.</p>
 .
 
-.betafeature.s2foundation.title=Updated journal page components
+.betafeature.nos2foundation.title=Temporarily revert updated journal page components
 
 .nofeatures=There are no features currently available for beta testing.
 


### PR DESCRIPTION
Gets us like 2/3 of the way to #2602, but doesn't close it yet. 

Opt-out betas are a little weird. Also, to keep the diff small, I'm switching
these "if" statements to "if (!)" instead of rewriting them; we'll hopefully be
removing them soon anyway.

This'll require a change to config-local.pl when it gets deployed. 