### PR TITLE
fix double escaping of file contents in /admin/fileedit

### DIFF
--- a/cgi-bin/DW/Controller/Admin/FileEdit.pm
+++ b/cgi-bin/DW/Controller/Admin/FileEdit.pm
@@ -101,7 +101,8 @@ sub index_controller {
         return error_ml( "$scope.error.noload", { filename => $vars->{file} } )
             unless defined $contents;
 
-        $vars->{contents} = LJ::eall($contents);
+        # this is escaped by form.textarea in the template
+        $vars->{contents} = $contents;
 
         $vars->{txt} = {
             r => ( $form_args->{r} || $DEF_ROW ) + 0,


### PR DESCRIPTION
The original BML file used raw HTML with manual escaping, whereas the converted page uses `form.textarea` in the template, which automatically escapes.