### PR TITLE
remove paragraph tags from explanatory CSS comments

### DIFF
--- a/htdocs/scss/skins/_entry-styles.scss
+++ b/htdocs/scss/skins/_entry-styles.scss
@@ -63,8 +63,8 @@ ul.text-links {
   }
 }
 
-// Don't add space after last element in an entry/comment. Avoids extra
-// gaps if there's <p> tags (markdown) instead of text nodes (casual HTML).
+// Don't add space after last element in an entry/comment. Avoids extra gaps
+// if there's paragraph tags (markdown) instead of text nodes (casual HTML).
 .comment-content, .entry-content {
   & > :last-child {
     margin-bottom: 0;

--- a/styles/core2base/layout.s2
+++ b/styles/core2base/layout.s2
@@ -587,8 +587,8 @@ h2#pagetitle {
 }
 .comment-content { border-top: 1px transparent solid; } /* for firefox */
 
-/* Don't add space after last element in an entry/comment. Avoids extra */
-/* gaps if there's <p> tags (markdown) instead of text nodes (casual HTML). */
+/* Don't add space after last element in an entry/comment. Avoids extra gaps */
+/* if there's paragraph tags (markdown) instead of text nodes (casual HTML). */
 .entry-content > :last-child,
 .comment-content > :last-child {
     margin-bottom: 0;


### PR DESCRIPTION
I don't know if this is identical to the emergency fix in prod, but some version of this needs to live on master since most styles are broken without it.

CODE TOUR: The fix from #2867 included some CSS comments that contained a paragraph tag, to explain the impact of the change. Unfortunately, our less-than-ideal CSS parser choked on rendering CSS that appeared to contain HTML tags. This rewrites the comments to avoid the problem.