### PR TITLE
[#2832] Don't drop edit reason when previewing a comment edit

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1491,9 +1491,8 @@ sub talkform {
         default_usertype => 'user',
 
         comment => {
-            editid     => $editid,
-            editreason => $form->{editreason}
-                // ( $comment ? $comment->edit_reason : '' ),
+            editid      => $editid,
+            editreason  => $form->{editreason} // ( $comment ? $comment->edit_reason : '' ),
             oidurl      => $form->{oidurl},
             oiddo_login => $form->{oiddo_login},
             user        => $form->{userpost},

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1493,7 +1493,7 @@ sub talkform {
         comment => {
             editid     => $editid,
             editreason => $form->{editreason}
-                || ( $comment ? $comment->edit_reason : '' ),
+                // ( $comment ? $comment->edit_reason : '' ),
             oidurl      => $form->{oidurl},
             oiddo_login => $form->{oiddo_login},
             user        => $form->{userpost},

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -1491,8 +1491,9 @@ sub talkform {
         default_usertype => 'user',
 
         comment => {
-            editid      => $editid,
-            editreason  => $comment ? $comment->edit_reason : '',
+            editid     => $editid,
+            editreason => $form->{editreason}
+                || ( $comment ? $comment->edit_reason : '' ),
             oidurl      => $form->{oidurl},
             oiddo_login => $form->{oiddo_login},
             user        => $form->{userpost},


### PR DESCRIPTION
Fixes #2832 

This is a relative of #2724 -- old preview would propagate unrecognized fields
as hidden values, so while the preview form wouldn't _show_ you the edit reason,
it _would_ retain it. The new preview actually includes an edit reason field,
but blanks out whatever value you entered before previewing (or resets it to the
saved edit reason, if this is the second+ edit).

Easy enough fix; it's just the talkform wasn't expecting to receive that field
in a partial form submission.