### PR TITLE
Allow details and summary tags in comments

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1626,6 +1626,7 @@ my @comment_all = qw(
     ul ol li dl dt dd
     area map form textarea
     img br hr p col
+    summary details
 );
 
 my $event_eat    = $subject_eat;


### PR DESCRIPTION
CODE TOUR: For security reasons, we specify what HTML tags are allowed to be used in entries and comments with a whitelist which says 'you can use these specific tags and NOTHING else' (as opposed to a blacklist, which says 'you CAN'T use these tags but you can use anything else'). This is the safer way to handle things, but means that when new tags get added to the HTML, we have to add them to the whitelist after we've decided they're safe. `details` and `summary` got added to the whitelist for entries, but not for comments. This change allows you to use them in comments now, too.

Fixes #2887 