### PR TITLE
SCSS: Replace tint and shade with mix

### DIFF
--- a/htdocs/scss/skins/_alert-colors-dark.scss
+++ b/htdocs/scss/skins/_alert-colors-dark.scss
@@ -1,6 +1,6 @@
 // shared colors for elements between themes
 $_gray:             #222;
-$_orange:           shade( #ffbc88, 20% );
+$_orange:           mix( #000000, #ffbc88, 20% );
 $_light-orange:     darken( #fff0e4, 8% );
 $_light-green:      darken( #e1eed7, 8% );
 $_light-yellow:     darken( #fbf9dd, 8% );

--- a/htdocs/scss/skins/_skin-colors.scss
+++ b/htdocs/scss/skins/_skin-colors.scss
@@ -17,10 +17,10 @@ $highlight-text-color: $body-font-color !default;
 // use an explicit value if it exists.
 
 $background-color-alternate:    darken( $background-color, 5% ) !default;
-$background-color-inactive:     tint( $inactive-color, 50% ) !default;
+$background-color-inactive:     mix( #ffffff, $inactive-color, 50% ) !default;
 $secondary-color-alternate:     darken( $secondary-color, 15% ) !default;
 $text-color-disabled:           scale-color($text-color, $lightness: 50%) !default;
-$anchor-font-color-visited:     shade( $anchor-font-color, 20% ) !default;
+$anchor-font-color-visited:     mix( #000000, $anchor-font-color, 20% ) !default;
 $page-title-color:              $primary-color !default;
 $border-color:                  $input-border-color !default;
 $screened-comment-bg:           $callout-panel-bg !default;
@@ -210,7 +210,7 @@ div.disabled, div.disabled * { color: $text-color-disabled; }
 // progress meter
 .progress-meter {
     li:before {
-        background-color: lighten( tint( $primary-color, 50% ), 10% );
+        background-color: lighten( mix( #ffffff, $primary-color, 50% ), 10% );
         color: $primary-text-color;
     }
 

--- a/htdocs/scss/skins/celerity.scss
+++ b/htdocs/scss/skins/celerity.scss
@@ -71,13 +71,13 @@ $header-font-color:                    lighten( $body-font-color, 5% );
 $list-side-margin:                     1em;
 
 // we want to base these on $body-font-color rather than the random variables they're based on
-$blockquote-font-color:                 tint( $body-font-color, 20% );
+$blockquote-font-color:                 mix( #ffffff, $body-font-color, 20% );
 $small-font-color:                      $body-font-color;
 
 // We use these to style anchors
 $anchor-text-decoration:               underline;
 $anchor-font-color:                    $link-color;
-$anchor-font-color-visited:            shade( $anchor-font-color, 30% );
+$anchor-font-color-visited:            mix( #000000, $anchor-font-color, 30% );
 $anchor-font-color-hover:              lighten( $anchor-font-color, 30% );
 
 // forms

--- a/htdocs/scss/skins/gradation/_gradation-base.scss
+++ b/htdocs/scss/skins/gradation/_gradation-base.scss
@@ -52,13 +52,13 @@ $header-font-color:                    darken( $body-font-color, 10% );
 $list-side-margin:                     1em;
 
 // we want to base these on $body-font-color rather than the random variables they're based on
-$blockquote-font-color:                 tint( $body-font-color, 20% );
+$blockquote-font-color:                 mix( #ffffff, $body-font-color, 20% );
 $small-font-color:                      $body-font-color;
 
 // We use these to style anchors
 $anchor-text-decoration:               underline;
 $anchor-font-color:                    $link-color;
-$anchor-font-color-visited:            shade( $anchor-font-color, 20% );
+$anchor-font-color-visited:            mix( #000000, $anchor-font-color, 20% );
 $anchor-font-color-hover:              lighten( $anchor-font-color, 30% );
 
 // forms
@@ -187,7 +187,7 @@ footer {
 
     p {
         font-size: small;
-        color: shade( $body-font-color, 20% );
+        color: mix( #000000, $body-font-color, 20% );
     }
 }
 


### PR DESCRIPTION
These functions were Compass-specific Ruby extensions to Sass. Compass is
deprecated abandonware, and using any of its gunk blocks any modernization of
the build toolchain.

mix() is a built-in Sass function. Learned this trick from the [compass-mixins-fixed](https://www.npmjs.com/package/compass-mixins-fixed) package (which I'd been planning to use, until I determined these were the only two Compass functions we were using). 

Tested this, and no visible differences in the site skins. Visited links are appropriately darkened, blockquote text is appropriately lightened. Doesn't affect compilation in any way either, but sets us up better for the future. 