### PR TITLE
remove error log method calls

### DIFF
--- a/cgi-bin/DW/Routing.pm
+++ b/cgi-bin/DW/Routing.pm
@@ -262,7 +262,6 @@ sub _call_hash {
     my $err = LJ::errobj($msg)
         or die "LJ::errobj didn't return anything.";
     unless ($T_TESTING_ERRORS) {
-        $err->log;
         warn $msg;
     }
 
@@ -304,7 +303,6 @@ sub _call_hash {
         my $err2 = LJ::errobj($msg2)
             or die "LJ::errobj didn't return anything.";
         unless ($T_TESTING_ERRORS) {
-            $err2->log;
             warn $msg2;
         }
 

--- a/cgi-bin/LJ/Global/BMLInit.pm
+++ b/cgi-bin/LJ/Global/BMLInit.pm
@@ -46,7 +46,6 @@ BML::register_hook(
         my $msg = shift;
 
         my $err = LJ::errobj($msg) or return;
-        $err->log;
         $msg = $err->as_html;
 
         chomp $msg;

--- a/cgi-bin/LJ/Setting.pm
+++ b/cgi-bin/LJ/Setting.pm
@@ -117,7 +117,6 @@ sub errors {
     eval "\@${errclass}::ISA = ( 'LJ::Error::SettingSave' );";
 
     my $eo = eval { $errclass->new( map => \%map ) };
-    $eo->log;
     $eo->throw;
 }
 


### PR DESCRIPTION
Commit c5f17af deleted some of the calls to a removed log method that were inadvertently re-added when the Apache notes removal patch was reverted. This attempts to delete the remaining re-added calls. (Note: this has not been tested, but it's only reintroducing some of the changes from 88785c5 that were backed out.)

CODE TOUR: Fixes some backend cleanup that was causing an obscure error to appear in some rare cases.