### PR TITLE
Don't warn about unclosed <li> tags

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1169,7 +1169,8 @@ TOKEN:
                                 $opencount{$close}--;
                                 next if $close =~ $slashclose_tags;
                                 $newdata .= "</$close>";
-                                push @unclosed_tags, "$close" unless $close eq 'p';
+                                push @unclosed_tags, "$close"
+                                    unless $close eq 'p' || $close eq 'li';
                             }
                         }
 
@@ -1359,7 +1360,7 @@ TOKEN:
         if ( $opencount{$tag} ) {
             $newdata .= "</$tag>";
             $opencount{$tag}--;
-            push @unclosed_tags, $tag unless $tag eq 'p';
+            push @unclosed_tags, $tag unless $tag eq 'p' || $tag eq 'li';
         }
     }
 


### PR DESCRIPTION
CODE TOUR: Did you know you don't have to close `<li>` tags in some circumstances under the HTML 4 and HTML 5 specs? I didn't! And neither did the HTML cleaner, which meant that the changes put in in https://github.com/dreamwidth/dw-free/pull/2885 to keep you from posting bad HTML would keep you from posting unclosed `<li>` tags, too. The cleaner is now aware of this and will no longer you stop you.