### PR TITLE
Improve robustness of concat_res and cachebuster params

### DIFF
--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -1238,7 +1238,19 @@ sub load_file_for_concat {
     { local $/ = undef; $contents = <FILE>; }
     close FILE;
 
-    return [ $contents, $stat[7], $stat[9], $mime ];
+    # Remove UTF-8 byte-order mark, in case someone set us up the BOM. (It's not
+    # valid after the first position in a file, and can screw up syntax when
+    # concatenating.)
+    $contents =~ s/\A\x{ef}\x{bb}\x{bf}//;
+
+    # Add a newline, juuuust to be safe.
+    $contents .= "\n";
+
+    # If we were handling unicode properly, we'd need to encode before checking
+    # length... but we aren't.
+    my $size = length($contents);
+
+    return [ $contents, $size, $stat[9], $mime ];
 }
 
 sub adult_interstitial {

--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -221,7 +221,7 @@ sub send_concat_res_response {
 
     # Might contain cache buster "?v=3234234234" at the end;
     # plus possibly other unique args (caught by the .*)
-    $args =~ s/\?v=\d*.*$//;
+    $args =~ s/\?v=.*$//;
 
     # Collect each file
     my ( $body, $size, $mtime, $mime ) = ( '', 0, 0, undef );

--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -1220,8 +1220,8 @@ sub load_file_for_concat {
     my $mime;
     if ( $fn =~ /\.([a-z]+)$/ ) {
         $mime = {
-            css => 'text/css',
-            js  => 'application/javascript',
+            css => 'text/css; charset=utf-8',
+            js  => 'application/javascript; charset=utf-8',
         }->{$1};
     }
     return undef unless $mime;

--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -221,7 +221,7 @@ sub send_concat_res_response {
 
     # Might contain cache buster "?v=3234234234" at the end;
     # plus possibly other unique args (caught by the .*)
-    $args =~ s/\?v=\d+.*$//;
+    $args =~ s/\?v=\d*.*$//;
 
     # Collect each file
     my ( $body, $size, $mtime, $mime ) = ( '', 0, 0, undef );

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -2804,7 +2804,16 @@ sub js_dumper {
             return $mtime;
         };
 
-        my $file  = LJ::resolve_file("htdocs/$key");
+        my $file;
+
+        # Prefer the compiled version, but fall back to source
+        if ( defined $LJ::STATDOCS ) {
+            $file = $LJ::STATDOCS . '/' . $key;
+        }
+        else {
+            $file = LJ::resolve_file("htdocs/$key");
+        }
+
         my $mtime = defined $file ? ( stat($file) )[9] : undef;
         return $set->($mtime);
     }

--- a/etc/config-local.pl.example
+++ b/etc/config-local.pl.example
@@ -174,6 +174,9 @@
                              imageshack.us levkonoe.com wikimedia.org plurk.com
                            /;
 
+
+    # The expected location for compiled static assets; see bin/build-static.sh
+    $STATDOCS = "$HOME/build/static";
 }
 
 1;


### PR DESCRIPTION
- Allow empty `?v=` params without just exploding.
- Provide more useful `?v=` params by looking for files in the same place the real server does.
- Guard against file quirks that can trash things if you concatenate stuff without checking yourself. 