### PR TITLE
[#2326] remove extra blank dropdown menu entry in subscription filters

### DIFF
--- a/htdocs/js/subfilters.js
+++ b/htdocs/js/subfilters.js
@@ -592,7 +592,7 @@ function compareFilters( a, b ) {
 
 function cfUpdateFilterSelect() {
     // regenerate HTML for the Filter: dropdown
-    var options = '<option value="0">( select filter )</option><option value="0"></option>';
+    var options = '<option value="0">( select filter )</option>';
 
     // sort by sortorder, then name
     var sortedFilters = [];


### PR DESCRIPTION
I had a brief moment of panic when I saw this menu was constructed in JS, but I tracked down the culprit eventually.

Fixes #2326.