### PR TITLE
Fix printing on Foundation site skins

### DIFF
--- a/htdocs/scss/components/foundation-custom/_print.scss
+++ b/htdocs/scss/components/foundation-custom/_print.scss
@@ -1,0 +1,37 @@
+// Print styles that don't blow up our icon links, etc. etc.
+// Partial copy of the stuff in foundation/type, which also says "Credit to Paul
+// Irish and HTML5 Boilerplate (html5boilerplate.com)"
+@media print {
+  * {
+    background: transparent !important;
+    color: $black !important; /* Black prints faster: h5bp.com/s */
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  a,
+  a:visited { text-decoration: underline;}
+
+  abbr[title]:after { content: " (" attr(title) ")"; }
+
+  pre,
+  blockquote {
+    border-left: 2px solid $black;
+    page-break-inside: avoid;
+  }
+
+  thead { display: table-header-group; /* h5bp.com/t */ }
+
+  tr,
+  img { page-break-inside: avoid; }
+
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3;
+  }
+
+  h2,
+  h3 { page-break-after: avoid; }
+}

--- a/htdocs/scss/foundation/_settings.scss
+++ b/htdocs/scss/foundation/_settings.scss
@@ -71,7 +71,7 @@ $base-line-height: 1.5;
 // most of the time, we'll just want the mixins or variables
 // and not the styles themselves
 $include-html-classes: false !default;
-// $include-print-styles: true;
+$include-print-styles: false; // see components/foundation-custom/print.
 $include-html-global-classes: $include-html-classes;
 
 // b. Grid

--- a/htdocs/scss/foundation/foundation.scss
+++ b/htdocs/scss/foundation/foundation.scss
@@ -57,5 +57,6 @@
 @import
   "components/foundation-custom/buttons",
   "components/foundation-custom/pagination",
+  "components/foundation-custom/print",
   "components/foundation-custom/tables",
   "components/foundation-custom/reveal";

--- a/htdocs/scss/skins/_nav.scss
+++ b/htdocs/scss/skins/_nav.scss
@@ -38,9 +38,8 @@ $nav-small-screen-header-height: 3em;
         }
     }
 
-    @media #{$small-only} {
-        /* Adjustments to the static account links display in the masthead */
-
+    /* Adjustments to the account links display in the masthead */
+    @media #{$small-only}, print {
         #account-links-userpic {
             margin-top: -11px;
             img {
@@ -48,7 +47,15 @@ $nav-small-screen-header-height: 3em;
                 width: auto;
             }
         }
+    }
 
+    @media print {
+        #account-links-text {
+            display: none;
+        }
+    }
+
+    @media #{$small-only} {
         /* This makes the account links text into a modal when the screen is small */
         #account-links-text {
             @include reveal-modal-base(


### PR DESCRIPTION
Printing an entry+comments page on the new site skins pretty much just EXPLODES.
Shoutout to anaraine and AlexSeanchai in the Discord for raising the issue.

First set of problems is in Foundation's print styles, which "helpfully" add the
URL after every link (including tiny chiclet icon links that carry no meaning in
print). So let's turn those off and add our own reduced set, because flipping
font to black and expanding abbreviations is still a pretty good idea.

Second set of problems involves the positioning of account links and the user's
icon in the header, but those are straightforward fixes too.

Third set of problems is specific to Tropo, which cuts off everything after the
first page. 😱 Addressed in dreamwidth/dw-nonfree#142.

After that we get into the innate problems that already existed on the old skins
-- showing threading through indentation alone makes a truly impossible mess
when printing deep threads, and that can't be fixed without a total rethink of
the threading styles. But at least this commit (plus nonfree 142) gets us back
to status quo ante.