### PR TITLE
Fix translation string location for custom layers. Fixes #2563

### DIFF
--- a/cgi-bin/DW/Controller/Customize/Advanced.pm
+++ b/cgi-bin/DW/Controller/Customize/Advanced.pm
@@ -397,10 +397,9 @@ sub layers_handler {
         my @ulayouts = ();
         push @ulayouts, map {
             $_,
-                BML::ml(
-                '.createlayer.layoutspecific.select.userlayer',
-                { 'name' => $ulay->{$_}->{'name'}, 'id' => $_ }
-                )
+                LJ::Lang::ml(
+                '/customize/advanced/layers.tt.createlayer.layoutspecific.select.userlayer',
+                { 'name' => $ulay->{$_}->{'name'}, 'id' => $_ } )
             }
             sort { $ulay->{$a}->{'name'} cmp $ulay->{$b}->{'name'} || $a <=> $b }
             grep { $ulay->{$_}->{'type'} eq 'layout' }


### PR DESCRIPTION
CODE TOUR: We had an error in the location for a translation string, which meant if you wanted to make a theme layer for a custom layout layer in /customize/advanced/layers, the section of the dropdown with your custom layout layers was missing the label for the layer. This has been remedied.
