### PR TITLE
[#2591] don't accept community invites from a maintainer that the user has banned

### DIFF
--- a/cgi-bin/LJ/Community.pm
+++ b/cgi-bin/LJ/Community.pm
@@ -33,7 +33,10 @@ sub send_comm_invite {
     # step 1: if the user has banned the community, don't accept the invite
     return LJ::error('comm_user_has_banned') if $u->has_banned($cu);
 
-    # step 2: lazily clean out old community invites.
+    # step 2: if the user has banned the maintainer, don't accept the invite
+    return LJ::error('comm_user_has_banned') if $u->has_banned($mu);
+
+    # step 3: lazily clean out old community invites.
     return LJ::error('db') unless $u->writer;
     $u->do(
         'DELETE FROM inviterecv WHERE userid = ? AND '


### PR DESCRIPTION
It's the same "comm_user_has_banned" error message that the maintainer sees if the community itself was banned. I didn't see the benefit of adding a different message for this particular case.

The previous step 3 had gone missing, so order has been restored, or something.

Fixes #2591.