### PR TITLE
[#2861] convert WHILE to FOREACH in views/profile/_blocks.tt

### DIFF
--- a/views/profile/_blocks.tt
+++ b/views/profile/_blocks.tt
@@ -109,9 +109,7 @@
   [% dw.img( 'id_openid', '' ); "[$s] "; %]
     [%- site_users = [];
         i = 0;
-        i_max = openid_info.sites.$s.size;
-        WHILE i < i_max;
-          user = openid_info.sites.$s.$i;
+        FOREACH user IN openid_info.sites.$s;
           text = openid_info.shortnames.$s.$i;
           linked_u = linkify( { url => user.profile_url, text => text } );
           PROCESS format_userlink;


### PR DESCRIPTION
WHILE has a hidden limit WHILE_MAX which will terminate a loop after 1000 iterations. FOREACH has no such restrictions.

Fixes #2861.

CODE TOUR: The logic loop for profile pages that would print the list of OpenID accounts on a user's access list was running up against a hidden limit where the loop would exit if the list was longer than 1000 items. This changes it to use a different type of logic loop instead, which avoids the problem.