### PR TITLE
Re-enable javascript in core1 with s2foundation features

### DIFF
--- a/styles/core1.s2
+++ b/styles/core1.s2
@@ -565,6 +565,9 @@ class Page
     function print_stylesheets
     "Prints all defined stylesheets, including default and user-defined ones.";
 
+    function builtin print_script_tags
+    "Prints the JavaScript tags that this page requires. If a layout overrides the Page::print function, it must call this function before closing the body tag.";
+
     function builtin print_trusted(string key)
     "Prints a trusted string by key.";
 }
@@ -2225,7 +2228,9 @@ body, td, th, table, p, div {
     $this->print_body();
     """\n<hr><address>""";
     server_sig();
-    """</address>\n</body></html>""";
+    """</address>\n""";
+    $this->print_script_tags();
+    """</body></html>""";
 }
 
 function Page::print_body() {


### PR DESCRIPTION
Fixes #2819 

I was speculating about ways to fix this without requiring changes to existing core1 styles, but @rshatch pointed out that core1 has been deprecated for the whole last decade and that requiring a one-line change to antique custom styles might not be unreasonable. 

----

To support newer components in journal styles, we needed to change how script
tags enter the document. core2 already had room to do this without disrupting
anything, but naturally core1 does not.

Since most legacy core1 layouts in the wild probably override Page::print(),
they'll need to update their code to call `$this->print_script_tags();` right
before closing the body tag.