### PR TITLE
make lastmodtime in FAQ preview look more like in LJ::Faq->load

### DIFF
--- a/cgi-bin/DW/Controller/Admin/FAQ.pm
+++ b/cgi-bin/DW/Controller/Admin/FAQ.pm
@@ -28,6 +28,8 @@ use DW::Template;
 
 use LJ::Faq;
 
+use POSIX qw( strftime );
+
 DW::Controller::Admin->register_admin_page(
     '/',
     path     => 'faq',
@@ -254,12 +256,10 @@ sub edit_handler {
 
     if ( $r->post_args->{'action:preview'} ) {
 
-        # TODO: make lastmodtime look more like in LJ::Faq->load
-
         my %faq_args = (
             faqid         => $vars->{id},
             lastmoduserid => $remote->id,
-            lastmodtime   => scalar gmtime,
+            lastmodtime   => strftime( '%B %e, %Y', gmtime ),
             unixmodtime   => time,
         );
         $faq_args{$_} = $vars->{$_} foreach qw( faqcat question summary answer sortorder lang );


### PR DESCRIPTION
When previewing changes to a FAQ, the time shown is the full date and time, which is a bit jarring since the final FAQ display just shows the date. So this fixes the TODO to make it look more similar.

(It's not identical because strftime doesn't have a format for 1st, 2nd, etc which is language specific. LJ::Faq->load uses MySQL's DATE_FORMAT when reading the date from the database, but since this is a preview page, we haven't saved it to the database yet.)