### PR TITLE
[#2841] Properly record anon comment IPs in the temp table for spam

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2324,7 +2324,7 @@ sub enter_comment {
     LJ::MemCache::incr( [ $journalu->{'userid'}, "talk2ct:$journalu->{'userid'}" ] );
 
     # record IP if anonymous
-    LJ::Talk::record_anon_comment_ip( $journalu, $comment->{talkid}, LJ::get_remote_ip() )
+    LJ::Talk::record_anon_comment_ip( $journalu, $jtalkid, LJ::get_remote_ip() )
         unless $posterid;
 
     # add to poster's talkleft table, or the xfer place
@@ -2489,7 +2489,6 @@ sub enter_imported_comment {
     my $jtalkid = LJ::alloc_user_counter( $journalu, "T" );
     return $err->( "Database Error", "Could not generate a talkid necessary to post this comment." )
         unless $jtalkid;
-    $comment->{talkid} = $jtalkid;
 
     # insert the comment
     my $errstr;
@@ -3156,7 +3155,7 @@ sub edit_comment {
     # If we need to rescreen the comment, do so now.
     my $state = $comment->{state} || "";
     if ( $state eq 'S' ) {
-        LJ::Talk::screen_comment( $journalu, $item->jitemid, $comment->{talkid} );
+        LJ::Talk::screen_comment( $journalu, $item->jitemid, $comment_obj->jtalkid );
     }
 
     # cluster tracking
@@ -3183,9 +3182,6 @@ sub edit_comment {
             "poster_type:" . $pu ? $pu->journaltype_readable : 'anonymous'
         ]
     );
-
-    LJ::Hooks::run_hooks( 'edit_comment', $journalu->{userid}, $item->jitemid, $comment->{talkid} )
-        ;    # This hook is never registered by anything in -free or -nonfree. -NF
 
     return ( 1, $comment_obj->jtalkid );
 }


### PR DESCRIPTION
Fixes #2841 
Caused by #2660 

This is another instance of #2738 -- edit_comment and enter_comment used to
mutate their `$comment` argument by adding a `talkid` key with the jtalkid, and
I missed a few things referenced that value via the mutated hashref rather than
one of their other handles to the jtalkid. In this case, it was preventing
anonymous comment spam reports by not properly writing the IP address of new
anon comments to the tempanonips table.

This time I hunted real hard for anything in the code that might access any
hashref key called `talkid`. As a result, this commit also:

* Fixes one more instance of That Thing (re-screening when editing).
* Just deletes the final remaining instance (an unused hook).
* Yanks a similar "mutate the `$comment` argument" behavior in
`enter_imported_comment` -- nothing ever references that hashref argument again
before it goes out of scope.

All the remaining hashrefs with `talkid` members seem to be either s2 comment
objects or the `parent` element of one of `prepare_and_validate_comment`'s
comment hashrefs.