### PR TITLE
Comment preview: Display toggleable truncated parent above preview

### DIFF
--- a/htdocs/js/jquery.talkpost.preview.js
+++ b/htdocs/js/jquery.talkpost.preview.js
@@ -1,0 +1,23 @@
+// Tiny script for hiding/revealing the full text of the comment/entry you're
+// replying to.
+jQuery(function($) {
+    "use strict";
+
+    var replyTo = $('#preview-parent-entry');
+    var toggleButtons = $('.js-parent-toggle');
+
+    // Move parent content to the top of the page, since it defaults to the
+    // bottom for no-JS users. This uses flex `order`, so it shouldn't obstruct
+    // screenreaders...
+    $('#talkpost-wrapper').addClass('js-preview');
+
+    // Set up initial state
+    replyTo.addClass('collapsed');
+    $('#js-preview-parent-expand').removeClass('js-hidden');
+
+    // And then:
+    toggleButtons.on('click', function(e) {
+        replyTo.toggleClass('collapsed');
+        toggleButtons.toggleClass('js-hidden');
+    });
+});

--- a/htdocs/scss/components/talkpost-preview.scss
+++ b/htdocs/scss/components/talkpost-preview.scss
@@ -1,0 +1,40 @@
+/**
+* Fancy behavior for the comment preview page.
+* See also jquery.talkpost.preview.js.
+*/
+
+#preview-parent, #preview-comment {
+  border-bottom: 1px solid;
+}
+
+#talkpost-wrapper {
+  .js-parent-toggle {
+    margin: 1em auto;
+    display: block;
+  }
+
+  .js-hidden {
+    display: none;
+  }
+}
+
+#talkpost-wrapper.js-preview {
+  display: flex;
+  flex-direction: column;
+
+  #preview-parent {
+    order: -1; // up top
+  }
+
+  #preview-parent-entry {
+    padding-bottom: 2em; // Avoid blurring out one-line comments.
+  }
+
+  #preview-parent-entry.collapsed {
+    overflow-y: hidden;
+    max-height: 17em;
+    // mask image can be any color. Opaque = visible.
+    -webkit-mask-image: linear-gradient(to bottom, rgba(255, 255, 255, 255) 80%, rgba(255,255,255,0) 95%);
+    mask-image: linear-gradient(to bottom, rgba(255, 255, 255, 255) 80%, rgba(255,255,255,0) 95%);
+  }
+}

--- a/views/talkpost_do.tt
+++ b/views/talkpost_do.tt
@@ -15,12 +15,30 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- sections.title = dw.ml(title) -%]
 
+<div id="talkpost-wrapper">
+
 [% IF preview %]
+    [%- dw.need_res( { group => "foundation"},
+        "js/jquery.talkpost.preview.js",
+        "stc/css/components/talkpost-preview.css"
+    ) -%]
+
+    [%# Delete after s2foundation beta ends: -%]
+    [%- dw.need_res( { group => "jquery"},
+        "js/jquery.talkpost.preview.js",
+        "stc/css/components/talkpost-preview.css"
+    ) -%]
+
     [% INCLUDE talkpost_do/preview_comment.tt %]
 [% END %]
 
+<div id="talkpost-main">
 [% html %]
+</div>
 
 [% IF preview %]
     [% INCLUDE talkpost_do/preview_parent.tt %]
 [% END %]
+
+</div>
+

--- a/views/talkpost_do/preview_comment.tt
+++ b/views/talkpost_do/preview_comment.tt
@@ -13,6 +13,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 -%]
 
+<div id="preview-comment">
+
 <h2>[% dw.ml('/talkpost_do.tt.preview.title') %]</h2>
 <p>[% dw.ml('/talkpost_do.tt.preview') %]</p>
 
@@ -87,7 +89,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 </div>
 
 
-</div> <!-- end .inner -->
-</div> <!-- end #comments -->
+</div> [%# end .inner %]
+</div> [%# end #comments %]
 
-<hr>
+</div> [%# end #preview-comment %]

--- a/views/talkpost_do/preview_parent.tt
+++ b/views/talkpost_do/preview_parent.tt
@@ -13,7 +13,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 'perldoc perlartistic' or 'perldoc perlgpl'.
 -%]
 
-<hr>
+<div id="preview-parent">
 
 <h3>Replying to:</h3>
 
@@ -35,7 +35,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         <div class="inner">
         </div>
     </div>
-    <div class="entry" id="preview-parent">
+    <div class="entry" id="preview-parent-entry">
         <div class="inner">
             <div class="header">
                 <div class="inner">
@@ -86,4 +86,21 @@ the same terms as Perl itself.  For a copy of the license, please reference
 </div>
 
 
-</div><!-- end reply page wrapper -->
+</div>[%# end .reply page wrapper %]
+
+[%- INCLUDE "components/icon-button-decorative.tt"
+    button = {
+      id = "js-preview-parent-expand"
+      class = "js-hidden js-parent-toggle"
+    }
+    icon = "plus"
+    text = "Show more" -%]
+[%- INCLUDE "components/icon-button-decorative.tt"
+    button = {
+      id = "js-preview-parent-collapse"
+      class = "js-hidden js-parent-toggle"
+    }
+    icon = "minus"
+    text = "Show less" -%]
+
+</div>[%# end #preview-parent %]


### PR DESCRIPTION
- Only takes effect if JS is enabled. No-JS folks get the parent below the reply
form, the way it is today.
- Uses flex `order` to hopefully not put it in the way of screenreaders; they
should still hear it below the reply form, since that's the DOM order.
- Does a pretty little blur at the truncation point, for browsers that support it.

<details><summary>Screenshots</summary>

**Collapsed:**

![Screenshot_2020-07-01 Comment Preview(3)](https://user-images.githubusercontent.com/484309/86291013-403ca100-bba3-11ea-816d-56025efe9a33.png)

**Expanded:**

![Screenshot_2020-07-01 Comment Preview(4)](https://user-images.githubusercontent.com/484309/86291021-43d02800-bba3-11ea-820b-27a335728dab.png)

**Collapsed (without s2foundation):**

![Screenshot_2020-07-01 Comment Preview(1)](https://user-images.githubusercontent.com/484309/86291039-4894dc00-bba3-11ea-9b9b-f688b69d364e.png)

**Expanded (without s2foundation):**

![Screenshot_2020-07-01 Comment Preview(2)](https://user-images.githubusercontent.com/484309/86291052-4af73600-bba3-11ea-9328-18235bb9c7ef.png)

</details>