### PR TITLE
Inbox tweaks round 2

### DIFF
--- a/cgi-bin/DW/Controller/Inbox.pm
+++ b/cgi-bin/DW/Controller/Inbox.pm
@@ -25,7 +25,6 @@ use DW::Routing;
 use DW::Template;
 use DW::FormErrors;
 use LJ::Hooks;
-use Data::Dumper;
 
 DW::Routing->register_string( '/inbox/new',          \&index_handler,    app => 1 );
 DW::Routing->register_string( '/inbox/new/compose',  \&compose_handler,  app => 1 );
@@ -133,6 +132,7 @@ sub index_handler {
     elsif ( $view eq "singleentry" ) {
         $mark_all_text   = "widget.inbox.menu.mark_all_read.entry.btn";
         $delete_all_text = "widget.inbox.menu.delete_all.entry.btn";
+        $vars->{itemid}  = $itemid;
     }
     else {
         $mark_all_text   = "widget.inbox.menu.mark_all_read.subfolder.btn";
@@ -369,6 +369,7 @@ sub items_by_view {
     else {
         @all_items = $inbox->all_items;
     }
+
     return \@all_items;
 }
 

--- a/htdocs/js/jquery.inbox.js
+++ b/htdocs/js/jquery.inbox.js
@@ -1,14 +1,17 @@
-$('#check_all').change(function() {
-    var checked = $( this );
+$('.check_all').change(function() {
+    var checked = $(this);
     $('.item_checkbox').prop("checked", checked.is(':checked'));
+    $('.item_checkbox').trigger('change');
+    // This is because we have two 'check-all' boxes, and we want them to be in sync
+    $('.check_all').prop("checked", checked.is(':checked'));
 });
 
-$('.action_button').click(function (e) {
+$('.action_button').click(function(e) {
     var action = $(this).data('action');
     mark_items(e, action);
 });
 
-$("#inbox_messages").on("click", ".item_expand_action", function(e){
+$("#inbox_messages").on("click", ".item_expand_action", function(e) {
     var qid = $(this).data('qid');
     var child = $(this).children();
     var item = $("#inbox_item_" + qid);
@@ -16,27 +19,53 @@ $("#inbox_messages").on("click", ".item_expand_action", function(e){
     if (item.hasClass('inbox_collapse')) {
         item.removeClass('inbox_collapse');
         item.addClass('inbox_expand');
-        child.attr({'src': '/img/expand.gif',
-                'alt': 'Collapse',
-                'title': 'Collapse'
-                });
+        child.attr({
+            'src': '/img/expand.gif',
+            'alt': 'Collapse',
+            'title': 'Collapse'
+        });
     } else {
         item.removeClass('inbox_expand');
         item.addClass('inbox_collapse');
-        child.attr({'src': '/img/collapse.gif',
-                'alt': 'Expand',
-                'title': 'Expand'
-                });
-        }
+        child.attr({
+            'src': '/img/collapse.gif',
+            'alt': 'Expand',
+            'title': 'Expand'
+        });
+    }
     e.preventDefault();
     e.stopPropagation();
 });
 
-$("#inbox_messages").on("click", ".item_bookmark_action", function(e){
+$("#inbox_messages").on("click", ".item_bookmark_action", function(e) {
     var action = $(this).data('action');
     var qid = $(this).data('qid');
     mark_items(e, action, qid);
 });
+
+$("#inbox_messages").on("click", ".inbox_item_row", function(e) {
+    let checkbox = $(e.currentTarget).find('.item_checkbox');
+
+    // Don't fire if the item clicked on was the checkbox (otherwise the change will trigger twice)
+    if (!$(e.target).hasClass('item_checkbox')) {
+        checkbox.prop("checked", !checkbox.is(':checked'));
+        checkbox.trigger('change');
+    }
+});
+
+
+$("#inbox_messages").on("change", ".item_checkbox", function(e) {
+    let checkbox = $(e.target);
+    let row = checkbox.parents('.inbox_item_row');
+    if (checkbox.prop('checked')) {
+        row.addClass('selected-msg');
+    } else {
+        row.removeClass('selected-msg');
+    }
+    e.preventDefault();
+    e.stopPropagation();
+});
+
 
 
 function mark_items(e, action, qid) {
@@ -55,47 +84,47 @@ function mark_items(e, action, qid) {
 
     // Grab param data from the hidden fields
     var auth_token = $("[name=lj_form_auth]").val();
-    var view  = $("[name=view]").val();
-    var page  = $("[name=page]").val();
-    var itemid  = $("[name=itemid]").val();
+    var view = $("[name=view]").val();
+    var page = $("[name=page]").val();
+    var itemid = $("[name=itemid]").val();
 
     var postData = {
-            'lj_form_auth': auth_token,
-            'ids': item_qids,
-            'action': action,
-            'view': view,
-            'page': page,
-            'itemid': itemid }
+        'lj_form_auth': auth_token,
+        'ids': item_qids,
+        'action': action,
+        'view': view,
+        'page': page,
+        'itemid': itemid
+    }
 
     $.ajax({
-      type: "POST",
-      url: "/__rpc_inbox_actions",
-      contentType: 'application/json',
-      data: JSON.stringify(postData),
-      success: function( data ) { 
-          if (data.success) {
-            $( "#inbox_message_list" ).html(data.success);
-          } else {
-            $( e.target ).ajaxtip()
-            .ajaxtip("error", data.error );
-          }
-                                        },
-      dataType: "json"
+        type: "POST",
+        url: "/__rpc_inbox_actions",
+        contentType: 'application/json',
+        data: JSON.stringify(postData),
+        success: function(data) {
+            if (data.success) {
+                $("#inbox_message_list").html(data.success);
+            } else {
+                $(e.target).ajaxtip()
+                    .ajaxtip("error", data.error);
+            }
+        },
+        dataType: "json"
     });
     e.preventDefault();
     e.stopPropagation();
 
     // We've reloaded the view, so set the select-all checkbox to unchecked.
-    $('#check_all').prop("checked", false);
+    $('.check_all').prop("checked", false);
 }
 
 // Only load this on the compose page
 if ($('#msg_to').length) {
     let source = autocomplete_list ? autocomplete_list : [];
-    $('#msg_to').autocompletewithunknown(
-        {populateSource: source,
-        }
-    );
+    $('#msg_to').autocompletewithunknown({
+        populateSource: source,
+    });
 }
 $('.folders').removeClass('no-js');
 $("#folder_btn").removeClass('no-js');
@@ -106,18 +135,19 @@ $("#folder_btn").click(function() {
     if (folders.hasClass('folder_collapsed')) {
         folders.removeClass('folder_collapsed');
         folders.addClass('folder_expanded');
-        img.attr({'src': '/img/expand.gif',
-        'alt': 'Collapse',
-        'title': 'Collapse'
+        img.attr({
+            'src': '/img/expand.gif',
+            'alt': 'Collapse',
+            'title': 'Collapse'
         });
 
     } else {
         folders.removeClass('folder_expanded');
         folders.addClass('folder_collapsed');
-        img.attr({'src': '/img/collapse.gif',
-        'alt': 'Expand',
-        'title': 'Expand'
+        img.attr({
+            'src': '/img/collapse.gif',
+            'alt': 'Expand',
+            'title': 'Expand'
         });
-        }
     }
-);
+});

--- a/htdocs/scss/pages/inbox.scss
+++ b/htdocs/scss/pages/inbox.scss
@@ -149,6 +149,9 @@
 
 #inbox_folders li {
   margin-bottom: 0;
+  ul {
+    margin-top: 0;
+  }
 }
 
 #inbox_messages {
@@ -187,10 +190,6 @@
   grid-area: message;
   overflow-wrap: anywhere;
   word-break: normal;
-}
-
-.read {
-  opacity: 0.5;
 }
 
 .inbox_collapse {

--- a/htdocs/scss/skins/_skin-colors.scss
+++ b/htdocs/scss/skins/_skin-colors.scss
@@ -255,3 +255,13 @@ div.disabled, div.disabled * { color: $text-color-disabled; }
 ul.pagination li a:visited {
     color: $pagination-link-visited-color
 }
+
+
+// Colors for inbox elements
+.selected-msg {
+    background-color: $highlight-color;
+}
+
+.read {
+    color: $text-color-disabled;
+}

--- a/views/inbox/index.tt
+++ b/views/inbox/index.tt
@@ -2,7 +2,7 @@
 [% dw.need_res( { group => "foundation" }, 'stc/css/pages/inbox.css', 'js/jquery.inbox.js', 'js/jquery.esn.js', 'js/jquery.commentmanage.js', 'js/jquery.ajaxtip.js' ) %]
 [%- sections.title = '.title' | ml -%]
 
-<div class="alert-box secondary">[% ".beta.on" | ml( aopts = "href='$site.root/betafeatures'", user = betacommunity.ljuser_display ) %]</div>
+<div class="alert-box secondary">[% ".beta.on" | ml( aopts = "href='$site.root/betafeatures'", user = dw_beta.ljuser_display ) %]</div>
 
 <div id="inbox">
     [% folder_html %]
@@ -15,7 +15,7 @@
         [% form.hidden(name = 'page', value = page) IF page%]
         [% form.hidden(name = 'itemid', value = itemid) IF itemid %]
             <div class="header searchhighlight" id="action_row">
-                <div class="checkbox">[% form.checkbox(name = 'check_all', id = 'check_all', value = 'check_all') %]</div>
+                <div class="checkbox">[% form.checkbox(name = 'check_all', class = 'check_all', value = 'check_all') %]</div>
                 <div class="actions">
                     [% form.submit(name = 'mark_read', value = dw.ml('widget.inbox.menu.mark_read.btn'), class = 'action_button button small', 'data-action' = 'mark_read') %]
                     [% form.submit(name = 'mark_unread', value = dw.ml('widget.inbox.menu.mark_unread.btn'), class = 'action_button button small', 'data-action' =  'mark_unread') %]
@@ -36,7 +36,7 @@
         [% item_html %]
         </div>
             <div class="header searchhighlight" id="action_row">
-                <div class="checkbox">[% form.checkbox(name = 'check_all', id = 'check_all', value = 'check_all') %]</div>
+                <div class="checkbox">[% form.checkbox(name = 'check_all', class = 'check_all', value = 'check_all') %]</div>
                 <div class="actions">
                     [% form.submit(name = 'mark_read', value = dw.ml('widget.inbox.menu.mark_read.btn'), class = 'action_button button small', 'data-action' = 'mark_read') %]
                     [% form.submit(name = 'mark_unread', value = dw.ml('widget.inbox.menu.mark_unread.btn'), class = 'action_button button small', 'data-action' =  'mark_unread') %]


### PR DESCRIPTION
- Make selected messages highlighted
- Clicking anywhere on messages now toggles selection
- Bottom select-all button now works
- Remove extra space between nested lists in the folders list
- Read PMs can now be expanded and collapsed
- Per-entry 'mark all' and 'delete all' buttons now work.