### PR TITLE
Fix extra-fluffy inbox comment notifications

### DIFF
--- a/cgi-bin/LJ/Event/JournalNewComment.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment.pm
@@ -201,8 +201,6 @@ sub content {
     my $dtalkid      = $comment->dtalkid;
     my $htmlid       = LJ::Talk::comment_htmlid($dtalkid);
 
-    $comment_body = LJ::html_newlines($comment_body);
-
     if ( $comment->is_edited ) {
         my $reason = LJ::ehtml( $comment->edit_reason );
         $comment_body .= "<br /><br /><div class='edittime'>"

--- a/cgi-bin/LJ/TextUtil.pm
+++ b/cgi-bin/LJ/TextUtil.pm
@@ -379,7 +379,7 @@ sub is_utf8_wrapper {
 # des-text: text to check if too long
 # des-maxbreaks: maximum number of linebreak
 # des-maxchars: maximum number of characters
-# returns: true if text has more than maxbreaks linebreaks or more than maxchars characters
+# returns: true if text has more than maxbreaks HTML linebreaks or more than maxchars characters
 # </LJFUNC>
 sub has_too_many {
     my ( $text, %opts ) = @_;
@@ -387,7 +387,12 @@ sub has_too_many {
     return 1 if exists $opts{chars} && length($text) > $opts{chars};
 
     if ( exists $opts{linebreaks} ) {
-        my @breaks = $text =~ m/(<br \/>|\n)/g;
+
+        # - we always call this on HTML, so ignore literal \n.
+        # - paragraphs count as two linebreaks.
+        # - this is ballpark guessing and ignores MANY things that can add
+        # vertical space (<li>s, blockquotes...) -- shrug!
+        my @breaks = $text =~ m!</?(?:p|br)[^>]*>!g;
         return 1 if scalar @breaks > $opts{linebreaks};
     }
 

--- a/t/textutil.t
+++ b/t/textutil.t
@@ -16,7 +16,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 22;
+use Test::More tests => 21;
 
 BEGIN { require "$ENV{LJHOME}/cgi-bin/LJ/Directories.pm"; }
 use LJ::TextUtil;
@@ -24,16 +24,17 @@ use LJ::TextUtil;
 note("html breaks");
 ok( LJ::has_too_many( "abcdn<br />" x 1, linebreaks => 0 ), "0 max, 1 break" );
 
-ok( !LJ::has_too_many( "abcdn<br />" x 1, linebreaks => 2 ), "2 max, 1 break" );
+ok( !LJ::has_too_many( "abcdn<br>" x 1,   linebreaks => 2 ), "2 max, 1 break" );
 ok( !LJ::has_too_many( "abcdn<br />" x 2, linebreaks => 2 ), "2 max, 2 breaks" );
-ok( LJ::has_too_many( "abcdn<br />" x 3, linebreaks => 2 ), "2 max, 3 breaks" );
 
-note("newlines");
-ok( LJ::has_too_many( "abcdn\n" x 1, linebreaks => 0 ), "0 max, 1 newline" );
+note("ignoring literal newlines");
+ok( !LJ::has_too_many( "abcdn<br />\n\n\n" x 1, linebreaks => 2 ), "2 max, 1 break" );
 
-ok( !LJ::has_too_many( "abcdn\n" x 1, linebreaks => 2 ), "2 max, 1 newline" );
-ok( !LJ::has_too_many( "abcdn\n" x 2, linebreaks => 2 ), "2 max, 2 newlines" );
-ok( LJ::has_too_many( "abcdn\n" x 3, linebreaks => 2 ), "2 max, 3 newlines" );
+note("paragraphs and mixtures");
+ok( LJ::has_too_many( "<p>abcdn</p>" x 1, linebreaks => 1 ), "1 max, 2 breaks" );
+
+ok( !LJ::has_too_many( "<p>abc<br>dn</p>" x 1, linebreaks => 4 ), "4 max, 3 breaks" );
+ok( !LJ::has_too_many( "<p>abcdn</p>" x 2,     linebreaks => 4 ), "4 max, 4 breaks" );
 
 note("characters");
 ok( LJ::has_too_many( "abcdn\n", chars => 0 ), "0 max, 6 characters" );
@@ -43,15 +44,15 @@ ok( !LJ::has_too_many( "abcdef\n", chars => 7 ), "7 max, 7 characters" );
 ok( LJ::has_too_many( "abcdefg\n", chars => 7 ), "7 max, 8 characters" );
 
 note("mix");
-ok( LJ::has_too_many( "abcdn\n", chars => 9, linebreaks => 0 ),
-    "9 chars, 6 chars; 0 linebreaks, 1 break" );
-ok( !LJ::has_too_many( "abcdn\n", chars => 9, linebreaks => 1 ),
-    "9 chars, 6 chars; 1 linebreaks, 1 break" );
+ok( LJ::has_too_many( "abcdn<br>", chars => 10, linebreaks => 0 ),
+    "10 chars, 9 chars; 0 linebreaks, 1 break" );
+ok( !LJ::has_too_many( "abcdn<br>", chars => 10, linebreaks => 1 ),
+    "10 chars, 9 chars; 1 linebreaks, 1 break" );
 
-ok( LJ::has_too_many( "abcdn\n", chars => 0, linebreaks => 5 ),
-    "0 chars, 6 chars; 5 linebreaks, 1 break" );
-ok( !LJ::has_too_many( "abcdn\n", chars => 9, linebreaks => 5 ),
-    "9 chars, 6 chars; 5 linebreaks, 1 break" );
+ok( LJ::has_too_many( "abcdn<br>", chars => 0, linebreaks => 5 ),
+    "0 chars, 9 chars; 5 linebreaks, 1 break" );
+ok( !LJ::has_too_many( "abcdn<br>", chars => 10, linebreaks => 5 ),
+    "10 chars, 9 chars; 5 linebreaks, 1 break" );
 
 note("striphtml user tags");
 is( LJ::strip_html(qq{<lj user="test">}),   "test", qq{ strip_html <lj user="test"> } );


### PR DESCRIPTION
Inbox notifications for new comments were adding extra line breaks to Markdown and raw HTML comments. Let's don't. s/o to alexseanchai for pointing this out. 