### PR TITLE
Two minor reply form tweaks

### DIFF
--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -66,9 +66,9 @@ function update(data,widget) {
         // .width() always gives content width, which is what we want here.
         var maxAvailableCommentWidth = firstCommentWidgetParent.width();
         var plannedWidth = widget.parent().width();
-        // 640 = 40em @ 16px, reasonable size on desktop. If we're mobile or
+        // 750px seems a reasonable size on desktop. If we're mobile or
         // otherwise too small for that, just max out what we've got.
-        var minWidth = Math.min( 640, maxAvailableCommentWidth );
+        var minWidth = Math.min( 750, maxAvailableCommentWidth );
         if ( plannedWidth < minWidth ) {
             // Ascend and grab the first non-transparent background color we
             // see, so the form fields aren't just dangling out in space

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -11,7 +11,7 @@
 
     @media #{$medium-up} {
         padding: .5em 1em;
-        max-width: 45rem;
+        max-width: 52rem;
     }
 
     // .de means warnings/alerts.

--- a/htdocs/scss/skins/_journal-typography.scss
+++ b/htdocs/scss/skins/_journal-typography.scss
@@ -4,7 +4,7 @@
 
 $journal-content-font-size: 1rem !default;
 
-.entry, #comments, .reply-page-wrapper {
+.entry, #comments, .reply-page-wrapper, #talkpost-wrapper {
   // Intended behavior:
   // - Skins that don't specify otherwise will display entries and comments
   //   in the default font size. (That's not the browser default, though,


### PR DESCRIPTION
- On preview page, use the same font as on other site skin pages. 
- On desktop, allow a little more max-width. 

Deep in a comment thread: 

![image](https://user-images.githubusercontent.com/484309/90459569-8ea3f180-e0b6-11ea-9ad2-646f5ba91804.png)

At top level: 

![image](https://user-images.githubusercontent.com/484309/90459597-a11e2b00-e0b6-11ea-9769-42ecdf602f8a.png)
