### PR TITLE
Hack: fix entry page icon chooser (mostly)

### DIFF
--- a/views/entry/module-icons.tt
+++ b/views/entry/module-icons.tt
@@ -28,7 +28,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
             [%- form.select(
             name = 'icon',
             id = 'prop_picture_keyword',
-            selected = current_icon_kw,
+
             items = remote.icon_keyword_menu,
         ) -%]
         </div>

--- a/views/entry/module-icons.tt
+++ b/views/entry/module-icons.tt
@@ -26,7 +26,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
     <div class="row">
         <div class="columns">
             [%- form.select(
-            name = 'prop_picture_keyword',
+            name = 'icon',
             id = 'prop_picture_keyword',
             selected = current_icon_kw,
             items = remote.icon_keyword_menu,


### PR DESCRIPTION
CODE TOUR: no-impact

(^^ since edits are still bugged, we're going to need to do SOME kind of better fix for this, even if it's not my PR. Whatever that fix is, it can report for the code tour. )

This is the hacky version of https://github.com/dreamwidth/dw-free/pull/2859. Just get posts and edits working again, even though the icon preview button doesn't show what it oughtta show when you start an edit. 

These commits are already part of #2859, so probably github will just swallow any merge conflicts if you merge that one later. 