### PR TITLE
Add PR template explaining the CODE TOUR: line

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+CODE TOUR: summarize here.
+
+<!--
+Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.
+
+The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.
+
+If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
+-->


### PR DESCRIPTION
CODE TOUR: Meta: encourage devs to leave hints for whoever writes the next code tour post! When devs submit code, they include a description of what they did... but it's intended for other developers on the same project, so it can often be opaque even to devs that work on other code. This just adds a reminder to also include a brief summary for non-devs in there.

We've all started doing this, and it seems like a good idea, so let's go ahead and codify it!

This is a magic file that GitHub uses to auto-populate the PR description textarea, so that a new WIP PR looks like this: 

![image](https://user-images.githubusercontent.com/484309/107102917-b86de380-67d0-11eb-9bb9-827b1d75484f.png)

It also still does the thing where it includes the commit message if it's a single-commit PR; IIRC that goes below the template content?