### PR TITLE
new page /admin/recent_accounts

### DIFF
--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -662,6 +662,14 @@ userproplist.nonmember_posting:
   multihomed: 0
   prettyname: Non-Member posting access
 
+userproplist.not_approved:
+  cldversion: 4
+  datatype: char
+  des: 1 if unexamined, 2 if flagged as spam
+  indexed: 1
+  multihomed: 0
+  prettyname: Awaiting Approval
+
 userproplist.no_mail_alias:
   cldversion: 4
   datatype: bool

--- a/cgi-bin/DW/Controller/Admin/Approve.pm
+++ b/cgi-bin/DW/Controller/Admin/Approve.pm
@@ -1,0 +1,137 @@
+#!/usr/bin/perl
+#
+# DW::Controller::Admin::Approve
+#
+# Interface for screening new accounts for spam content.
+#
+# Authors:
+#      Jen Griffin <kareila@livejournal.com>
+#
+# Copyright (c) 2020 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::Controller::Admin::Approve;
+
+use strict;
+
+use DW::Controller;
+use DW::Routing;
+use DW::Template;
+use DW::FormErrors;
+
+my $privs = [
+    'siteadmin:approvenew',     # just for this page
+    'siteadmin:spamreports',    # include existing antispam team
+    'suspend',                  # include anyone with generic suspend privs
+    'suspend:recent',           # just for this page
+];
+
+DW::Controller::Admin->register_admin_page(
+    '/',
+    path     => 'recent_accounts',
+    ml_scope => '/admin/recent_accounts/review.tt',
+    privs    => $privs
+);
+
+DW::Routing->register_string( '/admin/recent_accounts', \&approve_handler, app => 1 );
+
+sub approve_handler {
+    my ( $ok, $rv ) = controller( form_auth => 1, privcheck => $privs );
+    return $rv unless $ok;
+
+    my $scope = '/admin/recent_accounts/review.tt';
+
+    my $prop = LJ::get_prop( 'user', 'not_approved' );
+    return error_ml( "$scope.error.disabled", { sitenameshort => $LJ::SITENAMESHORT } )
+        unless $prop && LJ::is_enabled('approvenew');
+
+    my $r         = $rv->{r};
+    my $remote    = $rv->{remote};
+    my $form_args = $r->post_args;
+    my $vars      = {};
+
+    $vars->{can_suspend} = 1
+        if $remote->has_priv( 'suspend', '' ) || $remote->has_priv( 'suspend', 'recent' );
+
+    return DW::Template->render_template( 'admin/recent_accounts/review.tt', $vars )
+        unless $r->did_post;
+
+    if ( $form_args->{begin} ) {
+
+        # get a user to review - we don't want to just get the first result,
+        # high chance of collision with multiple active reviewers
+        my @uids;
+        my $dbr = LJ::get_db_reader();
+        my $sth = $dbr->prepare( "SELECT userid FROM userproplite2 "
+                . "WHERE upropid=? AND value=? ORDER BY userid LIMIT 5" );
+        $sth->execute( $prop->{id}, 1 );
+        die $dbr->errstr if $dbr->err;
+        while ( $_ = $sth->fetchrow_arrayref ) {
+            push @uids, $_->[0];
+        }
+        my $users = LJ::load_userids(@uids);
+
+        # make sure the accounts are at least an hour old - sorting
+        # SELECT by userid means oldest accounts will be reviewed first
+        my $now = time;
+        foreach ( keys %$users ) {
+            delete $users->{$_} if $users->{$_}->timecreate > $now - 3600;
+        }
+
+        my @ids = sort keys %$users;
+        if ( my $num = scalar @ids ) {
+            my $pickrand = int( rand($num) );
+            $vars->{user} = $users->{ $ids[$pickrand] };
+            $vars->{ago}  = LJ::diff_ago_text( $vars->{user}->timecreate );
+            return DW::Template->render_template( 'admin/recent_accounts/user.tt',
+                $vars, { no_sitescheme => 1 } );
+        }
+        else {
+            return error_ml("$scope.error.nousers");
+        }
+    }
+
+    if ( $form_args->{uid} ) {
+        my $u       = LJ::load_userid( $form_args->{uid} );
+        my $success = DW::FormErrors->new;
+        my $value;
+
+        # take action based on form_args - either clear or escalate
+        $value = 0 if $form_args->{yes};
+        $value = 2 if $form_args->{no};
+
+        return error_ml('error.invalidform') unless defined $value;
+
+        my $act = $value ? 'rejected' : 'approved';
+        $success->add( '', ".success.$act", { user => $u->ljuser_display } );
+
+        # reinforce the different colors for rejection vs approval
+        $vars->{ $value ? 'errors' : 'success' } = $success;
+
+        # force lookup in case someone else just changed this -
+        # we still show the success message to the user, but
+        # we don't perform the actions again
+        delete $u->{"not_approved"};
+        $u->preload_props( { use_master => 1 }, "not_approved" );
+
+        if ( $u->prop('not_approved') && $u->prop('not_approved') == 1 ) {
+            $u->set_prop( not_approved => $value );
+            my $msg = sprintf( "new account %s $act by %s", $u->user, $remote->user );
+            LJ::statushistory_add( $u, $remote, 'approvenew', $msg );
+
+            # I thought about automatically doing the suspension here if
+            # $remote had suspend privs, but I think it's better to give the
+            # user a chance to review their actions in case of fat fingering
+        }
+
+        return DW::Template->render_template( 'admin/recent_accounts/review.tt', $vars );
+    }
+
+    return error_ml('error.invalidform');    # no form args we know how to handle
+}
+
+1;

--- a/cgi-bin/DW/Controller/Admin/Approve.pm
+++ b/cgi-bin/DW/Controller/Admin/Approve.pm
@@ -60,20 +60,25 @@ sub approve_handler {
     return DW::Template->render_template( 'admin/recent_accounts/review.tt', $vars )
         unless $r->did_post;
 
+    my $dbr = LJ::get_db_reader();
+    my $sth = $dbr->prepare( "SELECT userid FROM userproplite2 "
+            . "WHERE upropid=? AND value=? ORDER BY userid LIMIT ?" );
+
+    my $get_users = sub {
+        my ( $value, $limit ) = @_;
+        $sth->execute( $prop->{id}, $value, $limit );
+        die $dbr->errstr if $dbr->err;
+
+        my @uids;
+        push @uids, $_->[0] while $_ = $sth->fetchrow_arrayref;
+        return LJ::load_userids(@uids);    # hashref
+    };
+
     if ( $form_args->{begin} ) {
 
         # get a user to review - we don't want to just get the first result,
         # high chance of collision with multiple active reviewers
-        my @uids;
-        my $dbr = LJ::get_db_reader();
-        my $sth = $dbr->prepare( "SELECT userid FROM userproplite2 "
-                . "WHERE upropid=? AND value=? ORDER BY userid LIMIT 5" );
-        $sth->execute( $prop->{id}, 1 );
-        die $dbr->errstr if $dbr->err;
-        while ( $_ = $sth->fetchrow_arrayref ) {
-            push @uids, $_->[0];
-        }
-        my $users = LJ::load_userids(@uids);
+        my $users = $get_users->( 1, 5 );
 
         # make sure the accounts are at least an hour old - sorting
         # SELECT by userid means oldest accounts will be reviewed first
@@ -112,9 +117,8 @@ sub approve_handler {
         # reinforce the different colors for rejection vs approval
         $vars->{ $value ? 'errors' : 'success' } = $success;
 
-        # force lookup in case someone else just changed this -
-        # we still show the success message to the user, but
-        # we don't perform the actions again
+        # force lookup in case someone else just changed this - we still show
+        # the success message to the user, but don't perform the actions again
         delete $u->{"not_approved"};
         $u->preload_props( { use_master => 1 }, "not_approved" );
 
@@ -127,6 +131,45 @@ sub approve_handler {
             # $remote had suspend privs, but I think it's better to give the
             # user a chance to review their actions in case of fat fingering
         }
+
+        return DW::Template->render_template( 'admin/recent_accounts/review.tt', $vars );
+    }
+
+    if ( $form_args->{suspend} ) {
+        return $r->redirect("$LJ::SITEROOT/admin/recent_accounts")
+            unless $vars->{can_suspend};
+
+        # get a list of flagged users to review for suspension
+        $vars->{users} = $get_users->( 2, 10 );
+
+        return DW::Template->render_template( 'admin/recent_accounts/suspend.tt', $vars );
+    }
+
+    if ( $form_args->{do_suspend} ) {
+        my @ids = split / /, $form_args->{uids};
+        return error_ml('error.invalidform') unless @ids && $vars->{can_suspend};
+
+        my $users   = LJ::load_userids(@ids);
+        my $success = DW::FormErrors->new;
+        my $count   = 0;
+
+        foreach my $uid (@ids) {
+            my $u = $users->{$uid};
+            next if $u->is_suspended;    # already done
+
+            if ( $form_args->{"user_$uid"} ) {
+                $u->set_suspended( $remote, "from /admin/recent_accounts" );
+                $count++;
+            }
+            else {
+                $u->set_prop( not_approved => 0 );
+                LJ::statushistory_add( $u, $remote, 'approvenew',
+                    sprintf( "new account %s approved by %s", $u->user, $remote->user ) );
+            }
+        }
+
+        $success->add( '', '.success.suspend', { count => $count } );
+        $vars->{success} = $success;
 
         return DW::Template->render_template( 'admin/recent_accounts/review.tt', $vars );
     }

--- a/cgi-bin/DW/Controller/Create.pm
+++ b/cgi-bin/DW/Controller/Create.pm
@@ -252,6 +252,9 @@ sub create_handler {
                 }
             );
 
+            # note that this user needs to be reviewed for spam content
+            $nu->set_prop( not_approved => 1 ) if LJ::is_enabled('approvenew');
+
             # we're all done
             $nu->make_login_session;
 

--- a/cgi-bin/DW/Hooks/PrivList.pm
+++ b/cgi-bin/DW/Hooks/PrivList.pm
@@ -134,7 +134,10 @@ LJ::Hooks::register_hook(
             }
             if $priv eq 'siteadmin';
 
-        $hr = { openid => "Only allowed to suspend OpenID accounts", }
+        $hr = {
+            openid => "Only allowed to suspend OpenID accounts",
+            recent => "Only allowed to suspend from /admin/recent_accounts",
+            }
             if $priv eq 'suspend';
 
         # extracted from LJ::Sysban::validate

--- a/cgi-bin/DW/Hooks/PrivList.pm
+++ b/cgi-bin/DW/Hooks/PrivList.pm
@@ -97,8 +97,8 @@ LJ::Hooks::register_hook(
 
         # extracted from grep -r statushistory_add
         if ( $priv eq 'historyview' ) {
-            my @shtypes = qw/ account_level_change b2lid_remap capedit
-                change_journal_type comment_action communityxfer
+            my @shtypes = qw/ account_level_change approvenew b2lid_remap
+                capedit change_journal_type comment_action communityxfer
                 create_from_invite create_from_promo
                 entry_action email_changed expunge_userpic
                 impersonate journal_status logout_user
@@ -113,6 +113,7 @@ LJ::Hooks::register_hook(
         }
 
         $hr = {
+            approvenew    => "Access to /admin/recent_accounts",
             commentview   => "Access to /admin/recent_comments",
             emailqueue    => "Access to /tools/recent_email",
             invites       => "Access to some invites functionality under /admin/invites",

--- a/cgi-bin/DW/Hooks/SiteSearch.pm
+++ b/cgi-bin/DW/Hooks/SiteSearch.pm
@@ -37,7 +37,10 @@ LJ::Hooks::register_hook(
             $bool = $opts{value} eq 'Y' ? 0 : 1;
         }
         elsif ( $opts{prop} eq 'not_approved' ) {
-            return if $opts{value};    # only act on this if it is being cleared
+
+            # only act on this if it is being cleared from a visible user
+            return if $opts{value};
+            return if $opts{u}->is_suspended;
             $bool = 1;
         }
         else {

--- a/cgi-bin/DW/Hooks/SiteSearch.pm
+++ b/cgi-bin/DW/Hooks/SiteSearch.pm
@@ -32,13 +32,23 @@ LJ::Hooks::register_hook(
     'setprop',
     sub {
         my %opts = @_;
-        return unless $opts{prop} eq 'opt_blockglobalsearch';
+        my $bool;
+        if ( $opts{prop} eq 'opt_blockglobalsearch' ) {
+            $bool = $opts{value} eq 'Y' ? 0 : 1;
+        }
+        elsif ( $opts{prop} eq 'not_approved' ) {
+            return if $opts{value};    # only act on this if it is being cleared
+            $bool = 1;
+        }
+        else {
+            return;
+        }
 
         my $dbh = _sphinx_db() or return 0;
         $dbh->do(
             q{UPDATE items_raw SET allow_global_search = ?, touchtime = UNIX_TIMESTAMP()
           WHERE journalid = ?},
-            undef, $opts{value} eq 'Y' ? 0 : 1, $opts{u}->id
+            undef, $bool, $opts{u}->id
         );
         die $dbh->errstr if $dbh->err;
 

--- a/cgi-bin/DW/Setting/GlobalSearch.pm
+++ b/cgi-bin/DW/Setting/GlobalSearch.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 
 sub should_render {
-    return $_[1] && ( $_[1]->is_person || $_[1]->is_community );
+    return $_[1] && ( $_[1]->is_person || $_[1]->is_community ) && $_[1]->is_approved;
 }
 
 sub label {

--- a/cgi-bin/LJ/Console/Command/Suspend.pm
+++ b/cgi-bin/LJ/Console/Command/Suspend.pm
@@ -45,6 +45,11 @@ sub execute {
     my $remote = LJ::get_remote();
     my $openid_only =
         $remote->has_priv( "suspend", "openid" ) && !$remote->has_priv( "suspend", "*" );
+    my $recent_only =
+        $remote->has_priv( "suspend", "recent" ) && !$remote->has_priv( "suspend", "*" );
+
+    return $self->error("You can only suspend users using /admin/recent_accounts.")
+        if $recent_only;
 
     my $entry = LJ::Entry->new_from_url($user);
     if ($entry) {

--- a/cgi-bin/LJ/Console/Command/Unsuspend.pm
+++ b/cgi-bin/LJ/Console/Command/Unsuspend.pm
@@ -108,10 +108,11 @@ sub execute {
             next;
         }
 
-        $u->update_self( { statusvis => 'V', raw => 'statusvisdate=NOW()' } );
-        $u->{statusvis} = 'V';
+        my $err;
+        $self->error($err)
+            unless $u->set_unsuspended( $remote, $reason, \$err );
 
-        LJ::statushistory_add( $u, $remote, "unsuspend", $reason );
+        $u->{statusvis} = 'V';
 
         $self->print("User '$username' unsuspended.");
     }

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -528,6 +528,9 @@ sub set_suspended {
 
     LJ::statushistory_add( $u, $who, "suspend", $reason );
 
+    # if not_approved was set, clear it
+    $u->set_prop( not_approved => 0 );
+
     LJ::Hooks::run_hooks( "account_cancel", $u );
 
     if ( my $err = LJ::Hooks::run_hook( "cdn_purge_userpics", $u ) ) {

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -557,6 +557,9 @@ sub set_unsuspended {
 
     LJ::statushistory_add( $u, $who, "unsuspend", $reason );
 
+    # if not_approved was set, clear it
+    $u->set_prop( not_approved => 0 );
+
     return $res;    # success
 }
 

--- a/cgi-bin/LJ/User/Account.pm
+++ b/cgi-bin/LJ/User/Account.pm
@@ -384,6 +384,15 @@ sub get_previous_statusvis {
     return @statusvis;
 }
 
+sub is_approved {
+    my $u = $_[0];
+
+    # if a dev server hasn't configured this, assume they don't want it
+    return 1 if $LJ::IS_DEV_SERVER && !exists $LJ::DISABLED{approvenew};
+    return 1 unless LJ::is_enabled('approvenew');
+    return $u->prop('not_approved') ? 0 : 1;
+}
+
 sub is_deleted {
     my $u = shift;
     return $u->statusvis eq 'D';
@@ -740,7 +749,8 @@ sub load_random_user {
             or next;
 
         # situational checks to ensure this user is a good one to show
-        next unless $u->is_visible;           # no suspended/deleted/etc users
+        next unless $u->is_visible;     # no suspended/deleted/etc users
+        next unless $u->is_approved;    # ignore accounts in holding pen
         next if $u->prop('latest_optout');    # they have chosen to be excluded
 
         # they've passed the checks, return this user

--- a/cgi-bin/LJ/User/Permissions.pm
+++ b/cgi-bin/LJ/User/Permissions.pm
@@ -714,6 +714,9 @@ sub include_in_global_search {
     # only P/C accounts should be globally searched
     return 0 unless $u->is_person || $u->is_community;
 
+    # ignore any accounts that haven't been screened for spam yet
+    return 0 unless $u->is_approved;
+
     # default) check opt_blockglobalsearch and use that if it's defined
     my $bgs = $u->prop('opt_blockglobalsearch');
     return $bgs eq 'Y' ? 0 : 1 if defined $bgs && length $bgs;
@@ -729,6 +732,7 @@ sub include_in_global_search {
 # whether this user wants to have their content included in the latest feeds or not
 sub include_in_latest_feed {
     my $u = $_[0];
+    return 0 unless $u->is_approved;
     return $u->prop('latest_optout') ? 0 : 1;
 }
 

--- a/etc/config.pl.example
+++ b/etc/config.pl.example
@@ -120,6 +120,7 @@
     # CPU & database intensive or that you simply don't want to use
     %DISABLED = (
                  adult_content => 0,
+                 approvenew => 1,
                  loggedout_support_requests => 1,
                  'community-logins' => 0,
                  captcha => 0,

--- a/views/admin/recent_accounts/review.tt
+++ b/views/admin/recent_accounts/review.tt
@@ -1,0 +1,38 @@
+[%# Interface for screening new accounts for spam content.
+  #
+  # Authors:
+  #      Jen Griffin <kareila@livejournal.com>
+  #
+  # Copyright (c) 2020 by Dreamwidth Studios, LLC.
+  #
+  # This program is free software; you may redistribute it and/or modify it
+  # under the same terms as Perl itself. For a copy of the license, please
+  # reference 'perldoc perlartistic' or 'perldoc perlgpl'.
+  #
+%]
+
+[%- sections.title='.title' | ml -%]
+
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%- INCLUDE components/errors.tt
+    errors = success
+    style = 'success' -%]
+
+<form method=post>
+  [% dw.form_auth %]
+
+  <p>[% '.intro' | ml %]</p>
+
+  [% form.submit( name = 'begin', value = dw.ml( '.button.begin' ) ) %]
+
+[%- IF can_suspend -%]
+  <hr />
+
+  <p>[% '.intro.suspend' | ml %]</p>
+
+  [% form.submit( name = 'suspend', value = dw.ml( '.button.suspend' ),
+                  disabled = 1 ); # not implemented yet %]
+[%- END -%]
+
+</form>

--- a/views/admin/recent_accounts/review.tt
+++ b/views/admin/recent_accounts/review.tt
@@ -31,8 +31,7 @@
 
   <p>[% '.intro.suspend' | ml %]</p>
 
-  [% form.submit( name = 'suspend', value = dw.ml( '.button.suspend' ),
-                  disabled = 1 ); # not implemented yet %]
+  [% form.submit( name = 'suspend', value = dw.ml( '.button.suspend' ) ) %]
 [%- END -%]
 
 </form>

--- a/views/admin/recent_accounts/review.tt.text
+++ b/views/admin/recent_accounts/review.tt.text
@@ -1,0 +1,23 @@
+;; -*- coding: utf-8 -*-
+.admin.link=Review New Accounts
+
+.admin.text=Screen new accounts for spam content.
+
+.button.begin=Let's Go!
+
+.button.suspend=Hammer Time!
+
+.error.disabled=This feature is not enabled for [[sitenameshort]].
+
+.error.nousers=No users found to review - come back again later!
+
+.intro=Click below to review a recently created account for content created solely for SEO spam purposes.
+
+.intro.suspend=Alternatively, you can review accounts previously flagged for suspension.
+
+.success.approved=Thanks for approving [[user]] - their journal will now be included in Site Search and Latest Things.
+
+.success.rejected=Thank you for reviewing [[user]]. They have been flagged for suspension by the antispam team.
+
+.title=Review New Accounts
+

--- a/views/admin/recent_accounts/review.tt.text
+++ b/views/admin/recent_accounts/review.tt.text
@@ -19,5 +19,7 @@
 
 .success.rejected=Thank you for reviewing [[user]]. They have been flagged for suspension by the antispam team.
 
+.success.suspend=Suspended [[count]] [[?count|account|accounts]].
+
 .title=Review New Accounts
 

--- a/views/admin/recent_accounts/suspend.tt
+++ b/views/admin/recent_accounts/suspend.tt
@@ -1,0 +1,45 @@
+[%# Interface for suspending new accounts that contain spam content.
+  #
+  # Authors:
+  #      Jen Griffin <kareila@livejournal.com>
+  #
+  # Copyright (c) 2020 by Dreamwidth Studios, LLC.
+  #
+  # This program is free software; you may redistribute it and/or modify it
+  # under the same terms as Perl itself. For a copy of the license, please
+  # reference 'perldoc perlartistic' or 'perldoc perlgpl'.
+  #
+%]
+
+[%- sections.title='.title' | ml -%]
+
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+<p><a href="/admin/recent_accounts">[% '.backlink' | ml %]</a></p>
+
+[%- IF users.size -%]
+
+<form method=post>
+  [% dw.form_auth %]
+  [% form.hidden( name = 'uids', value = users.keys.nsort.join(' ') ) %]
+
+  <p>[% '.intro' | ml %]</p>
+
+  <div style="margin-bottom: 1.5em;">
+  [%- FOREACH u IN users.values -%]
+
+    [% form.checkbox( name = "user_${u.id}", value = 1, selected = 1 ) %]
+    [% u.ljuser_display %]
+    <br />
+
+  [%- END -%]
+  </div>
+
+  [% form.submit( name = 'do_suspend', value = dw.ml( '.button.suspend' ) ) %]
+</form>
+
+[%- ELSE -%]
+
+<p>[% '.error.nousers' | ml %]</p>
+
+[%- END -%]

--- a/views/admin/recent_accounts/suspend.tt.text
+++ b/views/admin/recent_accounts/suspend.tt.text
@@ -1,0 +1,11 @@
+;; -*- coding: utf-8 -*-
+.backlink=&lt;&lt; Back
+
+.button.suspend=Suspend Users
+
+.error.nousers=No users found to review - come back again later!
+
+.intro=The accounts listed below have been flagged for spam. Please uncheck any you believe were erroneously flagged, and submit the form to suspend the checked accounts.
+
+.title=Suspend Flagged Accounts
+

--- a/views/admin/recent_accounts/user.tt
+++ b/views/admin/recent_accounts/user.tt
@@ -1,0 +1,36 @@
+<html>
+  <head>
+    <title>[% '.title' | ml %]</title>
+    <style type="text/css">
+      body { margin: 0; }
+      .container iframe { width: 100%; height: 100%; }
+      .container { height: 100%; width: 100%; overflow: hidden; }
+      .headform  { height: auto; background-color: #eee; padding: 0.5em 1em; }
+      .headform  { font-family: Calibri, Helvetica, Arial, sans-serif; }
+      .headform form { display: inline; }
+      .buttons input { margin: 0.5em; }
+      .yes { background-color: #b5e7a0; }
+      .no  { background-color: #eca1a6; }
+    </style>
+  </head>
+
+  <body>
+    <div class="container">
+      <div class="headform">
+        <p>[% '.intro' | ml( user = user.ljuser_display, ago = ago ) %]</p>
+        <form method=post>
+          [% dw.form_auth %]
+          [% form.hidden( name = 'uid', value = user.id ) %]
+          <div class="buttons">
+            [% form.submit( name =  'yes', value = dw.ml( '.button.yes' ),
+                            class = 'yes' ) %]
+            [% form.submit( name  = 'no',  value = dw.ml( '.button.no' ),
+                            class = 'no' ) %]
+          </div>
+        </form>
+      </div>
+
+      <iframe src="[% user.journal_base %]"></iframe>
+    </div>
+  </body>
+</html>

--- a/views/admin/recent_accounts/user.tt.text
+++ b/views/admin/recent_accounts/user.tt.text
@@ -1,0 +1,9 @@
+;; -*- coding: utf-8 -*-
+.button.no=No, this looks bogus.
+
+.button.yes=Looks good to me!
+
+.intro=Reviewing [[user]], created [[ago]]. <br /> Does this look like a legitimate account?
+
+.title=Review New Accounts
+


### PR DESCRIPTION
Right now when I'm checking recently created accounts for spammers, it requires a lot of time and resources on my part. So I brainstormed with @rahaeli about a way to crowdsource reviewing recently created accounts with trusted volunteers in a way that made it easy to participate on mobile devices for a few minutes here and there and distribute the workload. This is what came out of that conversation.

- Newly created personal accounts have a new userprop, `not_approved`, set to 1 at account creation time.

- Any accounts with `not_approved` set are excluded from /search, /latest, and /random. (New user method `$u->is_approved` faciliates this.)

- After an hour, the new accounts will begin to appear on /admin/recent_accounts for review by users with the existing priv siteadmin:spamreports or the new priv siteadmin:approvenew.

- One of these volunteers will review the journal and flag it as spam or not. If it's not, `not_approved` is cleared and the account is made available in the site features where it was previously excluded. If it is judged to be spam, `not_approved` is incremented from 1 to 2 and it goes into another queue to be suspended.

- Another new priv, suspend:recent, is available for volunteers to suspend only accounts flagged from the /admin/recent_accounts page. Suspending or unsuspending an account will also clear the userprop.

All of this is switched off if `LJ::is_enabled('approvenew')` returns false. I left it turned off in the example config, but it should be active in production unless we explicitly disable it.

Screenshot of journal review form (yes it's an iframe):

![Screen_Shot_2020-08-02_at_4 56 58_PM](https://user-images.githubusercontent.com/1976742/89588183-c1253300-d808-11ea-8b39-d2d20ec53693.png)
