### PR TITLE
use more sitescheme error templates

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -2000,6 +2000,7 @@ general error.interest.chars.words
 general error.interest.excessive
 general error.interest.words
 general error.tag.noarg
+general error.vhost.nocomm
 general error.vhost.nostyle
 general esn.add_friend
 general esn.befriended.email_text

--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -1999,6 +1999,7 @@ general error.interest.bytes.chars.words
 general error.interest.chars.words
 general error.interest.excessive
 general error.interest.words
+general error.tag.noarg
 general error.vhost.nostyle
 general esn.add_friend
 general esn.befriended.email_text

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -972,8 +972,6 @@ error.utf8=Invalid UTF-8 Input
 
 error.vhost.noalias1=The domain aliasing feature has been retired.
 
-error.vhost.nocomm=This account isn't a community journal.
-
 error.vhost.nodomain1=URLs like <nobr><b>https://<i>username</i>.[[user_domain]]/</b></nobr> are not available for this user's account type.
 
 esn.addedtocircle.trusted.email_text<<

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -876,6 +876,8 @@ error.nojournal=Unknown Journal
 
 error.nojournal.openid=This user is an OpenID account and does not maintain a journal here. You might be able to see their content at <a [[aopts]]>[[id]]</a>.
 
+error.nojournal.openid.title=OpenID Account
+
 error.nojournal.text=There is no known user <b>[[user]]</b> at <a href='[[siteroot]]'>[[sitename]].</a>
 
 error.nojournal.title=Account Not Found

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -954,8 +954,6 @@ error.tag.invalid=Sorry, the tag list specified is invalid.
 
 error.tag.name=Tag Error
 
-error.tag.noarg=You must provide tags to filter by.
-
 error.tag.s1=Sorry, tag filtering is not supported within S1 styles.
 
 error.tag.undef=Sorry, one or more specified tags do not exist.

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -932,6 +932,10 @@ error.support.norequest=You did not enter a support request.
 
 error.support.nosummary=You must enter a problem summary.
 
+error.suspended.entry=This entry has been suspended. You can visit the journal <a [[aopts]]>here</a>.
+
+error.suspended.entry.title=Suspended Entry
+
 error.suspended.name=Suspended
 
 error.suspended.text=This journal has been either temporarily or permanently suspended by [[sitename]] for policy violation.  If you are [[user]], contact us for more information.

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -876,6 +876,10 @@ error.nojournal=Unknown Journal
 
 error.nojournal.openid=This user is an OpenID account and does not maintain a journal here. You might be able to see their content at <a [[aopts]]>[[id]]</a>.
 
+error.nojournal.text=There is no known user <b>[[user]]</b> at <a href='[[siteroot]]'>[[sitename]].</a>
+
+error.nojournal.title=Account Not Found
+
 error.nopermission=You do not have permission to view this entry.
 
 error.noschwartz=TheSchwartz not installed or not configured properly.

--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -1384,12 +1384,6 @@ sub journal_content {
         # Apache handle the 404
         return 404;
     }
-    elsif ( $opts->{'baduser'} ) {
-        $status = "404 Unknown User";
-        $html =
-"<h1>Unknown User</h1><p>There is no user <b>$user</b> at <a href='$LJ::SITEROOT'>$LJ::SITENAME.</a></p>";
-        $generate_iejunk = 1;
-    }
     elsif ( $opts->{'badfriendgroup'} ) {
 
         # give a real 404 to the journal owner

--- a/cgi-bin/LJ/User/Styles.pm
+++ b/cgi-bin/LJ/User/Styles.pm
@@ -855,9 +855,12 @@ sub make_journal {
         return $u->display_journal_deleted( $remote, journal_opts => $opts ) if $u->is_deleted;
 
         if ( $u->is_suspended ) {
-            my $warning = BML::ml( 'error.suspended.text',
-                { user => $u->ljuser_display, sitename => $LJ::SITENAME } );
-            return $error->( $warning, "403 Forbidden", BML::ml('error.suspended.name') );
+            ${ $opts->{handle_with_siteviews_ref} } = 1;
+            return DW::Template->render_template_misc(
+                "error/suspended.tt",
+                { u     => $u },
+                { scope => 'journal', scope_data => $opts }
+            );
         }
 
         my $entry = $opts->{ljentry};
@@ -867,8 +870,12 @@ sub make_journal {
             return $error->( $warning, "403 Forbidden", BML::ml('error.suspended.name') );
         }
     }
-    return $error->( BML::ml('error.purged.text'), "410 Gone", BML::ml('error.purged.name') )
-        if $u->is_expunged;
+
+    if ( $u->is_expunged ) {
+        ${ $opts->{handle_with_siteviews_ref} } = 1;
+        return DW::Template->render_template_misc( "error/purged.tt", {},
+            { scope => 'journal', scope_data => $opts } );
+    }
 
     my %valid_identity_views = (
         read  => 1,

--- a/cgi-bin/LJ/User/Styles.pm
+++ b/cgi-bin/LJ/User/Styles.pm
@@ -465,12 +465,12 @@ sub make_journal {
     LJ::set_active_journal($u);
 
     my ($styleid);
-    if ( $opts->{'styleid'} ) {            # s1 styleid
+    if ( $opts->{'styleid'} ) {    # s1 styleid
         confess 'S1 was removed, sorry.';
     }
     else {
 
-        $view ||= "lastn";                 # default view when none specified explicitly in URLs
+        $view ||= "lastn";         # default view when none specified explicitly in URLs
         if (   $LJ::viewinfo{$view}
             || $view eq "month"
             || $view eq "entry"
@@ -888,18 +888,17 @@ sub make_journal {
 
     my %valid_identity_views = (
         read  => 1,
-        res   => 1,
+        res   => 1,    # res is a resource, such as an external stylesheet
         icons => 1,
     );
 
-    # FIXME: pretty this up at some point, to maybe auto-redirect to
-    # the external URL or something, but let's just do this for now
-    # res is a resource, such as an external stylesheet
     if ( $u->is_identity && !$valid_identity_views{$view} ) {
-        my $location = $u->openid_identity;
-        my $warning =
-            BML::ml( 'error.nojournal.openid', { aopts => "href='$location'", id => $location } );
-        return $error->( $warning, "404 Not here" );
+        ${ $opts->{handle_with_siteviews_ref} } = 1;
+        return DW::Template->render_template_misc(
+            "error/openid-user.tt",
+            { u     => $u },
+            { scope => 'journal', scope_data => $opts }
+        );
     }
 
     $opts->{'view'} = $view;

--- a/cgi-bin/LJ/User/Styles.pm
+++ b/cgi-bin/LJ/User/Styles.pm
@@ -452,10 +452,16 @@ sub make_journal {
     $opts->{getargs} = $geta;
 
     my $u = $opts->{'u'} || LJ::load_user($user);
+
     unless ($u) {
-        $opts->{'baduser'} = 1;
-        return "<!-- No such user -->";    # return value ignored
+        ${ $opts->{handle_with_siteviews_ref} } = 1;
+        return DW::Template->render_template_misc(
+            "error/unknown-user.tt",
+            { user  => $user },
+            { scope => 'journal', scope_data => $opts }
+        );
     }
+
     LJ::set_active_journal($u);
 
     my ($styleid);

--- a/cgi-bin/LJ/User/Styles.pm
+++ b/cgi-bin/LJ/User/Styles.pm
@@ -669,7 +669,8 @@ sub make_journal {
         return $notice->( BML::ml('error.vhost.nocomm') );
     }
     if ( $view eq "network" && !LJ::get_cap( $u, "friendsfriendsview" ) ) {
-        return BML::ml('cprod.friendsfriendsinline.text3.v1');
+        my $errmsg = LJ::Lang::ml('cprod.friendsfriendsinline.text3.v1');
+        return $error->( 'error.tt', { message => $errmsg } );
     }
 
     # signal to LiveJournal.pm that we can't handle this

--- a/cgi-bin/LJ/User/Styles.pm
+++ b/cgi-bin/LJ/User/Styles.pm
@@ -665,9 +665,10 @@ sub make_journal {
         return $notice->( BML::ml('error.vhost.noalias1') );
     }
     if ( $opts->{'vhost'} eq "community" && $u->journaltype !~ /[CR]/ ) {
-        $opts->{'badargs'} = 1;    # Output a generic 'bad URL' message if available
-        return $notice->( BML::ml('error.vhost.nocomm') );
+        $opts->{'badargs'} = 1;
+        return;    # 404 Not Found
     }
+
     if ( $view eq "network" && !LJ::get_cap( $u, "friendsfriendsview" ) ) {
         my $errmsg = LJ::Lang::ml('cprod.friendsfriendsinline.text3.v1');
         return $error->( 'error.tt', { message => $errmsg } );

--- a/cgi-bin/LJ/User/Styles.pm
+++ b/cgi-bin/LJ/User/Styles.pm
@@ -865,9 +865,12 @@ sub make_journal {
 
         my $entry = $opts->{ljentry};
         if ( $entry && $entry->is_suspended_for($remote) ) {
-            my $journal_base = $u->journal_base;
-            my $warning = BML::ml( 'error.suspended.entry', { aopts => "href='$journal_base/'" } );
-            return $error->( $warning, "403 Forbidden", BML::ml('error.suspended.name') );
+            ${ $opts->{handle_with_siteviews_ref} } = 1;
+            return DW::Template->render_template_misc(
+                "error/suspended-entry.tt",
+                { u     => $u },
+                { scope => 'journal', scope_data => $opts }
+            );
         }
     }
 

--- a/views/error/openid-user.tt
+++ b/views/error/openid-user.tt
@@ -1,0 +1,23 @@
+[%# Page to print when trying to view the nonexistent journal of an OpenID user
+  #
+  # Authors:
+  #     Jen Griffin <kareila@livejournal.com>
+  #
+  # Copyright (c) 2020 by Dreamwidth Studios, LLC.
+  #
+  # This program is free software; you may redistribute it and/or modify it under
+  # the same terms as Perl itself.  For a copy of the license, please reference
+  # 'perldoc perlartistic' or 'perldoc perlgpl'.
+%]
+
+[%- CALL dw.request_status( 404 ); # 404 Not Found -%]
+
+[%- sections.title = 'error.nojournal.openid.title' | ml -%]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%# make sure $u is passed in from the caller %]
+
+[%- location = u.openid_identity -%]
+
+<p>[% 'error.nojournal.openid' | ml( aopts = "href='$location'",
+                                     id = location ) %]</p>

--- a/views/error/suspended-entry.tt
+++ b/views/error/suspended-entry.tt
@@ -1,0 +1,21 @@
+[%# Page to print when trying to view information about a suspended entry
+  #
+  # Authors:
+  #     Jen Griffin <kareila@livejournal.com>
+  #
+  # Copyright (c) 2020 by Dreamwidth Studios, LLC.
+  #
+  # This program is free software; you may redistribute it and/or modify it under
+  # the same terms as Perl itself.  For a copy of the license, please reference
+  # 'perldoc perlartistic' or 'perldoc perlgpl'.
+%]
+
+[%- CALL dw.request_status( 403 ); # 403 Forbidden -%]
+
+[%- sections.title = 'error.suspended.name' | ml -%]
+[%- sections.windowtitle = 'error.suspended.entry.title' | ml -%]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%# make sure $u is passed in from the caller %]
+
+<p>[% 'error.suspended.entry' | ml( aopts = "href='${u.journal_base}/'" ) %]</p>

--- a/views/error/tagview.tt
+++ b/views/error/tagview.tt
@@ -1,0 +1,20 @@
+[%# Page to print for tag-related journal errors
+  #
+  # Authors:
+  #     Jen Griffin <kareila@livejournal.com>
+  #
+  # Copyright (c) 2020 by Dreamwidth Studios, LLC.
+  #
+  # This program is free software; you may redistribute it and/or modify it under
+  # the same terms as Perl itself.  For a copy of the license, please reference
+  # 'perldoc perlartistic' or 'perldoc perlgpl'.
+%]
+
+[%- CALL dw.request_status( 404 ); # 404 Not Found -%]
+
+[%- sections.title = 'error.tag.name' | ml -%]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%# make sure $errmsg is passed in from the caller %]
+
+<p>[% errmsg | ml %]</p>

--- a/views/error/unknown-user.tt
+++ b/views/error/unknown-user.tt
@@ -1,0 +1,22 @@
+[%# Page to print when trying to view information about a nonexistent user
+  #
+  # Authors:
+  #     Jen Griffin <kareila@livejournal.com>
+  #
+  # Copyright (c) 2020 by Dreamwidth Studios, LLC.
+  #
+  # This program is free software; you may redistribute it and/or modify it under
+  # the same terms as Perl itself.  For a copy of the license, please reference
+  # 'perldoc perlartistic' or 'perldoc perlgpl'.
+%]
+
+[%- CALL dw.request_status( 404 ); # 404 Not Found -%]
+
+[%- sections.title = 'error.nojournal' | ml -%]
+[%- sections.windowtitle = 'error.nojournal.title' | ml -%]
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%# make sure $user is passed in from the caller %]
+
+<p>[% 'error.nojournal.text' | ml( user = user, siteroot = site.root,
+                                   sitename = site.name ) %]</p>

--- a/views/error/vhost.tt
+++ b/views/error/vhost.tt
@@ -1,0 +1,25 @@
+[%# Page to print for vhost-related errors
+  #
+  # Authors:
+  #     Jen Griffin <kareila@livejournal.com>
+  #
+  # Copyright (c) 2020 by Dreamwidth Studios, LLC.
+  #
+  # This program is free software; you may redistribute it and/or modify it under
+  # the same terms as Perl itself.  For a copy of the license, please reference
+  # 'perldoc perlartistic' or 'perldoc perlgpl'.
+%]
+
+[%- sections.title = 'Notice' -%]
+
+[%- sections.head = BLOCK %]
+  [% u.meta_discovery_links( { feeds => 1, openid => 1 } ) %]
+[%- END -%]
+
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%- url = u.journal_base -%]
+
+<p>[% msg %]</p>
+
+<p>Instead, please use <nobr><a href="[% url %]">[% url %]</a></nobr></p>


### PR DESCRIPTION
Plain Apache error pages are sad-looking, especially when they need that hidden junk padding to get over the 512 byte threshold to even display to the user.

I started adding some sitescheme error templates when I converted the profile page. This adds more so that every non-rendering error returned from LJ::make_journal now uses sitescheme error templates.

Fixes #2177, maybe?