### PR TITLE
Tweaks for Foundationized entry pages

### DIFF
--- a/htdocs/scss/foundation/_settings.scss
+++ b/htdocs/scss/foundation/_settings.scss
@@ -251,7 +251,7 @@ $small-font-size: 80%;
 // $paragraph-font-family: inherit;
 // $paragraph-font-weight: $font-weight-normal;
 // $paragraph-font-size: 1rem;
-// $paragraph-line-height: 1.6;
+$paragraph-line-height: 1.5;
 // $paragraph-margin-bottom: rem-calc(20);
 // $paragraph-aside-font-size: rem-calc(14);
 // $paragraph-aside-line-height: 1.35;

--- a/htdocs/scss/skins/_entry-styles.scss
+++ b/htdocs/scss/skins/_entry-styles.scss
@@ -188,6 +188,11 @@ ul.entry-management-links {
     min-width: 75vw;
   }
 
+  .invisible {
+    position: relative;
+    top: 0;
+    left: 0;
+  }
   .edittime {
     margin-top: 1.5em;
   }
@@ -206,7 +211,6 @@ ul.entry-management-links {
 
     .comment-info, .userpic {
       border-bottom: 1px solid;
-      border-color: $soft-accent-color;
     }
     .comment-info {
       border-right: 1px solid;
@@ -251,6 +255,7 @@ ul.entry-management-links {
 .comment-depth-odd > .dwexpcomment .header {
   .comment-info, .userpic {
     background-color: $secondary-color-alternate;
+    border-color: $strong-accent-color !important;
   }
 }
 
@@ -324,4 +329,9 @@ ul.entry-management-links {
   .entry .footer {
     display: none;
   }
+}
+
+.entry table tr, .entry table {
+  background: none;
+  border: none;
 }

--- a/htdocs/scss/skins/_page-layout-hacks.scss
+++ b/htdocs/scss/skins/_page-layout-hacks.scss
@@ -15,7 +15,7 @@
 // same specificity as a class, so it's easy to override.
 [id="content"] li {
     margin-left: 2em;
-    margin-bottom: 0.75em;
+    margin-bottom: 0.25em;
 }
 
 // Case in point: override bottom spacing for success links

--- a/htdocs/scss/skins/lynx.scss
+++ b/htdocs/scss/skins/lynx.scss
@@ -17,6 +17,7 @@ $highlight-border: unset;
 
 // Color variables required by entry-styles:
 $soft-accent-color: unset;
+$strong-accent-color: unset;
 $secondary-color-alternate: #c0c0c0;
 $secondary-color: #e2e2e2;
 $screened-comment-bg: #C29B9B; // old Tropo screened comment color, why not.


### PR DESCRIPTION
-Change line-height back to 1.5
-Restore blank space when no comment title is set
-Remove default table background colors in entry contents
-Make comment header border alternate colors, like the background does
-Reduce spacing between list items.