### PR TITLE
Icon browser: save some space on mobile, re-fix message body focus

### DIFF
--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -48,19 +48,19 @@ function IconBrowser($el, options) {
             }
 
             // the browser blew away the user's tab-through position, so restore
-            // it on whatever makes most sense to focus. Defaulting to the icon
+            // it on whatever makes most sense to focus. Defaults to the icon
             // menu, since that's what they just indirectly set a value for, but
-            // if you want something else, set
-            // data-focus-after-browse="selector" on the icon menu.
+            // in comment forms we ask to focus the message body instead.
             var $focusTarget = $el;
-            if ( $el.data('focusAfterBrowse') ) {
-                var $altTarget = $( $el.data('focusAfterBrowse') ).first();
+            if ( options.focusAfterBrowse ) {
+                var $altTarget = $( options.focusAfterBrowse ).first();
                 if ( $altTarget.length === 1 ) {
                     $focusTarget = $altTarget;
                 }
             }
-            // Avoid yanking the focus if the user somehow managed to focus
-            // something else before this handler fired.
+            // Only force-reset the focus if we know it's still wrong! If the
+            // user somehow managed to focus something else before this handler
+            // fired, don't jerk them around.
             if ( document.activeElement.tagName === 'BODY' ) {
                 $focusTarget.focus();
             }
@@ -401,6 +401,7 @@ $.fn.extend({
             var defaults = {
                 // triggerSelector: "#icon-browse-button, #icon-preview",
                 // modalId: "icon-browser",
+                // focusAfterBrowse: "",
                 // preferences: { metatext: true, smallicons: false, keywordorder: false }
             };
 

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -198,9 +198,7 @@ IconBrowser.prototype = {
     keyboardNav: function(e) {
         if ( $(e.target).is('#js-icon-browser-search') ) return;
 
-        if ( e.key === 'Enter' || (! e.key && e.keyCode === 13) ) {
-            $(e.target).trigger('click');
-        } else if ( e.key === '/' || (! e.key && e.keyCode === 191) ) {
+        if ( e.key === '/' || (! e.key && e.keyCode === 191) ) {
             e.preventDefault();
             $("#js-icon-browser-search").focus();
         }

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -179,7 +179,6 @@ IconBrowser.prototype = {
             .on("dblclick", ".icon-browser-item", this.selectByDoubleClick.bind(this));
 
         $("#js-icon-browser-search").on("keyup click", this.filter.bind(this));
-        $("#js-icon-browser-select").on("click", this.updateOwner.bind(this));
 
         this.modal.on("sortByKeyword.iconbrowser", this.sortByKeyword.bind(this));
         this.modal.on("sortByDate.iconbrowser", this.sortByDate.bind(this));

--- a/htdocs/js/components/jquery.icon-browser.js
+++ b/htdocs/js/components/jquery.icon-browser.js
@@ -179,6 +179,7 @@ IconBrowser.prototype = {
             .on("dblclick", ".icon-browser-item", this.selectByDoubleClick.bind(this));
 
         $("#js-icon-browser-search").on("keyup click", this.filter.bind(this));
+        $("#icon-browser-options-visibility").on("click", this.toggleOptions.bind(this));
 
         this.modal.on("sortByKeyword.iconbrowser", this.sortByKeyword.bind(this));
         this.modal.on("sortByDate.iconbrowser", this.sortByDate.bind(this));
@@ -269,6 +270,9 @@ IconBrowser.prototype = {
     },
     close: function() {
         this.modal.foundation('reveal', 'close');
+    },
+    toggleOptions: function() {
+        this.modal.toggleClass("show-options");
     },
     sortByKeyword: function() {
         this.iconBrowserItems.sort(function(a, b) {

--- a/htdocs/js/components/jquery.icon-select.js
+++ b/htdocs/js/components/jquery.icon-select.js
@@ -33,6 +33,7 @@ if ( $.fn.iconBrowser ) {
     iconSelect.iconBrowser({
         triggerSelector: "#lj_userpicselect, #js-icon-browse",
         modalId: "js-icon-browser",
+        focusAfterBrowse: $('#lj_userpicselect').data('iconbrowserFocusAfterBrowse'),
         preferences: {
             "keywordorder": $('#lj_userpicselect').data('iconbrowserKeywordorder'),
             "metatext": $('#lj_userpicselect').data('iconbrowserMetatext'),

--- a/htdocs/scss/components/icon-browser.scss
+++ b/htdocs/scss/components/icon-browser.scss
@@ -105,6 +105,42 @@
         }
     }
 
+    // Stash the options toggles out of the way on mobile
+    #icon-browser-options-visibility {
+        display: none;
+    }
+    @media #{$small-only} {
+        #icon-browser-options-visibility {
+            display: block;
+        }
+        &:not(.show-options) {
+            .top-controls fieldset {
+                display: none;
+            }
+        }
+        &.show-options {
+            #icon-browser-options-visibility img {
+                transform: rotate(90deg);
+            }
+        }
+    }
+    // Make the toggle button summarize the current options
+    .icon-browser-options-summary-small {display: none;}
+    .icon-browser-options-summary-no-meta {display: none;}
+    .icon-browser-options-summary-keyword {display: none;}
+    &.small-icons {
+        .icon-browser-options-summary-large {display: none;}
+        .icon-browser-options-summary-small {display: inline;}
+    }
+    &.no-meta {
+        .icon-browser-options-summary-meta {display: none;}
+        .icon-browser-options-summary-no-meta {display: inline;}
+    }
+    &.keyword-order {
+        .icon-browser-options-summary-date {display: none;}
+        .icon-browser-options-summary-keyword {display: inline;}
+    }
+
     p.icon-browser-help {
         font-size: smaller;
         margin-bottom: 1rem;

--- a/views/components/icon-browser.tt
+++ b/views/components/icon-browser.tt
@@ -25,7 +25,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
         <div class="row">
             <div class="columns top-controls">
                 <button type="button" id="icon-browser-options-visibility" aria-label="Show or hide icon browser display options">
-                    <img alt="" src="[% site.imgroot %]/collapse.svg">
+                    <img alt="" src="[% site.imgroot %]/collapse.svg" style="border: 0; width: 1em; padding: 0.2em; box-sizing: content-box; vertical-align: text-bottom;">
                     <span class="icon-browser-options-summary-large">Large</span>
                     <span class="icon-browser-options-summary-small">Small</span>
                     /

--- a/views/components/icon-browser.tt
+++ b/views/components/icon-browser.tt
@@ -24,6 +24,18 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
         <div class="row">
             <div class="columns top-controls">
+                <button type="button" id="icon-browser-options-visibility" aria-label="Show or hide icon browser display options">
+                    <img alt="" src="[% site.imgroot %]/collapse.svg">
+                    <span class="icon-browser-options-summary-large">Large</span>
+                    <span class="icon-browser-options-summary-small">Small</span>
+                    /
+                    <span class="icon-browser-options-summary-meta">Text</span>
+                    <span class="icon-browser-options-summary-no-meta">No text</span>
+                    /
+                    <span class="icon-browser-options-summary-date">By date</span>
+                    <span class="icon-browser-options-summary-keyword">By keyword</span>
+                </button>
+
                 <fieldset class="icon-browser-options" id="js-icon-browser-order-option">
                     <legend>Order by</legend>
 

--- a/views/components/icon-select-dropdown.tt
+++ b/views/components/icon-select-dropdown.tt
@@ -1,3 +1,8 @@
+[%# arguments:
+  - remote (needs to be a real user object)
+  - current_icon_kw (string, icon keyword)
+  - omit_random_button (bool, defaults to false)
+#%]
 [%- icons = remote.icon_keyword_menu() -%]
 [%- IF icons.size > 0 -%]
     <div class='block-icon-controls'>

--- a/views/components/icon-select-icon.tt
+++ b/views/components/icon-select-icon.tt
@@ -1,3 +1,8 @@
+[%# Arguments:
+  - remote (needs to be a real user object)
+  - current_icon (optional, should be a real userpic object)
+  - focus_after_browse (optional CSS selector for the form element we should focus upon dismissal; defaults (in JS) to the icon menu select element)
+#%]
 [%- icons = remote.icon_keyword_menu() -%]
 [%- can_use_userpic_select = (remote.can_use_userpic_select && icons.size > 0) -%]
 [%- INCLUDE "components/icon-browser.tt" -%]
@@ -10,7 +15,12 @@
 <div class='block-icon no-label'>
 [% IF icons.size > 0 %]
   [%- IF can_use_userpic_select -%]
-    <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" data-iconbrowser-keywordorder="[%- remote.iconbrowser_keywordorder -%]">
+    <button type='button' id='lj_userpicselect'
+        data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]"
+        data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]"
+        data-iconbrowser-keywordorder="[%- remote.iconbrowser_keywordorder -%]"
+        data-iconbrowser-focus-after-browse="[%- focus_after_browse -%]"
+    >
   [%- ELSE -%]
     <a href="[% remote.allpics_base %]">
   [%- END -%]

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -22,7 +22,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
   <input type="button" id="submitmoreopts" name="submitmoreopts" value="[% '.button.more' | ml %]" />
 
-[% INCLUDE "components/icon-select-icon.tt" %]
+[% INCLUDE "components/icon-select-icon.tt" focus_after_browse = "#body" %]
 
 [% INCLUDE "components/icon-select-dropdown.tt" %]
 

--- a/views/journal/talkform.tt
+++ b/views/journal/talkform.tt
@@ -314,7 +314,8 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 <div class='qr-meta'>
 [%- current_icon = comment.current_icon;
-   current_icon_kw = comment.current_icon_kw; -%]
+   current_icon_kw = comment.current_icon_kw;
+   focus_after_browse = "#body" -%]
 [% INCLUDE "components/icon-select-icon.tt" IF remote %]
 [% INCLUDE "components/icon-select-dropdown.tt" IF remote %]
 </div>


### PR DESCRIPTION
CODE TOUR: Two small fixes for the icon browser. 1. Save a bit of space on mobile by stashing the display options behind a handy toggle button. 2. In comment forms, focus the message body after dismissing the icon browser. 

The message body re-focus thing was originally part of #2825 but died to rebasing in #2840. Well, the implementation was dirty anyway (tied it to the select instead of the button with the other options), so maybe for the best.

<details><summary>Screenshots</summary>

![Screenshot_2021-02-03 sheworks4themoney Tryin yah he’ll(1)](https://user-images.githubusercontent.com/484309/106797253-3aafa980-6611-11eb-9f7e-b84aa1eb3e21.png)

![Screenshot_2021-02-03 sheworks4themoney Tryin yah he’ll](https://user-images.githubusercontent.com/484309/106797262-3c796d00-6611-11eb-912b-99da5f754d3e.png)

![Screenshot_2021-02-03 sheworks4themoney Recent Entries(1)](https://user-images.githubusercontent.com/484309/106797267-3daa9a00-6611-11eb-87a7-8a2eff7faaff.png)

![Screenshot_2021-02-03 sheworks4themoney Recent Entries](https://user-images.githubusercontent.com/484309/106797269-3e433080-6611-11eb-88da-39438c1f2272.png)

</details>

As you can see, the close button sometimes overlaps the summary text a bit at iPhone 5 sizes, but that's a persistent problem with these Foundation modals, and it doesn't obscure the function of the control at all. And at iPhone 6 sizes (the next-smallest of current devices?), it's totally fine.

The design is unchanged above 640px wide. 