### PR TITLE
Force markup FAQ link to open in new tab/window

### DIFF
--- a/views/entry/form.tt
+++ b/views/entry/form.tt
@@ -185,7 +185,7 @@ postFormInitData.strings = {
                   items = editors.items
                 ) -%]
 
-                <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1">[%-
+                <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1" target="_blank">[%-
                   dw.img('help', '',
                     {
                       alt   => dw.ml('markup.helplink.alttext'),

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -83,7 +83,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
       items = editors.items
     ) -%]
 
-    <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1">[%-
+    <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1" target="_blank">[%-
       dw.img('help', '',
         {
           alt   => dw.ml('markup.helplink.alttext'),

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -405,7 +405,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
       items = editors.items
     ) -%]
 
-    <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1">[%-
+    <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1" target="_blank">[%-
       dw.img('help', '',
         {
           alt   => dw.ml('markup.helplink.alttext'),
@@ -887,7 +887,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         items = editors.items
       ) -%]
 
-      <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1">[%-
+      <a href="[% 'markup.helplink.url' | ml %]" tabindex="-1" target="_blank">[%-
         dw.img('help', '',
           {
             alt   => dw.ml('markup.helplink.alttext'),


### PR DESCRIPTION
Most of our help icons have the target set properly so they don't navigate away from the page the user is currently on, but the markup FAQ links didn't!