### PR TITLE
Restore space between body and crosspost footer

### DIFF
--- a/cgi-bin/DW/External/XPostProtocol.pm
+++ b/cgi-bin/DW/External/XPostProtocol.pm
@@ -116,7 +116,7 @@ sub create_footer {
             my $footer_text_redirect_key =
                 $local_nocomments ? 'xpost.redirect' : 'xpost.redirect.comment2';
 
-            return "\n\n"
+            return "\n<br><br>\n"
                 . LJ::Lang::ml( $footer_text_redirect_key,
                 { postlink => $entry->url, openidlink => "$LJ::SITEROOT/openid/" } );
         }
@@ -132,7 +132,7 @@ sub create_footer {
         my $footer_text_redirect_key =
             $local_nocomments ? 'xpost.redirect' : 'xpost.redirect.comment2';
 
-        return "\n\n"
+        return "\n<br><br>\n"
             . LJ::Lang::ml( $footer_text_redirect_key,
             { postlink => $entry->url, openidlink => "$LJ::SITEROOT/openid/" } );
     }


### PR DESCRIPTION
Part of #2812.

We now pre-process all our autoformatting and send the result to LJ-alikes as
opt_preformatted, so we can do things they don't support and not have to
maintain a working understanding of THEIR auto-formatting.

Crosspost footer was expecting to land in NON-preformatted text tho, and gets
jammed onto the end of the last sentence if the post is being treated as raw
HTML. Presumably this already used to break on preformatted crossposts, so I'm
surprised we didn't hear about it before, but anyway, now it hits everything so
let's fix.