### PR TITLE
The last great woodchuck hunt

### DIFF
--- a/htdocs/scss/pages/entry/new.scss
+++ b/htdocs/scss/pages/entry/new.scss
@@ -229,11 +229,9 @@
 
     input, select, textarea {
         #canvas & { // exclude from Lynx skin
-            font-size: .8rem;
-        }
-        @media (pointer: coarse) {
-            // dramatic woodchuck deterrent for mobile, still relevant on Lynx
-            font-size: 16px;
+            @media (pointer: fine) { // Desktop only, don't attract woodchucks.
+                font-size: .8rem;
+            }
         }
     }
 
@@ -295,10 +293,8 @@
     }
 
     button { // match sizes of nearby inputs
-        font-size: .8rem;
-
-        @media (pointer: coarse) {
-            font-size: 16px;
+        @media (pointer: fine) {
+            font-size: .8rem;
         }
     }
 

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -857,6 +857,13 @@ ul.userlite-interaction-links.text-links {
 
 .tags_cloud li, .module-tags_cloud li { display: inline; }
 
+/* avoid Dramatic Woodchuck zoom effect on form fields (polls, search, etc.) */
+@media (pointer: coarse) {
+    input[type="text"], select {
+        font-size: 16px;
+    }
+}
+
 $userpic_css
     """;
 }


### PR DESCRIPTION
Fixes #2421 

This bug has been open long enough, and I haven't run across too many more of these, so let's just call it a day. 

- Fixes woodchuck in the little panel components on beta create entries. (I think that might have been fixed for a while, but I messed up the selector specificity during the Lynx de-make. This fix should be more robust.) 
- Fixes woodchuck for poll fields and the journal search field in core2base's default stylesheet. Hopefully that should deal with the issue for the styles that inherit from Tabula Rasa? (Which seems to be all of the most "modern" styles -- most of the non-rasa styles have enough other stuff wrong with them on mobile that a little woodchucking shouldn't be too surprising.)

I think I was putting this off because I wanted to Fix Poll Formatting For Good, but on further thought that's a whole other task, and it wouldn't touch the same stuff anyway.