### PR TITLE
Site skin comments: set vertical-align: middle on icon links

### DIFF
--- a/htdocs/scss/skins/_entry-styles.scss
+++ b/htdocs/scss/skins/_entry-styles.scss
@@ -49,6 +49,10 @@ ul.text-links {
   }
 }
 
+.icon-links img {
+  vertical-align: middle;
+}
+
 .bottomcomment,
 .entry .footer .inner,
 .comment-pages {


### PR DESCRIPTION
Another stealth casualty of removing that global vertical-align: middle rule.

before:

![Screenshot_2020-07-08 dw_maintenance Code push Saturday, June 27th, 4pm Pacific 11pm UTC(2)](https://user-images.githubusercontent.com/484309/86998251-d5700480-c164-11ea-9748-9d15a72f38d1.png)

fixed:

![Screenshot_2020-07-08 dw_maintenance Code push Saturday, June 27th, 4pm Pacific 11pm UTC](https://user-images.githubusercontent.com/484309/86998265-dbfe7c00-c164-11ea-8c12-80d517d58e51.png)

before: 

![Screenshot_2020-07-08 dw_maintenance Code push Saturday, June 27th, 4pm Pacific 11pm UTC(3)](https://user-images.githubusercontent.com/484309/86998274-e0c33000-c164-11ea-9a31-0365523a0b6d.png)

fixed:

![Screenshot_2020-07-08 dw_maintenance Code push Saturday, June 27th, 4pm Pacific 11pm UTC(1)](https://user-images.githubusercontent.com/484309/86998281-e587e400-c164-11ea-9b5c-b42de0eabef0.png)