### PR TITLE
widen ip columns in database tables

### DIFF
--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -1597,7 +1597,7 @@ EOC
 register_tablecreate( "spamreports", <<'EOC');    # global
 CREATE TABLE spamreports (
     reporttime  INT(10) UNSIGNED NOT NULL,
-    ip          VARCHAR(15),
+    ip          VARCHAR(45),
     journalid   INT(10) UNSIGNED NOT NULL,
     posterid    INT(10) UNSIGNED NOT NULL DEFAULT 0,
     subject     VARCHAR(255) BINARY,
@@ -4157,7 +4157,12 @@ q{INSERT INTO media_versions (userid, mediaid, versionid, width, height, filesiz
 
         # widen ip column for IPv6 addresses
         if ( column_type( "spamreports", "ip" ) eq "varchar(15)" ) {
-            do_alter( "spamreports", "ALTER TABLE spamreports " . "MODIFY ip VARCHAR(45)" );
+            do_alter( "spamreports", "ALTER TABLE spamreports MODIFY ip VARCHAR(45)" );
+        }
+
+        # widen ip column for IPv6 addresses
+        if ( column_type( "userlog", "ip" ) eq "varchar(15)" ) {
+            do_alter( "userlog", "ALTER TABLE userlog MODIFY ip VARCHAR(45)" );
         }
 
         unless ( column_type( 'ml_items', 'itcode' ) =~ /120/ ) {
@@ -4184,11 +4189,6 @@ q{INSERT INTO media_versions (userid, mediaid, versionid, width, height, filesiz
             do_alter( 'userpic2',
 "ALTER TABLE userpic2 MODIFY COLUMN description VARCHAR(600) BINARY NOT NULL default ''"
             );
-        }
-
-        # widen ip column for IPv6 addresses
-        if ( column_type( "userlog", "ip" ) eq "varchar(15)" ) {
-            do_alter( "spamreports", "ALTER TABLE userlog MODIFY ip VARCHAR(45)" );
         }
 
     }

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -1992,7 +1992,7 @@ CREATE TABLE loginlog (
     logintime INT UNSIGNED NOT NULL,
     INDEX     (userid, logintime),
     sessid    MEDIUMINT UNSIGNED NOT NULL,
-    ip        VARCHAR(15),
+    ip        VARCHAR(45),
     ua        VARCHAR(100)
 )
 EOC
@@ -4168,6 +4168,11 @@ q{INSERT INTO media_versions (userid, mediaid, versionid, width, height, filesiz
         # widen ip column for IPv6 addresses
         if ( column_type( "userlog", "ip" ) eq "varchar(15)" ) {
             do_alter( "userlog", "ALTER TABLE userlog MODIFY ip VARCHAR(45)" );
+        }
+
+        # widen ip column for IPv6 addresses
+        if ( column_type( "loginlog", "ip" ) eq "varchar(15)" ) {
+            do_alter( "loginlog", "ALTER TABLE loginlog MODIFY ip VARCHAR(45)" );
         }
 
         unless ( column_type( 'ml_items', 'itcode' ) =~ /120/ ) {

--- a/bin/upgrading/update-db-general.pl
+++ b/bin/upgrading/update-db-general.pl
@@ -1614,7 +1614,7 @@ EOC
 register_tablecreate( "tempanonips", <<'EOC');    # clustered
 CREATE TABLE tempanonips (
     reporttime  INT(10) UNSIGNED NOT NULL,
-    ip          VARCHAR(15) NOT NULL,
+    ip          VARCHAR(45) NOT NULL,
     journalid   INT(10) UNSIGNED NOT NULL,
     jtalkid     INT(10) UNSIGNED NOT NULL,
 
@@ -4158,6 +4158,11 @@ q{INSERT INTO media_versions (userid, mediaid, versionid, width, height, filesiz
         # widen ip column for IPv6 addresses
         if ( column_type( "spamreports", "ip" ) eq "varchar(15)" ) {
             do_alter( "spamreports", "ALTER TABLE spamreports MODIFY ip VARCHAR(45)" );
+        }
+
+        # widen ip column for IPv6 addresses
+        if ( column_type( "tempanonips", "ip" ) eq "varchar(15)" ) {
+            do_alter( "tempanonips", "ALTER TABLE tempanonips MODIFY ip VARCHAR(45) NOT NULL" );
         }
 
         # widen ip column for IPv6 addresses


### PR DESCRIPTION
This adds tempanonips and loginlog to the list of tables that have had their ip columns widened from 15 characters to 45. The tables for spamreports and userlog had already been widened previously.

I've tested this by running update-db.pl on my hack and making sure the column definitions were updated as expected.