### PR TITLE
Improve display of polls

### DIFF
--- a/cgi-bin/LJ/Poll.pm
+++ b/cgi-bin/LJ/Poll.pm
@@ -1060,7 +1060,7 @@ sub render {
             }
         }
 
-        $results_table .= "<div style='margin: 10px 0 10px 40px' class='poll-response'>";
+        $results_table .= "<div style='margin: 10px 0 10px 5%;' class='poll-response'>";
 
         ### get statistics, for scale questions
         my ( $valcount, $valmean, $valstddev, $valmedian );
@@ -1154,7 +1154,8 @@ sub render {
                     'maxlength' => $max,
                     'class'     => "poll-$pollid",
                     'name'      => "pollq-$qid",
-                    'value'     => $prevanswer
+                    'value'     => $prevanswer,
+                    'style'     => 'max-width: 100%; box-sizing: border-box;',
                 }
             );
         }
@@ -1172,7 +1173,8 @@ sub render {
                 {
                     'name'     => "pollq-$qid",
                     'class'    => "poll-$pollid",
-                    'selected' => $prevanswer
+                    'selected' => $prevanswer,
+                    'style'    => 'max-width: 100%; box-sizing: border-box;',
                 },
                 @optlist
             );
@@ -1237,7 +1239,8 @@ sub render {
                     {
                         'name'     => "pollq-$qid",
                         'class'    => "poll-$pollid",
-                        'selected' => $prevanswer
+                        'selected' => $prevanswer,
+                        'style'    => 'max-width: 100%; box-sizing: border-box;',
                     },
                     @optlist
                 );

--- a/cgi-bin/LJ/Poll.pm
+++ b/cgi-bin/LJ/Poll.pm
@@ -1186,43 +1186,29 @@ sub render {
             my $count     = int( ( $to - $from ) / $by ) + 1;
             my $do_radios = ( $count <= 11 );
 
-            # few opts, display radios
             if ($do_radios) {
 
-                $results_table .= "<table summary=''><tr valign='top' align='center'>";
-
-                # appends the lower end
-                $results_table .= "<td style='padding-right: 5px;'><b>$lowlabel</b></td>"
-                    if defined $lowlabel;
-
+                # few opts, display radios
+                my @all_values;
                 for ( my $at = $from ; $at <= $to ; $at += $by ) {
-
-                    my $selectedanswer =
-                        !$clearanswers && ( defined $preval{$qid} && $at == $preval{$qid} );
-                    $results_table .= "<td style='text-align: center;'>";
-                    $results_table .= LJ::html_check(
-                        {
-                            'type'     => 'radio',
-                            'name'     => "pollq-$qid",
-                            'class'    => "poll-$pollid",
-                            'value'    => $at,
-                            'id'       => "pollq-$pollid-$qid-$at",
-                            'selected' => $selectedanswer
-                        }
-                    );
-                    $results_table .= "<br /><label for='pollq-$pollid-$qid-$at'>$at</label></td>";
+                    push @all_values, $at;
                 }
+                $results_table .= DW::Template->template_string(
+                    'poll/scale_radio.tt',
+                    {
+                        lowlabel       => $lowlabel,
+                        highlabel      => $highlabel,
+                        selectedanswer => $clearanswers ? '' : ( $preval{$qid} // '' ),
+                        pollid         => $pollid,
+                        qid            => $qid,
+                        values         => \@all_values,
+                    }
+                );
 
-                # appends the higher end
-                $results_table .= "<td style='padding-left: 5px;'><b>$highlabel</b></td>"
-                    if defined $highlabel;
-
-                $results_table .= "</tr></table>\n";
-
-                # many opts, display select
-                # but only if displaying form
             }
             else {
+                # many opts, display select
+                # but only if displaying form
                 $prevanswer = $clearanswers ? "" : $preval{$qid};
 
                 my @optlist = ( '', '' );

--- a/cgi-bin/LJ/Poll/Question.pm
+++ b/cgi-bin/LJ/Poll/Question.pm
@@ -118,19 +118,27 @@ sub preview_as_html {
         my $count     = int( ( $to - $from ) / $by ) + 1;
         my $do_radios = ( $count <= 11 );
 
-        # few opts, display radios
         if ($do_radios) {
-            $ret .= "<table summary=''><tr valign='top' align='center'>\n";
-            $ret .= "<td style='padding-right: 5px;'><b>$lowlabel</b></td>";
-            for ( my $at = $from ; $at <= $to ; $at += $by ) {
-                $ret .= "<td>" . LJ::html_check( { 'type' => 'radio' } ) . "<br />$at</td>\n";
-            }
-            $ret .= "<td style='padding-left: 5px;'><b>$highlabel</b></td>";
-            $ret .= "</tr></table>\n";
 
-            # many opts, display select
+            # few opts, display radios
+            my @all_values;
+            for ( my $at = $from ; $at <= $to ; $at += $by ) {
+                push @all_values, $at;
+            }
+            $ret .= DW::Template->template_string(
+                'poll/scale_radio.tt',
+                {
+                    lowlabel       => $lowlabel,
+                    highlabel      => $highlabel,
+                    selectedanswer => '',
+                    pollid         => '',
+                    qid            => '',
+                    values         => \@all_values,
+                }
+            );
         }
         else {
+            # many opts, display select
             my @optlist = ( '', ' ' );
             push @optlist, ( $from, $from . " " . $lowlabel );
 

--- a/cgi-bin/LJ/Poll/Question.pm
+++ b/cgi-bin/LJ/Poll/Question.pm
@@ -103,7 +103,7 @@ sub preview_as_html {
             }
         }
     }
-    $ret .= "<div style='margin: 10px 0 10px 40px'>";
+    $ret .= "<div style='margin: 10px 0 10px 5%'>";
 
     # text questions
     if ( $type eq 'text' ) {

--- a/views/poll/scale_radio.tt
+++ b/views/poll/scale_radio.tt
@@ -1,0 +1,39 @@
+[%# Render a poll question about a range of values, using radio buttons.
+arguments:
+    lowlabel
+    highlabel
+    selectedanswer
+    pollid
+    qid
+    values
+-%]
+
+[%-
+    container_style = "display: flex; flex-wrap: wrap; align-items: center; text-align: center;"
+    item_style = "display: inline-block; padding: 3px 6px 3px 0;"
+-%]
+
+<div style="[% container_style %]">
+    [%- IF lowlabel -%]
+        <div style="[% item_style %]"><strong>[% lowlabel %]</strong></div>
+    [%- END -%]
+
+    [%- FOREACH val = values -%]
+        [%- val_id = "pollq-$pollid-$qid-$val" -%]
+        <div style="[% item_style %]">
+            [%- form.radio(
+                name = "pollq-$qid"
+                class = "poll-$pollid"
+                value = val
+                id = val_id
+                selected = val == selectedanswer
+            ) -%]
+            <br>
+            <label for="[% val_id %]">[% val %]</label>
+        </div>
+    [%- END -%]
+
+    [%- IF highlabel -%]
+        <div style="[% item_style %]"><strong>[% highlabel %]</strong></div>
+    [%- END -%]
+</div>


### PR DESCRIPTION
Polls love to overflow all over the place on mobile, and their markup is uhhhhh truly vintage. 

This is a set of minor, contained adjustments to make polls behave better, on mobile and really on everywhere. I'm tryin' realll hard to not rewrite the universe on this one. 

<details><summary>Miscellaneous pile of screenshots</summary>

![IMG_8554](https://user-images.githubusercontent.com/484309/87480092-7cc7be00-c5e1-11ea-92d1-904d8a6cbb78.PNG)
![IMG_8553](https://user-images.githubusercontent.com/484309/87480094-7d605480-c5e1-11ea-8960-5398a84ba964.PNG)
![IMG_8552](https://user-images.githubusercontent.com/484309/87480096-7d605480-c5e1-11ea-9bcf-8aa42ac6ce0f.PNG)
![IMG_8551](https://user-images.githubusercontent.com/484309/87480097-7df8eb00-c5e1-11ea-84f2-9b5b22e366e5.PNG)
![Screenshot_2020-07-14 sheworks4themoney woodchuck hunting(2)](https://user-images.githubusercontent.com/484309/87480099-7df8eb00-c5e1-11ea-8d85-b851587d0eba.png)
![Screenshot_2020-07-14 sheworks4themoney Recent Entries(2)](https://user-images.githubusercontent.com/484309/87480100-7df8eb00-c5e1-11ea-9123-672ffd7146e2.png)
![Screenshot_2020-07-14 sheworks4themoney woodchuck hunting(1)](https://user-images.githubusercontent.com/484309/87480102-7e918180-c5e1-11ea-8082-97da5b25c6f3.png)
![Screenshot_2020-07-14 sheworks4themoney Recent Entries(1)](https://user-images.githubusercontent.com/484309/87480105-7e918180-c5e1-11ea-9755-52b5b6c82e1f.png)

</details>