### PR TITLE
Fix login/logout redirect glitches on newer browsers

### DIFF
--- a/cgi-bin/DW/Controller/Auth.pm
+++ b/cgi-bin/DW/Controller/Auth.pm
@@ -52,12 +52,11 @@ sub logout_handler {
         }
 
         # If the logout form asked to be sent back to the original page (with a
-        # hidden 'ret=1' form input), do so (as long as the logout was
-        # successful).
-        if ( $vars->{success} && $post_args->{ret} ) {
-            my $referer = $r->header_in('Referer');
-            if ( $referer && LJ::check_referer( '', $referer ) ) {
-                return $r->redirect($referer);
+        # hidden 'ret=1' form input and a return url), do so (as long as the logout
+        # was successful).
+        if ( $vars->{success} && $post_args->{returnto} && $post_args->{ret} ) {
+            if ( LJ::check_referer( '', $post_args->{returnto} ) ) {
+                return $r->redirect( $post_args->{returnto} );
             }
         }
     }

--- a/cgi-bin/DW/Template.pm
+++ b/cgi-bin/DW/Template.pm
@@ -365,6 +365,11 @@ sub render_scheme {
     my $r = DW::Request->get;
     my $out;
 
+    my $args    = $r->query_string;
+    my $baseuri = "$LJ::PROTOCOL://" . $r->host . $r->uri;
+    $baseuri .= $args ? "?$args" : "";
+    my $euri = LJ::eurl($baseuri);
+
     my $opts = $scheme->get_vars;
     $opts->{sections}       = $sections;
     $opts->{inheritance}    = [ map { "$_.tt" } reverse $scheme->inheritance ];
@@ -372,6 +377,7 @@ sub render_scheme {
     $opts->{get}            = $r->get_args;
     $opts->{resource_group} = $LJ::ACTIVE_RES_GROUP;
     $opts->{msgs}           = $r->msgs;
+    $opts->{returnto}       = $euri;
 
     $scheme_engine->process( "_init.tt", $opts, \$out )
         or die $scheme_engine->error->as_string;

--- a/cgi-bin/DW/Template.pm
+++ b/cgi-bin/DW/Template.pm
@@ -368,7 +368,6 @@ sub render_scheme {
     my $args    = $r->query_string;
     my $baseuri = "$LJ::PROTOCOL://" . $r->host . $r->uri;
     $baseuri .= $args ? "?$args" : "";
-    my $euri = LJ::eurl($baseuri);
 
     my $opts = $scheme->get_vars;
     $opts->{sections}       = $sections;
@@ -377,7 +376,7 @@ sub render_scheme {
     $opts->{get}            = $r->get_args;
     $opts->{resource_group} = $LJ::ACTIVE_RES_GROUP;
     $opts->{msgs}           = $r->msgs;
-    $opts->{returnto}       = $euri;
+    $opts->{returnto}       = $baseuri;
 
     $scheme_engine->process( "_init.tt", $opts, \$out )
         or die $scheme_engine->error->as_string;

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -3303,6 +3303,9 @@ sub control_strip {
         #     .selected => ""
         'viewoptions' => [],
         'search_html' => LJ::Widget::Search->render,
+
+        # url of the rendered page, for the login/logout form to redirect back to
+        'returnto' => $euri,
     };
 
     # Shortcuts for the two nested array refs that get repeatedly dereferenced later

--- a/schemes/common.tt
+++ b/schemes/common.tt
@@ -99,7 +99,7 @@ the table based way can be removed when the entire site is Foundation-based.
     <form action='[% site.root %]/logout' method='post'>
         [%- dw.form_auth -%]
         [%- remote.ljuser_display -%]
-        <input type="hidden" name="returnto" value="[% returnto %]" />
+        <input type="hidden" name="returnto" value="[% returnto | html %]" />
         <input type="hidden" name="ret" value="1" />
         <input class="logout button secondary" type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />
     </form>
@@ -130,7 +130,7 @@ the table based way can be removed when the entire site is Foundation-based.
     <div id='nav-login-form' class="reveal-modal" data-reveal>
       <div class="row"><div class="columns">
       <form action='[% site.root %]/login?ret=1' method='post' class='lj_login_form'>
-        <input type="hidden" name="returnto" value="[% returnto %]" />
+        <input type="hidden" name="returnto" value="[% returnto | html %]" />
         <input type='hidden' name='chal' class='lj_login_chal' value='[% chal %]' />
         <input type='hidden' name='response' class='lj_login_response' value='' />
         <div class="row">
@@ -170,7 +170,7 @@ the table based way can be removed when the entire site is Foundation-based.
     <form action='[% site.root %]/logout' method='post'>
         [%- dw.form_auth -%]
         [%- remote.ljuser_display -%]
-        <input type="hidden" name="returnto" value="[% returnto %]" />
+        <input type="hidden" name="returnto" value="[% returnto | html %]" />
         <input type="hidden" name="ret" value="1" />
         <input type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />
     </form>
@@ -190,7 +190,7 @@ the table based way can be removed when the entire site is Foundation-based.
 [%- ELSE -%] [%# no remote, logged out %]
     [%- chal = dw_scheme.challenge_generate(300) -%]
     [%- -%]<form action='[% site.root %]/login?ret=1' method='post' class='lj_login_form'>
-    [%- -%]<input type="hidden" name="returnto" value="[% returnto %]" />
+    [%- -%]<input type="hidden" name="returnto" value="[% returnto | html %]" />
     [%- -%]<input type='hidden' name='chal' class='lj_login_chal' value='[% chal %]' />
     <input type='hidden' name='response' class='lj_login_response' value='' />
     <table summary='' id='login-table'>

--- a/schemes/common.tt
+++ b/schemes/common.tt
@@ -99,6 +99,7 @@ the table based way can be removed when the entire site is Foundation-based.
     <form action='[% site.root %]/logout' method='post'>
         [%- dw.form_auth -%]
         [%- remote.ljuser_display -%]
+        <input type="hidden" name="returnto" value="[% returnto %]" />
         <input type="hidden" name="ret" value="1" />
         <input class="logout button secondary" type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />
     </form>
@@ -129,7 +130,7 @@ the table based way can be removed when the entire site is Foundation-based.
     <div id='nav-login-form' class="reveal-modal" data-reveal>
       <div class="row"><div class="columns">
       <form action='[% site.root %]/login?ret=1' method='post' class='lj_login_form'>
-        <input type="hidden" name="returnto" value="[% get.returnto | html %]" />
+        <input type="hidden" name="returnto" value="[% returnto %]" />
         <input type='hidden' name='chal' class='lj_login_chal' value='[% chal %]' />
         <input type='hidden' name='response' class='lj_login_response' value='' />
         <div class="row">
@@ -169,6 +170,7 @@ the table based way can be removed when the entire site is Foundation-based.
     <form action='[% site.root %]/logout' method='post'>
         [%- dw.form_auth -%]
         [%- remote.ljuser_display -%]
+        <input type="hidden" name="returnto" value="[% returnto %]" />
         <input type="hidden" name="ret" value="1" />
         <input type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />
     </form>
@@ -188,7 +190,7 @@ the table based way can be removed when the entire site is Foundation-based.
 [%- ELSE -%] [%# no remote, logged out %]
     [%- chal = dw_scheme.challenge_generate(300) -%]
     [%- -%]<form action='[% site.root %]/login?ret=1' method='post' class='lj_login_form'>
-    [%- -%]<input type="hidden" name="returnto" value="[% get.returnto | html %]" />
+    [%- -%]<input type="hidden" name="returnto" value="[% returnto %]" />
     [%- -%]<input type='hidden' name='chal' class='lj_login_chal' value='[% chal %]' />
     <input type='hidden' name='response' class='lj_login_response' value='' />
     <table summary='' id='login-table'>

--- a/views/journal/controlstrip.tt
+++ b/views/journal/controlstrip.tt
@@ -22,6 +22,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
       <div>
         [%- dw.form_auth -%]
         [%- form.hidden( name = "user", value = remote.user ) -%]
+        [%- form.hidden( name = "returnto", value = returnto ) -%]
         [%- IF remote.sessid -%]
           [%- form.hidden( name = "sessid", value = remote.sessid ) -%]
         [%- END -%]
@@ -47,6 +48,7 @@ the same terms as Perl itself.  For a copy of the license, please reference
   <div id='lj_controlstrip_login'>
     <form id="login" class="lj_login_form" action="[%- site.root -%]/login?ret=1" method="post">
       [%- form.hidden( name = "mode", value = "login" ) -%]
+      [%- form.hidden( name = "returnto", value = returnto ) -%]
       [% form.textbox(
           name = "user",
           label = dw.ml( '/login.bml.login.username' ),

--- a/views/login.tt
+++ b/views/login.tt
@@ -24,7 +24,7 @@ reference 'perldoc perlartistic' or 'perldoc perlgpl'.
         <label for="lj_login_password" class="left">[% '.login.password' | ml %]</label> 
         <input type="password" id="lj_login_password" name="password" class="lj_login_password text" size="20" maxlength="[% password_maxlength %]" tabindex="12" aria-required="true" />
       </fieldset>
-      <input type="hidden" name="returnto" value="[% returnto %]"/>
+      <input type="hidden" name="returnto" value="[% returnto | html %]"/>
       <fieldset class="pkg nostyle"> 
         <p><input type="checkbox" name="remember_me" id="remember_me" value="1" tabindex="13" /> <label for="remember_me">[% '.login.remember' | ml %]</label></p>
       </fieldset> 


### PR DESCRIPTION
- Remove reliance on referrer-sniffing for logouts
- Use 'returnto' form field in logout post for proper redirecting
- Set 'returnto' field properly in journal control-strip
- Set 'returnto' field properly in Foundationized site-scheme pages

Fixes #2868

CODE TOUR: When we switched to more modern site pages, we started using the HTTP Referer header to redirect users back to the page they were originally on when they made the login/logout request. Recent updates in both Chrome and Firefox have started placing restrictions on reading the Referer header, for security reasons, with the result that users weren't getting sent back to the page they had come from properly. After some back-and-forth, we decided the nicest solution was to explicitly set the return location (which, incidentally, is more or less what the older BML pages did)
