### PR TITLE
Tweaks to the new inbox design

### DIFF
--- a/cgi-bin/DW/Controller/Inbox.pm
+++ b/cgi-bin/DW/Controller/Inbox.pm
@@ -185,9 +185,9 @@ sub render_items {
         if ($contents) {
             LJ::ehtml( \$contents );
 
-            my $is_expanded = $remote->prop('esn_inbox_default_expand');
+            my $is_expanded = $expand && $expand == $item->qid;
+            $is_expanded ||= $remote->prop('esn_inbox_default_expand');
             $is_expanded = 0 if $item->read;
-            $is_expanded = $expand && $expand == $item->qid;
 
             $is_expanded = 1 if ( $view eq "usermsg_sent_last" );
             $expanded    = $is_expanded ? "inbox_expand" : "inbox_collapse";
@@ -260,6 +260,9 @@ sub render_folders {
         push @children,
             { view => 'usermsg_sent', label => 'sent', unread => $inbox->usermsg_sent_event_count };
     }
+
+    # put 'unread' at the very top
+    unshift @children, { view => 'unread', label => 'unread', unread => $inbox->all_event_count };
     push @children, { view => 'bookmark', label => 'bookmarks', unread => $inbox->bookmark_count };
     push @children, { view => 'archived', label => 'archive' } if LJ::is_enabled('esn_archive');
 

--- a/htdocs/scss/pages/inbox.scss
+++ b/htdocs/scss/pages/inbox.scss
@@ -1,195 +1,237 @@
 @import "foundation/base";
 
 @media #{$medium-up} {
-    #inbox {
-        display: grid;
-        grid-template-areas: "folder messages";
-        grid-template-rows: auto;
-        grid-template-columns: auto 1fr;
-        width: 100%;
-        grid-column-gap: 1em;
-        column-gap: 1em;
-        }
+  #inbox {
+    display: grid;
+    grid-template-areas: "folder messages";
+    grid-template-rows: auto;
+    grid-template-columns: auto 1fr;
+    width: 100%;
+    grid-column-gap: 1em;
+    column-gap: 1em;
+  }
 
-        #folder_btn {display:none;}
-        #folder_list.even {background-color: transparent;}
-       
+  #folder_btn {
+    display: none;
+  }
+  #folder_list.even {
+    background-color: transparent;
+  }
 }
 
 @media #{$large-up} {
-    #action_row {
-        display: grid;
-        grid: "checkbox actions pages actions-all" auto 
-                / 2em auto 1fr auto;
-        }
-        
-    .inbox_item_row {
-        display: grid;
-        grid: "checkbox message time" auto
-            / 2em 1fr 8.5em;
-        padding: 5px;
-    }
+  #action_row {
+    display: grid;
+    grid:
+      "checkbox actions pages actions-all" auto
+      / 2em auto 1fr auto;
+  }
+
+  .inbox_item_row {
+    display: grid;
+    grid:
+      "checkbox message time" auto
+      / 2em 1fr 8.5em;
+    padding: 5px;
+  }
 }
 
 @media #{$medium-only} {
-    #action_row {
-        display: grid;
-        grid:  "pages pages pages" auto
-                "checkbox actions actions-all" auto
-                / 2em auto 1fr;
+  #action_row {
+    display: grid;
+    grid:
+      "pages pages pages" auto
+      "checkbox actions actions-all" auto
+      / 2em auto 1fr;
+  }
 
-        }
-
-        .inbox_item_row {
-            display: grid;
-            grid:"checkbox time" auto
-                "message message" auto
-                / 2em 1fr;
-            padding: 5px;
-        }
-    
+  .inbox_item_row {
+    display: grid;
+    grid:
+      "checkbox time" auto
+      "message message" auto
+      / 2em 1fr;
+    padding: 5px;
+  }
 }
 
 @media #{$small-only} {
-    #inbox {
-        display: grid;
-        grid: "folder" auto
-               "messages" auto 
-                / 1fr;
-        width: 100%;
-        }
+  #inbox {
+    display: grid;
+    grid:
+      "folder" auto
+      "messages" auto
+      / 1fr;
+    width: 100%;
+  }
 
-    #action_row {
-        display: grid;
-        grid:  "pages pages pages" auto
-                "checkbox actions actions-all" auto
-                / 2em auto 1fr;
+  #action_row {
+    display: grid;
+    grid:
+      "pages pages pages" auto
+      "checkbox actions actions-all" auto
+      / 2em auto 1fr;
+  }
 
-        }
+  .inbox_item_row {
+    display: grid;
+    grid:
+      "checkbox time" auto
+      "message message" auto
+      / 2em 1fr;
+    padding: 5px;
+  }
+  #folder_list {
+    padding: 0.25rem;
+  }
 
-    .inbox_item_row {
-        display: grid;
-        grid:"checkbox time" auto
-            "message message" auto
-            / 2em 1fr;
-        padding: 5px;
+  #inbox_compose {
+    margin-top: 0.5em;
+    input.inline,
+    select.inline,
+    .autocomplete-container.inline input {
+      width: 100%;
     }
-    #folder_list {padding: 0.25rem;}
+  }
 
-    #inbox_compose { 
-        margin-top: 0.5em;
-        input.inline, select.inline, .autocomplete-container.inline input {width: 100%;}
-    
+  #folder_btn {
+    display: block;
+    cursor: pointer;
+
+    h3 {
+      display: inline-block;
     }
-
-
-
-    #folder_btn {
-        display: block;
-        cursor: pointer;
-
-        h3 { display: inline-block;}
-    }
-    .folder_collapsed .folders {display: none;}
-    .folder_expanded .folders {display: block;}
+  }
+  .folder_collapsed .folders {
+    display: none;
+  }
+  .folder_expanded .folders {
+    display: block;
+  }
 }
 
-#folder-btn.no-js {display: none;}
-.folders.no-js {display: block;}
+#folder-btn.no-js {
+  display: none;
+}
+.folders.no-js {
+  display: block;
+}
 
-.selected_filter {display: none;}
-.entry-tags {text-align: right; font-style: italic;}
-.folders {margin-top: 0;}
-.links { text-align: center;}
+.selected_filter {
+  display: none;
+}
+.entry-tags {
+  text-align: right;
+  font-style: italic;
+}
+.folders {
+  margin-top: 0;
+}
+.links {
+  text-align: center;
+}
 #action_row {
-    ul, .button, input {
-        margin-bottom: 5px;
-    }
-    padding: 0.75rem 0.25rem 0.5rem 0.25rem;
+  ul,
+  .button,
+  input {
+    margin-bottom: 5px;
+  }
+  padding: 0.75rem 0.25rem 0.5rem 0.25rem;
 }
-    
+
 #inbox_folders {
-grid-area: folder;
+  grid-area: folder;
 }
 
 .compose_btn {
-    width: 100%;
+  width: 100%;
 }
 
 #inbox_folders li {
-margin-bottom: 0;}
+  margin-bottom: 0;
+}
 
 #inbox_messages {
-grid-area: messages;
-width: 100%;
+  grid-area: messages;
+  width: 100%;
 }
 
 .actions {
-grid-area: actions;
+  grid-area: actions;
 }
 
 .actions-all {
-    grid-area: actions-all;
-    text-align: right;
-    padding-right: 0.5rem;
-    }
+  grid-area: actions-all;
+  text-align: right;
+  padding-right: 0.5rem;
+}
 
 .pages {
-grid-area: pages;
-text-align: center;}
+  grid-area: pages;
+  text-align: center;
+}
 
 .checkbox {
-grid-area: checkbox;
-text-align: center;
+  grid-area: checkbox;
+  text-align: center;
 }
 
 .time {
-grid-area: time;
-font-size: smaller;}
+  grid-area: time;
+  font-size: smaller;
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+}
 
 .item {
-    grid-area: message;
-    overflow-wrap: anywhere;
-    word-break: break-all;}
+  grid-area: message;
+  overflow-wrap: anywhere;
+  word-break: normal;
+}
 
-    .read {
-    opacity: 0.5;}
+.read {
+  opacity: 0.5;
+}
 
-    .inbox_collapse {
-    display: none;}
+.inbox_collapse {
+  display: none;
+}
 
-    #compose_header_fields, #compose_icon {
-    display: inline-block;
-    }
+#compose_header_fields,
+#compose_icon {
+  display: inline-block;
+}
 
-    #compose {
-        display: grid;
-        grid-template-columns: 100px 1fr;
-        grid-column-gap: 1em;
-        column-gap: 1em;
-    }
+#compose {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  grid-column-gap: 1em;
+  column-gap: 1em;
+}
 
-    #metainfo {
-        grid-column-end: span 2;
-    }
+#metainfo {
+  grid-column-end: span 2;
+}
 
-    #compose_header_fields label, #compose_icon {
-    padding-right: 0.5em;
-    }
+#compose_header_fields label,
+#compose_icon {
+  padding-right: 0.5em;
+}
 
-    #compose .pkg {
-        display: grid;
-        grid-template-columns: auto 1fr;
-    }
+#compose .pkg {
+  display: grid;
+  grid-template-columns: auto 1fr;
+}
 
-    .qr-icon a, .qr-icon button {
-    position: relative;
-    display: block;
-    width: 100%;
-    height: 100%;
-    border: 0;
-    padding: 0;
-    margin: 0;
-    background: 0;
-    cursor: pointer;
+.qr-icon a,
+.qr-icon button {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: 0;
+  cursor: pointer;
 }

--- a/views/inbox/index.tt
+++ b/views/inbox/index.tt
@@ -35,6 +35,24 @@
         <div id="inbox_message_list">
         [% item_html %]
         </div>
+            <div class="header searchhighlight" id="action_row">
+                <div class="checkbox">[% form.checkbox(name = 'check_all', id = 'check_all', value = 'check_all') %]</div>
+                <div class="actions">
+                    [% form.submit(name = 'mark_read', value = dw.ml('widget.inbox.menu.mark_read.btn'), class = 'action_button button small', 'data-action' = 'mark_read') %]
+                    [% form.submit(name = 'mark_unread', value = dw.ml('widget.inbox.menu.mark_unread.btn'), class = 'action_button button small', 'data-action' =  'mark_unread') %]
+                    [% form.submit(name = 'delete', value = dw.ml('.menu.delete.btn'), class = 'action_button button small', 'data-action' =  'delete') %]
+                </div>
+                <div class="pages">
+                    [%- INCLUDE components/pagination.tt
+                        current => page
+                        total_pages => last_page -%]
+                </div>
+                <div class="actions-all">
+                    [% form.submit(name = 'mark_all', value = dw.ml(mark_all), class = 'action_button button small', 'data-action' = 'mark_all') %]
+                    [% form.submit(name = 'delete_all', value = dw.ml(delete_all), class = 'action_button button small', 'data-action' = 'delete_all') %]
+                </div>
+        </div>
+
     </form>
     </div>
 </div>


### PR DESCRIPTION
- Unread items are now expanded by default
- Fixed bad word-wrapping settings
- Added a touch of margin to timestamps so they don't run up right against subject lines
- Added the 'unsent' filter view back in.
- Add controls back to the bottom of the message list

CODE TOUR: Round one of tweaks to the new inbox design, based on user feedback!
