### PR TITLE
fix missing strings from converting /shop/receipt to TT

### DIFF
--- a/htdocs/shop/history.bml
+++ b/htdocs/shop/history.bml
@@ -50,8 +50,8 @@ body<=
         $ret .= "<td>" . $cart->id . "</td>";
         $ret .= "<td>" . $date->strftime( "%F %r %Z" ) . "</td>";
         $ret .= "<td>" . $cart->display_total . "</td>";
-        $ret .= "<td>$ML{\"/shop/receipt.bml.cart.paymentmethod.$paymentmethod\"}</td>";
-        $ret .= "<td>$ML{\"/shop/receipt.bml.cart.status.$state\"}</td>";
+        $ret .= "<td>$ML{\"/shop/receipt.tt.cart.paymentmethod.$paymentmethod\"}</td>";
+        $ret .= "<td>$ML{\"/shop/receipt.tt.cart.status.$state\"}</td>";
         $ret .= "<td><a href='$LJ::SITEROOT/shop/receipt?ordernum=" . $cart->ordernum . "'>$ML{'.cart.details'}</a></td>";
         $ret .= "</tr>";
     }

--- a/views/admin/pay/vieworder.tt
+++ b/views/admin/pay/vieworder.tt
@@ -76,10 +76,18 @@
 </table>
 
 <h2>raw: pp_trans (PayPal transactions)</h2>
+  [%- IF engine.ppid.defined -%]
 [% dump( 'SELECT * FROM pp_trans WHERE ppid = ?', engine.ppid ) %]
+  [%- ELSE -%]
+<p>[% '.error.notransid' | ml %]</p>
+  [%- END -%]
 
 <h2>raw: pp_log (PayPal raw log)</h2>
+  [%- IF engine.ppid.defined -%]
 [% dump( 'SELECT * FROM pp_log WHERE ppid = ?', engine.ppid ) %]
+  [%- ELSE -%]
+<p>[% '.error.notransid' | ml %]</p>
+  [%- END -%]
 
 [%- ELSIF classname == 'GoogleCheckout' -%]
 <h2>GCO Payer Details</h2>
@@ -92,7 +100,11 @@
 </table>
 
 <h2>raw: gco_log (GCO raw)</h2>
+  [%- IF engine.gcoid.defined -%]
 [% dump( 'SELECT * FROM gco_log WHERE gcoid = ?', engine.gcoid ) %]
+  [%- ELSE -%]
+<p>[% '.error.notransid' | ml %]</p>
+  [%- END -%]
 
 [%- ELSIF classname == 'CreditCard' -%]
 <h2>raw: cc_trans (raw transaction data)</h2>

--- a/views/admin/pay/vieworder.tt
+++ b/views/admin/pay/vieworder.tt
@@ -30,8 +30,8 @@
                          : dw.ml( '.user.loggedout', { uniq => cart.uniq } );
     date = from_epoch( cart.starttime );
     pay_method = cart.paymentmethod_visible;
-    pay_string = '/shop/receipt.bml.cart.paymentmethod';
-    status_string = '/shop/receipt.bml.cart.status';
+    pay_string = '/shop/receipt.tt.cart.paymentmethod';
+    status_string = '/shop/receipt.tt.cart.status';
     view_pay_method = dw.ml( pay_method ? "${pay_string}.${pay_method}"
                                         : '.cart.notyet' ) -%]
 <table border='1'>

--- a/views/admin/pay/vieworder.tt.text
+++ b/views/admin/pay/vieworder.tt.text
@@ -34,6 +34,8 @@
 
 .error.notfound=The requested information was not found in the database.
 
+.error.notransid=No transaction id available.
+
 .error.unpaidcode=This code does not appear to have any paid time on it.
 
 .goback=Back to Index

--- a/views/admin/pay/viewuser.tt
+++ b/views/admin/pay/viewuser.tt
@@ -115,8 +115,8 @@
   [% FOREACH cart = carts;
      date = from_epoch( cart.starttime );
      pay_method = cart.paymentmethod_visible;
-     pay_string = '/shop/receipt.bml.cart.paymentmethod';
-     status_string = '/shop/receipt.bml.cart.status';
+     pay_string = '/shop/receipt.tt.cart.paymentmethod';
+     status_string = '/shop/receipt.tt.cart.status';
      view_pay_method = dw.ml( pay_method ? "${pay_string}.${pay_method}"
                                          : '.cart.notyet' ) -%]
   <tr>


### PR DESCRIPTION
Oh no, I forgot to check for other shop files referencing strings defined in receipt.bml.