### PR TITLE
Fix icon browser on create entries page

### DIFF
--- a/htdocs/scss/components/icon-browser.scss
+++ b/htdocs/scss/components/icon-browser.scss
@@ -93,6 +93,7 @@
                 margin-left: .4rem;
             }
 
+            margin-top: 0;
             margin-bottom: 1rem;
             white-space: nowrap;
         }
@@ -100,7 +101,6 @@
         // Override ultra-fluffy Foundation styling for fieldsets, we don't have
         // space for that nonsense.
         fieldset {
-            margin: 0;
             padding: .3em .8em .6em;
         }
     }

--- a/htdocs/scss/foundation/components/_reveal.scss
+++ b/htdocs/scss/foundation/components/_reveal.scss
@@ -156,6 +156,7 @@ $z-index-base: 1005;
 // $color - Default: $reveal-close-color || $base
 @mixin reveal-close($color:$reveal-close-color) {
   color: $color;
+  background-color: inherit; // prevent gross overlaps if a box impinges on its space
   cursor: $cursor-pointer-value;
   font-size: $reveal-close-font-size;
   font-weight: $reveal-close-weight;

--- a/htdocs/scss/pages/entry/new.scss
+++ b/htdocs/scss/pages/entry/new.scss
@@ -92,6 +92,7 @@
 
     input, select, output, button {
         margin-right: 0;
+        vertical-align: top;
     }
 
     li {

--- a/htdocs/scss/pages/entry/new.scss
+++ b/htdocs/scss/pages/entry/new.scss
@@ -398,11 +398,6 @@
     padding: 0;
 }
 
-.reveal-modal fieldset {
-    border: none;
-}
-
-
 /* toolbar (temp) */
 @-moz-keyframes rotate { 100% { -moz-transform: rotate(90deg); } }
 @-webkit-keyframes rotate { 100% { -webkit-transform: rotate(90deg); } }

--- a/views/components/icon-browser.tt
+++ b/views/components/icon-browser.tt
@@ -24,41 +24,35 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
         <div class="row">
             <div class="columns top-controls">
-                <form class="icon-browser-options" id="js-icon-browser-order-option">
-                    <fieldset>
-                        <legend>Order by</legend>
+                <fieldset class="icon-browser-options" id="js-icon-browser-order-option">
+                    <legend>Order by</legend>
 
-                        <input type="radio" name="js-icon-browser-order" value="date" id="js-icon-browser-order-date">
-                        <label for="js-icon-browser-order-date">Date</label>
+                    <input type="radio" name="js-icon-browser-order" value="date" id="js-icon-browser-order-date">
+                    <label for="js-icon-browser-order-date">Date</label>
 
-                        <input type="radio" name="js-icon-browser-order" value="keyword" id="js-icon-browser-order-keyword">
-                        <label for="js-icon-browser-order-keyword">Keyword</label>
-                    </fieldset>
-                </form>
+                    <input type="radio" name="js-icon-browser-order" value="keyword" id="js-icon-browser-order-keyword">
+                    <label for="js-icon-browser-order-keyword">Keyword</label>
+                </fieldset>
 
-                <form class="icon-browser-options" id="js-icon-browser-meta-option">
-                    <fieldset>
-                        <legend>Icon keywords</legend>
+                <fieldset class="icon-browser-options" id="js-icon-browser-meta-option">
+                    <legend>Icon keywords</legend>
 
-                        <input type="radio" name="js-icon-browser-meta" value="text" id="js-icon-browser-meta-text">
-                        <label for="js-icon-browser-meta-text">Show</label>
+                    <input type="radio" name="js-icon-browser-meta" value="text" id="js-icon-browser-meta-text">
+                    <label for="js-icon-browser-meta-text">Show</label>
 
-                        <input type="radio" name="js-icon-browser-meta" value="no-text" id="js-icon-browser-meta-no-text">
-                        <label for="js-icon-browser-meta-no-text">Hide</label>
-                    </fieldset>
-                </form>
+                    <input type="radio" name="js-icon-browser-meta" value="no-text" id="js-icon-browser-meta-no-text">
+                    <label for="js-icon-browser-meta-no-text">Hide</label>
+                </fieldset>
 
-                <form class="icon-browser-options" id="js-icon-browser-size-option">
-                    <fieldset>
-                        <legend>Size</legend>
+                <fieldset class="icon-browser-options" id="js-icon-browser-size-option">
+                    <legend>Size</legend>
 
-                        <input type="radio" name="js-icon-browser-size" value="small" id="js-icon-browser-size-small">
-                        <label for="js-icon-browser-size-small">Small</label>
+                    <input type="radio" name="js-icon-browser-size" value="small" id="js-icon-browser-size-small">
+                    <label for="js-icon-browser-size-small">Small</label>
 
-                        <input type="radio" name="js-icon-browser-size" value="large" id="js-icon-browser-size-large">
-                        <label for="js-icon-browser-size-large">Large</label>
-                    </fieldset>
-                </form>
+                    <input type="radio" name="js-icon-browser-size" value="large" id="js-icon-browser-size-large">
+                    <label for="js-icon-browser-size-large">Large</label>
+                </fieldset>
 
                 <label class='invisible' for='js-icon-browser-search'>Search</label>
                 <input type='search' id='js-icon-browser-search' placeholder='Search' />

--- a/views/entry/module-access.tt
+++ b/views/entry/module-access.tt
@@ -18,29 +18,31 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
     [%- WRAPPER components/modal.tt id="js-custom-groups" class="custom-groups" -%]
     <fieldset>
-    <div class="row"><div class="columns">
       <legend>[% ".header.custom" | ml %]</legend>
-      <ul class="no-bullet">
-        [% FOREACH group IN customgroups %]
-            <li>[%- form.checkbox( label = group.label
-                        name = "custom_bit"
-                        id = "custom-bit-$group.value"
+      <div class="row"><div class="columns">
+        <ul class="no-bullet">
+          [% FOREACH group IN customgroups %]
+              <li>[%- form.checkbox( label = group.label
+                          name = "custom_bit"
+                          id = "custom-bit-$group.value"
 
-                        value = group.value
-            ) -%]</li>
-        [% END %]
-      </ul>
-    </div></div>
-    <div class="row"><div class="columns">
-      <button id='js-custom-groups-select'>[% '.select' | ml %]</button>
-    </div></div>
+                          value = group.value
+              ) -%]</li>
+          [% END %]
+        </ul>
+      </div></div>
+      <div class="row"><div class="columns">
+        <button id='js-custom-groups-select'>[% '.select' | ml %]</button>
+      </div></div>
     </fieldset>
 
-    <fieldset class="row"><div class="columns">
+    <fieldset>
       <legend>[% ".header.custom_member" | ml %]</legend>
-      <ul class="no-bullet" id="js-custom-group-members">
-      </ul>
-    </div></fieldset>
+      <div class="row"><div class="columns">
+        <ul class="no-bullet" id="js-custom-group-members">
+        </ul>
+      </div></div>
+    </fieldset>
     [% END %]
 
     [% END %]


### PR DESCRIPTION
🚨 This is a fix for a bug I introduced in #2825! 

The create entries page spawns the icon browser inside a `<form>` element, which means using nested `<forms>` for the options toggles is a NO-GO. Luckily, those weren't really needed, so this PR removes them in favor of just using `<fieldsets>` with the appropriate IDs. 

Also contains minor fixes for some surrounding issues that chose to get in my way. 