### PR TITLE
Reconcile icon select component with beta entry page

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -254,6 +254,10 @@ sub new_handler {
     );
     $vars->{formdata}->{editor} = $vars->{editors}->{selected};
 
+    # Set up info for the icon select/preview/browse components
+    $vars->{current_icon_kw} = $vars->{formdata}->{prop_picture_keyword};
+    $vars->{current_icon}    = LJ::Userpic->new_from_keyword( $remote, $vars->{current_icon_kw} );
+
     $vars->{editable} = { map { $_ => 1 } @modules };
 
     $vars->{action} = { url => LJ::create_url( undef, keep_args => 1 ), };
@@ -617,6 +621,10 @@ sub _edit {
     # so we'll update it in place with what DW::Formats thinks we should use.
     $vars->{formdata}->{editor} = $vars->{editors}->{selected};
 
+    # Set up info for the icon select/preview/browse components
+    $vars->{current_icon_kw} = $vars->{formdata}->{prop_picture_keyword};
+    $vars->{current_icon}    = LJ::Userpic->new_from_keyword( $remote, $vars->{current_icon_kw} );
+
     my %editable = map { $_ => 1 } @modules;
     $vars->{editable} = \%editable;
 
@@ -710,7 +718,8 @@ sub _form_to_backend {
             if defined $post->{$formname};
     }
     $props->{taglist}         = $post->{taglist} if defined $post->{taglist};
-    $props->{picture_keyword} = $post->{icon}    if defined $post->{icon};
+    $props->{picture_keyword} = $post->{prop_picture_keyword}
+        if defined $post->{prop_picture_keyword};
     $props->{opt_backdated} = $post->{entrytime_outoforder} ? 1 : 0;
 
     # This form always uses the editor prop instead of opt_preformatted.
@@ -911,10 +920,10 @@ sub _backend_to_form {
         subject => $entry->subject_raw,
         event   => $event,
 
-        icon       => $entry->userpic_kw,
-        security   => $security,
-        custom_bit => \@custom_groups,
-        is_sticky  => $entry->journal->sticky_entries_lookup->{ $entry->ditemid },
+        prop_picture_keyword => $entry->userpic_kw,
+        security             => $security,
+        custom_bit           => \@custom_groups,
+        is_sticky            => $entry->journal->sticky_entries_lookup->{ $entry->ditemid },
 
         %formprops,
         %otherprops,

--- a/views/components/icon-select-dropdown.tt
+++ b/views/components/icon-select-dropdown.tt
@@ -7,7 +7,6 @@
           id = 'prop_picture_keyword',
           selected = current_icon_kw,
           items = icons,
-          class = 'inline'
       ) -%]
 
       <input type="button" id="randomicon" value="Random" style="display: none;" />

--- a/views/components/icon-select-dropdown.tt
+++ b/views/components/icon-select-dropdown.tt
@@ -1,7 +1,7 @@
 [%- icons = remote.icon_keyword_menu() -%]
 [%- IF icons.size > 0 -%]
     <div class='block-icon-controls'>
-      <label for='prop_picture_keyword' class="left">[%- '/journal/talkform.tt.label.picturetouse2' | ml -%]</label>
+      <label for='prop_picture_keyword' class="invisible">[%- '/journal/talkform.tt.label.picturetouse2' | ml -%]</label>
       [%- form.select(
           name = 'prop_picture_keyword',
           id = 'prop_picture_keyword',

--- a/views/components/icon-select-dropdown.tt
+++ b/views/components/icon-select-dropdown.tt
@@ -1,6 +1,5 @@
 [%- icons = remote.icon_keyword_menu() -%]
 [%- IF icons.size > 0 -%]
-
     <div class='block-icon-controls'>
       <label for='prop_picture_keyword' class="left">[%- '/journal/talkform.tt.label.picturetouse2' | ml -%]</label>
       [%- form.select(
@@ -8,9 +7,9 @@
           id = 'prop_picture_keyword',
           selected = current_icon_kw,
           items = icons,
-            class= 'inline'
+          class = 'inline'
       ) -%]
 
       <input type="button" id="randomicon" value="Random" style="display: none;" />
     </div>
-  [%- END -%]
+[%- END -%]

--- a/views/components/icon-select-dropdown.tt
+++ b/views/components/icon-select-dropdown.tt
@@ -9,6 +9,8 @@
           items = icons,
       ) -%]
 
-      <input type="button" id="randomicon" value="Random" style="display: none;" />
+      [%- UNLESS omit_random_button -%]
+          <input type="button" id="randomicon" value="Random" style="display: none;" />
+      [%- END -%]
     </div>
 [%- END -%]

--- a/views/components/icon-select-icon.tt
+++ b/views/components/icon-select-icon.tt
@@ -1,25 +1,26 @@
 [%- can_use_userpic_select = (remote.can_use_userpic_select && remote.icon_keyword_menu().size > 0) -%]
-  [%- INCLUDE "components/icon-browser.tt" -%]
+[%- INCLUDE "components/icon-browser.tt" -%]
 
-[% dw.need_res({ group => "foundation"}, 
+[% dw.need_res({ group => "foundation"},
     'stc/css/components/icon-select.css',
     'js/components/jquery.icon-select.js',
 ) %]
-  <div class='block-icon no-label'>
-  [% IF remote.icon_keyword_menu.size > 0 %]
-    [%- IF can_use_userpic_select -%]
-      <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" data-iconbrowser-keywordorder="[%- remote.iconbrowser_keywordorder -%]">
-    [%- ELSE -%]
-      <a href="[% remote.allpics_base %]">
-    [%- END -%]
-      [%- selected = current_icon || remote.userpic -%]
-      [%- selected.imgtag -%]
-    [%- IF can_use_userpic_select -%]
-      </button>
-    [%- ELSE -%]
-      </a>
-    [%- END -%]
-  [% ELSE %]
-    <a href="[% site.root %]/manage/icons" class="no-icon">[%- dw.img( "nouserpic_sitescheme", "" ) -%]</a>
-  [% END %]
-  </div>
+
+<div class='block-icon no-label'>
+[% IF remote.icon_keyword_menu.size > 0 %]
+  [%- IF can_use_userpic_select -%]
+    <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" data-iconbrowser-keywordorder="[%- remote.iconbrowser_keywordorder -%]">
+  [%- ELSE -%]
+    <a href="[% remote.allpics_base %]">
+  [%- END -%]
+    [%- selected = current_icon || remote.userpic -%]
+    [%- selected.imgtag -%]
+  [%- IF can_use_userpic_select -%]
+    </button>
+  [%- ELSE -%]
+    </a>
+  [%- END -%]
+[% ELSE %]
+  <a href="[% site.root %]/manage/icons" class="no-icon">[%- dw.img( "nouserpic_sitescheme", "" ) -%]</a>
+[% END %]
+</div>

--- a/views/entry/module-icons.tt
+++ b/views/entry/module-icons.tt
@@ -28,7 +28,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
             [%- form.select(
             name = 'icon',
             id = 'prop_picture_keyword',
-            selected = current_icon_kw,
+
             items = remote.icon_keyword_menu,
         ) -%]
         </div>

--- a/views/entry/module-icons.tt
+++ b/views/entry/module-icons.tt
@@ -26,7 +26,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <div class="row">
         <div class="columns">
             [%- form.select(
-            name = 'prop_picture_keyword',
+            name = 'icon',
             id = 'prop_picture_keyword',
             selected = current_icon_kw,
             items = remote.icon_keyword_menu,

--- a/views/entry/module-icons.tt
+++ b/views/entry/module-icons.tt
@@ -22,18 +22,13 @@ the same terms as Perl itself.  For a copy of the license, please reference
             <div class="icon">[% INCLUDE "components/icon-select-icon.tt" %]</div>
         </div>
     </div>
-    [% IF remote.icon_keyword_menu.size > 0 %]
     <div class="row">
         <div class="columns">
-            [%- form.select(
-                name = 'icon',
-                id = 'prop_picture_keyword',
-
-                items = remote.icon_keyword_menu,
-            ) -%]
+            [% INCLUDE "components/icon-select-dropdown.tt" omit_random_button = 1 %]
         </div>
     </div>
 
+    [% IF remote.icon_keyword_menu.size > 0 %]
     <div class="row js-only">
         <div class="columns medium-6">
             <input class="small secondary button" id="randomicon" value="Random" type="button"/>

--- a/views/entry/module-icons.tt
+++ b/views/entry/module-icons.tt
@@ -26,11 +26,11 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <div class="row">
         <div class="columns">
             [%- form.select(
-            name = 'icon',
-            id = 'prop_picture_keyword',
+                name = 'icon',
+                id = 'prop_picture_keyword',
 
-            items = remote.icon_keyword_menu,
-        ) -%]
+                items = remote.icon_keyword_menu,
+            ) -%]
         </div>
     </div>
 


### PR DESCRIPTION
CODE TOUR: Fixed a bug where the beta create entries page wasn't properly saving the icon you chose. We recently started handling the icon menu more consistently, and one place that used it still really wanted to do things differently.

#2840 left the entry page using a one-off implementation of the icon select menu, but it didn't quite match what the controller expected. So, let's just sort out the controller so it can handle the component version properly — the component needs to get one extra conditional, and the controller gets slightly more verbose, but this way we only need to maintain one version of that `form.select` call.