### PR TITLE
Update external site constructor to use https

### DIFF
--- a/cgi-bin/DW/External/Site.pm
+++ b/cgi-bin/DW/External/Site.pm
@@ -254,7 +254,7 @@ sub journal_url {
     # AND YOU WILL SEE WHAT INFINITE RECURSION LOOKS LIKE.
 
     # override this on a site-by-site basis if needed
-    return "http://$self->{hostname}/users/" . $u->user . '/';
+    return "https://$self->{hostname}/users/" . $u->user . '/';
 }
 
 # returns an entry link for this user on this site.


### PR DESCRIPTION
Fixes #2627

CODE TOUR: User links to external sites will now use https, instead of http.

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
