### PR TITLE
[#2785] fix community import error

### DIFF
--- a/cgi-bin/DW/Controller/Importer.pm
+++ b/cgi-bin/DW/Controller/Importer.pm
@@ -54,7 +54,7 @@ sub importer_handler {
     }
 
     return error_ml('/tools/importer/index.tt.error.notperson')
-        unless $u->is_person;
+        unless $remote->is_person;
 
     if ( $r->did_post ) {
 

--- a/views/tools/importer/index.tt
+++ b/views/tools/importer/index.tt
@@ -2,7 +2,7 @@
 [% dw.need_res( { group => "foundation" }, 'stc/importer.css', 'js/jquery.importer.js' ) %]
 [%- sections.title = '.title' | ml -%]
 
-<p class='intro'>[% '.intro' | ml(sitename => site.nameshort, user => remote.ljuser_display ) %]</p>
+<p class='intro'>[% '.intro' | ml(sitename => site.nameshort, user => u.ljuser_display ) %]</p>
     <div class="importer-queue">
         <strong>Importer Queue Depth:</strong><br />
     [% queue %]


### PR DESCRIPTION
In the original BML file, $u was the logged in user and $remote was the authas user, which is backwards from what the controller provides. So this error needs to be checking $remote, not $u.

Fixes #2785.