### PR TITLE
Fix send-email working on dreamhacks

### DIFF
--- a/cgi-bin/DW/Task/SendEmail.pm
+++ b/cgi-bin/DW/Task/SendEmail.pm
@@ -65,9 +65,13 @@ sub work {
             "Temporary failure connecting to $LJ::EMAIL_VIA_SES{hostname}, will retry.")
             unless $smtp;
 
-        $smtp->auth( $LJ::EMAIL_VIA_SES{username}, $LJ::EMAIL_VIA_SES{password} )
-            or
-            return $failed->("Couldn't authenticate to $LJ::EMAIL_VIA_SES{hostname}, will retry.");
+        # Only try auth if we have username/pw configured for mail server
+        if ( $LJ::EMAIL_VIA_SES{username} && $LJ::EMAIL_VIA_SES{password} ) {
+            $smtp->auth( $LJ::EMAIL_VIA_SES{username}, $LJ::EMAIL_VIA_SES{password} )
+                or return $failed->(
+                "Couldn't authenticate to $LJ::EMAIL_VIA_SES{hostname}, will retry.");
+        }
+
     }
     $last_email = time();
 


### PR DESCRIPTION
CODE TOUR: When we moved email notifications to AWS, we accidentally broke email sending from DreamHacks, because the AWS mailer uses some options sendmail on the hack box does not. This now checks if those options are set before trying to use them, and skipping them if not.