### PR TITLE
Lay some mojibake traps around the inbox and front page

### DIFF
--- a/cgi-bin/DW/Widget/LatestInbox.pm
+++ b/cgi-bin/DW/Widget/LatestInbox.pm
@@ -76,6 +76,7 @@ sub render_body {
     }
 
     $ret .= "</div>";
+    LJ::warn_for_perl_utf8($ret);
     return $ret;
 }
 

--- a/cgi-bin/DW/Widget/LatestNews.pm
+++ b/cgi-bin/DW/Widget/LatestNews.pm
@@ -101,6 +101,7 @@ sub render_body {
 
     $ret .= "</div>";
 
+    LJ::warn_for_perl_utf8($ret);
     return $ret;
 }
 

--- a/cgi-bin/DW/Widget/RecentlyActiveComms.pm
+++ b/cgi-bin/DW/Widget/RecentlyActiveComms.pm
@@ -61,6 +61,7 @@ sub render_body {
     $ret .= "<li><em> " . BML::ml('widget.comms.notavailable') . "</em></li>" unless $ct;
     $ret .= "</ul>\n";
 
+    LJ::warn_for_perl_utf8($ret);
     return $ret;
 }
 

--- a/cgi-bin/DW/Widget/UserTagCloud.pm
+++ b/cgi-bin/DW/Widget/UserTagCloud.pm
@@ -46,6 +46,8 @@ sub render_body {
     }
 
     $ret .= LJ::tag_cloud($tag_items);
+
+    LJ::warn_for_perl_utf8($ret);
     return $ret;
 }
 

--- a/cgi-bin/LJ/Event/JournalNewComment.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment.pm
@@ -268,7 +268,8 @@ sub content_summary {
     return undef unless $self->_can_view_content( $comment, $target );
 
     my $body_summary = $comment->body_html_summary(300);
-    my $ret          = $body_summary;
+    LJ::warn_for_perl_utf8($body_summary);
+    my $ret = $body_summary;
     $ret .= "..." if $comment->body_html ne $body_summary;
 
     if ( $comment->is_edited ) {
@@ -278,9 +279,11 @@ sub content_summary {
             { reason => $reason } )
             . "</div>"
             if $reason;
+        LJ::warn_for_perl_utf8($ret);
     }
 
     $ret .= $self->as_html_actions;
+    LJ::warn_for_perl_utf8($ret);
 
     return $ret;
 }
@@ -311,9 +314,12 @@ sub as_html {
     my $url = $comment->url;
 
     my $in_text = '<a href="' . $entry->url . "\">$entry_subject</a>";
+    LJ::warn_for_perl_utf8($in_text);
     my $subject = $comment->subject_text ? ' "' . $comment->subject_text . '"' : '';
+    LJ::warn_for_perl_utf8($subject);
 
     my $poster = $comment->poster ? "by $pu" : '';
+    LJ::warn_for_perl_utf8($poster);
     my $ret;
     if ( $comment->is_edited ) {
         $ret = "Edited <a href=\"$url\">comment</a> $subject $poster on $in_text in $ju.";

--- a/cgi-bin/LJ/TextUtil.pm
+++ b/cgi-bin/LJ/TextUtil.pm
@@ -17,6 +17,8 @@ use strict;
 use LJ::ConvUTF8;
 use HTML::TokeParser;
 use HTML::Entities;
+use Carp qw(cluck);
+use Encode;
 
 # <LJFUNC>
 # name: LJ::trim
@@ -312,6 +314,16 @@ sub is_ascii {
     my $text = $_[0];
     return 1 unless defined $text;
     return ( $text !~ m/[^\x01-\x7f]/ );
+}
+
+# Logs a warning if text has Perl's internal UTF8 flag set, so we can track it
+# down later. This is intended for debugging problems on prod that can't be
+# reproduced in dev.
+sub warn_for_perl_utf8 {
+    my $text = $_[0];
+    if ( Encode::is_utf8($text) ) {
+        cluck("MOJIBAKE ALERT: Found text with Perl UTF8 flag set!");
+    }
 }
 
 # <LJFUNC>

--- a/cgi-bin/LJ/Widget/InboxFolder.pm
+++ b/cgi-bin/LJ/Widget/InboxFolder.pm
@@ -231,6 +231,7 @@ sub render_body {
             $content_div = qq {
                 <div class="InboxItem_Content usercontent" style="display: $display;">$contents</div>
                 };
+            LJ::warn_for_perl_utf8($content_div);
         }
 
         $messagetable .= qq {
@@ -273,6 +274,7 @@ sub render_body {
         . $class->ml('widget.inboxfolder.confirm.delete')
         . "';</script>";
 
+    LJ::warn_for_perl_utf8($msgs_body);
     return $msgs_body;
 }
 

--- a/cgi-bin/LJ/Widget/InboxFolderNav.pm
+++ b/cgi-bin/LJ/Widget/InboxFolderNav.pm
@@ -126,6 +126,7 @@ sub render_body {
             </p></div>&nbsp;<br />
     };
 
+    LJ::warn_for_perl_utf8($body);
     return $body;
 }
 


### PR DESCRIPTION
(Although, perhaps it's krakozyabry rather than mojibake, since it's been our Cyrillic users running into this.)



There's a persistent problem of mojibake on the front page and inbox _under
certain unknown conditions on prod that no devs have managed to reproduce yet._
There's early evidence that strings from the translation system might have been
causing _some_ of this, but there still seem to be some instances hanging
around.

If we can figure out which choke-points the contaminated strings are passing
through, we can maybe start following them back to their lair.