### PR TITLE
[#2755] Fix wonky pagination links in s2foundation

### DIFF
--- a/htdocs/scss/skins/_compatibility-styles.scss
+++ b/htdocs/scss/skins/_compatibility-styles.scss
@@ -7,6 +7,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    text-align: center;
 
     margin-top: 20px;
     margin-bottom: 20px;

--- a/styles/siteviews/layout.s2
+++ b/styles/siteviews/layout.s2
@@ -54,7 +54,7 @@ function ItemRange::print(string{} opts) {
     var string anchor = $opts{"anchor"} ? "#$opts{"anchor"}" : "";
     var string class = $opts{"class"} ? $opts{"class"} : "action-box";
 
-    """<div class="$class">""";
+    """<div class="$class"><div>""";
     print """<p style="font-weight: bolder; margin: 0 0 .5em 0;">""" + lang_page_of_pages($.current, $.total) + "</p>";
     var string url_prev = $this->url_of($.current - 1);
     """<span class="page-prev">""";
@@ -86,7 +86,7 @@ function ItemRange::print(string{} opts) {
         """<p><a href="$.url_all">View All</a></p>""";
     }
 
-    "</div>";
+    "</div></div>";
 }
 
 # IconsPage


### PR DESCRIPTION
Fixes #2755

So tbh, I really wanted to shim in a call to the components/pagination.tt
template instead, and just replace that whole custom situation. But the scope of
that started ballooning out of control, so let's fix the immediate grossness the
easy way, and maybe we can come back to that after we've totally ripped out the
nos2foundation siteviews styles.

Using an `.action-box` without an `.inner` (for the tinted background) seems
weird, but it was already doing that, so that's one more question for another
day.

**Fixed:**

![image](https://user-images.githubusercontent.com/484309/87258345-aead1900-c457-11ea-9463-cb4e221c19de.png)

**No s2foundation:** (aka what we're copying)

![nos2foundation](https://user-images.githubusercontent.com/1976742/87236916-c2ec0a00-c3b4-11ea-97ae-331cc338c9c3.png)

**Before the fix:**

![unfixed](https://user-images.githubusercontent.com/1976742/87236919-c7182780-c3b4-11ea-9628-dda054f3cc41.png)