### PR TITLE
new function LJ::CleanHTML::legacy_markdown

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -850,7 +850,7 @@ sub _backend_to_form {
     # except that if we're detecting old-style !markdown, we DO want to also
     # mutate the body text, which makes it hairy.
     unless ($editor) {
-        if ( $event =~ s/^\s*!markdown\s*\r?\n//s ) {
+        if ( LJ::CleanHTML::legacy_markdown( \$event ) ) {    # mutates $event
             $editor = 'markdown0';
         }
         elsif ( $entry->prop('opt_preformatted') ) {

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1646,7 +1646,7 @@ sub clean_event {
 
     # ...and if not, here's how we guess.
     if ( !$formatting ) {
-        if ( $$ref =~ s/^\s*!markdown\s*\r?\n//s ) {
+        if ( legacy_markdown($ref) ) {
 
             # Old-style Markdown: remove the special !markdown prefix,
             # and switch to Markdown formatting.
@@ -2035,6 +2035,13 @@ sub user_link_html {
     else {
         return "<b>[Unknown site tag]</b>";
     }
+}
+
+# detect and remove "!markdown" at beginning of entry text;
+# return true if the marker was found, false otherwise
+sub legacy_markdown {
+    my ($ref) = @_;
+    return $$ref =~ s/^\s*!markdown\s*\r?\n//is;
 }
 
 1;


### PR DESCRIPTION
The first commit defines LJ::CleanHTML::legacy_markdown in order to have the regular expression defined in a single place. The regexp is now case-insensitive, which fixes #2419. I tested this and confirmed that using `!Markdown` with a capital M now works as expected.

The second commit I'm less sure about. It uses LJ::CleanHTML::legacy_markdown when fetching entry text for the sphinx index, so that searching for "markdown" won't hit every entry formatted with markdown using the old syntax. That fixes #2385, in theory. Unfortunately, this only removes the text at the time of indexing, so older results will still turn up unless they get reindexed. Furthermore, the markdown formatting will appear uninterpolated in the results, since we just stripped out the indicator, but that seems okay under the circumstances? I don't know, it's a tradeoff. I wasn't able to test this at all since I don't have Sphinx set up.

(Fun fact: searching for your favorite multicharacter HTML tag will match on every entry that uses that tag, since all the HTML content is indexed as well. It's a more general problem that might benefit from a more general solution.)