### PR TITLE
fix Sphinx comment jobs

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -3168,7 +3168,7 @@ sub edit_comment {
     if (@LJ::SPHINX_SEARCHD) {
         push @jobs,
             TheSchwartz::Job->new_from_array( 'DW::Worker::Sphinx::Copier',
-            { userid => $journalu->id, jtalkid => $comment->{talkid}, source => "commtedt" } );
+            { userid => $journalu->id, jtalkid => $comment_obj->jtalkid, source => "commtedt" } );
     }
 
     DW::TaskQueue->dispatch(@jobs) if @jobs;


### PR DESCRIPTION
When the comment construction path was recently refactored, we missed a step and ended up submitting requests for Sphinx to reindex edited comment text without submitting the ID for finding the comment in the database, which is an unhappy outcome for all involved. This updates the job arguments to be valid again.

(This fix is already live in production since we had built up a backlog of over a million sphinx-copier jobs before we understood what was happening. The failure mode of not having the correct comment ID was to reindex the entire journal...)