### PR TITLE
[#2764] remove bml suffix from faqbrowse links in site configs

### DIFF
--- a/cgi-bin/redirect.dat
+++ b/cgi-bin/redirect.dat
@@ -1,10 +1,10 @@
 /community.bml                      /community/
 /communities                        /community/
 /support.bml                        /support/
-/memories.bml                       /tools/memories.bml
-/memadd.bml                         /tools/memadd.bml
-/faq.bml                            /support/faq.bml
-/faqbrowse.bml                      /support/faqbrowse.bml
+/memories.bml                       /tools/memories
+/memadd.bml                         /tools/memadd
+/faq.bml                            /support/faq
+/faqbrowse.bml                      /support/faqbrowse
 /customize/advanced.bml             /customize/
 /customize/preview.bml              /customize/
 /customize/style.bml                /customize/

--- a/etc/kubernetes/web/secrets/config-local.pl
+++ b/etc/kubernetes/web/secrets/config-local.pl
@@ -32,7 +32,7 @@
     # if you define these, little help bubbles appear next to common
     # widgets to the URL you define:
     %HELPURL = (
-        paidaccountinfo => "https://www.dreamwidth.org/support/faqbrowse.bml?faqid=4",
+        paidaccountinfo => "https://www.dreamwidth.org/support/faqbrowse?faqid=4",
     );
 
     # Configuration for suggestions community & adminbot


### PR DESCRIPTION
See also dreamwidth/dw-nonfree#138.

Fixes #2764.