### PR TITLE
Tidy up some s2foundation form controls

### DIFF
--- a/htdocs/scss/skins/_nav.scss
+++ b/htdocs/scss/skins/_nav.scss
@@ -204,7 +204,7 @@ $nav-small-screen-header-height: 3em;
             padding: 1px .25em;
         }
         select {
-            padding: 1px 1rem 1px .25em; // leave room on right for dropdown arrow
+            padding: 1px 24px 1px .25rem; // leave room on right for dropdown arrow
         }
         input.button {
             padding: 0 .5em;

--- a/htdocs/scss/skins/_nav.scss
+++ b/htdocs/scss/skins/_nav.scss
@@ -196,11 +196,15 @@ $nav-small-screen-header-height: 3em;
     .nav-search {
         input, select {
             margin: 0;
-            padding: 1px .25em;
-            height: auto;
             width: auto;
             display: inline-block;
             font-size: 0.875rem;
+        }
+        input {
+            padding: 1px .25em;
+        }
+        select {
+            padding: 1px 1em;
         }
         input.button {
             padding: 0 .5em;

--- a/htdocs/scss/skins/_nav.scss
+++ b/htdocs/scss/skins/_nav.scss
@@ -204,7 +204,7 @@ $nav-small-screen-header-height: 3em;
             padding: 1px .25em;
         }
         select {
-            padding: 1px 1em;
+            padding: 1px 1rem 1px .25em; // leave room on right for dropdown arrow
         }
         input.button {
             padding: 0 .5em;

--- a/htdocs/scss/skins/_reply-form-styles.scss
+++ b/htdocs/scss/skins/_reply-form-styles.scss
@@ -19,13 +19,13 @@
   // Foundation likes stretching selects to 100% for some reason. It also
   // draws an artificial dropdown triangle we need to leave room for.
   width: auto;
-  padding-right: 1rem;
+  padding-right: 24px;
 }
 
 @mixin hack-smaller-select {
   width: auto;
   height: 1.6rem;
-  padding: 0 1rem 0 0.5rem;
+  padding: 0 24px 0 0.5rem;
 }
 
 @mixin hack-smaller-button {

--- a/htdocs/scss/skins/_reply-form-styles.scss
+++ b/htdocs/scss/skins/_reply-form-styles.scss
@@ -19,13 +19,18 @@
   // Foundation likes stretching selects to 100% for some reason. It also
   // draws an artificial dropdown triangle we need to leave room for.
   width: auto;
-  padding-left: 0.8rem;
-  padding-right: 0.8rem;
+  padding-right: 1rem;
 }
 
-@mixin hack-smaller-controls {
+@mixin hack-smaller-select {
+  width: auto;
   height: 1.6rem;
-  padding: 0 0.8rem;
+  padding: 0 1rem 0 0.5rem;
+}
+
+@mixin hack-smaller-button {
+  height: 1.6rem;
+  padding: 0 0.5rem;
 }
 
 #qrformdiv {
@@ -52,23 +57,16 @@
     display: inline;
   }
 
-  select {
-    @include hack-normal-select;
-  }
-
   // Foundation hates textarea resizers
   textarea {
     max-width: unset;
   }
 
-  // Shrink subject and quote button a bit
+  // Shrink subject a bit
   .qr-subject {
     input[type="text"] {
       height: 2.2rem;
       padding: 0.3em;
-    }
-    input[type="button"], button {
-      height: 2.2rem;
     }
   }
 
@@ -80,16 +78,25 @@
     }
     // Make more options and icon controls smaller so they don't tower over the
     // icon preview.
-    select, button, input[type="button"] {
-      @include hack-smaller-controls;
+    select {
+      @include hack-smaller-select;
+    }
+
+    button, input[type="button"] {
+      @include hack-smaller-button;
     }
   }
 
   .qr-markup {
-    // Default form controls are too huge for an extra row between subj/body.
-    select, button, input[type="button"] {
-      @include hack-smaller-controls;
+    // Default form controls are too huge to go between subject and body.
+    select {
+      @include hack-smaller-select;
       vertical-align: top; // Lets the help link image triangulate properly.
+    }
+
+    button, input[type="button"] {
+      @include hack-smaller-button;
+      vertical-align: top;
     }
   }
 }

--- a/htdocs/scss/skins/_reply-form-styles.scss
+++ b/htdocs/scss/skins/_reply-form-styles.scss
@@ -3,14 +3,42 @@
 * (To make them fit better with Foundation's odd form control styles.)
 */
 
+@mixin hack-normal-button {
+  @include button;
+  @include button-style($bg:$secondary-color, $bg-hover:$secondary-button-bg-hover, $border-color:$secondary-button-border-color);
+  @include inset-shadow();
+}
+
+@mixin hack-match-input-height {
+  // Foundation sets input/select heights weirdly, and doesn't have a built-in
+  // way to make nearby buttons not look janky. So copy that height logic.
+  height: ($input-font-size + ($form-spacing * 1.5) - rem-calc(1));
+}
+
+@mixin hack-normal-select {
+  // Foundation likes stretching selects to 100% for some reason. It also
+  // draws an artificial dropdown triangle we need to leave room for.
+  width: auto;
+  padding-left: 0.8rem;
+  padding-right: 0.8rem;
+}
+
+@mixin hack-smaller-controls {
+  height: 1.6rem;
+  padding: 0 0.8rem;
+}
+
 #qrformdiv {
   // Consistent Foundation styles for most buttons
   input[type="button"],
   button:not(#lj_userpicselect),
   input[type="submit"]:not(#submitpost) {
-    @include button;
-    @include button-style($bg:$secondary-color, $bg-hover:$secondary-button-bg-hover, $border-color:$secondary-button-border-color);
+    @include hack-normal-button;
     margin-bottom: 3px;
+  }
+
+  #submitpost {
+    @include inset-shadow();
   }
 
   // Clear unwanted extra button styles for icon browse button.
@@ -24,9 +52,8 @@
     display: inline;
   }
 
-  // Foundation likes stretching selects to 100% for some reason
   select {
-    width: auto;
+    @include hack-normal-select;
   }
 
   // Foundation hates textarea resizers
@@ -54,8 +81,15 @@
     // Make more options and icon controls smaller so they don't tower over the
     // icon preview.
     select, button, input[type="button"] {
-      height: 1.6rem;
-      padding: 0 0.8rem;
+      @include hack-smaller-controls;
+    }
+  }
+
+  .qr-markup {
+    // Default form controls are too huge for an extra row between subj/body.
+    select, button, input[type="button"] {
+      @include hack-smaller-controls;
+      vertical-align: top; // Lets the help link image triangulate properly.
     }
   }
 }
@@ -64,10 +98,13 @@
 * Hack to make the "multiform" comment editing controls match site-skin without
 * messing with the S2 markup
 */
+#multiform_mode {
+  @include hack-normal-select;
+  vertical-align: top;
+}
+
 #multiform_submit {
-  @extend .submit;
-  @extend .postfix;
-  display: inline-block;
-  width: auto;
-  padding: 0 1rem;
+  @include hack-normal-button;
+  @include hack-match-input-height;
+  vertical-align: top;
 }


### PR DESCRIPTION
Fixes #2777 

This makes the multi-comment action button less obtrusive, and also cleans up some janky little details that were starting to pile up. It also has a couple tiny adjustments to the top nav bar. 

<details><summary>Screenshots</summary>

- Fixing button color, alignment of things, text overlap when longest option is selected, little white reflection on button:

**before:**

![Screenshot_2020-07-22 sheworks4themoney lowlabel ](https://user-images.githubusercontent.com/484309/88214616-50c6c100-cc0f-11ea-9c8d-7439020f3952.png)

**after:** 

![Screenshot_2020-07-22 sheworks4themoney lowlabel (2)](https://user-images.githubusercontent.com/484309/88214608-4efcfd80-cc0f-11ea-88b6-b15abae2a0dd.png)

- Fixing relative heights of controls, text overlap: 

**before:**

<img width="382" alt="Screen Shot 2020-07-22 at 11 26 17 AM" src="https://user-images.githubusercontent.com/484309/88214614-502e2a80-cc0f-11ea-8b2c-58a77954436f.png">

**after:**

![Screenshot_2020-07-22 sheworks4themoney lowlabel (3)](https://user-images.githubusercontent.com/484309/88214606-4efcfd80-cc0f-11ea-9d6f-50e52d83b879.png)

- Fixing over-fluffy markup controls, little white reflections on buttons, vertical alignment of help icon:

**before:**

![Screenshot_2020-07-22 sheworks4themoney lowlabel (1)](https://user-images.githubusercontent.com/484309/88214611-4f959400-cc0f-11ea-96e2-f005c28666e6.png)

**after:**

![Screenshot_2020-07-22 sheworks4themoney lowlabel (4)](https://user-images.githubusercontent.com/484309/88214604-4dcbd080-cc0f-11ea-8679-22b7424d9837.png)

</details>