### PR TITLE
Make icon browser remember that you previously used keyword/date order

### DIFF
--- a/htdocs/js/components/jquery.icon-select.js
+++ b/htdocs/js/components/jquery.icon-select.js
@@ -34,6 +34,7 @@ if ( $.fn.iconBrowser ) {
         triggerSelector: "#lj_userpicselect, #js-icon-browse",
         modalId: "js-icon-browser",
         preferences: {
+            "keywordorder": $('#lj_userpicselect').data('iconbrowserKeywordorder'),
             "metatext": $('#lj_userpicselect').data('iconbrowserMetatext'),
             "smallicons": $('#lj_userpicselect').data('iconbrowserSmallicons')
         }


### PR DESCRIPTION
CODE TOUR: The icon browser can now optionally sort by keyword order (🙌🏼), but unlike the other toggles (size, text), it wasn't remembering your preference the next time you used it. Now it does! (Short explanation: This was always meant to remember your choice, but got glitched because two devs were editing the same files around the same time.)

Carrying over the signal from the data attribute on the browse button.

This was present when this logic lived in jquery.replyforms.js, but probably got
dropped when resolving a merge conflict during #2840.