### PR TITLE
[#2565] fix malformed pagination links when working as a community

### DIFF
--- a/cgi-bin/DW/Controller/Comments.pm
+++ b/cgi-bin/DW/Controller/Comments.pm
@@ -49,7 +49,7 @@ sub received_handler {
     my $vars;
     $vars->{u}           = $u;
     $vars->{authas_html} = $rv->{authas_html};
-    $vars->{getextra}    = ( $u ne $remote ) ? ( "?authas=" . $u->user ) : '';
+    $vars->{getextra}    = ( $u ne $remote ) ? { authas => $u->user } : {};
 
     my %LJ_cmtinfo = %{ LJ::Comment->info($u) };
     $LJ_cmtinfo{form_auth} = LJ::form_auth(1);
@@ -264,7 +264,7 @@ sub posted_handler {
     my $vars;
     $vars->{u}           = $u;
     $vars->{authas_html} = $rv->{authas_html};
-    $vars->{getextra}    = ( $u ne $remote ) ? ( "?authas=" . $u->user ) : '';
+    $vars->{getextra}    = ( $u ne $remote ) ? { authas => $u->user } : {};
 
     my %LJ_cmtinfo = %{ LJ::Comment->info($u) };
     $LJ_cmtinfo{form_auth} = LJ::form_auth(1);

--- a/views/comments/posted.tt
+++ b/views/comments/posted.tt
@@ -32,14 +32,15 @@ the same terms as Perl itself. For a copy of the license, please reference
 [% IF u.is_person %]
     [[% '.latest.posted' | ml %]]
 [% END %]
-[<a href='[% site.root %]/manage/comments[% getextra %]'>[% '.managesettings' | ml %]</a>]<br />
+[<a href='[% dw.create_url( "/manage/comments", args => getextra ) %]'>[% '.managesettings' | ml %]</a>]<br />
 [% '.view.latest' | ml %] [
 [% FOREACH val = values %]
     [% IF val <= max %]
         [% IF val == count %]
             <b>[% val %]</b>
         [% ELSE %]
-            <a href='?show=[% val %][% getextra %]'>[% val %]</a>
+            [%- getextra.show = val -%]
+            <a href='[% dw.create_url( undef, args => getextra ) %]'>[% val %]</a>
         [% END %]
     [% END %]
 [% END %]

--- a/views/comments/recent.tt
+++ b/views/comments/recent.tt
@@ -32,14 +32,15 @@ the same terms as Perl itself. For a copy of the license, please reference
         [<a href='[% site.root %]/comments/posted'>[% '.latest.posted' | ml %]</a>]
     [% END %]
 [% END %]
-[<a href='[% site.root %]/manage/comments[% getextra %]'>[% '.managesettings' | ml %]</a>]<br />
+[<a href='[% dw.create_url( "/manage/comments", args => getextra ) %]'>[% '.managesettings' | ml %]</a>]<br />
 [% '.view.latest' | ml %] [
 [% FOREACH val = values %]
     [% IF val <= max %]
         [% IF val == count %]
             <b>[% val %]</b>
         [% ELSE %]
-            <a href='?show=[% val %][% getextra %]'>[% val %]</a>
+            [%- getextra.show = val -%]
+            <a href='[% dw.create_url( undef, args => getextra ) %]'>[% val %]</a>
         [% END %]
     [% END %]
 [% END %]


### PR DESCRIPTION
Not wanting to manually construct query strings is why we wrote the create_url function.

Fixes #2565.