### PR TITLE
Fix content centering in Gradation Horizontal

### DIFF
--- a/htdocs/scss/skins/_nav.scss
+++ b/htdocs/scss/skins/_nav.scss
@@ -292,6 +292,7 @@ $nav-small-screen-header-height: 3em;
             #content {
                 border-left: $sidebar-width solid $topbar-bg;
                 margin-left: 0; // so that it doesn't try to center the content on the page
+                padding-left: ($column-gutter/2);
                 min-height: 73rem;
             }
         }

--- a/htdocs/scss/skins/gradation/_gradation-base.scss
+++ b/htdocs/scss/skins/gradation/_gradation-base.scss
@@ -162,8 +162,7 @@ ul { list-style: circle; }
 
 #content {
     @include grid-row();
-    margin-left: 0;
-    padding: 1.5em 0 0 ($column-gutter/2);
+    padding-top: 1.5rem;
 }
 
 /**


### PR DESCRIPTION
The gradation skins both slam the `#content` div over to the left, but that's
only appropriate on the vertical nav one; the horizontal one should act like the
tropos do and center it.