### PR TITLE
Have /data/edges return an error if accessed without first logging in

### DIFF
--- a/cgi-bin/DW/Controller/Edges.pm
+++ b/cgi-bin/DW/Controller/Edges.pm
@@ -44,6 +44,9 @@ sub edges_handler {
         return $r->OK;
     };
 
+    # Don't allow access unless we have a logged-in user
+    return $error_out->( 404, 'Must log in first' ) unless LJ::get_remote();
+
     # Load the account or error
     return $error_out->( 404, 'Need account name as user parameter' ) unless $opts->username;
     my $u = LJ::load_user_or_identity( $opts->username )


### PR DESCRIPTION
CODE TOUR: This is a rarely used API endpoint with the potential to slow down the site for everyone if a badly behaved program accesses it repeatedly. To reduce the likelihood of abuse, only return the requested data if the user is logged in.

(This is currently returning 404 for all requests in production, but we can lift that restriction once this gets deployed.)