### PR TITLE
Tests: Pin (some) @-mention tests to latest format versions

### DIFF
--- a/t/cleaner-markdown.t
+++ b/t/cleaner-markdown.t
@@ -128,7 +128,8 @@ sub check_doesnt_use_markdown {
 }
 
 # local content, converts users when not inside html
-check_doesnt_use_markdown( 'local entry made in default editor (newest casual HTML version)', editor => undef );
+check_doesnt_use_markdown( 'local entry made in default editor (newest casual HTML version)',
+    editor => undef );
 check_uses_markdown( 'local entry made in markdown editor', editor => 'markdown' );
 is( $clean->( '@system', editor => undef ),
     $lju_sys, 'user tag in plain text converted (undef editor)' );

--- a/t/cleaner-markdown.t
+++ b/t/cleaner-markdown.t
@@ -29,7 +29,7 @@ my $url             = 'https://medium.com/@username/title-of-page';
 my $clean = sub {
     my ( $text, %opts ) = @_;
     unless (%opts) {
-        %opts = ( editor => 'markdown' );
+        %opts = ( editor => 'markdown_latest' );
     }
     LJ::CleanHTML::clean_event( \$text, \%opts );
     chomp $text;
@@ -128,7 +128,7 @@ sub check_doesnt_use_markdown {
 }
 
 # local content, converts users when not inside html
-check_doesnt_use_markdown( 'local entry made in old editor', editor => undef );
+check_doesnt_use_markdown( 'local entry made in default editor (newest casual HTML version)', editor => undef );
 check_uses_markdown( 'local entry made in markdown editor', editor => 'markdown' );
 is( $clean->( '@system', editor => undef ),
     $lju_sys, 'user tag in plain text converted (undef editor)' );


### PR DESCRIPTION
I just had one of my occasional visions of the future, is all.

We already have a format alias for "give me the newest Markdown" (to accommodate
email posts), so this commit updates the @-mentions tests to use that by
default.

This way if we switch Markdown processors to one that deliberately eats the
escaping backslash in front of punctuation (like @), we'll get a nice early
warning that we need to tweak something in the rendering path.

(The tests that use the default format by passing editor => undef should already be fine, because the default should remain "newest casual HTML.") 