### PR TITLE
give all cookies the secure attribute on HTTPS sites

### DIFF
--- a/cgi-bin/DW/Request/Base.pm
+++ b/cgi-bin/DW/Request/Base.pm
@@ -82,6 +82,9 @@ sub add_cookie {
     confess "Must provide value (try delete_cookie if you really mean this)"
         unless exists $args{value};
 
+    # we need to give all cookies the secure attribute on HTTPS sites
+    $args{secure} = 1 if $LJ::PROTOCOL eq "https";
+
     # extraneous parenthesis inside map {} needed to force BLOCK mode map
     my $cookie = CGI::Cookie->new( map { ( "-$_" => $args{$_} ) } keys %args );
     $self->err_header_out_add( 'Set-Cookie' => $cookie );

--- a/cgi-bin/DW/Request/Base.pm
+++ b/cgi-bin/DW/Request/Base.pm
@@ -83,7 +83,18 @@ sub add_cookie {
         unless exists $args{value};
 
     # we need to give all cookies the secure attribute on HTTPS sites
-    $args{secure} = 1 if $LJ::PROTOCOL eq "https";
+    if ( $LJ::PROTOCOL eq "https" ) {
+        $args{secure} = 1;
+    }
+    else {    # if we're not secure, hopefully we're in a development environment
+        $args{SameSite} = 'Lax' if $LJ::IS_DEV_SERVER;
+
+        # TODO: test and see if the site works as expected with
+        # SameSite=Lax turned on for all cookies - Lax prevents
+        # cross-domain POST requests but GETs are allowed. Not
+        # setting it at all is equivalent to SameSite=None, which
+        # newer browsers only allow if the secure attribute is set.
+    }
 
     # extraneous parenthesis inside map {} needed to force BLOCK mode map
     my $cookie = CGI::Cookie->new( map { ( "-$_" => $args{$_} ) } keys %args );

--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -2,6 +2,7 @@ Authen::OATH
 Authen::Passphrase::Clear
 Authen::Passphrase::BlowfishCrypt
 Business::CreditCard
+CGI@4.50
 CGI::Cookie
 Cache::Memcached
 Captcha::reCAPTCHA@0.99


### PR DESCRIPTION
Momiji got a Firefox warning saying cookies with the 'sameSite' attribute set to 'none' or an invalid value would be rejected without the 'secure' attribute. This updates the add_cookie method to add the 'secure' attribute to all our cookies when LJ::PROTOCOL is https. The 'secure' attribute will cause the cookie not to be sent if the connection is not over SSL.