### PR TITLE
Cache API keys for faster lookup

### DIFF
--- a/cgi-bin/DW/API/Key.pm
+++ b/cgi-bin/DW/API/Key.pm
@@ -57,12 +57,17 @@ sub new_for_user {
 sub get_key {
     my ( $class, $hash ) = @_;
     return undef unless $hash;
+    my $memkey = [ $hash, "api_key:" . $hash ];
 
-    my $dbh     = LJ::get_db_writer() or croak "Failed to get database";
-    my $keydata = $dbh->selectrow_hashref(
-        "SELECT keyid, userid, hash FROM api_key WHERE hash = ? AND state = 'A'",
-        undef, $hash );
-    carp $dbh->errstr if $dbh->err;
+    my $keydata = LJ::MemCache::get($memkey);
+    unless ( defined $keydata ) {
+        my $dbh = LJ::get_db_writer() or croak "Failed to get database";
+        $keydata = $dbh->selectrow_hashref(
+            "SELECT keyid, userid, hash FROM api_key WHERE hash = ? AND state = 'A'",
+            undef, $hash );
+        LJ::MemCache::set( $memkey, $keydata, 60 * 60 * 24 ); # cache for one day
+        carp $dbh->errstr if $dbh->err;
+    }
 
     if ($keydata) {
         my $user = LJ::want_user( $keydata->{userid} );
@@ -100,7 +105,7 @@ sub get_keys_for_user {
 # Usage: create ( user, key )
 # Creates and returns a new key object given a user and key hash.
 # Don't call this directly, as it neither verifies nor saves keys.
-# new() or lookup() is probably what you want instead.
+# new_for_user() or get_key() is probably what you want instead.
 sub _create {
     my ( $class, $user, $keyid, $keyhash ) = @_;
 
@@ -145,11 +150,13 @@ sub delete {
         or croak "need a user!\n";
 
     $self->valid_for_user($user) or croak "key doesn't belong to user";
+    my $memkey = [ $self->{keyhash}, "api_key:" . $self->{keyhash} ];
 
     my $dbw = LJ::get_db_writer() or croak "Failed to get database";
     $dbw->do( q{UPDATE api_key SET state = 'D' WHERE state = 'A' AND hash = ?},
         undef, $self->{keyhash} );
 
+    LJ::MemCache::delete( $memkey ); 
     return 1 unless $dbw->err;
 
     carp $dbw->errstr if $dbw->err;

--- a/cgi-bin/DW/API/Key.pm
+++ b/cgi-bin/DW/API/Key.pm
@@ -65,7 +65,7 @@ sub get_key {
         $keydata = $dbh->selectrow_hashref(
             "SELECT keyid, userid, hash FROM api_key WHERE hash = ? AND state = 'A'",
             undef, $hash );
-        LJ::MemCache::set( $memkey, $keydata, 60 * 60 * 24 ); # cache for one day
+        LJ::MemCache::set( $memkey, $keydata, 60 * 60 * 24 );    # cache for one day
         carp $dbh->errstr if $dbh->err;
     }
 
@@ -156,7 +156,7 @@ sub delete {
     $dbw->do( q{UPDATE api_key SET state = 'D' WHERE state = 'A' AND hash = ?},
         undef, $self->{keyhash} );
 
-    LJ::MemCache::delete( $memkey ); 
+    LJ::MemCache::delete($memkey);
     return 1 unless $dbw->err;
 
     carp $dbw->errstr if $dbw->err;

--- a/cgi-bin/DW/API/Key.pm
+++ b/cgi-bin/DW/API/Key.pm
@@ -57,7 +57,7 @@ sub new_for_user {
 sub get_key {
     my ( $class, $hash ) = @_;
     return undef unless $hash;
-    my $memkey = [ $hash, "api_key:" . $hash ];
+    my $memkey = "api_key:$hash";
 
     my $keydata = LJ::MemCache::get($memkey);
     unless ( defined $keydata ) {
@@ -65,8 +65,8 @@ sub get_key {
         $keydata = $dbh->selectrow_hashref(
             "SELECT keyid, userid, hash FROM api_key WHERE hash = ? AND state = 'A'",
             undef, $hash );
-        LJ::MemCache::set( $memkey, $keydata, 60 * 60 * 24 );    # cache for one day
         carp $dbh->errstr if $dbh->err;
+        LJ::MemCache::set( $memkey, $keydata, 60 * 60 * 24 );    # cache for one day
     }
 
     if ($keydata) {
@@ -150,7 +150,7 @@ sub delete {
         or croak "need a user!\n";
 
     $self->valid_for_user($user) or croak "key doesn't belong to user";
-    my $memkey = [ $self->{keyhash}, "api_key:" . $self->{keyhash} ];
+    my $memkey = "api_key:" . $self->{keyhash};
 
     my $dbw = LJ::get_db_writer() or croak "Failed to get database";
     $dbw->do( q{UPDATE api_key SET state = 'D' WHERE state = 'A' AND hash = ?},


### PR DESCRIPTION
CODE TOUR: A while ago, we added API keys! These have to be sent with every API request - right now, there's not a lot you can do with the API, so there isn't many of those, but in the future, this will hopefully increase. Right now, the server has to check the database every time to see if an API key is valid. Checking the database is expensive in terms of time and resources, so we ideally want to reduce the number of times that happens. This change makes the server cache successful key lookups, so if you make a bunch of API requests in a row, it will 'remember' the key after the first one and not have to check the database.