### PR TITLE
Add /dev/formats page

### DIFF
--- a/cgi-bin/DW/Formats.pm
+++ b/cgi-bin/DW/Formats.pm
@@ -33,36 +33,44 @@ our $default_format = 'html_casual1';
 # obsolete version => newest version:
 our %format_upgrades = ( html_casual0 => 'html_casual1', );
 
+# format hashref keys:
+# id: identifies formats everywhere, including the HTML cleaner.
+# name: displayed in web UI.
+# description and features: displayed on /dev/formats.
 our %formats = (
     html_casual0 => {
-        id   => 'html_casual0',
-        name => "Casual HTML (legacy 0)",
-        description =>
-"Text with normal line breaks, plus HTML tags for formatting. Doesn't support \@mentions.",
+        id          => 'html_casual0',
+        name        => "Casual HTML (legacy 0)",
+        features    => q{DW tags, auto linebreaks, auto links},
+        description => q{An older version of casual HTML that doesn't support @mentions.},
     },
     html_casual1 => {
-        id   => 'html_casual1',
-        name => "Casual HTML",
+        id       => 'html_casual1',
+        name     => "Casual HTML",
+        features => q{@mentions, DW tags, auto linebreaks, auto links},
         description =>
-            "Text with normal line breaks, plus \@mentions and HTML tags for formatting.",
+q{The classic default format: uses HTML tags for formatting, but automatically formats paragraphs.},
     },
     html_raw0 => {
-        id   => 'html_raw0',
-        name => "Raw HTML",
+        id       => 'html_raw0',
+        name     => "Raw HTML",
+        features => q{DW tags},
         description =>
-"Pre-formatted HTML. Doesn't automatically detect paragraph breaks, and doesn't support \@mentions.",
+q{Normal HTML, plus Dreamwidth's special <code>&lt;user&gt;</code> and <code>&lt;cut&gt;</code> tags. Doesn't automatically format paragraphs, and doesn't support @mentions.},
     },
     html_extra_raw => {
-        id   => 'html_extra_raw',
-        name => "Raw HTML (external source)",
+        id       => 'html_extra_raw',
+        name     => "Raw HTML (external source)",
+        features => q{none},
         description =>
-"Pre-formatted HTML from a feed or some other external source. Doesn't support special Dreamwidth tags like &lt;user&gt;.",
+q{Normal HTML from a feed or some other external source. Doesn't support any special Dreamwidth syntax, including tags like <code>&lt;user&gt;</code>.},
     },
     markdown0 => {
-        id   => 'markdown0',
-        name => "Markdown",
+        id       => 'markdown0',
+        name     => "Markdown",
+        features => q{Markdown syntax, @mentions, DW tags},
         description =>
-"Markdown, a lightweight text format that makes paragraphs from normal line breaks and provides shortcuts for the most common HTML tags. Supports \@mentions, and supports real HTML tags for more complex formatting.",
+q{A lightweight markup syntax that automatically formats paragraphs, provides shortcuts for the most common HTML tags, and allows inline HTML for more complex formatting. This implementation uses Perl's Text::Markdown module (which is very close to <a href="https://daringfireball.net/projects/markdown/">the original Markdown syntax</a>), plus some DW-specific extensions.},
     },
 );
 

--- a/cgi-bin/DW/Formats.pm
+++ b/cgi-bin/DW/Formats.pm
@@ -109,7 +109,7 @@ sub select_items {
 # Return the canonical version of the provided format ID if valid, empty string if not.
 sub validate {
     my $format = $_[0];
-    if ( $formats{$format} ) {
+    if ( $format && $formats{$format} ) {
         return $formats{$format}->{id};
     }
     else {
@@ -119,7 +119,7 @@ sub validate {
 
 sub is_active {
     my $format = $_[0];
-    if ( grep( $_ eq $format, @active_formats ) ) {
+    if ( $format && grep( $_ eq $format, @active_formats ) ) {
         return 1;
     }
     return 0;
@@ -127,7 +127,7 @@ sub is_active {
 
 sub display_name {
     my $format = $_[0];
-    if ( $formats{$format} ) {
+    if ( $format && $formats{$format} ) {
         return $formats{$format}->{name};
     }
     return "Unknown markup format";

--- a/views/dev/formats.tt
+++ b/views/dev/formats.tt
@@ -1,0 +1,82 @@
+[%# List of all markup formats and their aliases, for developers. (Normal users
+don't need all these details, and should learn a subset of this stuff from a faq
+page.)
+
+Authors:
+    Nick Fagerlund <nick.fagerlund@gmail.com>
+
+Copyright (c) 2020 by Dreamwidth Studios, LLC.
+
+This program is free software; you may redistribute it and/or modify it under
+the same terms as Perl itself.  For a copy of the license, please reference
+'perldoc perlartistic' or 'perldoc perlgpl'.
+-%]
+
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%- sections.title = "Markup Formats" -%]
+
+<h2>About Formats</h2>
+
+<p>Dreamwidth supports a handful of different markup formats for user-submitted text like entries and comments. The format ID is stored alongside the text of each item, and it determines how we transform the user's raw text when displaying it on the web.</p>
+
+<p>Some formats have multiple versions — we sometimes want to change how the markup rules work going forward, so we retain the old versions to preserve any content written before the changes took effect.</p>
+
+<p>Some formats also have aliases, either to preserve some existing behavior or as a convenience for requesting the current version of a format. When content is submitted with an aliased format, it gets saved as the canonical ID that the alias currently resolves to.</p>
+
+<p>A subset of formats are marked as "active." Although any format can be used in contexts that accept a raw format ID, the web UI's format selectors only display the active formats. (When editing old content that already uses an inactive format, that format is also included in the UI.)</p>
+
+<h2>Contents</h2>
+
+<ul>
+    <li>Active Formats
+        <ul>
+            [% FOREACH format = active_formats %]
+                <li><a href="#[% format.id %]">[% format.id %]</a></li>
+            [% END %]
+        </ul>
+    </li>
+
+    <li>Other Formats
+        <ul>
+            [% FOREACH format = other_formats %]
+                <li><a href="#[% format.id %]">[% format.id %]</a></li>
+            [% END %]
+        </ul>
+    </li>
+</ul>
+
+<h2>Active Formats</h2>
+
+<dl>
+[% FOREACH format = active_formats -%]
+    [% INCLUDE print_format %]
+[%- END -%]
+</dl>
+
+<h2>Other Formats</h2>
+
+<dl>
+[% FOREACH format = other_formats -%]
+    [% INCLUDE print_format %]
+[%- END -%]
+</dl>
+
+[%- BLOCK print_format -%]
+    <dt id="[% format.id %]">[% format.id %]</dt>
+    <dd>
+        <p>[% format.description %]</p>
+        <h5>Display Name:</h5>
+        <p>[% format.name %]</p>
+        [% IF format.features -%]
+            <h5>Features:</h5>
+            <p>[% format.features %]</p>
+        [%- END %]
+        [% IF aliases.${format.id} -%]
+            <h5>Aliases:</h5>
+            <ul>
+                [% FOREACH alias = aliases.${format.id} %]<li>[% alias %]</li>[% END %]
+            </ul>
+        [%- END %]
+    </dd>
+[%- END -%]


### PR DESCRIPTION
The user-facing docs for formats will be in the faq, but we'll still need a sort
of escape hatch with full details for developers, API users, folks with odd
email posting scripts, or others who might have a reason to provide a raw format
ID instead of picking an active format from the drop-down. So let's generate
that page directly from the code so it's always up-to-date, and link to it from
a footnote in the faq page.

/dev/ seems like the correct parent path for this.

<details><summary>Screenshot</summary>

Try and ignore the `rich1` business, that's from experiments in another branch and I didn't feel like resetting my entire dev server. 😅

![image](https://user-images.githubusercontent.com/484309/86962227-61f3d600-c117-11ea-9692-80a95d9ca92d.png)

</details>