### PR TITLE
Updating LJXMLRPC URL references to use HTTPS

### DIFF
--- a/cgi-bin/DW/External/XPostProtocol/LJXMLRPC.pm
+++ b/cgi-bin/DW/External/XPostProtocol/LJXMLRPC.pm
@@ -202,7 +202,7 @@ sub crosspost {
 
     # get the xml-rpc proxy and start the connection.
     # use the custom serviceurl if available, or the default using the hostname
-    my $proxyurl = $extacct->serviceurl || "http://" . $extacct->serverhost . "/interface/xmlrpc";
+    my $proxyurl = $extacct->serviceurl || "https://" . $extacct->serverhost . "/interface/xmlrpc";
 
     # load up the req.  if it's a delete, just set event as blank
     my $req;
@@ -257,7 +257,7 @@ sub get_friendgroups {
     my ( $self, $extacct, $auth ) = @_;
 
     # use the custom serviceurl if available, or the default using the hostname
-    my $proxyurl = $extacct->serviceurl || "http://" . $extacct->serverhost . "/interface/xmlrpc";
+    my $proxyurl = $extacct->serviceurl || "https://" . $extacct->serverhost . "/interface/xmlrpc";
 
     my $xpost_result = $self->call_xmlrpc( $proxyurl, 'getfriendgroups', {}, $auth );
     if ( $xpost_result->{success} ) {
@@ -531,7 +531,7 @@ sub challenge {
 
     # get the xml-rpc proxy and start the connection.
     # use the custom serviceurl if available, or the default using the hostname
-    my $proxyurl = $extacct->serviceurl || "http://" . $extacct->serverhost . "/interface/xmlrpc";
+    my $proxyurl = $extacct->serviceurl || "https://" . $extacct->serverhost . "/interface/xmlrpc";
     my $xmlrpc   = eval { XMLRPC::Lite->proxy( $proxyurl, timeout => 3 ); };
     return 0 unless $xmlrpc;
 

--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
@@ -495,7 +495,7 @@ sub call_xmlrpc {
 
     my $xmlrpc = XMLRPC::Lite->new;
     $xmlrpc->proxy(
-        "http://" . ( $opts->{server} || $opts->{hostname} ) . "/interface/xmlrpc",
+        "https://" . ( $opts->{server} || $opts->{hostname} ) . "/interface/xmlrpc",
         agent => "$LJ::SITENAME Content Importer ($LJ::ADMIN_EMAIL)"
     );
 

--- a/htdocs/manage/externalaccount.bml
+++ b/htdocs/manage/externalaccount.bml
@@ -403,7 +403,7 @@ sub account_isvalid {
     if  ( $extacct->{site} ne -1 ) {
         my $siteid = $extacct->{site};
         my $externalsite = DW::External::Site->get_site_by_id( $siteid );
-        $proxyurl = "http://" . $externalsite->{domain} . "/interface/xmlrpc";
+        $proxyurl = "https://" . $externalsite->{domain} . "/interface/xmlrpc";
         $protocol_id = $externalsite->servicetype;
     } else {
         $proxyurl = $extacct->{serviceurl};


### PR DESCRIPTION
The XMLRPC references for both the crossposter and importer were using http:// addresses,
which was incompatible with InsaneJournal's switch to using https everywhere (Aug 2021).

Under the same logic as bug #2627, we are safe to update to using https for all sites.
Also explicitly tested and works with IJ, LJ, and DW accounts under the new code.

Fixes #2900

CODE TOUR: makes importer and crossposter work for InsaneJournal again.

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
