### PR TITLE
Keep gap after entry/comment content consistent

### DIFF
--- a/htdocs/scss/skins/_entry-styles.scss
+++ b/htdocs/scss/skins/_entry-styles.scss
@@ -63,6 +63,14 @@ ul.text-links {
   }
 }
 
+// Don't add space after last element in an entry/comment. Avoids extra
+// gaps if there's <p> tags (markdown) instead of text nodes (casual HTML).
+.comment-content, .entry-content {
+  & > :last-child {
+    margin-bottom: 0;
+  }
+}
+
 /**
 * Primary item styles:
 * (The primary item is always an entry on entry pages, but is sometimes a

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -587,6 +587,13 @@ h2#pagetitle {
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
+/* Don't add space after last element in an entry/comment. Avoids extra */
+/* gaps if there's <p> tags (markdown) instead of text nodes (casual HTML). */
+.entry-content > :last-child,
+.comment-content > :last-child {
+    margin-bottom: 0;
+}
+
 /* To prevent overlapping when icon's on the left */
 /* and list is the first thing in content */
 .entry-content li,


### PR DESCRIPTION
CODE TOUR: Comments and entries that were written in Markdown had an extra little gap at the bottom when compared to content that was written in casual HTML. Now fixed in _most_ places... but since this is a CSS thing and each journal style has its own CSS, some journal styles might still have the extra gap.

Mentioned in #2812. Restricting this to the last DIRECT child of the content div
should do the right thing 90%+ of the time without risking unintended
consequences.

This only fixes this for site skin comment pages and Tabula Rasa-based journal
styles; other journal styles still do whatever they do.