### PR TITLE
reformat converted FAQ Search page

### DIFF
--- a/htdocs/stc/faq.css
+++ b/htdocs/stc/faq.css
@@ -4,5 +4,7 @@
     list-style-position: outside;
 }
 
-.summary {font-weight: bold;}
+.summary { font-weight: bold; }
 
+#search-q, #search-lang { width: auto; display: inline; margin: 1em; }
+#search-lang { padding-right: 2rem; }

--- a/views/support/faqsearch.tt
+++ b/views/support/faqsearch.tt
@@ -6,29 +6,9 @@
 [%- sections.title = dw.ml('.title') -%]
 
 <p>[% '.info' | ml %]</p>
-<form method='GET'>
-    <div class="row">
-        <div class="columns large-3 text-right">[% '.label.term' | ml %]:</div>
-        <div class="columns large-6">
-            [%- form.textbox( size = 30, value = q, name = 'q') -%]
-        </div>
-        <div class="columns large-3">
-            [%- form.submit( 'value' = dw.ml('.button.search')) -%]
-        </div>
-    </div>
 
-    <div class="row">
-        <div class="columns large-3 text-right">
-            [% '.label.lang' | ml %]
-        </div>
-        <div class="columns large-3">
-            [%- form.select( name = 'lang', selected = sel, items = langs) -%]
-        </div>
-        <div class="columns large-6">
-            [% '.example' | ml %]
-        </div>
-    </div>
-</form>
+<p>[% '.example' | ml %]</p>
+
 [%- IF q && q.length < 1 -%]
 <p><i>[% '.error.noterm' | ml %]</i></p>
 [%- END -%]
@@ -36,6 +16,21 @@
 [%- IF q && q.length < 2 -%]
 <p><i>[% '.error.tooshort' | ml %]</i></p>
 [%- END -%]
+
+<form method='GET'>
+    <div>
+            [% '.label.term' | ml %]:
+            [%- form.textbox( size = 30, value = q, name = 'q',
+	                      id = 'search-q' ) -%]
+            [%- form.submit( 'value' = dw.ml('.button.search') ) -%]
+    </div>
+
+    <div>
+            [% '.label.lang' | ml %]:
+            [%- form.select( name = 'lang', selected = sel, items = langs,
+	                     id = 'search-lang' ) -%]
+    </div>
+</form>
 
 [%- IF results -%]
     [%- IF results.size < 1 -%]


### PR DESCRIPTION
I think this is an improvement? The old layout really wasn't working for me.

Before:
![Screen Shot 2020-12-07 at 4 52 51 PM](https://user-images.githubusercontent.com/1976742/101415549-c32dfa00-38ad-11eb-8401-c284c72d7fe4.png)

After:
![Screen Shot 2020-12-07 at 4 53 09 PM](https://user-images.githubusercontent.com/1976742/101415556-c75a1780-38ad-11eb-995d-56f3d7ed892d.png)
