### PR TITLE
make sure the initial system user is associated with a journal style

### DIFF
--- a/bin/upgrading/make_system.pl
+++ b/bin/upgrading/make_system.pl
@@ -51,6 +51,9 @@ unless ($u) {
     exit 1;
 }
 
+# Make sure the system journal has a style to use
+$u->set_default_style;
+
 print "Giving 'system' account 'admin' priv on all areas...\n";
 if ( $u->has_priv( "admin", "*" ) ) {
     print "Already has it.\n";


### PR DESCRIPTION
Add a call to set_default_style after creating the user object.

From Discord:

`Error running style: Died in S2::run_code running RecentPage::print(): Can't use an undefined value as a subroutine reference at (eval 1271)[/home/mark/dw/src/s2/S2.pm:234] line 498.`

> @zorkian: Oh probably because I didn't have a style set and it was running core..? hmm. Well, selecting a style works and now it works.
> @momijizukamori: oh yeah there's some weird behavior if there's no style set, I've hit that with the system account on my hack in the past
> @kareila: sounds like the make system user script doesn't call whatever function gets called when a regular user is created to assign them the default journal style - in prod no one cares but everyone who runs a hack tests stuff as the system user so it should probably get fixed

Not tested since I didn't want to set up a scratch installation and create a new system user, but it's a straightforward one line change.