### PR TITLE
Make it possible to ban from communities again

### DIFF
--- a/cgi-bin/DW/Controller/Manage/Ban.pm
+++ b/cgi-bin/DW/Controller/Manage/Ban.pm
@@ -32,12 +32,16 @@ sub ban_handler {
 
     my $r = DW::Request->get;
 
-    my $u    = $rv->{remote};
-    my $POST = $r->post_args;
-    my $GET  = $r->get_args;
+    my $u      = $rv->{u};
+    my $remote = $rv->{remote};
+    my $POST   = $r->post_args;
+    my $GET    = $r->get_args;
 
     my $submit_msg = 0;
     my %editvals;
+
+    die "User cannot modify this community"
+        unless $remote->can_manage($u);
 
     if ( $r->did_post ) {
 


### PR DESCRIPTION
CODE TOUR:  When we converted the /manage/banusers page to the new site style, we accidentally introduced a bug which meant that even if you tried to work as a comm, the page would only show the banlist for your personal journal, and only add/remote accounts from that banlist. This is now fixed!