### PR TITLE
Fix link colors in `th` elements that occur in a `tbody`

### DIFF
--- a/htdocs/scss/skins/_page-layout-hacks.scss
+++ b/htdocs/scss/skins/_page-layout-hacks.scss
@@ -32,15 +32,15 @@ ul.successlinks li {
 }
 
 // fix for illegible table header links
-[id="content"] table th a {
+[id="content"] table thead th a {
     color: $primary-text-color;
 }
 
-[id="content"] table th a:visited {
+[id="content"] table thead th a:visited {
     color: $secondary-color;
 }
 
-[id="content"] table th a:hover, [id="content"] table th a:visited:hover {
+[id="content"] table thead th a:hover, [id="content"] table thead th a:visited:hover {
     color: $highlight-color;
 }
 


### PR DESCRIPTION
This hack was to work around the fact that Foundation puts a background color on
the `thead` that matches the link color in the rest of the document. But `th`
cells can also occur in the `tbody` (to act as a header for a row instead of a
column), in which case we want the normal link color. So restrict the reversed
links to the `thead` where they're needed.

Relevant to https://www.dreamwidth.org/support/see_request?id=42173