### PR TITLE
Fix embeds in feed content

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -680,7 +680,7 @@ TOKEN:
                 foreach (@attrstrip) {
 
                     # maybe there's a better place for this?
-                    next if ( lc $tag eq 'lj-embed' && lc $_ eq 'id' && !$nodwtags );
+                    next if ( lc $tag eq 'lj-embed' && lc $_ eq 'id' );
                     delete $hash->{$_};
                 }
 


### PR DESCRIPTION
Fixes #2821

When adding the `nodwtags` option to the HTML cleaner, I didn't realize that
feed content DOES get its embeds mangled into `site-embed` tags. This commit
exempts site-embed from the "no special tags" behavior, to hopefully fix youtube
etc. embeds in feeds.