### PR TITLE
The Squish, Part Four

### DIFF
--- a/htdocs/js/jquery.imageshrink.js
+++ b/htdocs/js/jquery.imageshrink.js
@@ -3,6 +3,7 @@
 // - Zooming (on click)
 // - Exempting decorative markup from Squish (should be pure CSS, but can't yet)
 // - Hiding zoom cursors for images that won't zoom
+// - Marking tall images so they get modified squish behavior
 jQuery(function($) {
 
     // First: Basic click-to-zoom. (.imageshrink-expanded on/off)
@@ -35,25 +36,56 @@ jQuery(function($) {
     // Check the whole document to start with.
     protectTheCodes(document);
 
-    // Third: Don't show zoom cursors for non-zooming images (.imageshrink-actualsize on/off)
-
-    // Dummied out observeImages function, to simplify browser support in (Fourth).
+    // Dummied out observeImages function, to simplify browser support in (Fifth).
     var observeImages = function(container) {return;};
 
     if (typeof ResizeObserver === 'function') {
-        var zoomCursorCleaner = new ResizeObserver(function(resizeList, observer) {
+        var imageShrinkResizeObserver = new ResizeObserver(function(resizeList, observer) {
             resizeList.forEach(function(entry) {
                 var img = entry.target;
                 if (img.tagName !== 'IMG') { return; }
 
-                // Zoomed images don't count.
-                if ( ! img.classList.contains('imageshrink-expanded')
-                    && img.width === img.naturalWidth
-                    && img.height === img.naturalHeight
-                ) {
+                // Third: Skip zoom cursors for images that won't zoom (.imageshrink-actualsize on/off)
+                // "Won't zoom" means it's in its "shrunk" state and is already
+                // either "natural" full size or "requested" full size (as per
+                // the height/width attributes).
+                // "Natural" is easy:
+                var isNaturalSize = img.width === img.naturalWidth && img.height === img.naturalHeight;
+                // "Requested" is hard. `object-fit: contain` w/ max-height means
+                // layout width might be wider than visible width. There's no way
+                // to directly measure visible width, and of course that's the one
+                // we care about. Plus maybe they only set one attribute. So we
+                // measure indirectly: if the layout aspect ratio doesn't match the
+                // natural aspect ratio (+/- some slop bc floats), it CAN'T be the
+                // requested size. (And at least one dimension has to match.)
+                // And yes, this ignores the use case of deliberately mutilating the
+                // aspect ratio for comedy; use something other than the height/width
+                // attrs for that.
+                var attrWidth = parseInt(img.getAttribute('width'));
+                var attrHeight = parseInt(img.getAttribute('height'));
+                var isRequestedSize =
+                    (    ( !isNaN(attrWidth) && attrWidth === img.width )
+                      || ( !isNaN(attrHeight) && attrHeight === img.height )
+                    )
+                    && Math.abs( (img.height / img.width) - (img.naturalHeight / img.naturalWidth) ) < 0.004;
+                    // Might want to tune that slop later. Or hey, maybe I nailed it. -NF
+
+                var isActualSize = isNaturalSize || isRequestedSize;
+
+                if ( isActualSize && ! img.classList.contains('imageshrink-expanded') ) {
                     img.classList.add('imageshrink-actualsize');
                 } else {
                     img.classList.remove('imageshrink-actualsize');
+                }
+
+                // Fourth: Mark tall images so we can let them scroll. Doing
+                // this in the ResizeObserver because images have unknown natural
+                // aspect ratios until load & decode; they'll fire a resize once
+                // the browser sorts it out.
+                if ( (img.naturalHeight / img.naturalWidth) >= 2 ) {
+                    img.classList.add('imageshrink-tall');
+                } else {
+                    img.classList.remove('imageshrink-tall');
                 }
             });
         });
@@ -63,7 +95,7 @@ jQuery(function($) {
             let images = container.querySelectorAll('.entry-content img, .comment-content img');
             // Anything with ResizeObserver definitely has NodeList.forEach.
             images.forEach(function(img) {
-                zoomCursorCleaner.observe(img);
+                imageShrinkResizeObserver.observe(img);
             });
         }
 
@@ -71,7 +103,7 @@ jQuery(function($) {
         observeImages(document);
     }
 
-    // Fourth: Repeat (Second) and (Third) when adding images to the page.
+    // Fifth: Repeat (Second), (Third), (Fourth) when adding images to the page.
     // (Via cut tags, comment expansion, or image placeholders.)
     if (typeof MutationObserver === 'function') {
         var imageUpdater = new MutationObserver(function(mutationList, observer) {

--- a/htdocs/scss/components/imageshrink.scss
+++ b/htdocs/scss/components/imageshrink.scss
@@ -1,46 +1,49 @@
 /* Constrain size of casually posted images.
     1: Don't trash the layout sideways.
-    2: Limit height to fit inside the viewport. Having to scroll to see a
-      portrait of someone is nonsense.
+    2: Limit height to fit inside the viewport. (UNLESS the aspect ratio is
+       greater than 1:2, in which case it's probably a tall comic.)
     3: Defend the native aspect ratio.
-    4: Respect the width/height HTML attributes for scaling down OR up
-      (within the limits of the container), but if they conflict with the aspect
-      ratio, treat them as maximums and let the aspect ratio win.
-    5: Let the user expand an individual image to max size by clicking.
-      (js/jquery.imageshrink.js)
+    4: Respect the width/height HTML attributes as the maximum size (in CSS
+       pixels) for the "zoomed in" state, since the image might be huge to
+       support high DPI devices.
+    5: Let the user expand an individual image to max size by clicking (UNLESS
+       it's inside a link). (js/jquery.imageshrink.js)
     6: Use a zoom-in/zoom-out cursor to show when users can zoom.
-    7: Undo zoom cursor for images that are actual size in their unexpanded
-      state (.imageshrink-actualsize; relies on JS for comparing effective and
-      natural dimensions).
-    8: NONE of the above applies to images inside tables or inline-styled divs.
-      (.imageshrink-exempt; relies on JS for heavy lifting.)
-
-      FIXME: Someday in the distant future, part 8 should be pure CSS, using
-      selectors kind of like this:
-      img:not(.journal-type-P .entry-content div[style]:not(.cuttag-open) img)
-      Unfortunately that's a CSS Selectors Level 4 thing, and as of 2020 only
-      Safari supports it (and that's just the earlier iteration; I didn't try
-      the one that skips .cuttag-open like that). Oh well.
+    7: Omit zoom cursor for images that are actual size in their unexpanded
+       state (.imageshrink-actualsize; relies on JS for comparing extrinsic and
+       intrinsic sizes).
+    8: Ignore all of the above for:
+       a: Images inside tables or inline-styled divs. (.imageshrink-exempt;
+          relies on JS for heavy lifting.)
+       b: Images with a style attribute.
 */
 
 @supports (object-fit: contain) {
   .entry-content, .comment-content {
-    img:not(.imageshrink-exempt) {
-      cursor: zoom-in;
-      height: auto;
-      max-width: 100%;
-      max-height: 95vh;
-      object-fit: contain;
-      object-position: left;
+    img:not(.imageshrink-exempt):not([style]) {
+      // A height or width value can be overridden, but it can never be truly
+      // *removed,* which means you lose the ability to default to the
+      // height/width HTML attributes as soon as you touch those CSS properties.
+      // That's why we're using this :not() selector -- once
+      // .imageshrink-expanded gets added to an image, it retroactively never
+      // had that "height: auto;" property, and thus the zoomed-in state can
+      // respect the height/width attributes.
+      &:not(.imageshrink-expanded) {
+        cursor: zoom-in;
+        height: auto; // If the image shrank, this prevents gross empty space above/below it.
+        max-width: 100%;
+        max-height: 95vh;
+        object-fit: contain;
+        object-position: left;
+
+        // Tall comics don't need to fit inside the viewport.
+        &.imageshrink-tall {
+          max-height: unset;
+        }
+      }
 
       &.imageshrink-expanded {
         cursor: zoom-out;
-        height: auto;
-        width: auto;
-        max-width: unset;
-        max-height: unset;
-        object-fit: unset;
-        object-position: unset;
       }
     }
   }


### PR DESCRIPTION
Fixes #2845 

The quest to perfect this image-shrinking behavior continues. This time:

- Distinguish between "normal" and "tall" (height > 2x width) casual images, and
let tall images scroll instead of fitting the viewport. Nicer un-zoomed state
for vertical comic strips.

- Any image with a `style="..."` attribute is exempt from the squish. Same
logic as the decorative code exemption: inline styles means you're spending
effort to make things Just So, and the only point of the squish is to save your
time when you _don't_ want to spend effort. (Sidenote: we can't use the
width/height attributes as this kind of signal, because casual "share" copypasta
often has large w/h values.)

- Use img width/height attributes as the maximum size for the _zoomed-in_ state.
Nicer zoom behavior when using an over-resolution image to look good on retina
screens.