### PR TITLE
add and use has_response method for DW::Captcha

### DIFF
--- a/cgi-bin/DW/Captcha.pm
+++ b/cgi-bin/DW/Captcha.pm
@@ -250,4 +250,14 @@ sub page      { return $_[0]->{page} }
 sub challenge { return $_[0]->{challenge} }
 sub response  { return $_[0]->{response} }
 
+# return true if the captcha has a valid response
+# (use this instead of "if response" since correct response might be 0)
+sub has_response {
+    my ($self) = @_;
+    my $resp = $self->response;
+
+    # this should only be false if the response is empty or zero characters
+    return defined $resp && length $resp ? 1 : 0;
+}
+
 1;

--- a/cgi-bin/DW/Captcha.pm
+++ b/cgi-bin/DW/Captcha.pm
@@ -173,6 +173,10 @@ Challenge text, provided by the CAPTCHA implementation
 
 User-provided response text
 
+=head2 C<< $captcha->has_response >>
+
+Tests for existence of user-provided response text, returns true/false
+
 =cut
 
 # must be implemented by subclasses

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2839,7 +2839,7 @@ sub prepare_and_validate_comment {
     my $captcha = DW::Captcha->new( undef, %{ $content || {} } );
 
     # are they sending us a response? Check it.
-    if ( $captcha->enabled && $captcha->response ) {
+    if ( $captcha->enabled && $captcha->has_response ) {
 
         # If this isn't their final pass through the form, they'll need a captcha next time too.
         $$need_captcha = 1;

--- a/htdocs/register.bml
+++ b/htdocs/register.bml
@@ -101,7 +101,7 @@ body<=
      if ( $u->is_identity ) {
         my $captcha = DW::Captcha->new( 'validate_openid', %POST );
 
-        if ( $captcha->response ) {
+        if ( $captcha->has_response ) {
             return LJ::bad_input( "error.invalidform" ) unless LJ::check_form_auth() && $captcha->enabled;
             my $err_ref;
             return LJ::bad_input( $err_ref )


### PR DESCRIPTION
I'm very grateful for @pinterface's illuminating comments on this issue, since I clearly whiffed when I failed to look outside the DW::Captcha module the last time I investigated this problem.

I took the advice about adding a has_response method and used it in the two places that were checking `if ( $captcha->response )` previously.

Fixes #2739.