### PR TITLE
add script dump-profile-editors.pl and associated hook

### DIFF
--- a/bin/misc/dump-profile-editors.pl
+++ b/bin/misc/dump-profile-editors.pl
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+#
+# dump-profile-editors.pl -- Read and reset the profile_editors key from memcache
+#
+# Copyright (c) 2022 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+use strict;
+use Getopt::Long;
+
+# parse input options
+my $ro;
+GetOptions( 'readonly' => \$ro );
+
+# now load in the beast
+BEGIN {
+    require "$ENV{'LJHOME'}/cgi-bin/ljlib.pl";
+}
+
+use LJ::MemCache;
+
+my $memval = LJ::MemCache::get('profile_editors') // [];
+LJ::MemCache::delete('profile_editors') unless $ro;
+
+my $us = LJ::load_userids(@$memval);
+
+my @users = sort { $a->user cmp $b->user } values %$us;
+
+foreach my $u (@users) {
+    next unless $u && $u->is_visible;
+
+    my $url     = $u->url;
+    my $urlname = $u->prop('urlname');
+    next if index( $url, '.' ) == -1 && index( $urlname, '.' ) == -1;
+
+    my $timecreate = scalar localtime( $u->timecreate );
+    my $user       = $u->user;
+
+    print "$user\t$timecreate\t$url\t$urlname\n";
+}

--- a/cgi-bin/DW/Hooks/ProfileSave.pm
+++ b/cgi-bin/DW/Hooks/ProfileSave.pm
@@ -1,0 +1,52 @@
+#!/usr/bin/perl
+#
+# DW::Hooks::ProfileSave
+#
+# This module implements a hook for lightweight logging of uids
+# who save profile edits, for later examination to detect
+# accounts being used for spam purposes.
+#
+# Authors:
+#      Jen Griffin <kareila@livejournal.com>
+#
+# Copyright (c) 2022 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::Hooks::ProfileSave;
+
+use strict;
+use warnings;
+
+use LJ::Hooks;
+use LJ::MemCache;
+
+LJ::Hooks::register_hook(
+    'profile_save',
+    sub {
+        my ( $u, $saved, $post ) = @_;
+        return unless defined $u && defined $saved && defined $post;
+
+        my $log_edit = 1;
+
+        # only log this if the URL changed and is non-null
+
+        my $oldurl = $saved->{url} // '';
+        my $newurl = $post->{url}  // '';
+
+        $log_edit = 0 if $oldurl eq $newurl;
+        $log_edit = 0 unless $newurl;
+
+        return unless $log_edit;
+
+        # set the new key - expires after a week if no activity
+        my $memval = LJ::MemCache::get('profile_editors') // [];
+        push @$memval, $u->id;
+        LJ::MemCache::set( 'profile_editors', $memval, 86400 * 7 );
+    }
+);
+
+1;

--- a/doc/raw/memcache-keys.txt
+++ b/doc/raw/memcache-keys.txt
@@ -130,3 +130,5 @@ invite_code_try_ip:<ip> = stores a value of 1 for the IP address of the person w
 
 <keyhash> api_key:<keyhash> = hashref of keyid, hash, and owning userid
 <uid> api_keys_list:<uid> = arrayref of all keyhashes owned by a given userid
+
+profile_editors = arrayref of uids used by profile_save hook

--- a/htdocs/manage/profile/index.bml
+++ b/htdocs/manage/profile/index.bml
@@ -72,6 +72,7 @@ body<=
     # to store values before they undergo normalisation
     my %saved = ();
     $saved{'name'} = $u->{'name'};
+    $saved{'url'}  = $u->{'url'};
 
     # clean userprops
     foreach (values %$u) { LJ::text_out(\$_); }
@@ -732,7 +733,7 @@ body<=
             $u->set_interests( \@valid_ints );
         }
 
-        LJ::Hooks::run_hooks('profile_save', $u);
+        LJ::Hooks::run_hooks('profile_save', $u, \%saved, \%POST);
         LJ::Hooks::run_hook('set_profile_settings_extra', $u, \%POST);
 
         # tell the user all is well


### PR DESCRIPTION
CODE TOUR: This is an admin utility script for retrieving for review a list of users who have recently edited their profile. 

We were previously doing this by parsing server log files, but this provides an alternate logging implementation using memcache to store the list. A hook appends to the list whenever a save happens, and the utility script resets the list when it is run.