### PR TITLE
Use Math::Random::Secure for auth generation

### DIFF
--- a/cgi-bin/DW/Auth/Helpers.pm
+++ b/cgi-bin/DW/Auth/Helpers.pm
@@ -23,6 +23,7 @@ my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
 use Crypt::Mode::CBC;
 use MIME::Base64 qw/ encode_base64 decode_base64 /;
+use Math::Random::Secure qw(rand);
 
 ################################################################################
 #

--- a/cgi-bin/DW/Auth/TOTP.pm
+++ b/cgi-bin/DW/Auth/TOTP.pm
@@ -23,6 +23,7 @@ my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
 use Authen::OATH;
 use Convert::Base32 qw/ decode_base32 encode_base32 /;
+use Math::Random::Secure qw/ rand irand /;
 
 use DW::Auth::Helpers;
 use DW::Auth::Password;
@@ -134,7 +135,7 @@ sub generate_secret {
     # For convenience, always deal with base32'd secrets, as specified
     # by Google Authenticator
     my $string;
-    $string .= chr( int( rand(256) ) ) for 1 .. 16;
+    $string .= chr( irand(256) ) for 1 .. 16;
     return encode_base32($string);
 }
 

--- a/cgi-bin/LJ/Auth.pm
+++ b/cgi-bin/LJ/Auth.pm
@@ -19,6 +19,7 @@ use strict;
 use Digest::HMAC_SHA1 qw(hmac_sha1_hex);
 use Digest::SHA1 qw(sha1_hex);
 use Carp qw (croak);
+use Math::Random::Secure qw(irand);
 
 # Generate an auth token for AJAX requests to use.
 # Arguments: ($remote, $action, %postvars)
@@ -217,7 +218,7 @@ sub make_auth_code {
     my $length = shift;
     my $digits = "abcdefghjkmnpqrstvwxyz23456789";
     my $auth;
-    for ( 1 .. $length ) { $auth .= substr( $digits, int( rand(30) ), 1 ); }
+    for ( 1 .. $length ) { $auth .= substr( $digits, irand(30), 1 ); }
     return $auth;
 }
 

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -84,6 +84,7 @@ use DBI::Role;
 use Digest::MD5  ();
 use Digest::SHA1 ();
 use HTTP::Date   ();
+use Math::Random::Secure qw(rand irand);
 use LJ::Hooks;
 use LJ::MemCache;
 use LJ::Error;
@@ -793,7 +794,7 @@ sub rand_chars {
     die "Invalid charset $charset" unless $digits && ( $digit_len > 0 );
 
     for ( 1 .. $length ) {
-        $chal .= substr( $digits, int( rand($digit_len) ), 1 );
+        $chal .= substr( $digits, irand($digit_len), 1 );
     }
     return $chal;
 }

--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -37,6 +37,7 @@ MIME::Lite
 MIME::Words
 Mail::GnuPG
 Math::BigInt::GMP
+Math::Random::Secure
 MogileFS::Client@1.17
 Moose
 Mozilla::CA


### PR DESCRIPTION
Our previous settings were proooobably sufficiently random, but it's better to be safe and use a more clear-cut good source of randomness.