### PR TITLE
Don't override browser display for details and summary

### DIFF
--- a/htdocs/scss/foundation/normalize.scss
+++ b/htdocs/scss/foundation/normalize.scss
@@ -32,7 +32,6 @@ body {
 
 article,
 aside,
-details,
 figcaption,
 figure,
 footer,
@@ -41,8 +40,7 @@ hgroup,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 

--- a/htdocs/stc/reset.css
+++ b/htdocs/stc/reset.css
@@ -23,7 +23,7 @@ time, mark, audio, video {
 	vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure,
+article, aside, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }


### PR DESCRIPTION
CODE TOUR: The `details` HTML element is basically a nice little native expand/collapse that allows you to hide and unhide blocks of text. By default, browsers usually style it with a little arrow at the side to indicate that it can be expanded and collapsed. We, however, had some CSS fixes for old browsers (IE and very old versions of Firefox) that didn't support this newer element - which were probably added when those browsers weren't super old and it was actually a good idea - that caused the arrow to vanish entirely for all browsers. Very silly. Now that we are in the future, those workarounds can be removed!