### PR TITLE
Add errors for bad markup to beta create page

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -713,19 +713,20 @@ sub _form_to_backend {
     my $clean_event = $post->{event};
     my $errref;
 
-    # TODO: accept editor prop and thread it through to the cleaner.
     my $editor = undef;
     my $verbose_err;
-    LJ::CleanHTML::clean_event( \$clean_event, { errref => \$errref, editor => $editor, verbose_err => \$verbose_err } );
+    LJ::CleanHTML::clean_event( \$clean_event,
+        { errref => \$errref, editor => $editor, verbose_err => \$verbose_err } );
 
-    if ($errors && $verbose_err) {
-        if (ref($verbose_err) eq 'HASH') {
+    if ( $errors && $verbose_err ) {
+        if ( ref($verbose_err) eq 'HASH' ) {
             $errors->add( undef, $verbose_err->{error}, $verbose_err->{opts} );
-        } else {
+        }
+        else {
             $errors->add( undef, $verbose_err );
         }
     }
-    
+
     # initialize props hash
     $req->{props} ||= {};
     my $props = $req->{props};

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -709,6 +709,23 @@ sub _form_to_backend {
     $errors->add( undef, ".error.noentry" )
         if $errors && $req->{event} eq "" && !$opts{allow_empty};
 
+    # warn the user of any bad markup errors
+    my $clean_event = $post->{event};
+    my $errref;
+
+    # TODO: accept editor prop and thread it through to the cleaner.
+    my $editor = undef;
+    my $verbose_err;
+    LJ::CleanHTML::clean_event( \$clean_event, { errref => \$errref, editor => $editor, verbose_err => \$verbose_err } );
+
+    if ($errors && $verbose_err) {
+        if (ref($verbose_err) eq 'HASH') {
+            $errors->add( undef, $verbose_err->{error}, $verbose_err->{opts} );
+        } else {
+            $errors->add( undef, $verbose_err );
+        }
+    }
+    
     # initialize props hash
     $req->{props} ||= {};
     my $props = $req->{props};

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -135,7 +135,7 @@ sub clean {
     my $preserve_lj_tags_for = $opts->{preserve_lj_tags_for} || 0;    # False or site name
     my $remove_positioning   = $opts->{'remove_positioning'} || 0;
     my $errref               = $opts->{errref};
-    my $verbose_err          = $opts->{verbose_err}; # Verbose parse errors
+    my $verbose_err = $opts->{verbose_err};                           # Verbose parse errors
     my @unclosed_tags;
 
     # for ajax cut tag parsing
@@ -234,13 +234,13 @@ sub clean {
         if ($cuturl) {
             my $cutlink = LJ::ehtml($cuturl);
             $err_str = '.error.markup';
-            $extra_text = 
+            $extra_text =
                   "<strong>"
-                  . LJ::Lang::ml( 'cleanhtml.error.markup', { aopts => "href='$cutlink'" } )
-                  ."</strong>";
+                . LJ::Lang::ml( 'cleanhtml.error.markup', { aopts => "href='$cutlink'" } )
+                . "</strong>";
         }
         else {
-            $err_str = {error => '.error.markup.extra', opts => { aopts => $tag }};
+            $err_str = { error => '.error.markup.extra', opts => { aopts => $tag } };
             $extra_text =
                   LJ::Lang::ml( 'cleanhtml.error.markup.extra', { aopts => $tag } )
                 . "<br /><br />"
@@ -249,11 +249,10 @@ sub clean {
                 . '</div>';
         }
 
-        $extra_text = "<div class='ljparseerror'>$extra_text</div>";
+        $extra_text   = "<div class='ljparseerror'>$extra_text</div>";
         $$verbose_err = $err_str if $verbose_err;
-        $$errref    =  "parseerror" if $errref;
+        $$errref      = "parseerror" if $errref;
 
-        
     };
 
     my $htmlcleaner = HTMLCleaner->new( valid_stylesheet => \&LJ::valid_stylesheet_url );
@@ -1193,7 +1192,7 @@ TOKEN:
                         if ( $opencount{$tag} ) {
                             $newdata .= "</$tag>";
                             $opencount{$tag}--;
-                            
+
                         }
                     }
                     elsif ( !$allow || $form_tag->{$tag} && !$opencount{form} ) {
@@ -1390,9 +1389,9 @@ qq{<div style="color: #000; font: 12px Verdana, Arial, Sans-Serif; background-co
 
     # only add verbose errors for unclosed tags if we don't have another verbose error set
     # otherwise, the tags error will overwrite more important errors like irreparable markup
-    if ($verbose_err && ref($verbose_err) eq 'SCALAR' && scalar(@unclosed_tags) > 0){
-        my $tag_str = "&lt;" . join("&gt;, &lt;", @unclosed_tags) . "&gt;";
-        $$verbose_err =  {error => ".error.markup.unclosed", opts => {tags => $tag_str }};
+    if ( $verbose_err && ref($verbose_err) eq 'SCALAR' && scalar(@unclosed_tags) > 0 ) {
+        my $tag_str = "&lt;" . join( "&gt;, &lt;", @unclosed_tags ) . "&gt;";
+        $$verbose_err = { error => ".error.markup.unclosed", opts => { tags => $tag_str } };
     }
 
     return 0;

--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -135,6 +135,8 @@ sub clean {
     my $preserve_lj_tags_for = $opts->{preserve_lj_tags_for} || 0;    # False or site name
     my $remove_positioning   = $opts->{'remove_positioning'} || 0;
     my $errref               = $opts->{errref};
+    my $verbose_err          = $opts->{verbose_err}; # Verbose parse errors
+    my @unclosed_tags;
 
     # for ajax cut tag parsing
     my $cut_retrieve = $opts->{cut_retrieve} || 0;
@@ -224,18 +226,21 @@ sub clean {
     my $total_fail = sub {
         my ( $cuturl, $tag ) = @_;
         $tag = LJ::ehtml($tag);
+        my $err_str;
 
         my $edata = LJ::ehtml($$data);
         $edata =~ s/\r?\n/<br \/>/g if $addbreaks;
 
         if ($cuturl) {
             my $cutlink = LJ::ehtml($cuturl);
-            $extra_text =
+            $err_str = '.error.markup';
+            $extra_text = 
                   "<strong>"
-                . LJ::Lang::ml( 'cleanhtml.error.markup', { aopts => "href='$cutlink'" } )
-                . "</strong>";
+                  . LJ::Lang::ml( 'cleanhtml.error.markup', { aopts => "href='$cutlink'" } )
+                  ."</strong>";
         }
         else {
+            $err_str = {error => '.error.markup.extra', opts => { aopts => $tag }};
             $extra_text =
                   LJ::Lang::ml( 'cleanhtml.error.markup.extra', { aopts => $tag } )
                 . "<br /><br />"
@@ -245,7 +250,10 @@ sub clean {
         }
 
         $extra_text = "<div class='ljparseerror'>$extra_text</div>";
-        $$errref    = "parseerror" if $errref;
+        $$verbose_err = $err_str if $verbose_err;
+        $$errref    =  "parseerror" if $errref;
+
+        
     };
 
     my $htmlcleaner = HTMLCleaner->new( valid_stylesheet => \&LJ::valid_stylesheet_url );
@@ -1162,6 +1170,7 @@ TOKEN:
                                 $opencount{$close}--;
                                 next if $close =~ $slashclose_tags;
                                 $newdata .= "</$close>";
+                                push @unclosed_tags, "$close" unless $close eq 'p';
                             }
                         }
 
@@ -1184,6 +1193,7 @@ TOKEN:
                         if ( $opencount{$tag} ) {
                             $newdata .= "</$tag>";
                             $opencount{$tag}--;
+                            
                         }
                     }
                     elsif ( !$allow || $form_tag->{$tag} && !$opencount{form} ) {
@@ -1337,6 +1347,7 @@ TOKEN:
     # if we have a textarea open, we *MUST* close it first
     if ( $opencount{textarea} ) {
         $newdata .= "</textarea>";
+        push @unclosed_tags, "textarea";
     }
     $opencount{textarea} = 0;
 
@@ -1349,6 +1360,7 @@ TOKEN:
         if ( $opencount{$tag} ) {
             $newdata .= "</$tag>";
             $opencount{$tag}--;
+            push @unclosed_tags, $tag unless $tag eq 'p';
         }
     }
 
@@ -1374,6 +1386,13 @@ qq{<div style="color: #000; font: 12px Verdana, Arial, Sans-Serif; background-co
         $msg .= "</div>";
 
         $$data = $msg . $$data;
+    }
+
+    # only add verbose errors for unclosed tags if we don't have another verbose error set
+    # otherwise, the tags error will overwrite more important errors like irreparable markup
+    if ($verbose_err && ref($verbose_err) eq 'SCALAR' && scalar(@unclosed_tags) > 0){
+        my $tag_str = "&lt;" . join("&gt;, &lt;", @unclosed_tags) . "&gt;";
+        $$verbose_err =  {error => ".error.markup.unclosed", opts => {tags => $tag_str }};
     }
 
     return 0;
@@ -1706,6 +1725,7 @@ sub clean_event {
             journal                 => $opts->{journal},
             ditemid                 => $opts->{ditemid},
             errref                  => $opts->{errref},
+            verbose_err             => $opts->{verbose_err},
         }
     );
 }

--- a/views/entry/form.tt.text
+++ b/views/entry/form.tt.text
@@ -25,6 +25,12 @@
 
 .error.nofind=Could not find selected journal entry.
 
+.error.markup=Irreparable invalid markup in entry.
+
+.error.markup.extra=Irreparable invalid markup ('&lt;[[aopts]]&gt;') in entry
+
+.error.markup.unclosed=Unclosed tag(s) in entry: [[tags]]
+
 .error.nonusercantpost=Non-[[sitename]] users can't post entries because they don't have journals here, but can leave comments in other journals.
 
 .error.login=Error logging in: [[error]]


### PR DESCRIPTION
CODE TOUR: Previously, if you had bad markup in an entry, you wouldn't find out until after you had already posted the entry and said bad markup was potentially on display for the world to see. Now the beta create page will give you the error before the post is saved, so you can preemptively fix it (note: this doesn't catch *all* bad markup - but it gets the most common cases)

This will warn for irreparable invalid markup, and unclosed tags that require closing (other than `<p>` and `<cut>`, because it's common to use those unclosed and they have well-defined behavior). At the moment the error is blocking - I'm open to the possibility of adding a way to say 'post anyway' but I would prefer to see if anyone complains and in what scenario first, because that logic is potentially a bit complicated (as I don't think we should allow irreparable markup to go through).

I'm also open to feedback on error strings, I mostly just grabbed the existing ones from HTMLCleaner.