### PR TITLE
Add Podomatic and Diode.Zone to Embed Whitelist

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -127,9 +127,7 @@ my %host_path_match = (
     "www.strava.com"     => [ qr!^/activities/\d+/embed/\w+$!, 1 ],
     "streamable.com"     => [ qr!^/s/!,                        1 ],
 
-    "embed.ted.com" => [ qr!^/talks/!,   1 ],
-    "clips.twitch.tv" => [ qr!^/embed$!, 1 ],
-    "player.twitch.tv" => [ qr!^/$!,     1 ],
+    "embed.ted.com" => [ qr!^/talks/!, 1 ],
 
     "vid.me"           => [ qr!^/e/!,                              1 ],
     "player.vimeo.com" => [ qr!^/video/\d+$!,                      1 ],

--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -65,9 +65,10 @@ my %host_path_match = (
     "coub.com"                => [ qr!^/embed/!,          1 ],
     "www.criticalcommons.org" => [ qr!/embed_view$!,      0 ],
 
-    "www.dailymotion.com" => [ qr!^/embed/video/!, 1 ],
-    "dotsub.com"          => [ qr!^/media/!,       1 ],
-    "discordapp.com"      => [ qr!^/widget$!,      1 ],
+    "www.dailymotion.com" => [ qr!^/embed/video/!,          1 ],
+    "diode.zone" => [ qr!^/videos/embed/[0-9a-fA-F\-]{36}!, 1 ],
+    "dotsub.com"          => [ qr!^/media/!,                1 ],
+    "discordapp.com"      => [ qr!^/widget$!,               1 ],
 
     "episodecalendar.com" => [ qr!^/icalendar/!, 0 ],
 
@@ -107,9 +108,10 @@ my %host_path_match = (
 
     "onedrive.live.com" => [ qr!^/embed$!, 1 ],
 
-    "playmoss.com"  => [ qr!^/embed/!,            1 ],
-    "www.plurk.com" => [ qr!^/getWidget$!,        1 ],
-    "pastebin.com"  => [ qr!^/embed_iframe/\w+$!, 1 ],
+    "playmoss.com"  => [ qr!^/embed/!,                  1 ],
+    "www.plurk.com" => [ qr!^/getWidget$!,              1 ],
+    "pastebin.com"  => [ qr!^/embed_iframe/\w+$!,       1 ],
+    "podomatic.com" => [ qr!^/embed/html5/episode/\d*!, 1 ],
 
     "www.reverbnation.com" => [ qr!^/widget_code/html_widget/artist_\d+$!, 1 ],
     "www.random.org"       => [ qr!^/widgets/integers/iframe.php$!,        1 ],
@@ -125,7 +127,9 @@ my %host_path_match = (
     "www.strava.com"     => [ qr!^/activities/\d+/embed/\w+$!, 1 ],
     "streamable.com"     => [ qr!^/s/!,                        1 ],
 
-    "embed.ted.com" => [ qr!^/talks/!, 1 ],
+    "embed.ted.com" => [ qr!^/talks/!,   1 ],
+    "clips.twitch.tv" => [ qr!^/embed$!, 1 ],
+    "player.twitch.tv" => [ qr!^/$!,     1 ],
 
     "vid.me"           => [ qr!^/e/!,                              1 ],
     "player.vimeo.com" => [ qr!^/video/\d+$!,                      1 ],

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 105;
+use Test::More tests => 101;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -242,10 +242,6 @@ note("misc");
     test_good_url(
 "http://i.cdn.turner.com/cnn/.element/apps/cvp/3.0/swf/cnn_416x234_embed.swf?context=embed&videoId=bestoftv/2012/09/05/exp-tsr-dem-platform-voice-vote.cnn"
     );
-    test_good_url("https://clips.twitch.tv/embed?clip=IncredulousAbstemiousFennelImGlitch&parent=streamernews.example.com&parent=embed.example.com");
-    test_good_url("https://player.twitch.tv/?channel=dallas&parent=streamernews.example.com&muted=true");
-    test_good_url("https://player.twitch.tv/?video=v40464143&parent=streamernews.example.com&autoplay=false");
-    test_good_url("https://player.twitch.tv/?collection=abcDeF1ghIJ2kL&parent=streamernews.example.com");
 
     # V
     test_good_url("https://vid.me/e/v63?stats=1&amp;tools=1");

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 99;
+use Test::More tests => 105;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -105,6 +105,7 @@ note("misc");
 
     # D
     test_good_url("http://www.dailymotion.com/embed/video/x1xx11x");
+    test_good_url("https://diode.zone/videos/embed/52a10666-3a18-4e73-93da-e8d3c12c305a");
     test_good_url("http://dotsub.com/media/9db493c6-6168-44b0-89ea-e33a31db48db/e/m");
     test_good_url("https://discordapp.com/widget?id=305444013354254349&theme=dark");
 
@@ -204,6 +205,7 @@ note("misc");
     test_good_url(
         "http://www.plurk.com/getWidget?uid=123123123&h=375&w=200&u_info=2&bg=cf682f&tl=cae7fd");
     test_good_url("https://pastebin.com/embed_iframe/Juks92Y2");
+    test_good_url("https://podomatic.com/embed/html5/episode/1234567?autoplay=false");
 
     # R
     test_good_url(
@@ -240,6 +242,10 @@ note("misc");
     test_good_url(
 "http://i.cdn.turner.com/cnn/.element/apps/cvp/3.0/swf/cnn_416x234_embed.swf?context=embed&videoId=bestoftv/2012/09/05/exp-tsr-dem-platform-voice-vote.cnn"
     );
+    test_good_url("https://clips.twitch.tv/embed?clip=IncredulousAbstemiousFennelImGlitch&parent=streamernews.example.com&parent=embed.example.com");
+    test_good_url("https://player.twitch.tv/?channel=dallas&parent=streamernews.example.com&muted=true");
+    test_good_url("https://player.twitch.tv/?video=v40464143&parent=streamernews.example.com&autoplay=false");
+    test_good_url("https://player.twitch.tv/?collection=abcDeF1ghIJ2kL&parent=streamernews.example.com");
 
     # V
     test_good_url("https://vid.me/e/v63?stats=1&amp;tools=1");


### PR DESCRIPTION
CODE TOUR: Added two new sites to the embed whitelist (Podomatic, Diode.Zone), and added tests to match.

* Podomatic addition to embed whitelist is straight-forward.

* Diode.Zone addition to embed whitelist is fairly straight-forward. This is a peertube channel. The video id is a full guid format. I've opted for a looser regex, but am happy to change to the more strict match if that's preferred.

Fixes #2649.
Closes support #46008 (which hasn't been opened here yet).
