### PR TITLE
Various new site skin fixes

### DIFF
--- a/htdocs/scss/skins/_entry-styles.scss
+++ b/htdocs/scss/skins/_entry-styles.scss
@@ -205,11 +205,13 @@ ul.entry-management-links {
     }
 
     .comment-info, .userpic {
-      border-bottom: 1px solid;
+      // Using "exploded" border properties so we can set the color later.
+      border-bottom-width: 1px;
+      border-bottom-style: solid;
     }
     .comment-info {
-      border-right: 1px solid;
-      border-color: $soft-accent-color;
+      border-right-width: 1px;
+      border-right-style: solid;
       flex-grow: 1;
     }
 
@@ -236,7 +238,7 @@ ul.entry-management-links {
   }
 }
 
-// Comment header backgrounds
+// Comment header backgrounds/borders
 // Structure is:
 // .comment-thread.comment-depth(odd|even)
   // .dwexpcomment
@@ -250,13 +252,14 @@ ul.entry-management-links {
 .comment-depth-odd > .dwexpcomment .header {
   .comment-info, .userpic {
     background-color: $secondary-color-alternate;
-    border-color: $strong-accent-color !important;
+    border-color: $strong-accent-color;
   }
 }
 
 .comment-depth-even > .dwexpcomment .header {
   .comment-info, .userpic {
     background-color: $secondary-color;
+    border-color: $soft-accent-color;
   }
 }
 
@@ -272,7 +275,8 @@ ul.entry-management-links {
 }
 
 .comment-info {
-  padding-left: .3em;
+  padding: .25em;
+  padding-left: .5em;
 
   & > span, & > ul, & > div {
     margin-right: .9em;
@@ -285,10 +289,10 @@ ul.entry-management-links {
   }
 
   .comment-title {
-    // TODO: Use media query to vary this depending on if we're mobile. We'd prefer not
-    // to take up this space on devices where space is at a premium! Once we do that,
-    // set this back to 0.6em for mobile deevices.
     min-height: 1.4em; // take up as much space as a subject would.
+    @media #{$small-only} {
+      min-height: 0.6em; // except on mobile, where we can't spare the space.
+    }
 
     margin: 0;
   }
@@ -328,9 +332,4 @@ ul.entry-management-links {
   .entry .footer {
     display: none;
   }
-}
-
-.entry table tr, .entry table {
-  background: none;
-  border: none;
 }

--- a/htdocs/scss/skins/_journal-typography.scss
+++ b/htdocs/scss/skins/_journal-typography.scss
@@ -72,11 +72,24 @@ $journal-content-font-size: 16px !default;
     width: auto;
   }
 
+  // People use textareas to share code sometimes.
+  textarea {
+    width: unset;
+    height: unset;
+  }
+
   .usercontent, .currents, .comment-title {
     word-wrap: break-word;
     overflow-wrap: break-word;
   }
 
+  // RPers especially love to abuse tables for decorative layout, but Foundation
+  // default styles assume tables are for tabular data. (Leaving Foundation's
+  // cell padding in place, though, since old skins also had some.)
+  table, table tr {
+    background: none;
+    border: none;
+  }
 }
 
 /**

--- a/htdocs/scss/skins/_reply-form-styles.scss
+++ b/htdocs/scss/skins/_reply-form-styles.scss
@@ -57,9 +57,13 @@
     display: inline;
   }
 
-  // Foundation hates textarea resizers
   textarea {
+    // Foundation hates textarea resizers
     max-width: unset;
+    // Foundation sets height to "illegible chiclet," then unsets it with an
+    // attribute selector on the "rows" attribute. Works fine, unless you're
+    // browsing with a potato that doesn't understand attribute selectors.
+    height: unset;
   }
 
   // Shrink subject a bit


### PR DESCRIPTION
(Many of these are mentioned in #2784.)

- The border colors on comment headers were wonky after re-adding the color
alternation. (One of them was half-highlight-color, half-black). Fixed by
exploding "border-bottom" into its constituent parts. (The "combined" border
properties implicitly set border-color to `currentcolor`, which is black-ish.)

- Add padding to .comment-info (comment header) boxes.

- Reduce the space we waste for absent comment headers on mobile.
Fixes #2793

- We shouldn't mess with table styles in Lynx (since they're browser default
anyway), so move that out of the "need this to display comment pages" file and
into the "fix bad Foundation behavior for thick siteskins" file.

- Remove default Foundation styling for textareas in entries (which are used to
share code).

- Fix a rare issue where the height of the comment form textarea got compressed.
(Only affects highly obsolete browsers.)