### PR TITLE
fix styleinfo_privs usage for varying argument types in different contexts

### DIFF
--- a/cgi-bin/DW/Controller/Admin/UserViews.pm
+++ b/cgi-bin/DW/Controller/Admin/UserViews.pm
@@ -31,8 +31,9 @@ use DW::Auth::Password;
 
 my $styleinfo_privs = [
     sub {
+        my $remote = LJ::isu( $_[0] ) ? $_[0] : $_[0]->{remote};
         return (
-            LJ::Support::has_any_support_priv( $_[0]->{remote} ),
+            LJ::Support::has_any_support_priv($remote),
             LJ::Lang::ml("/admin/index.tt.anysupportpriv")
         );
     },


### PR DESCRIPTION
CODE TOUR: The /admin/styleinfo page was inaccessible due to a code glitch, which this fixes.

I'm pretty sure this isn't really MY fault...

So, privileges for admin pages can be passed around as a list of subroutines in lieu of hardcoded priv names. However, the code in the `DW::Controller::Admin->register_admin_page` method expected the remote user to be the `remote` key in the argument hashref, while the code in the privcheck option for `DW::Controller::controller` expected the remote user to be the argument itself.

Since it doesn't make sense from a code maintenance standpoint to duplicate the privilege check info, I edited that part of the function to figure out whether it was given the user object or the hashref containing the user object, and act accordingly.

It would probably make more sense to update one of the other methods so that they both take the same argument type, but that would be likely to break something somewhere else.