### PR TITLE
Add Beta flag for new inbox redesign

### DIFF
--- a/cgi-bin/DW/Controller/Inbox.pm
+++ b/cgi-bin/DW/Controller/Inbox.pm
@@ -27,9 +27,9 @@ use DW::FormErrors;
 use LJ::Hooks;
 use Data::Dumper;
 
-DW::Routing->register_string( '/inbox',          \&index_handler,    app => 1 );
-DW::Routing->register_string( '/inbox/compose',  \&compose_handler,  app => 1 );
-DW::Routing->register_string( '/inbox/markspam', \&markspam_handler, app => 1 );
+DW::Routing->register_string( '/inbox/new',          \&index_handler,    app => 1 );
+DW::Routing->register_string( '/inbox/new/compose',  \&compose_handler,  app => 1 );
+DW::Routing->register_string( '/inbox/new/markspam', \&markspam_handler, app => 1 );
 DW::Routing->register_rpc( 'inbox_actions', \&action_handler, format => 'json' );
 
 my $PAGE_LIMIT = 15;

--- a/htdocs/inbox/compose.bml
+++ b/htdocs/inbox/compose.bml
@@ -1,0 +1,334 @@
+<?_c
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+_c?>
+<?page
+body<=
+<?_code
+{
+    use strict;
+    use vars qw(%GET %POST);
+
+    use warnings;
+    use LJ::Message;
+    use LJ::JSUtil;
+
+    return $ML{'.messaging.disabled'} unless LJ::is_enabled( 'user_messaging' );
+
+    my $remote = LJ::get_remote() or return "<?needlogin?>";
+    my $remote_id = $remote->{'userid'};
+
+    return "<?p " . BML::ml('protocol.not_validated', { sitename => $LJ::SITENAMESHORT, siteroot => $LJ::SITEROOT }) . " p?>"
+        unless $remote->is_validated;
+
+    # $_[1] is a pre-request scratch area
+    # put variables here so that we can access them later
+    # outside of this _code block
+    my $head     = \$_[1]->{'head'};
+
+    my $body = '';
+
+    my $reply_to; # User replying to
+    my $reply_u; # User replying to
+    my $disabled_to = 0; # disable To field if sending a reply message
+    my $msg_subject = ''; # reply subject
+    my $msg_body = ''; # reply body
+    my $msg_parent = ''; # Hidden msg field containing id of parent message
+    my $msg_limit = $remote->count_usermessage_length;
+    my $subject_limit = 255;
+    my $force = 0; # flag for if user wants to force an empty PM
+
+    my @errors;
+
+    push @errors, $ML{'.suspended.cannot.send'} if $remote->is_suspended;
+
+    # Submitted message
+    if (LJ::did_post()) {
+        my $mode = $POST{'mode'};
+
+        push @errors, $ML{'error.invalidform'}
+            unless LJ::check_form_auth();
+
+        if ($mode eq 'send') {
+            # test encoding
+            my $msg_subject_text = $POST{'msg_subject'};
+            push @errors, $ML{'.error.text.encoding.subject'}
+                unless LJ::text_in($msg_subject_text);
+            my ( $subject_length_b, $subject_length_c ) = LJ::text_length( $msg_subject_text );
+            push @errors, BML::ml( ".error.subject.length",
+                {
+                    subject_length => LJ::commafy( $subject_length_c ),
+                    subject_limit  => LJ::commafy( $subject_limit ),
+                } )
+                unless $subject_length_c <= $subject_limit;
+
+            # test encoding and length
+            my $msg_body_text = $POST{'msg_body'};
+            push @errors, $ML{'.error.text.encoding.text'}
+                unless LJ::text_in($msg_body_text);
+            my ($msg_len_b, $msg_len_c) = LJ::text_length($msg_body_text);
+            push @errors, BML::ml( ".error.message.length",
+                  { msg_length => LJ::commafy( $msg_len_c ),
+                    msg_limit => LJ::commafy( $msg_limit ) } )
+                unless ($msg_len_c <= $msg_limit);
+
+            # checks if the PM is empty (no text)
+            $force = $POST{'force'};
+            unless ( $msg_len_c > 0 || $force ) {
+               push @errors, $ML{'.warning.empty.message'};
+               $force = 1;
+            }
+
+            # Get list of recipients
+            my $to_field = $POST{'msg_to'};
+            $to_field =~ s/\s//g;
+            # Get recipient list without duplicates
+            my %to_hash = map { lc($_), 1 } split(",", $to_field);
+            my @to_list = keys %to_hash;
+            push @to_list, $remote->username if $POST{'cc_msg'};
+            my @msg_list;
+
+            # persist the default value of the cc_msg option
+            $remote->cc_msg( $POST{'cc_msg'} ? 1 : 0 );
+
+            # must be at least one username
+            push @errors, $ML{'.error.no.username'} unless ( scalar( @to_list ) > 0 );
+
+            # Check each user being sent a message
+            foreach my $to (@to_list) {
+                # Check the To field
+                my $tou = LJ::load_user_or_identity( $to );
+                unless ($tou) {
+                    push @errors, BML::ml( '.error.invalid.username',
+                                    { to => $to } );
+                    next;
+                }
+
+                # Can only send to other individual users
+                unless ($tou->is_person || $tou->is_identity || $tou->is_renamed) {
+                    push @errors, BML::ml( 'error.message.individual', { ljuser => $tou->ljuser_display } );
+                    next;
+                }
+
+                # Can't send to unvalidated users
+                unless ( $tou->is_validated || $remote->has_priv( "siteadmin", "*" ) ) {
+                    push @errors, BML::ml( 'error.message.unvalidated',
+                      { ljuser => $tou->ljuser_display } );
+                    next;
+                }
+
+                # Will target user accept messages from sender
+                unless ($tou->can_receive_message($remote)) {
+                    push @errors, BML::ml( 'error.message.canreceive', { ljuser => $tou->ljuser_display } );
+                    next;
+                }
+
+                my $msguserpic;
+                $msguserpic = $POST{'prop_picture_keyword'} if ( defined $POST{'prop_picture_keyword'} );
+
+                push @msg_list, LJ::Message->new({journalid => $remote_id,
+                                            otherid   => $tou->{userid},
+                                            subject   => $msg_subject_text,
+                                            body      => $msg_body_text,
+                                            parent_msgid => $POST{'msg_parent'} || undef,
+                                            userpic      => $msguserpic,
+                                           });
+
+            }
+
+            # Check that the rate limit will not be exceeded
+            # This is only necessary if there are multiple recipients
+            if (scalar(@msg_list) > 1) {
+                my $up;
+                $up = LJ::Hooks::run_hook('upgrade_message', $remote, 'message');
+                $up = "<br />$up" if ($up);
+                push @errors, BML::ml( ".error.rate.limit", { up => $up } )
+                    unless LJ::Message::ratecheck_multi(userid => $remote_id, msg_list => \@msg_list)
+            }
+
+            # check if any of the messages will throw an error
+            unless (@errors) {
+                foreach my $msg (@msg_list) {
+                    $msg->can_send(\@errors);
+                }
+            }
+
+            # send all the messages and display confirmation
+            unless (@errors) {
+                foreach my $msg (@msg_list) {
+                    $msg->send(\@errors);
+                }
+
+                unless (@errors) {
+                    $body .= $ML{'.message.sent'};
+                    $body .= "<?p $ML{'.message.sent.options'} <ul>";
+                    $body .= "<li><a href='$LJ::SITEROOT/inbox/?page=0&view=usermsg_sent_last'>$ML{'.link.view.message'}</a> $ML{'.link.view.warning'}</li>";
+                    $body .= "<li><a href='$LJ::SITEROOT/inbox/compose'>$ML{'.link.send.message'}</a></li>";
+                    $body .= "<li><a href='$LJ::SITEROOT/inbox/'>$ML{'.link.inbox'}</a></li>";
+                    $body .= "<li><a href='$LJ::SITEROOT/'>$ML{'.link.home'}</a></li>";
+                    $body .= "</ul> p?>\n";
+                    return $body;
+                }
+            }
+        }
+    }
+
+    # Display errors
+    $body .= LJ::error_list(@errors) if (@errors);
+
+    # Sending a reply to a message
+    if (($GET{mode} && $GET{mode} eq 'reply') || $POST{'msgid'}){
+        my $msgid = $GET{'msgid'} || $POST{'msgid'};
+        next unless $msgid;
+
+        my $msg = LJ::Message->load({msgid => $msgid, journalid => $remote_id});
+        push @errors, $ML{'.error.cannot.reply'}
+            unless ($msg->can_reply($msgid, $remote_id));
+
+        if (@errors) {
+            $body .= LJ::error_list(@errors);
+            return $body;
+        }
+
+        $reply_u = $msg->other_u;
+        $reply_to = $reply_u->display_name;
+        $disabled_to = 1;
+        $msg_subject = $msg->subject_raw || "(no subject)";
+        $msg_subject = "Re: " . $msg_subject
+            unless $msg_subject =~ /Re: /;
+        $msg_body = $msg->body_raw;
+        $msg_body =~ s/(.{70}[^\s]*)\s+/$1\n/g;
+        $msg_body =~ s/(^.*)/\> $1/gm;
+        $msg_body = "\n\n--- $reply_to wrote:\n" . $msg_body;
+        $msg_parent .= LJ::html_hidden({
+                          name => 'msg_parent',
+                          value => "$msgid",
+                       });
+    }
+
+    my @userpics = LJ::Userpic->load_user_userpics($remote);
+    my @pickws;
+    foreach my $pic (@userpics) {
+        push @pickws, map { ($_, $_) } $pic->keywords;
+    }
+
+    # Inbox Nav
+    $body .= qq{
+        <table summary='' class='inbox-compose'><tr><td style="padding-right: 12px">};
+    $body .= LJ::Widget::InboxFolderNav->render();
+    $body .= qq{
+        </td>
+        <td width="1" height="100%" style="border-left: 1px solid #ccc"><img src="$LJ::IMGPREFIX/spacer.gif" alt="" /></td>
+        <td valign="top" style="padding-left: 10px; width: 100%;">
+    };
+
+    $body .= '<form action="./compose" method="POST" id="compose">';
+
+    $body .= LJ::form_auth();
+    my $pic = ''; # displays chosen/default pic
+    my $picform = ''; # displays form drop-down
+    LJ::Widget::UserpicSelector->render(
+                picargs => [ $remote, \$$head, \$pic, \$picform ],
+                prop_picture_keyword => $POST{prop_picture_keyword} );
+    $body .= $pic;
+
+    $body .= "<div id='metainfo'>";
+    $body .= '<p class="pkg"><label class="left">To:</label> ';
+
+    if ($disabled_to) {
+        $body .= $reply_u->ljuser_display;
+        $body .= LJ::html_hidden({
+                    name      => 'msg_to',
+                    value     => $reply_u->username,
+                 });
+    } else {
+        $body .= LJ::html_text({
+                    name      => 'msg_to',
+                    size      => '15',
+                    id        => 'msg_to',
+                    value     => $POST{'msg_to'} || $GET{'user'} || undef,
+                    raw       => "autocomplete='off'",
+                 });
+    }
+
+    $body .= LJ::html_hidden( { name  => 'force',
+                                value => $force,
+                                id    => 'force' } );
+    $body .= "</p>\n";
+    # autocomplete To field with trusted and watched people
+    my @flist = ();
+    if ( LJ::isu( $remote ) ) {
+        my %trusted_and_watched_userids = map { $_ => 1 } ( $remote->trusted_userids, $remote->watched_userids );
+        my $us = LJ::load_userids( keys %trusted_and_watched_userids );
+        @flist = map { $us->{$_}->display_name } grep { $us->{$_}->is_personal || $us->{$_}->is_identity } keys %trusted_and_watched_userids;
+    }
+    $body .= LJ::JSUtil::autocomplete(field => 'msg_to', list => \@flist);
+
+    # The drop-down userpic menu
+    $body .= $picform;
+
+    # Are we sending a copy of the message to the user?
+    my $cc_msg_option = $remote->cc_msg;
+
+    $body .= LJ::html_check( {
+        name     => 'cc_msg',
+        id       => 'cc_msg',
+        value    => 1,
+        selected => $cc_msg_option,
+    } );
+    $body .= " <label for='cc_msg' style='font-weight: normal; font-size: smaller; font-style:italic;'>" . BML::ml( '.form.label.cc' ) . "</label></div>";
+
+    $body .= "<div class='inbox_formmes'><p><label class='subj-l'>Subject:</label> ";
+    $body .= LJ::html_text({
+                name    => 'msg_subject',
+                size    => '50',
+                maxlength => $subject_limit,
+                value   => $POST{'msg_subject'} || $msg_subject,
+                class   => 'subj-t'
+             });
+    $body .= "</p>\n";
+    $body .= "<div class='msg_txt'>";
+    $body .= "<textarea name='msg_body' rows=6 cols=55 wrap=soft>";
+    $body .= LJ::ehtml( $POST{'msg_body'} || $msg_body );
+    $body .= "</textarea><br />";
+    $body .= "<span class='helper'>Up to " . LJ::commafy($msg_limit) . " characters. Plain text, no HTML.";
+    $body .= "</span></div>\n";
+
+    $body .= $msg_parent;
+    $body .= LJ::html_hidden({
+                name => 'mode',
+                value => 'send',
+             });
+
+    $body .= LJ::html_submit("Send");
+    $body .= "</form></div>";
+    $body .= qq{
+        </td></tr></table>
+    };
+
+
+    return $body;
+}
+_code?>
+<=body
+title=><?_code return "Compose Message"; _code?>
+head<=
+<?_code
+    use strict;
+
+    my $ret = $_[1]->{'head'};
+
+    return $ret;
+_code?>
+<=head
+page?>

--- a/htdocs/inbox/compose.bml.text
+++ b/htdocs/inbox/compose.bml.text
@@ -1,0 +1,39 @@
+;; -*- coding: utf-8 -*-
+.error.cannot.reply=You cannot reply to this message
+
+.error.invalid.username="[[to]]" is not a valid username
+
+.error.message.length=Message body is too long ([[msg_length]] characters). It should not exceed [[msg_limit]] characters.
+
+.error.no.username=Please enter a valid username
+
+.error.rate.limit=This message will exceed your limit and cannot be sent.[[up]]
+
+.error.subject.length=Subject is too long ([[subject_length]] characters). It should not exceed [[subject_limit]] characters.
+
+.error.text.encoding.subject=Invalid text encoding for message subject
+
+.error.text.encoding.text=Invalid text encoding for message text
+
+.form.label.cc=Send me a copy of my own message
+
+.link.home=Return Home
+
+.link.inbox=Return to Inbox
+
+.link.send.message=Send a new message
+
+.link.view.message=View your message
+
+.link.view.warning=(If your message doesn't appear yet, please wait a few minutes and refresh the page.)
+
+.message.sent=Your message has been sent successfully.
+
+.message.sent.options=From here you can:
+
+.messaging.disabled=User messaging is currently disabled
+
+.suspended.cannot.send=Suspended accounts can't send private messages.
+
+.warning.empty.message=Warning: You are trying to send a message with no text. Please resubmit if this is correct.
+

--- a/htdocs/inbox/index.bml
+++ b/htdocs/inbox/index.bml
@@ -1,0 +1,295 @@
+<?_c
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+_c?>
+<?page
+body<=
+<?_code
+{
+    use strict;
+    use vars qw($title $body $head %GET %POST);
+    use LJ::NotificationInbox;
+    use LJ::Event;
+
+    $title = $ML{'.title'};
+    $body = "";
+
+    my $remote = LJ::get_remote()
+        or return "<?needlogin?>";
+
+    return $ML{'.error.not_ready'} unless $remote->can_use_esn;
+
+    return BML::redirect( LJ::create_url( "/inbox/new", cur_args => \%GET, keep_args => 1 ) )
+            if ! LJ::did_post() && LJ::BetaFeatures->user_in_beta( $remote => "inbox" );
+
+    LJ::need_res(qw(
+                  js/6alib/core.js
+                  js/6alib/dom.js
+                  js/6alib/view.js
+                  js/6alib/datasource.js
+                  js/6alib/checkallbutton.js
+                  js/6alib/selectable_table.js
+                  js/6alib/httpreq.js
+                  js/6alib/hourglass.js
+                  js/esn_inbox.js
+                  stc/esn.css
+                  stc/lj_base.css
+                  ));
+
+    my $formauth = LJ::form_auth();
+
+    # get the user's inbox
+    my $inbox = $remote->notification_inbox
+        or return LJ::error_list( BML::ml('.error.couldnt_retrieve_inbox', { 'user' => $remote->{user} }) );
+
+    # 2 instances of action buttons
+    # map each to one variable
+    my @buttons = qw{markRead markUnread delete markAllRead deleteAll};
+    foreach my $button (@buttons) {
+        for (my $i=1; $i<=2; $i++) {
+            my $sfx_button = $button . "_" . $i;
+            $GET{$button} = $GET{$sfx_button} if($GET{$sfx_button} && !$GET{$button});
+            $POST{$button} = $POST{$sfx_button} if($POST{$sfx_button} && !$POST{$button});
+        }
+    }
+
+    # Take a supplied filter but default it to undef unless it is valid
+    my $view = $POST{view} || $GET{view} || undef;
+    $view = undef if $view eq 'archive' && ! LJ::is_enabled('esn_archive');
+    $view = undef if $view && !LJ::NotificationInbox->can("${view}_items");
+
+    my $itemid = $view eq "singleentry" ? int( $POST{itemid} || $GET{itemid} || 0 ) : 0;
+
+    # Bolds the selected View/Folder
+    my $selected_folder = $view || 'all';
+    $selected_folder = "entrycomment" if $selected_folder eq "singleentry";
+
+    $selected_folder = qq(
+        <style>
+            .filterlink_$view {display: none;}
+            .entry-tags {text-align: right; font-style: italic;}
+        </style>
+        );
+    $head = $selected_folder;
+
+    # get events sitting in inbox
+    my @notifications = $inbox->items;
+
+    my @errors;
+
+    if (LJ::did_post()) {
+
+        # operate on notices by default but switch if view parameter specified
+        my $nitems = \@notifications;
+        my $name = "all";
+        if ($view) {
+            my @items = eval "\$inbox->${name}_items";
+            push @items, $inbox->usermsg_sent_items;
+            $nitems = \@items;
+        }
+
+        if ($POST{markAllRead}) {
+            $inbox->mark_all_read( $view, itemid => $itemid );
+        } elsif ($POST{deleteAll}) {
+            $inbox->delete_all( $view, itemid => $itemid );
+        } else {
+            # go through each item and see if it's checked
+            foreach my $item (@$nitems) {
+                my $qid = eval { $item->qid } or next;
+                my $checked = $POST{"${name}_Check-$qid"};
+                next unless $checked;
+
+                if ($POST{markRead}) {
+                    $item->mark_read;
+                } elsif ($POST{markUnread}) {
+                    $item->mark_unread;
+                } elsif ($POST{delete}) {
+                    $item->delete;
+                }
+            }
+
+            # reload inbox after making changes
+            @$nitems = eval "\$inbox->${name}_items";
+        }
+    }
+
+    # Allow bookmarking to work without Javascript
+    # or before JS events are bound
+    if ($GET{bookmark_off} && $GET{bookmark_off} =~ /^\d+$/) {
+        push @errors, $ML{'.error.max_bookmarks'}
+            unless $inbox->add_bookmark($GET{bookmark_off});
+    }
+    if ($GET{bookmark_on} && $GET{bookmark_on} =~ /^\d+$/) {
+        $inbox->remove_bookmark($GET{bookmark_on});
+    }
+
+    # Pagination
+    my $page = int($POST{page} || $GET{page});
+
+    $body .= LJ::error_list(@errors) if (@errors);
+
+    my $viewarg = $view  ? "&view=$view" : "";
+    my $itemidarg = $itemid ? "&itemid=$itemid" : "";
+
+    # Inbox Nav
+    $body .= qq{
+        <table summary='' id="table_inbox" style="width: 100%"><tr><td id="table_inbox_folders" valign="top" style="padding-right: 12px">};
+    $body .= LJ::Widget::InboxFolderNav->render( 'page' => 1, 'view' => $view );
+
+    $body .= qq{
+        </td>
+        <td width="1" height="100%" style="border-left: 1px solid #ccc"><img src="$LJ::IMGPREFIX/spacer.gif" alt="" /></td>
+        <td id="table_inbox_messages" valign="top" style="padding-left: 10px; width: 100%;">
+            <div class="inbox_newitems pkg">
+                <span class="esnlinks" style="float: left"><a href="$LJ::SITEROOT/inbox/?page=$page$viewarg$itemidarg" id="RefreshLink"><?_ml inbox.refresh _ml?></a> |
+                    <a href="$LJ::SITEROOT/manage/settings/?cat=notifications"><?_ml inbox.manage_settings _ml?></a></span>
+            </div>
+
+    };
+
+    # Filter by view if specified
+    my @all_items;
+    if ($view) {
+        if ( $view eq "singleentry" ) {
+            @all_items = eval "\$inbox->${view}_items( $itemid )";
+        } else {
+            @all_items = eval "\$inbox->${view}_items";
+        }
+    } else {
+        @all_items = $inbox->all_items;
+    }
+
+    my $itemcount = scalar @all_items;
+
+    $body .= LJ::error_list( $@ ) if $@;
+
+    # Pagination
+    $page = int($POST{page} || $GET{page});
+    
+    $body .= LJ::Widget::InboxFolder->render(
+                     folder  => "all",
+                     reply_btn => 1,
+                     expand    => $GET{expand},
+                     inbox     => $inbox,
+                     page      => $page,
+                     view      => $view,
+                     mode      => $GET{mode},
+                     items     => \@all_items,
+                     itemid    => $itemid,
+              );
+
+    # Repeat refresh/manage links if we have more than a few items (15 max per page)
+    $body .= qq{
+            <div class="inbox_newitems pkg">
+                <span class="esnlinks" style="float: left"><a href="$LJ::SITEROOT/inbox/?page=$page$viewarg$itemidarg"><?_ml inbox.refresh _ml?></a> |
+                    <a href="$LJ::SITEROOT/manage/settings/?cat=notifications"><?_ml inbox.manage_settings _ml?></a></span>
+            </div>
+    } if $itemcount > 10;
+
+    $body .= qq{
+        </td></tr></table>
+    };
+
+    # send the i18n variables to the js page context
+    $body .= "<script type='text/javascript'>\n";
+    $body .= "expanded = '$ML{'widget.inbox.notification.expanded'}';\n";
+    $body .= "collapsed = '$ML{'widget.inbox.notification.collapsed'}';\n";
+    $body .= "add_bookmark = '$ML{'widget.inbox.notification.add_bookmark'}';\n";
+    $body .= "rem_bookmark = '$ML{'widget.inbox.notification.rem_bookmark'}';\n";
+    $body .="</script>\n"; $body .= "</p>\n";
+
+
+    return $body;
+}
+ _code?>
+<=body
+title=><?_code return $title; _code?>
+head<=
+
+<?_code return $head; _code?>
+
+<script>
+LJ_cmtinfo = {};
+LJ_cmtinfo['disableInlineDelete'] = 1;
+var pageNum;
+var cur_folder = '<?_code return $POST{view} || $GET{view} || undef; _code?>';
+var itemid = <?_code return int( $POST{itemid} || $GET{itemid} || 0 ) _code?>;
+
+document.addEventListener("DOMContentLoaded", setup, cur_folder);
+
+var tableview;
+var checkallButton;
+/* Can have multiple tables or folders displayed on the same page */
+var folders = ['all'];
+
+function setup (e) {
+    if (! Site.has_remote) return;
+
+    for (var i=0; i<folders.length; i++) {
+        var name = folders[i];
+        tableview = new View();
+
+        tableview.init({ "view": $(name + "_Table"), "selectedClass": "selected" });
+
+        // 2 instances of action buttons
+        for (var i=1; i<=2; i++) {
+            checkallButton = new CheckallButton();
+            checkallButton.init({
+                  "class": "InboxItem_Check",
+                  "button": $(name + "_CheckAll_" + i),
+                  "parent": tableview.getView()
+            });
+            if( checkallButton.button )
+                checkallButton.button.checked = false;
+        }
+    }
+
+// 2 instances of action buttons
+for (var i=1; i<=2; i++) {
+    if( $("Page_Prev_"+i) )
+        DOM.addEventListener($("Page_Prev_"+i), "click", Page_Prev);
+    if( $("Page_Next_"+i) )
+        DOM.addEventListener($("Page_Next_"+i), "click", Page_Next);
+}
+
+if ($("pageNum")) pageNum = parseInt($("pageNum").value, 10);
+}
+
+function xtra_args () {
+    var args = '';
+    var view = $("inbox_view").value;
+    if (view) args += "&view=" + view;
+    if (itemid) args += "&itemid="+itemid;
+    return args;
+}
+
+function Page_Prev (e) {
+    if (pageNum) {
+        var args = xtra_args();
+        window.location.href = "<?siteroot?>/inbox/?page=" + (pageNum - 1) + args;
+    }
+}
+
+function Page_Next (e) {
+    if (pageNum) {
+        var args = xtra_args();
+        window.location.href = "<?siteroot?>/inbox/?page=" + (pageNum + 1) + args;
+    }
+}
+
+</script>
+
+<=head
+
+bodyopts=><?_code return "id='page_inbox' class='self_wrap'" _code?>
+page?>

--- a/htdocs/inbox/index.bml.text
+++ b/htdocs/inbox/index.bml.text
@@ -1,0 +1,35 @@
+;; -*- coding: utf-8 -*-
+.error.couldnt_retrieve_inbox=Couldn't retrieve inbox for [[user]]
+
+.error.max_bookmarks=Maximum number of flagged items reached
+
+.error.not_ready=Not Ready
+
+.manage_settings=Manage Settings
+
+.menu.all=All
+
+.menu.birthdays=Birthdays
+
+.menu.bookmarks=Bookmarks
+
+.menu.delete_all.btn=Delete All
+
+.menu.entries_and_comments=Entries and Comments
+
+.menu.friend_updates=Relationship Updates
+
+.menu.mark_all_read.btn=Mark All Read
+
+.menu.messages=Messages
+
+.menu.new_friends=New Subscriptions
+
+.menu.new_message.btn=New Message
+
+.menu.sent=Sent
+
+.refresh=Refresh
+
+.title=Inbox
+

--- a/htdocs/inbox/markspam.bml
+++ b/htdocs/inbox/markspam.bml
@@ -1,0 +1,106 @@
+<?_c
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+_c?>
+<?page
+body<=
+<?_code
+{
+    use strict;
+    use vars qw(%GET %POST);
+
+    use LJ::Message;
+
+    BML::decl_params(msgid   => 'digits',
+                     confirm => '.',
+                     spam    => '.',
+                     ban     => '.',
+                     lj_form_auth => '.',
+                    );
+
+    my $remote = LJ::get_remote() or return "<?needlogin?>";
+    my $remote_id = $remote->{'userid'};
+
+    my $msg_id = $GET{msgid} || $POST{msgid};
+    my $msg = LJ::Message->load({msgid => $msg_id, journalid => $remote_id});
+
+    return "<?p Message cannot be loaded p?>"
+        unless $msg && $msg->valid;
+
+    return "<?p You cannot report a message you sent as spam. p?>"
+        if $msg->type eq "out";
+
+    return "<?p You are not allowed to report messages as spam. p?>"
+        if LJ::sysban_check( 'spamreport', $remote->user );
+
+    my $body = '';
+
+    if (LJ::did_post() && $POST{'confirm'}) {
+        return "<?h1 $ML{'Error'} h1?><?p $ML{'error.invalidform'} p?>"
+            unless LJ::check_form_auth();
+
+        # Some action must be selected
+        return "<?h1 $ML{'Error'} h1?><?p No action selected p?>"
+            unless ($POST{spam} || $POST{'ban'});
+
+        $body .= '<ul>';
+        # Mark as spam
+        if ($POST{spam}) {
+            $body .= '<li>Message marked as spam.</li>'
+                if $msg->mark_as_spam;
+        }
+
+        # Ban user
+        if ($POST{'ban'}) {
+            LJ::set_rel($remote_id, $msg->otherid, 'B');
+            $remote->log_event('ban_set', { actiontarget => $msg->otherid, remote => $remote });
+            $body .= '<li>User banned.</li>';
+        }
+
+        $body .= "</ul>\n";
+
+        $body .= "<?p What would you like to do next? p?>\n";
+        $body .= "<ul><li><a href='$LJ::SITEROOT/inbox/'>Go to the Inbox</a></li>";
+        $body .= "<li><a href='$LJ::SITEROOT/'>Go to the Home page</a></li>";
+        $body .= "<li><a href='$LJ::SITEROOT/manage/profile/'>Edit your profile</a></li></ul>";
+
+        return $body;
+    }
+
+    $body .= "<?p Are you sure you want to mark this message as spam? p?>";
+
+    $body .= "<form method='post'>";
+    $body .= LJ::form_auth();
+
+    $body .= "<div class='highlight-box'>" . LJ::html_check({name => 'spam', id => 'spam', checked => "checked"});
+    $body .= "<label for='spam'>Mark this message as spam</label></div>";
+
+    $body .= "<div>" . LJ::html_check({ 'type' => 'check', 'name' => 'ban', 'id' => 'ban' });
+    $body .= "<label for='ban'>";
+    $body .= "Ban ". LJ::ljuser($msg->other_u) ." from sending you messages and commenting in your journal.";
+    $body .= "</label></div>";
+
+    $body .= "<div align='center' style='margin: 8px'>";
+    $body .= LJ::html_hidden({name => 'msgid', value => $msg->msgid});
+    $body .= LJ::html_submit('confirm', 'Confirm') . "</div>\n";
+    $body .= "</form>";
+
+    $body .= "<p><strong>Note:</strong> From the <a href='/manage/profile/'>Edit Profile</a> page, you can change your $LJ::SITENAMEABBREV User Messaging settings.</p>";
+
+    return $body;
+}
+_code?>
+<=body
+title=><?_code return "Mark Message as Spam"; _code?>
+<=body
+page?>

--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -49,6 +49,22 @@
 
 .betafeature.nos2foundation.title=Temporarily revert updated journal page components
 
+.betafeature.inbox.cantadd=Sorry, your account is not eligible to test this feature.
+
+.betafeature.inbox.off<<
+<p>Activate the testing version of the new Inbox page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion.</p>
+
+<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?>.</p>
+.
+
+.betafeature.inbox.on<<
+<p>You are currently testing the new Inbox page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion.</p>
+
+<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?>.</p>
+.
+
+.betafeature.inbox.title=New Inbox Page
+
 .nofeatures=There are no features currently available for beta testing.
 
 .staytuned.newscomm=Stay tuned to [[news]] for upcoming testing opportunities. Thank you.

--- a/views/beta.tt.text
+++ b/views/beta.tt.text
@@ -54,13 +54,13 @@
 .betafeature.inbox.off<<
 <p>Activate the testing version of the new Inbox page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion.</p>
 
-<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?>.</p>
+<p>To report bugs with the new Inbox page, <a href="https://dw-beta.dreamwidth.org/15010.html">leave a comment</a> in <?ljuser dw_beta ljuser?>.</p>
 .
 
 .betafeature.inbox.on<<
 <p>You are currently testing the new Inbox page. This is a complete rewrite of the existing update page in order to modernize the code and allow for future feature expansion.</p>
 
-<p>To report bugs with the new Create Entries page, <a href="https://dw-beta.dreamwidth.org/12259.html">leave a comment</a> in <?ljuser dw_beta ljuser?>.</p>
+<p>To report bugs with the new Inbox page, <a href="https://dw-beta.dreamwidth.org/15010.html">leave a comment</a> in <?ljuser dw_beta ljuser?>.</p>
 .
 
 .betafeature.inbox.title=New Inbox Page

--- a/views/inbox/folders.tt
+++ b/views/inbox/folders.tt
@@ -1,17 +1,17 @@
         <div id="inbox_folders">
                 <div class="links">
-                    <a href="[% dw.create_url('/inbox', keep_args => ['page', 'view', 'itemid']) %]" id="RefreshLink">[% 'inbox.refresh' | ml %]</a> |
+                    <a href="[% dw.create_url('/inbox/new', keep_args => ['page', 'view', 'itemid']) %]" id="RefreshLink">[% 'inbox.refresh' | ml %]</a> |
                     <a href="[% site.root %]/manage/settings/?cat=notifications">[% 'inbox.manage_settings' | ml %]</a>
                 </div>
             [%- IF user_messaging -%]
-                <a href="/inbox/compose">[% form.submit(value=dw.ml('inbox.menu.new_message.btn'),class="button large compose_btn") %]</a>
+                <a href="/inbox/new/compose">[% form.submit(value=dw.ml('inbox.menu.new_message.btn'),class="button large compose_btn") %]</a>
             [%- END -%]
             <div id="folder_list" class="folder_collapsed  even">
             <div id="folder_btn">
             [% dw.img('inbox_collapse') %] <h3>Folders</h3></div>
             <div class="folders">
                 [% BLOCK folder %]
-                    <a href="/inbox?view=[% f.view %]" id="esn_folder_[% f.view %]" [% 'class="selected"' IF view == f.view %]>
+                    <a href="/inbox/new?view=[% f.view %]" id="esn_folder_[% f.view %]" [% 'class="selected"' IF view == f.view %]>
                         [% "inbox.menu.${f.label}" | ml %]  <span class='unread_count'>[% "($f.unread)" IF f.unread %]</span>
                     </a>
                     [% IF f.children %]

--- a/views/inbox/index.tt
+++ b/views/inbox/index.tt
@@ -7,7 +7,7 @@
 
     <div id="inbox_messages">
 
-    <form action="[% site.root %]/inbox" method="POST">
+    <form action="[% site.root %]/inbox/new" method="POST">
         [% dw.form_auth() %]
         [% form.hidden(name = 'view', value = view) IF view %]
         [% form.hidden(name = 'page', value = page) IF page%]

--- a/views/inbox/index.tt
+++ b/views/inbox/index.tt
@@ -2,6 +2,8 @@
 [% dw.need_res( { group => "foundation" }, 'stc/css/pages/inbox.css', 'js/jquery.inbox.js', 'js/jquery.esn.js', 'js/jquery.commentmanage.js', 'js/jquery.ajaxtip.js' ) %]
 [%- sections.title = '.title' | ml -%]
 
+<div class="alert-box secondary">[% ".beta.on" | ml( aopts = "href='$site.root/betafeatures'", user = betacommunity.ljuser_display ) %]</div>
+
 <div id="inbox">
     [% folder_html %]
 

--- a/views/inbox/index.tt.text
+++ b/views/inbox/index.tt.text
@@ -1,3 +1,5 @@
+.beta.on=You are beta-testing the new Inbox page. If you notice any problems, please report them in [[user]]. To turn off beta testing, visit the <a [[aopts]]>beta features</a> page.
+
 .error.couldnt_retrieve_inbox="Couldn't retrieve inbox for [[user]]"
 
 .error.max_bookmarks=Maximum number of flagged items reached


### PR DESCRIPTION
CODE TOUR: After we accidentally pushed the inbox update live without planning to, and got a bunch of feedback, we realized we uhhhh should probably make it a beta, until we get all the bugs ironed out, as it's a pretty major rewrite of the code.


NB: This needs a new block added to `%BETA_FEATURES` in config-local.pl:
```
       "inbox" => {
            start_time => 0,
            end_time => "Inf",
        },
```

Also, when we finally remove the old inbox page, we will need to revert a few of the changes here (the `/new` bits, which are to keep paths from conflicting with the old inbox)