### PR TITLE
Fix some random invalid CSS

### DIFF
--- a/htdocs/scss/foundation/components/_global.scss
+++ b/htdocs/scss/foundation/components/_global.scss
@@ -429,7 +429,7 @@ $cursor-text-value: text !default;
   @if $include-js-meta-styles {
 
     meta.foundation-version {
-      font-family: "/{{VERSION}}/";
+      font-family: "/5.5.3/";
     }
 
     meta.foundation-mq-small {

--- a/htdocs/stc/base-colors-dark.css
+++ b/htdocs/stc/base-colors-dark.css
@@ -35,7 +35,6 @@
 }
 .ui-widget-header {
   background-color:#727272;
-  background-image: url();
 }
 .ui-widget-content, .ui-sortable {
   border-color: #999

--- a/htdocs/stc/blueshift/blueshift.css
+++ b/htdocs/stc/blueshift/blueshift.css
@@ -237,9 +237,6 @@ footer {
     background-color: #D6DCE9 !important;
 }
 
-/*insert class of screened comments here*/ {
-    background-color: #EEEEEE; }
-
 /* PROFILE.CSS OVERRIDES */
 #profile_top {
     min-width: 0;

--- a/htdocs/stc/jquery/jquery.ui.base.css
+++ b/htdocs/stc/jquery/jquery.ui.base.css
@@ -10,16 +10,16 @@
  */
 @import url("jquery.ui.core.css");
 
-@import url("jquery.ui.accordion.css");
+/* @import url("jquery.ui.accordion.css"); */
 @import url("jquery.ui.autocomplete.css");
 @import url("jquery.ui.button.css");
 @import url("jquery.ui.datepicker.css");
 @import url("jquery.ui.dialog.css");
 @import url("jquery.ui.menu.css");
-@import url("jquery.ui.progressbar.css");
+/* @import url("jquery.ui.progressbar.css"); */
 @import url("jquery.ui.resizable.css");
 @import url("jquery.ui.selectable.css");
-@import url("jquery.ui.slider.css");
-@import url("jquery.ui.spinner.css");
-@import url("jquery.ui.tabs.css");
+/* @import url("jquery.ui.slider.css"); */
+/* @import url("jquery.ui.spinner.css"); */
+/* @import url("jquery.ui.tabs.css"); */
 @import url("jquery.ui.tooltip.css");

--- a/htdocs/stc/textcaptcha.css
+++ b/htdocs/stc/textcaptcha.css
@@ -3,4 +3,3 @@ p { line-height: 1.5em; margin: 0; padding: 0;}
 textarea { height: 2.5em; width: 50%; display: block; }
 
 form, .textcaptcha {padding: 0 !important; margin: 0;}
-.


### PR DESCRIPTION
CODE TOUR: no-impact - Some very old CSS files had invalid junk code left in them. 

My tooling found these syntax errors when I was working on the next-gen build-static (CSS minifier barfed on em), but they aren't otherwise related to that, so they might as well have their own PR. 

Those `@import` statements _would_ have been valid, except the files don't exist. 