### PR TITLE
Remove touch feature-detect

### DIFF
--- a/htdocs/js/jquery.fileupload.js
+++ b/htdocs/js/jquery.fileupload.js
@@ -70,12 +70,11 @@ $(function() {
         })
     };
 
-    if ( ! Modernizr.touch ) {
-        $(".upload-form-file-inputs")
-            .find('.row')
-                .prepend('<div class="large-12 columns"><div class="drop_zone">or drop images here</div></div>')
-            .end()
-    }
+    $(".upload-form-file-inputs")
+        .find('.row')
+            .prepend('<div class="large-12 columns"><div class="drop_zone">or drop images here</div></div>')
+        .end()
+
     $(".upload-form-file-inputs")
     .find('input[type=file]')
         .attr( 'multiple', 'multiple' )


### PR DESCRIPTION
CODE TOUR: We had code that tried to detect if you were on a mobile device, and hide the drop target on the image upload page, because mobile OSes generally do not support drag-and-drop of files into another application. However, the main way to try to detect this is checking for support of touch APIs and 1) this is not all that reliable (which is common for feature detection) and 2) most desktop OSes now support touchscreens as well, which meant that the drop target wasn't showing up even on non-touchscreen devices in some browsers. So that detection went away - so you may see the drop target in some instances where you can't actually drag and drop files, but this is on the whole less annoying that not having it when you *can*.

Fixes #2911 