### PR TITLE
Fix non-integer comparison warning in icon components

### DIFF
--- a/cgi-bin/LJ/User/Icons.pm
+++ b/cgi-bin/LJ/User/Icons.pm
@@ -907,21 +907,21 @@ sub _create_mapid {
 #      building a drop-down icons menu.
 # args: user
 # des-user: a user object.
-# returns: An array of hashrefs like:
-#          {value => ..., text => ..., data => { url => ..., description => ... }}
-#          which can be passed directly to an LJ::html_select(). Includes an
-#          item for each keyword (thus duplicating icons with multiple
-#          keywords), and an item for the default userpic. If no userpics or if
-#          user is undefined, returns an empty array.
+# returns: An arrayref of hashrefs like:
+#          [{value => ..., text => ..., data => { url => ..., description => ... }}, ...]
+#          which can be passed directly to the form.select() template helper.
+#          Includes an item for each keyword (thus duplicating icons with
+#          multiple keywords), and an item for the default userpic. If no
+#          userpics or if user is undefined, returns an empty array.
 # </LJFUNC>
 sub icon_keyword_menu {
     my ($user) = @_;
 
-    return () unless ($user);
+    return [] unless ($user);
 
     my @icons = grep { !( $_->inactive || $_->expunged ) } LJ::Userpic->load_user_userpics($user);
 
-    return () unless (@icons);
+    return [] unless (@icons);
 
     # Get a sorted array of { keyword => "...", userpic => userpic_object } hashrefs:
     @icons = LJ::Userpic->separate_keywords( \@icons );
@@ -934,9 +934,9 @@ sub icon_keyword_menu {
         ? $default_icon->url
         : ( $LJ::IMGPREFIX . $LJ::Img::img{nouserpic_sitescheme}->{src} );
 
-    # Finally, return the expected format for an LJ::html_select,
+    # Finally, return the expected format for the form.select() template helper,
     # including an item for the default icon:
-    return (
+    return [
         {
             value => "",
             text  => LJ::Lang::ml('entryform.opt.defpic'),
@@ -955,7 +955,7 @@ sub icon_keyword_menu {
                 },
             }
         } @icons
-    );
+    ];
 }
 
 1;

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -875,9 +875,6 @@ sub create_qr_div {
         $hidden_form_elements .= LJ::html_hidden( "chrp1", "$chal-$res" );
     }
 
-    # For userpic selector
-    my @icons = $remote->icon_keyword_menu;
-
     # hashref with "selected" and "items" keys
     my $editors = DW::Formats::select_items( preferred => $remote->prop('comment_editor'), );
 

--- a/t/userpic-keyword-select.t
+++ b/t/userpic-keyword-select.t
@@ -16,7 +16,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 6;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Test qw( temp_user temp_comm );
@@ -30,14 +30,6 @@ my $ICON1 = do { local $/; <$fh> };
 
 open( my $fh2, 'good.jpg' ) or die $!;
 my $ICON2 = do { local $/; <$fh2> };
-
-note("called with falsy or undefined user object");
-{
-    my $bogususer;
-    my $icons = $bogususer->icon_keyword_menu;
-    my $empty = [];
-    is_deeply( $icons, $empty, "No user, empty icons list" );
-}
 
 note("called for user with...");
 {

--- a/t/userpic-keyword-select.t
+++ b/t/userpic-keyword-select.t
@@ -1,6 +1,6 @@
 # t/userpic-keyword-select.t
 #
-# Test the LJ::icon_keyword_menu(user) function, which is used to build
+# Test the LJ::User::icon_keyword_menu() function, which is used to build
 # a select element for choosing an icon for a post or comment.
 #
 # Authors:
@@ -34,29 +34,29 @@ my $ICON2 = do { local $/; <$fh2> };
 note("called with falsy or undefined user object");
 {
     my $bogususer;
-    my @icons = $bogususer->icon_keyword_menu;
+    my $icons = $bogususer->icon_keyword_menu;
     my $empty = [];
-    is_deeply( \@icons, $empty, "No user, empty icons list" );
+    is_deeply( $icons, $empty, "No user, empty icons list" );
 }
 
 note("called for user with...");
 {
     my $u = temp_user();
     LJ::set_remote($u);
-    my @icons;
+    my $icons;
 
     note("  ...no icons");
-    @icons = $u->icon_keyword_menu;
+    $icons = $u->icon_keyword_menu;
     my $empty = [];
-    is_deeply( \@icons, $empty, "No user, empty icons list" );
+    is_deeply( $icons, $empty, "No user, empty icons list" );
 
     note("  ...one icon, one keyword, no default");
     my $icon1 = LJ::Userpic->create( $u, data => \$ICON1 );
     $icon1->set_keywords("rad pic");
-    @icons = $u->icon_keyword_menu;
-    is( @icons, 2, "Select would have two items" );
+    $icons = $u->icon_keyword_menu;
+    is( @$icons, 2, "Select would have two items" );
     ok(
-        defined $icons[0]->{data}->{url},
+        defined $icons->[0]->{data}->{url},
         "Default icon slot still has a URL for a placeholder image, even though there's no default"
     );
 
@@ -65,11 +65,11 @@ note("called for user with...");
     $icon1->set_keywords("b, z");
     $icon2->set_keywords("a, c, y");
     $icon1->make_default;
-    @icons = $u->icon_keyword_menu;
-    is( @icons, 6, "Select would have six items" );
-    my @keywords   = map  { $_->{value} } @icons;
+    $icons = $u->icon_keyword_menu;
+    is( @$icons, 6, "Select would have six items" );
+    my @keywords   = map  { $_->{value} } @$icons;
     my $b_keywords = grep { $_ eq 'b' } @keywords;
     is( $b_keywords, 1, "The 'value' key of each hashref contains the keyword" );
-    is( $icons[0]->{data}->{url},
+    is( $icons->[0]->{data}->{url},
         $icon1->url, "First icon slot's URL matches the real default icon's URL" );
 }

--- a/views/components/icon-select-icon.tt
+++ b/views/components/icon-select-icon.tt
@@ -1,4 +1,5 @@
-[%- can_use_userpic_select = (remote.can_use_userpic_select && remote.icon_keyword_menu().size > 0) -%]
+[%- icons = remote.icon_keyword_menu() -%]
+[%- can_use_userpic_select = (remote.can_use_userpic_select && icons.size > 0) -%]
 [%- INCLUDE "components/icon-browser.tt" -%]
 
 [% dw.need_res({ group => "foundation"},
@@ -7,7 +8,7 @@
 ) %]
 
 <div class='block-icon no-label'>
-[% IF remote.icon_keyword_menu.size > 0 %]
+[% IF icons.size > 0 %]
   [%- IF can_use_userpic_select -%]
     <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" data-iconbrowser-keywordorder="[%- remote.iconbrowser_keywordorder -%]">
   [%- ELSE -%]


### PR DESCRIPTION
CODE TOUR: Something internal didn't like the way some of our code was arranged, so it started complaining and annoying the devs. (It was still doing the correct thing for users, we think, but it didn't _like_ it.)

Weird template toolkit behavior around functions that return lists. 