### PR TITLE
remove ineffective editjournal feature action:saveunsuspend

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -262,6 +262,7 @@ general /friends/nudge.bml.success.text
 general /editjournal.bml.enterlogin
 general /editjournal.bml.lostinfo.head
 general /editjournal.bml.lostinfo.text
+general /editjournal.bml.success.editedunsuspend
 
 general /editjournal_do.bml.error.mustlogin
 general /editjournal_do.bml.success.edit
@@ -1943,6 +1944,7 @@ general /interests/int.tt.nousers.header
 general /interests/int.tt.nousers.text2
 general /interests/int.tt.users.header
 
+general cleanhtml.suspend_msg_with_supportid
 general contentflag.viewingconcepts.byadmin
 general contentflag.viewingexplicit.byadmin
 general cprod.todomaxitems.text2.v1
@@ -1994,6 +1996,8 @@ general email.newacct2.body
 general email.newacct4.body
 general entryform.music.detect
 general entryform.public
+general entryform.saveandrequestunsuspend
+general entryform.saveandrequestunsuspend2
 general error.badpassword
 general error.interest.bytes.chars.words
 general error.interest.chars.words

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -41,8 +41,6 @@ cleanhtml.error.template.video=[Error: unknown template 'video']
 
 cleanhtml.suspend_msg=This is a suspended entry.
 
-cleanhtml.suspend_msg_with_supportid=This is a suspended entry. <a [[aopts]]>An unsuspension request</a> has been opened and this entry will be reviewed soon.
-
 collapsible.collapsed=Expand
 
 collapsible.expanded=Collapse
@@ -666,10 +664,6 @@ entryform.preview=Preview
 entryform.save=Save
 
 entryform.save.maintainer=Save Administrator Override Settings
-
-entryform.saveandrequestunsuspend=Save Entry & Request Unsuspension
-
-entryform.saveandrequestunsuspend2=Save and Request Unsuspension
 
 entryform.security=Security:
 

--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -1687,13 +1687,6 @@ logproplist.unknown8bit:
   sortorder: 99
   ownership: user
 
-logproplist.unsuspend_supportid:
-  datatype: num
-  des: The support request ID of the unsuspension request submitted by a user whose entry was suspended. Undef or 0 if no request is currently open.
-  prettyname: Support Request ID for Unsuspension Request
-  sortorder: 99
-  ownership: system
-
 logproplist.used_rte:
   datatype: bool
   des: True if entry was composed using the rich text editor

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -829,13 +829,12 @@ sub _form_to_backend {
 sub _backend_to_form {
     my ($entry) = @_;
 
-#             my $entry = {
-#                 'usejournal' => $usejournal,
-#                 'auth' => $auth,
-#                 'richtext' => LJ::is_enabled('richtext'),
-#                 'suspended' => $suspend_msg,
-#                 'unsuspend_supportid' => $suspend_msg ? $entry_obj->prop("unsuspend_supportid") : 0,
-#             };
+    #             my $entry = {
+    #                 'usejournal' => $usejournal,
+    #                 'auth' => $auth,
+    #                 'richtext' => LJ::is_enabled('richtext'),
+    #                 'suspended' => $suspend_msg,
+    #             };
 
     # direct translation of prop values to the form
 

--- a/cgi-bin/DW/Controller/RPC/CutExpander.pm
+++ b/cgi-bin/DW/Controller/RPC/CutExpander.pm
@@ -86,12 +86,11 @@ sub load_cuttext {
 
     my $suspend_msg    = $entry_obj && $entry_obj->should_show_suspend_msg_to($remote) ? 1 : 0;
     my $cleanhtml_opts = {
-        cuturl              => $entry_obj->url,
-        journal             => $journal->username,
-        ditemid             => $ditemid,
-        suspend_msg         => $suspend_msg,
-        unsuspend_supportid => $suspend_msg ? $entry_obj->prop('unsuspend_supportid') : 0,
-        cut_retrieve        => $cutid,
+        cuturl       => $entry_obj->url,
+        journal      => $journal->username,
+        ditemid      => $ditemid,
+        suspend_msg  => $suspend_msg,
+        cut_retrieve => $cutid,
     };
 
     #load and prepare text of entry

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -130,11 +130,10 @@ sub clean {
           ( exists $opts->{'blocked_link_substitute'} ) ? $opts->{'blocked_link_substitute'}
         : ($LJ::BLOCKED_LINK_SUBSTITUTE)                ? $LJ::BLOCKED_LINK_SUBSTITUTE
         :                                                 '#';
-    my $suspend_msg          = $opts->{'suspend_msg'}         || 0;
-    my $unsuspend_supportid  = $opts->{'unsuspend_supportid'} || 0;
-    my $to_external_site     = $opts->{to_external_site}      || 0;
-    my $preserve_lj_tags_for = $opts->{preserve_lj_tags_for}  || 0;    # False or site name
-    my $remove_positioning   = $opts->{'remove_positioning'}  || 0;
+    my $suspend_msg          = $opts->{'suspend_msg'}        || 0;
+    my $to_external_site     = $opts->{to_external_site}     || 0;
+    my $preserve_lj_tags_for = $opts->{preserve_lj_tags_for} || 0;    # False or site name
+    my $remove_positioning   = $opts->{'remove_positioning'} || 0;
     my $errref               = $opts->{errref};
 
     # for ajax cut tag parsing
@@ -1369,23 +1368,8 @@ TOKEN:
     if ($suspend_msg) {
         my $msg =
 qq{<div style="color: #000; font: 12px Verdana, Arial, Sans-Serif; background-color: #ffeeee; background-repeat: repeat-x; border: 1px solid #ff9999; padding: 8px; margin: 5px auto; width: auto; text-align: left; background-image: url('$LJ::IMGPREFIX/message-error.gif');">};
-        my $link_style =
-            "color: #00c; text-decoration: underline; background: transparent; border: 0;";
 
-        if ($unsuspend_supportid) {
-            $msg .= LJ::Lang::ml(
-                'cleanhtml.suspend_msg_with_supportid',
-                {
-                    aopts =>
-"href='$LJ::SITEROOT/support/see_request?id=$unsuspend_supportid' style='$link_style'"
-                }
-            );
-        }
-        else {
-            $msg .= LJ::Lang::ml( 'cleanhtml.suspend_msg',
-                { aopts => "href='$LJ::SITEROOT/abuse/report' style='$link_style'" } );
-        }
-
+        $msg .= LJ::Lang::ml('cleanhtml.suspend_msg');
         $msg .= "</div>";
 
         $$data = $msg . $$data;
@@ -1715,7 +1699,6 @@ sub clean_event {
             transform_embed_wmode   => $opts->{transform_embed_wmode},
             rewrite_embed_param     => $opts->{rewrite_embed_param} ? 1 : 0,
             suspend_msg             => $opts->{suspend_msg} ? 1 : 0,
-            unsuspend_supportid     => $opts->{unsuspend_supportid},
             to_external_site        => $opts->{to_external_site} ? 1 : 0,
             preserve_lj_tags_for    => $opts->{preserve_lj_tags_for} || 0,
             cut_retrieve            => $opts->{cut_retrieve},

--- a/cgi-bin/LJ/Console/Command/Unsuspend.pm
+++ b/cgi-bin/LJ/Console/Command/Unsuspend.pm
@@ -57,9 +57,7 @@ sub execute {
         return $self->error("Entry is not currently suspended.")
             if $entry->is_visible;
 
-        $entry->set_prop( statusvis           => "V" );
-        $entry->set_prop( unsuspend_supportid => 0 )
-            if $entry->prop("unsuspend_supportid");
+        $entry->set_prop( statusvis => "V" );
 
         $reason = "entry: " . $entry->url . "; reason: $reason";
         LJ::statushistory_add( $journal, $remote, "unsuspend", $reason );

--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -913,14 +913,13 @@ sub event_html {
 
     my $remote      = LJ::get_remote();
     my $suspend_msg = $self->should_show_suspend_msg_to($remote) ? 1 : 0;
-    $opts->{suspend_msg}         = $suspend_msg;
-    $opts->{unsuspend_supportid} = $suspend_msg ? $self->prop("unsuspend_supportid") : 0;
-    $opts->{journal}             = $self->{u}->user;
-    $opts->{ditemid}             = $self->{ditemid};
-    $opts->{is_syndicated}       = $self->{u}->is_syndicated;
-    $opts->{is_imported}         = defined $self->{props}{import_source};
-    $opts->{editor}              = $self->prop('editor');
-    $opts->{logtime_mysql} = $self->logtime_mysql;    # for format guessing
+    $opts->{suspend_msg}   = $suspend_msg;
+    $opts->{journal}       = $self->{u}->user;
+    $opts->{ditemid}       = $self->{ditemid};
+    $opts->{is_syndicated} = $self->{u}->is_syndicated;
+    $opts->{is_imported}   = defined $self->{props}{import_source};
+    $opts->{editor}        = $self->prop('editor');
+    $opts->{logtime_mysql} = $self->logtime_mysql;                    # for format guessing
 
     $self->_load_text unless $self->{_loaded_text};
     my $event = $self->{event};

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -2321,20 +2321,6 @@ PREVIEW
                 ) . "&nbsp;\n";
             }
 
-            if ( !$opts->{'disabled_save'} && $opts->{suspended} && !$opts->{unsuspend_supportid} )
-            {
-                $out .= LJ::html_submit(
-                    'action:saveunsuspend',
-                    BML::ml('entryform.saveandrequestunsuspend2'),
-                    {
-                        'onclick'  => $onclick,
-                        'disabled' => $opts->{'disabled_save'},
-                        'class'    => 'xpost_submit',
-                        'tabindex' => $tabindex->()
-                    }
-                ) . "&nbsp;\n";
-            }
-
             # do a double-confirm on delete if we have crossposts that
             # would also get removed
             my $delete_onclick =

--- a/htdocs/editjournal.bml
+++ b/htdocs/editjournal.bml
@@ -226,7 +226,7 @@ body<=
             }
 
             # they clicked the save or delete button
-            if (!$spellcheck_html && ($POST{'action:save'} || $POST{'action:saveunsuspend'} || $POST{'action:delete'} || $POST{'action:deletespam'})) {
+            if (!$spellcheck_html && ($POST{'action:save'} || $POST{'action:delete'} || $POST{'action:deletespam'})) {
                 return LJ::bad_input($ML{'error.invalidform'}) unless LJ::check_form_auth();
 
                 my %req = ( 'mode' => 'editevent',
@@ -324,27 +324,8 @@ body<=
                         "<?p $ML{'.success.edited'} p?>";
                     $result .= "<div class='alert-box'>$message</div>" if $message;
                     $result .= $xpost_result;
-                    # open a request about the unsuspension if one doesn't already exist
-                    if ($POST{'action:saveunsuspend'} && !$entry_obj->prop("unsuspend_supportid") && $LJ::UNSUSPENSION_REQUEST_SPCATID) {
-                        my %req;
-                        $req{reqtype} = "user";
-                        $req{requserid} = $remote->id;
-                        $req{uniq} = LJ::UniqCookie->current_uniq;
-                        $req{spcatid} = $LJ::UNSUSPENSION_REQUEST_SPCATID;
-                        $req{ignore_dup_check} = 1; # can't have dup checking in case a particular entry gets re-suspended after unsuspension
-                        $req{subject} = "Unsuspension Request from " . $remote->user;
-                        $req{body} = "The suspended entry at " . $entry_obj->url . " has been edited and the poster requests unsuspension.";
-
-                        my @errors;
-                        my $spid = LJ::Support::file_request(\@errors, \%req);
-
-                        if ($spid) {
-                            $entry_obj->set_prop( unsuspend_supportid => $spid );
-                            my $url = "$LJ::SITEROOT/support/see_request?id=$spid";
-                            $result .= "<?p " . BML::ml('.success.editedunsuspend', { url => "<a href='$url'>$url</a>" }) . " p?>";
-                        }
-                    } elsif ($POST{'action:save'} && $entry_obj->is_suspended && !$entry_obj->prop("unsuspend_supportid")) {
-                        $result .= "<?p " . BML::ml('.success.editedstillsuspended', { aopts => "href='$LJ::SITEROOT/abuse/report'" }) . " p?>";
+                    if ($POST{'action:save'} && $entry_obj->is_suspended) {
+                        $result .= "<?p " . BML::ml('.success.editedstillsuspended') . " p?>";
                     }
                 }
 
@@ -464,7 +445,6 @@ body<=
                 'disabled_spamdelete' => $disabled_spamdelete,
                 'maintainer_mode' => !$disabled_spamdelete,
                 'suspended' => $suspend_msg,
-                'unsuspend_supportid' => $suspend_msg ? $entry_obj->prop("unsuspend_supportid") : 0,
             };
             for (my $i = 1; $i <= $res{'prop_count'}; $i++) {
                 $entry->{"prop_" . $res{"prop_${i}_name"}} = $res{"prop_${i}_value"};

--- a/htdocs/editjournal.bml.text
+++ b/htdocs/editjournal.bml.text
@@ -43,8 +43,6 @@
 
 .success.editedstillsuspended=Please note that your entry is still suspended.
 
-.success.editedunsuspend=Additionally, an unsuspension request has been opened at [[url]], and your entry will be reviewed soon.
-
 .success.fromhere=From here you can:
 
 .success.fromhere.editentry=Edit this entry again


### PR DESCRIPTION
The intent of this feature was to automatically open a new support request when a suspended entry was edited to remove offending content. This had no effect because `$LJ::UNSUSPENSION_REQUEST_SPCATID` was never set.

Most of the actual changes here are related to removing the `unsuspend_supportid` entryprop, intended to link the suspended entry and the support request. The only user-visible change is the removal of the extra (useless) button on /editjournal.