### PR TITLE
[#2735] Include "admin post" labels in new comment preview

### DIFF
--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -871,7 +871,7 @@ sub preview_parent_args {
             $poster      = $parentitem->poster->ljuser_display;
             $poster_name = $parentitem->poster->name_html;
 
-            if ( $parentitem->poster->user eq $entry->journal->user ) {
+            if ( $parentitem->poster->equals( $entry->journal ) ) {
                 $in_journal = '';
             }
         }
@@ -894,7 +894,7 @@ sub preview_parent_args {
         # Replying to entry
 
         my $in_journal =
-            $entry->poster->user eq $entry->journal->user ? '' : $entry->journal->ljuser_display;
+            $entry->poster->equals( $entry->journal ) ? '' : $entry->journal->ljuser_display;
 
         return {
             type        => 'entry',

--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -835,6 +835,7 @@ sub preview_comment_args {
         body        => $cleanbody,
         subject     => $cleansubject,
         icon        => $icon,
+        admin_post  => $comment->{admin_post},
     };
 
     return $preview;
@@ -864,9 +865,15 @@ sub preview_parent_args {
 
         my $poster      = 'Anonymous';
         my $poster_name = '';
+        my $in_journal  = $entry->journal->ljuser_display;
+
         if ( $parentitem->poster ) {
             $poster      = $parentitem->poster->ljuser_display;
             $poster_name = $parentitem->poster->name_html;
+
+            if ( $parentitem->poster->user eq $entry->journal->user ) {
+                $in_journal = '';
+            }
         }
 
         return {
@@ -875,20 +882,27 @@ sub preview_parent_args {
             subject     => $parentitem->subject_html,
             poster      => $poster,
             poster_name => $poster_name,
+            in_journal  => $in_journal,
+            admin_post  => $parentitem->prop('admin_post'),
             icon        => $userpic_tag->($parentitem),
-            time        => $parentitem->{datepost},       # convert?
+            time        => $parentitem->{datepost},
             url         => $parentitem->url,
             entry_url   => $entry->url,
         };
     }
     else {
         # Replying to entry
+
+        my $in_journal =
+            $entry->poster->user eq $entry->journal->user ? '' : $entry->journal->ljuser_display;
+
         return {
             type        => 'entry',
             body        => $entry->event_html,
             subject     => $entry->subject_html,
             poster      => $entry->poster->ljuser_display,
             poster_name => $entry->poster->name_html,
+            in_journal  => $in_journal,
             icon        => $userpic_tag->($entry),
             time        => $entry->eventtime_mysql,
             url         => $entry->url,

--- a/views/talkpost_do/preview_comment.tt
+++ b/views/talkpost_do/preview_comment.tt
@@ -51,6 +51,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
                                 [% END %]
                                 <span class="poster comment-poster">
                                     [% comment.poster %]
+                                    [% IF comment.admin_post %]
+                                        <span>(<span class="admin-post-icon">[% dw.img('admin-post') %]</span> as admin)</span>
+                                    [% END %]
                                 </span>
 
                                 [%# This is just lorem-ipsum so the spatial relationships look right. %]

--- a/views/talkpost_do/preview_parent.tt
+++ b/views/talkpost_do/preview_parent.tt
@@ -43,7 +43,14 @@ the same terms as Perl itself.  For a copy of the license, please reference
                         [% parent.icon %]
                     </div>
                     <div class="poster-info">
-                        <span class="poster entry-poster"> [% parent.poster_name %] ( [% parent.poster %] ) wrote </span>
+                        <span class="poster entry-poster"> [% parent.poster_name %] ([% parent.poster %]) wrote </span>
+                        [%- IF parent.in_journal %]
+                            in
+                            [% parent.in_journal %]
+                        [%- END -%]
+                        [% IF parent.admin_post %]
+                            <span>(<span class="admin-post-icon">[% dw.img('admin-post') %]</span> as admin)</span>
+                        [% END %]
                         <span class="datetime">
                             <span class="comment-date-text"></span>
                             <span> [% parent.time %] </span>


### PR DESCRIPTION
Fixes #2735 

I missed this the first time around! Admin post labels can appear on both the
WIP comment, and on the reply target.

I also missed the "in (journal)" label the first time around, so let's get that
in there too. Based on the siteviews S2 layout, that appears on both comments
and entries when they're posted somewhere other than the poster's own journal.
(Well, with comments that only appears when they're the target of a ReplyPage.
Entries get it on EntryPages as well.)

![Screenshot_2020-07-01 Comment Preview(5)](https://user-images.githubusercontent.com/484309/86318649-59674100-bbe7-11ea-82d8-21614cfe5c57.png)