### PR TITLE
[#2592] fix username swap bug with tokens owned by different accounts

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2353,6 +2353,8 @@ rename.error.reserved="[[to]]" is a reserved username.
 
 rename.error.tokenapplied=This token has already been used.
 
+rename.error.tokenduplicate=The same token was provided twice; two distinct tokens are required.
+
 rename.error.tokeninvalid=The provided token is not a valid token.
 
 rename.error.tokentoofew=Too few tokens; you need two to perform a swap.

--- a/cgi-bin/DW/Controller/Rename.pm
+++ b/cgi-bin/DW/Controller/Rename.pm
@@ -258,12 +258,13 @@ sub handle_swap_post {
 
     my $remote = $opts{user};
     my $get_unused_tokens =
-        sub { @{ DW::RenameToken->by_owner_unused( userid => $_[0]->id ) || [] } };
+        sub { @{ DW::RenameToken->by_owner_unused( userid => $_[0] ) || [] } };
 
     my @check_users = ( $journal, $swapjournal );
     unshift @check_users, $remote if $remote;
+    my %check_uids = map { $_->id => 1 } @check_users;    # remove duplicates
 
-    my @unused_tokens = grep { defined } map { $get_unused_tokens->($_) } @check_users;
+    my @unused_tokens = grep { defined } map { $get_unused_tokens->($_) } keys %check_uids;
 
     $errors->add(
         '',

--- a/cgi-bin/DW/Controller/Rename.pm
+++ b/cgi-bin/DW/Controller/Rename.pm
@@ -290,7 +290,7 @@ sub handle_swap_post {
         journal     => $journal->ljuser_display,
         swapjournal => $swapjournal->ljuser_display
         }
-        unless $errors->exist;
+        unless $swap_errors->exist;
 
     # the list of errors should be present in the caller
     return 0;

--- a/cgi-bin/DW/User/Rename.pm
+++ b/cgi-bin/DW/User/Rename.pm
@@ -262,7 +262,7 @@ sub swap_usernames {
     }
 
     if ( scalar @tokens >= 2 ) {
-        $errors->add( 'token', 'rename.error.tokeninvalid' )
+        $errors->add( 'token', 'rename.error.tokenduplicate' )
             if ( $tokens[0]->token eq $tokens[1]->token );
     }
     else {


### PR DESCRIPTION
Fixes #2592.

I took the "better diagnostics" and "less work" changes suggested in the issue and implemented them. It would be too much bother to figure out how to reproduce the problem in testing, but I'm sure my approach is correct.

I also just spotted another potential bug where the wrong error variable is checked after calling swap_usernames, so I'll fix that here as well. (Both error variables point to the same object in the caller, so it was effectively equivalent despite being wrong.)