### PR TITLE
Fix comment-eating form_auth expiry bug

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -838,6 +838,8 @@ error.invalidauth=You couldn't be authenticated as the specified account.
 
 error.invalidform=Invalid form submission.  Please go back and try again.
 
+error.invalidform.quickerreply=The form on this page expired. Use the "More Options" button to get a fresh form, then try posting again.
+
 error.invaliduser=Unable to load specified user.
 
 error.ipbanned=Your IP address is temporarily banned for exceeding the log in failure rate.

--- a/cgi-bin/DW/Controller/RPC/Misc.pm
+++ b/cgi-bin/DW/Controller/RPC/Misc.pm
@@ -307,7 +307,7 @@ sub addcomment_handler {
     my $r      = DW::Request->get;
     my $post   = $r->post_args;
 
-    return DW::RPC->err( LJ::Lang::ml('error.invalidform') )
+    return DW::RPC->err( LJ::Lang::ml('error.invalidform.quickerreply') )
         if $r->did_post && !LJ::check_form_auth( $post->{lj_form_auth} );
 
     # build the comment

--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -222,7 +222,7 @@ sub talkpost_do_handler {
         push @errors, "You chose to cancel your identity verification"
             if $csr->user_cancel;
     }
-    elsif ( !LJ::did_post() ) {
+    elsif ( !$r->did_post ) {
 
         # If it's a GET and you're NOT coming back from the OpenID dance, wyd
         return error_ml('/talkpost_do.tt.error.badrequest');

--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -158,10 +158,9 @@ DW::Routing->register_string( '/talkpost_do', \&talkpost_do_handler, app => 1 );
 
 sub talkpost_do_handler {
 
-    # This route handles form_auth manually instead of passing form_auth => 1 to
-    # controller() -- we want to fail gently AFTER we have our post args, so we
-    # can regenerate the comment form and not lose your text.
-    my ( $ok, $rv ) = controller( anonymous => 1 );
+    # This route handles form_auth manually; we want to get the post args, fail
+    # gently, regenerate the comment form, and not lose your text.
+    my ( $ok, $rv ) = controller( form_auth => 0, anonymous => 1 );
     return $rv unless $ok;
 
     my $r      = $rv->{r};

--- a/cgi-bin/DW/Controller/Talk.pm
+++ b/cgi-bin/DW/Controller/Talk.pm
@@ -198,15 +198,21 @@ sub talkpost_do_handler {
             push @errors, LJ::Lang::ml('/talkpost_do.tt.error.invalidform');
         }
     }
-    elsif (( $GET->{'openid.mode'} eq 'id_res' || $GET->{'openid.mode'} eq 'cancel' )
-        && $GET->{jid}
-        && $GET->{pendcid} )
-    {
+    elsif ( my $mode = $GET->{'openid.mode'} ) {
+
         # If they're coming back from an OpenID identity server, restore the
         # POST hash we saved before they left.
+
+        unless ( $GET->{jid}
+            && $GET->{pendcid}
+            && ( $mode eq 'id_res' || $mode eq 'cancel' ) )
+        {
+            return error_ml('/talkpost_do.tt.error.badrequest');
+        }
+
         my $csr = LJ::OpenID::consumer( $GET->mixed );
 
-        if ( $GET->{'openid.mode'} eq 'id_res' ) {    # Verify their identity
+        if ( $mode eq 'id_res' ) {    # Verify their identity
 
             unless ( LJ::check_referer( '/talkpost_do', $GET->{'openid.return_to'} ) ) {
                 return error_ml( '/openid/login.tt.error.invalidparameter',


### PR DESCRIPTION
Controller's automatic form_auth handling happens too early, so it ends up
throwing away your WIP comment if your form expires, and then you're at the
mercy of your back button cache. To protect the text, we need to handle
form_auth manually after we have our POST args.

This was handled properly in the old talkpost_do.bml, but it broke during
the big update because I didn't understand the timing implications. (I guess it
technically broke in the initial conversion, but
de8ce76 was where I removed the old
implementation.)

I'm being a bit more conservative than the old version -- if form_auth fails,
we won't even try and validate your identity, because let's NOT do anything with
side-effects if we think something sketchy is going on. (Letting you start the
OpenID flow from a known-bad state seems especially dodgy.) And without your
identity, there's not much point in trying to validate your comment, so we'll
skip that too. Basically I'm treating form_auth failure as "slightly more fatal"
than all of the other negotiably-fatal errors that we let you recover from.