### PR TITLE
Stop "closing" `<br>` tags at the ends of paragraphs

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1160,6 +1160,7 @@ TOKEN:
                             my $close;
                             while ( ( $close = pop @tagstack ) && $close ne $tag ) {
                                 $opencount{$close}--;
+                                next if $close =~ $slashclose_tags;
                                 $newdata .= "</$close>";
                             }
                         }

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -78,7 +78,7 @@ my $onechar;
 #
 # In HTML5 these are called "void elements".
 my $slashclose_tags =
-qr/^(?:area|base|basefont|br|col|embed|frame|hr|img|input|isindex|link|meta|param|wbr|lj-embed|site-embed)$/i;
+qr/^(?:area|base|basefont|br|col|embed|frame|hr|img|input|isindex|link|meta|param|source|track|wbr|lj-embed|site-embed)$/i;
 
 # <LJFUNC>
 # name: LJ::CleanHTML::clean

--- a/t/cleaner-event.t
+++ b/t/cleaner-event.t
@@ -17,7 +17,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 41;
+use Test::More tests => 42;
 
 BEGIN { require "$ENV{LJHOME}/t/lib/ljtestlib.pl"; }
 use LJ::CleanHTML;
@@ -277,6 +277,12 @@ qq{&lt;select ... &gt;&lt;option ... &gt;hello&lt;/option&gt;&lt;option ... &gt;
     $clean->();
     is( $orig_post, $clean_post,
         "self-closing tags that aren't actually self-closing should still be closed." );
+
+    $orig_post  = qq{<p>line one<br>line two<br>line three<br>line four</p><p>new paragraph</p>};
+    $clean_post = qq{<p>line one<br>line two<br>line three<br>line four</p><p>new paragraph</p>};
+    $clean->( { editor => 'html_raw0' } );
+    is( $orig_post, $clean_post,
+        "empty tags don't get erroneously closed when closing their parent element." );
 
     $entry_text = qq{before <strong><cut text="cut">in strong</strong>out strong</cut>after};
 


### PR DESCRIPTION
- `<br>` is an [empty element](https://developer.mozilla.org/en-US/docs/Glossary/empty_element), so it has no closing tag. 
- `</br>` is invalid, but browsers appear to interpret it as a `<br>` tag instead of ignoring it.
- `<br>` is the canonical, correct form of `<br>`. However, `<br />` is also accepted, because once upon a time someone was trying to make XHTML happen, so a lot of tools still (wrongly) emit that. (XHTML is _not_ going to happen.) 
- We have two implementations of the thing in the cleaner that closes tags: a per-tag one, and an end-of-document one. The latter handles `<br>` just fine, and the other one craps itself because it is trying to make XHTML happen. (XHTML is _not_ going to happen.)