### PR TITLE
Icon browser revisions

### DIFF
--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -478,6 +478,14 @@ userproplist.icbm:
   multihomed: 0
   prettyname: ICBM Address
 
+userproplist.iconbrowser_keywordorder:
+  cldversion: 4
+  datatype: bool
+  des: Whether to sort the icon browser by keyword, instead of upload date
+  indexed: 0
+  multihomed: 0
+  prettyname: Icon browser keyword order
+
 userproplist.iconbrowser_metatext:
   cldversion: 4
   datatype: bool

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -433,6 +433,7 @@ sub _init {
         icons => \@icons,
 
         icon_browser => {
+            keywordorder   => $u ? $u->iconbrowser_keywordorder   : "",
             metatext   => $u ? $u->iconbrowser_metatext   : "",
             smallicons => $u ? $u->iconbrowser_smallicons : "",
         },

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -433,9 +433,9 @@ sub _init {
         icons => \@icons,
 
         icon_browser => {
-            keywordorder   => $u ? $u->iconbrowser_keywordorder   : "",
-            metatext   => $u ? $u->iconbrowser_metatext   : "",
-            smallicons => $u ? $u->iconbrowser_smallicons : "",
+            keywordorder => $u ? $u->iconbrowser_keywordorder : "",
+            metatext     => $u ? $u->iconbrowser_metatext     : "",
+            smallicons   => $u ? $u->iconbrowser_smallicons   : "",
         },
 
         moodtheme => \%moodtheme,

--- a/cgi-bin/DW/Controller/RPC/IconBrowserOptions.pm
+++ b/cgi-bin/DW/Controller/RPC/IconBrowserOptions.pm
@@ -30,6 +30,10 @@ sub iconbrowser_save {
 
     my $remote = LJ::get_remote();
 
+    if ( $post->{keywordorder} ) {
+        $remote->iconbrowser_keywordorder( $post->{keywordorder} eq "true" ? "Y" : "N" );
+    }
+
     if ( $post->{metatext} ) {
         $remote->iconbrowser_metatext( $post->{metatext} eq "true" ? "Y" : "N" );
     }

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1544,6 +1544,7 @@ sub talkform {
                 && $remote->can_manage($journalu),
 
             can_use_userpic_select => $remote->can_use_userpic_select && ( scalar(@icons) > 0 ),
+            iconbrowser_keywordorder   => $remote->iconbrowser_keywordorder ? "true" : "false",
             iconbrowser_metatext   => $remote->iconbrowser_metatext ? "true" : "false",
             iconbrowser_smallicons => $remote->iconbrowser_smallicons ? "true" : "false",
             }

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1543,10 +1543,10 @@ sub talkform {
                 && $remote
                 && $remote->can_manage($journalu),
 
-            can_use_userpic_select => $remote->can_use_userpic_select && ( scalar(@icons) > 0 ),
-            iconbrowser_keywordorder   => $remote->iconbrowser_keywordorder ? "true" : "false",
-            iconbrowser_metatext   => $remote->iconbrowser_metatext ? "true" : "false",
-            iconbrowser_smallicons => $remote->iconbrowser_smallicons ? "true" : "false",
+            can_use_userpic_select   => $remote->can_use_userpic_select && ( scalar(@icons) > 0 ),
+            iconbrowser_keywordorder => $remote->iconbrowser_keywordorder ? "true" : "false",
+            iconbrowser_metatext     => $remote->iconbrowser_metatext ? "true" : "false",
+            iconbrowser_smallicons   => $remote->iconbrowser_smallicons ? "true" : "false",
             }
         : 0,
         journal => {

--- a/cgi-bin/LJ/User/Permissions.pm
+++ b/cgi-bin/LJ/User/Permissions.pm
@@ -648,6 +648,26 @@ sub hide_join_post_link {
     return $u->prop('hide_join_post_link');
 }
 
+=head3 C<< $self->iconbrowser_keywordorder( [ $keyword_order ] ) >>
+
+If no argument, returns whether to sort the icon browser by keyword order
+(instead of upload order). Default is upload order.
+
+If argument is passed in, acts as setter. Argument can be "Y" / "N"
+
+=cut
+
+sub iconbrowser_keywordorder {
+    my $u = $_[0];
+
+    if ( $_[1] ) {
+        my $newval = $_[1] eq "Y" ? "Y" : undef;
+        $u->set_prop( iconbrowser_keywordorder => $newval );
+    }
+
+    return ( $_[1] || $u->prop('iconbrowser_keywordorder') || "N" ) eq 'Y' ? 1 : 0;
+}
+
 =head3 C<< $self->iconbrowser_metatext( [ $arg ] ) >>
 
 If no argument, returns whether to show meta text in the icon browser or not.

--- a/cgi-bin/LJ/Userpic.pm
+++ b/cgi-bin/LJ/Userpic.pm
@@ -572,7 +572,7 @@ sub keywords {
         # if list context return the array
         return ( $raw ? ('') : ( "pic#" . $self->id ) ) unless @pickeywords;
 
-        return @pickeywords;
+        return sort { lc $a cmp lc $b } @pickeywords;
     }
     else {
         # if scalar context return comma-seperated list of keywords, or "pic#12345" if no keywords

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -968,6 +968,7 @@ sub create_qr_div {
                 icons_url              => $remote->allpics_base,
                 icons                  => \@icons,
                 can_use_userpic_select => $remote->can_use_userpic_select && ( scalar(@icons) > 0 ),
+                iconbrowser_keywordorder   => $remote->iconbrowser_keywordorder ? "true" : "false",
                 iconbrowser_metatext   => $remote->iconbrowser_metatext ? "true" : "false",
                 iconbrowser_smallicons => $remote->iconbrowser_smallicons ? "true" : "false",
             },

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -968,9 +968,9 @@ sub create_qr_div {
                 icons_url              => $remote->allpics_base,
                 icons                  => \@icons,
                 can_use_userpic_select => $remote->can_use_userpic_select && ( scalar(@icons) > 0 ),
-                iconbrowser_keywordorder   => $remote->iconbrowser_keywordorder ? "true" : "false",
-                iconbrowser_metatext   => $remote->iconbrowser_metatext ? "true" : "false",
-                iconbrowser_smallicons => $remote->iconbrowser_smallicons ? "true" : "false",
+                iconbrowser_keywordorder => $remote->iconbrowser_keywordorder ? "true" : "false",
+                iconbrowser_metatext     => $remote->iconbrowser_metatext ? "true" : "false",
+                iconbrowser_smallicons   => $remote->iconbrowser_smallicons ? "true" : "false",
             },
 
             journal => {

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -48,9 +48,22 @@ function IconBrowser($el, options) {
             }
 
             // the browser blew away the user's tab-through position, so restore
-            // it on the icon menu, since that's what they just indirectly set a
-            // value for.
-            $el.focus();
+            // it on whatever makes most sense to focus. Defaulting to the icon
+            // menu, since that's what they just indirectly set a value for, but
+            // if you want something else, set
+            // data-focus-after-browse="selector" on the icon menu.
+            var $focusTarget = $el;
+            if ( $el.data('focusAfterBrowse') ) {
+                var $altTarget = $( $el.data('focusAfterBrowse') ).first();
+                if ( $altTarget.length === 1 ) {
+                    $focusTarget = $altTarget;
+                }
+            }
+            // Avoid yanking the focus if the user somehow managed to focus
+            // something else before this handler fired.
+            if ( document.activeElement.tagName === 'BODY' ) {
+                $focusTarget.focus();
+            }
         });
 }
 

--- a/htdocs/js/jquery.replyforms.js
+++ b/htdocs/js/jquery.replyforms.js
@@ -55,6 +55,7 @@ jQuery(function($) {
             triggerSelector: "#lj_userpicselect",
             modalId: "js-icon-browser",
             preferences: {
+                "keywordorder": $('#lj_userpicselect').data('iconbrowserKeywordorder'),
                 "metatext": $('#lj_userpicselect').data('iconbrowserMetatext'),
                 "smallicons": $('#lj_userpicselect').data('iconbrowserSmallicons')
             }

--- a/htdocs/scss/components/icon-browser.scss
+++ b/htdocs/scss/components/icon-browser.scss
@@ -110,90 +110,65 @@
         margin-bottom: 1rem;
     }
 
-    .keyword, .icon-browser-options a {
-        display: inline-block;
-        max-width: 100%;
+    // Style reset for icon/keyword buttons
+    button {
+        display: block;
+        border: none;
+        margin: 0;
+        padding: 0;
+        background: none;
+        border-radius: initial;
+        box-shadow: none;
+        color: inherit;
+        text-align: inherit;
+        font-size: inherit;
+        font-weight: inherit;
+        text-decoration: inherit;
+        line-height: inherit;
+    }
+
+    // Hack: We wrap buttons in a dummy 'a' element to grab an appropriate color
+    // for controls, so we can fit in on journal styles while still being
+    // accessible.
+    a.color-wrapper {
+        display: block;
+        text-decoration: none;
+    }
+
+    // Styles specifically for keyword buttons
+    .keyword {
+        display: block;
+        width: 100%;
         cursor: pointer;
         text-decoration: none;
         border-width: 1px;
         border-style: solid;
-        margin: .2em;
-        margin-left: 0;
-        padding: .1em .3em;
+        margin: 0 0 .2em;
+        padding: calc(.1em + 2px) calc(.3em + 2px); // Don't change size when border changes
         line-height: 1.5;
         transition-duration: 300ms;
         transition-timing-function: ease-out;
         transition-property: color, background-color;
 
-        &.active, &.inactive-toggle {
-            // Journal styles don't know about ".active" controls so they don't
-            // do the inverted colors thing you see in site skins. But border
-            // thickness will do in a pinch.
-            border-width: 3px;
-            margin: calc(.2em - 2px); // absorb extra border size
-            margin-left: 0;
-        }
+    }
+    a.active .keyword {
+        // Journal styles don't know about site skins' "a.active" controls so
+        // they don't do the inverted colors thing. But border thickness will do
+        // in a pinch.
+        border-width: 3px;
+        padding: .1em .3em;
     }
 
     .icon-browser-item-meta {
         word-wrap: break-word;
         overflow-wrap: break-word;
+        min-width: 0; // makes children shrinkable by grid/flex
         font-size: smaller;
-    }
-
-    // Keyword menus: the inline one is the modern one, and the legacy one is
-    // for old browsers that can't handle display: grid, because there's no way
-    // to make it work inline without tearing my hair out.
-    #inline-keyword-menu { // when no icon selected, or redundant bc meta text = yes
-        display: none;
-    }
-
-    #legacy-keyword-menu {
-        min-height: 4em;
-
-        @supports (display: grid) {
-            display: none;
-        }
-
-        label.left {
-            float: left;
-            margin-right: .5rem;
-        }
-    }
-
-    #icon-browser-select-button-wrapper {
-        display: none; // when no icon selected
-    }
-
-    #js-icon-browser-select {
-        margin-top: .5rem;
-        margin-bottom: .5rem;
-    }
-
-    .icon-browser-content #icon-browser-select-button-wrapper {
-        display: block;
-        display: flex;
-        justify-content: center;
-        align-items: center;
     }
 
     &.no-meta {
         .icon-browser-item-meta {
             display: none;
-        }
-
-        @supports (display: grid) { // no inline menu for old browsers
-            .icon-browser-content #inline-keyword-menu {
-                display: block;
-                grid-column: 1 / -1;
-
-                .keywords {
-                    display: flex;
-                    justify-content: center;
-                    flex-wrap: wrap;
-                    margin-bottom: .5rem;
-                }
-            }
         }
     }
 
@@ -203,6 +178,7 @@
         border-color: inherit;
     }
 
+    // Main grid
     .js-icon-browser-icon-grid {
         list-style: none;
         padding: 0;
@@ -211,6 +187,7 @@
         display: grid;
         grid-auto-flow: row dense;
         grid-template-columns: repeat(auto-fill, 110px);
+        justify-content: center;
         grid-column-gap: 1rem;
         grid-row-gap: 1rem;
 
@@ -234,19 +211,81 @@
         }
     }
 
-    // Pack em in:
-    &.small-icons.no-meta .js-icon-browser-icon-grid {
-        grid-template-columns: repeat(auto-fill, 58px);
+    // Per-item grid
+    .icon-browser-item {
+        display: grid;
+        grid-template-columns: 1fr;
+        grid-template-rows: 108px 1fr;
+        grid-row-gap: .5em;
+        grid-column-gap: .5em;
     }
 
-    .icon-browser-icon-image img {
-        max-width: 100%;
-        height: auto;
-        // Foundation's .th thumbnail class sets images to display: inline-block
-        // instead of inline, which makes border-box sizing affect their
-        // height/width attributes. So without this, a 100 x 100 icon will
-        // display as 92 x 92.
-        box-sizing: content-box;
+    // Icons sit on the ground, centered.
+    .icon-browser-icon-image {
+        align-self: end;
+        justify-self: center;
+
+        // Fallback for non-grid browsers
+        margin-bottom: .5em;
+        @supports (display: grid) {
+            margin-bottom: 0;
+        }
+    }
+
+    // Large + notext: get rid of extra vertical gap
+    &.no-meta {
+        .icon-browser-item {
+            grid-row-gap: 0;
+        }
+    }
+
+    // Small + text: Bigger cell width, icon beside text.
+    &.small-icons {
+        .js-icon-browser-icon-grid {
+            grid-template-columns: repeat(auto-fill, 180px);
+        }
+        .icon-browser-item {
+            grid-template-columns: 58px 1fr;
+            grid-template-rows: 1fr;
+        }
+        // Icon aligns w/ start of text.
+        .icon-browser-icon-image {
+            align-self: start;
+        }
+    }
+
+    // small + notext: shrink main grid, item grid adjusts fine.
+    &.small-icons.no-meta {
+        .js-icon-browser-icon-grid {
+            grid-template-columns: repeat(auto-fill, 58px);
+        }
+        // Icons can sit on the ground again.
+        .icon-browser-item {
+            grid-template-rows: minmax(58px, 1fr);
+        }
+        .icon-browser-icon-image {
+            align-self: end;
+            justify-self: center;
+        }
+    }
+
+    .icon-browser-icon-image {
+        a {
+            cursor: pointer; // since it has no href.
+            // Don't save useless space below the image:
+            display: block;
+            line-height: 0;
+        }
+
+        img {
+            max-width: 100%;
+            height: auto;
+            // Foundation's .th thumbnail class sets images to display: inline-block
+            // instead of inline, which makes border-box sizing affect their
+            // height/width attributes. So without this, a 100 x 100 icon will
+            // display as 92 x 92.
+            box-sizing: content-box;
+        }
     }
 
     &.small-icons {

--- a/htdocs/scss/components/icon-browser.scss
+++ b/htdocs/scss/components/icon-browser.scss
@@ -51,7 +51,8 @@
     }
 
     #js-icon-browser-search {
-        width: auto; // don't stretch to 100% on site skin
+        width: 8em; // don't stretch to 100% on site skin
+        flex-grow: 1;
         @media (pointer: coarse) {
             font-size: 16px; // dramatic woodchuck repellent
         }
@@ -88,10 +89,19 @@
             margin-right: 2em;
 
             @supports (display: flex) {
-                margin-right: 0;
+                margin-right: .4rem;
+                margin-left: .4rem;
             }
 
             margin-bottom: 1rem;
+            white-space: nowrap;
+        }
+
+        // Override ultra-fluffy Foundation styling for fieldsets, we don't have
+        // space for that nonsense.
+        fieldset {
+            margin: 0;
+            padding: .3em .8em .6em;
         }
     }
 

--- a/views/components/icon-browser.tt
+++ b/views/components/icon-browser.tt
@@ -24,34 +24,45 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
         <div class="row">
             <div class="columns top-controls">
-                <div class="display-toggles">
-                    <div class='icon-browser-options icon-browser-meta-toggle' id='js-icon-browser-meta-toggle'>
-                        <a href="#" role="button" data-action="text">Text</a> /
-                        <a href="#" role="button" data-action="no-text">No text</a>
-                    </div>
+                <form class="icon-browser-options" id="js-icon-browser-order-option">
+                    <fieldset>
+                        <legend>Order by</legend>
 
-                    <div class='icon-browser-options icon-browser-size-toggle' id='js-icon-browser-size-toggle'>
-                        <a href="#" role="button" data-action="small">Small</a> /
-                        <a href="#" role="button" data-action="large">Large</a>
-                    </div>
-                </div>
+                        <input type="radio" name="js-icon-browser-order" value="date" id="js-icon-browser-order-date">
+                        <label for="js-icon-browser-order-date">Date</label>
+
+                        <input type="radio" name="js-icon-browser-order" value="keyword" id="js-icon-browser-order-keyword">
+                        <label for="js-icon-browser-order-keyword">Keyword</label>
+                    </fieldset>
+                </form>
+
+                <form class="icon-browser-options" id="js-icon-browser-meta-option">
+                    <fieldset>
+                        <legend>Icon keywords</legend>
+
+                        <input type="radio" name="js-icon-browser-meta" value="text" id="js-icon-browser-meta-text">
+                        <label for="js-icon-browser-meta-text">Show</label>
+
+                        <input type="radio" name="js-icon-browser-meta" value="no-text" id="js-icon-browser-meta-no-text">
+                        <label for="js-icon-browser-meta-no-text">Hide</label>
+                    </fieldset>
+                </form>
+
+                <form class="icon-browser-options" id="js-icon-browser-size-option">
+                    <fieldset>
+                        <legend>Size</legend>
+
+                        <input type="radio" name="js-icon-browser-size" value="small" id="js-icon-browser-size-small">
+                        <label for="js-icon-browser-size-small">Small</label>
+
+                        <input type="radio" name="js-icon-browser-size" value="large" id="js-icon-browser-size-large">
+                        <label for="js-icon-browser-size-large">Large</label>
+                    </fieldset>
+                </form>
 
                 <label class='invisible' for='js-icon-browser-search'>Search</label>
                 <input type='search' id='js-icon-browser-search' placeholder='Search' />
             </div>
-        </div>
-
-        <div id="legacy-keyword-menu" class="keyword-menu">
-            <label class="left">Keywords of selected icon:</label>
-            <div class='keywords'></div>
-        </div>
-
-        <div id="inline-keyword-menu" class="keyword-menu">
-            <div class='keywords'></div>
-        </div>
-
-        <div id='icon-browser-select-button-wrapper'>
-            <button id='js-icon-browser-select'>Select</button>
         </div>
 
         <div id="js-icon-browser-content" class="icon-browser-content">

--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -100,6 +100,7 @@ postFormInitData.strings = {
 
 [%- IF remote && remote.can_use_userpic_select -%]
     postFormInitData.iconBrowser = {
+        "keywordorder": [%- icon_browser.keywordorder ? "true" : "false" -%],
         "metatext": [%- icon_browser.metatext ? "true" : "false" -%],
         "smallicons": [%- icon_browser.smallicons ? "true": "false" -%]
     };

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -48,6 +48,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
           id = 'prop_picture_keyword',
           selected = current_icon_kw,
           items = remote.icons
+          'data-focus-after-browse' = '#body'
       ) -%]
 
       <input type="button" id="randomicon" value="Random" style="display: none;" />

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -24,7 +24,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
   <div class='qr-icon'>
     [%- IF remote.can_use_userpic_select -%]
-      <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
+      <button type='button' id='lj_userpicselect' data-iconbrowser-keywordorder="[%- remote.iconbrowser_keywordorder -%]" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
     [%- ELSE -%]
       <a href="[% remote.icons_url %]">
     [%- END -%]

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -339,6 +339,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         id = 'prop_picture_keyword',
         selected = comment.current_icon_kw,
         items = remote.icons
+        'data-focus-after-browse' = '#body'
       ) -%]
 
       <input type="button" id="randomicon" value="Random" style="display: none;" />

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -315,7 +315,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 <div class='qr-meta'>
   <div class='qr-icon no-label'>
     [%- IF remote.can_use_userpic_select -%]
-      <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
+      <button type='button' id='lj_userpicselect' data-iconbrowser-keywordorder="[%- remote.iconbrowser_keywordorder -%]" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
     [%- ELSIF remote -%]
       <a href="[% remote.icons_url %]">
     [%- END -%]
@@ -866,7 +866,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         ) -%]
 
         [%- IF remote.can_use_userpic_select -%]
-          <button type="button" class="js-only" style="display: none;" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
+          <button type="button" class="js-only" style="display: none;" id="lj_userpicselect" data-iconbrowser-keywordorder="[%- remote.iconbrowser_keywordorder -%]" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
               Browse
           </button>
         [%- END -%]


### PR DESCRIPTION
I broke out the keyword order stuff into separate commits, but there's a fairly large catch-all commit at the end anyway, because there were a bunch of interactions and it wasn't practical to separate everything out.

This is a revision to respond to post-beta feedback, mostly from the Plurk thread momiji kicked off. The main parts are: 

- Sort by keyword, FINALLY. Fixes #1663 
- Yank the keywords menu that appeared below an icon in no-text mode. **No-text means no-text.**
- One click and done, no more intermediate selected state or "Select" button. 

### Screens: 

<details><summary>a bunch of em</summary>

![Screenshot_2020-08-07 sheworks4themoney Recent Entries(1)](https://user-images.githubusercontent.com/484309/89701450-fe162600-d8eb-11ea-83b6-40f6dafda637.png)

![Screenshot_2020-08-07 sheworks4themoney Recent Entries](https://user-images.githubusercontent.com/484309/89701452-00788000-d8ec-11ea-83df-f94d4fb2d061.png)

![Screenshot_2020-08-07 sheworks4themoney (Reply)(4)](https://user-images.githubusercontent.com/484309/89701454-01a9ad00-d8ec-11ea-80f2-1301c957c634.png)

![Screenshot_2020-08-07 sheworks4themoney (Reply)(3)](https://user-images.githubusercontent.com/484309/89701455-02424380-d8ec-11ea-8495-68c5d2bd45ad.png)

![Screenshot_2020-08-07 sheworks4themoney (Reply)(2)](https://user-images.githubusercontent.com/484309/89701456-02424380-d8ec-11ea-8119-bfcf255911b3.png)

![Screenshot_2020-08-07 sheworks4themoney (Reply)(1)](https://user-images.githubusercontent.com/484309/89701457-02dada00-d8ec-11ea-9919-f677b550c602.png)

![Screenshot_2020-08-07 sheworks4themoney (Reply)](https://user-images.githubusercontent.com/484309/89701458-03737080-d8ec-11ea-952c-ee67ee594eed.jpg)

![Screenshot_2020-08-07 sheworks4themoney (Reply)](https://user-images.githubusercontent.com/484309/89701459-040c0700-d8ec-11ea-89fe-c75ec7760813.png)

</details>