### PR TITLE
fix utf8 encoding issues in API returns

### DIFF
--- a/cgi-bin/DW/API/Method.pm
+++ b/cgi-bin/DW/API/Method.pm
@@ -151,7 +151,7 @@ sub rest_ok {
     # if we have JSON, call the formatter to pretty-print it. Otherwise, we assume
     # other content-types have already been properly formatted for us.
     if ( $content_type eq "application/json" ) {
-        $r->print( to_json( $response, { convert_blessed => 1, pretty => 1 } ) );
+        $r->print( to_json( $response, { convert_blessed => 1, latin1 => 1, pretty => 1 } ) );
     }
     else {
         $r->print($response);


### PR DESCRIPTION
CODE TOUR: Non-ASCII UTF8 text was being returned as gibberish from API endpoints. For reasons that are probably 'Perl UTF8 support is bad', setting the Latin-1 flag on the JSON encoder fixes this? Genuinely, I do not know and have given up trying to figure it out.

Fixes #2899 