### PR TITLE
[#2762] .bml requests for converted pages should be handled, not 404

### DIFF
--- a/cgi-bin/DW/Routing.pm
+++ b/cgi-bin/DW/Routing.pm
@@ -110,6 +110,11 @@ sub get_call_opts {
     ( $uri, $format ) = ( $1, $2 )
         if $uri =~ m/^(.+?)\.([a-z]+)$/;
 
+    # redirect to html if the caller requested bml from an ancient link
+    if ( $format && $format eq 'bml' ) {
+        $format = 'html';
+    }
+
     # Role determination: if the URL starts with '/api/vX' then it's an API
     # call, and we should extract that information for our call options.
     if ( $uri =~ m!^/api/v(\d+)(/.+)$! ) {

--- a/cgi-bin/DW/Routing.pm
+++ b/cgi-bin/DW/Routing.pm
@@ -110,9 +110,9 @@ sub get_call_opts {
     ( $uri, $format ) = ( $1, $2 )
         if $uri =~ m/^(.+?)\.([a-z]+)$/;
 
-    # redirect to html if the caller requested bml from an ancient link
+    # discard format if the caller requested bml from an ancient link
     if ( $format && $format eq 'bml' ) {
-        $format = 'html';
+        $format = undef;
     }
 
     # Role determination: if the URL starts with '/api/vX' then it's an API


### PR DESCRIPTION
This fixes #2762 in my testing, by continuing to treat /page.bml as a valid link to a controller registered with /page.