### PR TITLE
Add a link for Discord to contrib docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,4 @@ We love having new contributors join us! Here's the quick summary of where to fi
 * Send in a [Contributor Licensing Agreement](http://wiki.dreamwidth.net/wiki/index.php/Contributor_Licensing_Agreement)
 * Start hacking!
 
-If you're having trouble, ask in the [dw-dev](https://dw-dev.dreamwidth.org) community.
+If you're having trouble, ask in the [dw-dev](https://dw-dev.dreamwidth.org) community, or join us on [Discord](https://dw-dev.dreamwidth.org/209778.html).


### PR DESCRIPTION
CODE TOUR: We moved to using Discord for dev communication rather than IRC, but this was not linked anywhere helpful in the repo itself. This has now been fixed!

(note - it's a link to an entry in dw-dev with the Discord invite link, both to lessen the chances of it getting scraped by bots, and also so if we ever update it, we only have to fix one spot)