### PR TITLE
[#2842] Stop closing `<poll-45123>` placeholder tags

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -78,7 +78,7 @@ my $onechar;
 #
 # In HTML5 these are called "void elements".
 my $slashclose_tags =
-qr/^(?:area|base|basefont|br|col|embed|frame|hr|img|input|isindex|link|meta|param|source|track|wbr|lj-embed|site-embed)$/i;
+qr/^(?:area|base|basefont|br|col|embed|frame|hr|img|input|isindex|link|meta|param|source|track|wbr|lj-embed|site-embed|poll-\d+|lj-poll-\d+)$/i;
 
 # <LJFUNC>
 # name: LJ::CleanHTML::clean


### PR DESCRIPTION
Fixes #2842 

The HTML cleaner closes dangling tags (both at document end, and when closing
tags mid-way), but exempts the HTML5 list of "empty" tags from that.

Once an entry with a poll is saved, the markup that was used to build the
poll gets replaced with a `<poll-nnn>` placeholder, so the poll can't be
subsequently modified. These placeholder tags are effectively empty tags, but
the cleaner doesn't really treat them as special because it's not in charge of
rendering them; `LJ::Poll->expand_entry` does that, and we call it _after_
`clean_event` when we're rendering an entry.

Anyway, the cleaner was helpfully "closing" these placeholders, so, let's don't.