### PR TITLE
Rate Limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
 
       - name: Module compilation (t/00-compile.t)
         run: prove -v t/00-compile.t
+
+      - name: Rate limiting (t/rate-limit.t)
+        run: prove -v t/rate-limit.t

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install CPAN dependencies
+        run: cpm install -v --show-build-log-on-failure --no-color --resolver metadb -L /opt/dreamwidth-extlib/ - < doc/dependencies-cpanm
+
       - name: Setup environment
         run: |
           # Config symlink (needed for Perl modules to load site config)

--- a/app.psgi
+++ b/app.psgi
@@ -179,5 +179,8 @@ builder {
     # Middleware for doing sysban blocking (IP bans, uniq bans, tempbans, noanon_ip)
     enable 'DW::Sysban';
 
+    # Rate limiting (after auth and sysban, before request dispatch)
+    enable 'DW::RateLimit';
+
     $app;
 };

--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -352,8 +352,11 @@ sub trans {
     if (
         $limit
         && $limit->exceeded(
+
+            # For logged in users, only check userid
+            # For anonymous users, only check IP
             userid => $remote ? $remote->userid : undef,
-            ip     => $ip
+            ip     => $remote ? undef           : $ip
         )
         )
     {
@@ -363,7 +366,7 @@ sub trans {
 
         my $retry_after = $limit->time_remaining(
             userid => $remote ? $remote->userid : undef,
-            ip     => $ip
+            ip     => $remote ? undef           : $ip
         );
         $apache_r->headers_out->{'Retry-After'} = $retry_after;
 

--- a/cgi-bin/Apache/LiveJournal.pm
+++ b/cgi-bin/Apache/LiveJournal.pm
@@ -369,7 +369,7 @@ sub trans {
     else {
         $limit = DW::RateLimit->get(
             "anonymous_requests",
-            rate => "30/60s"    # 30 requests per minute
+            rate => "30/60s"     # 30 requests per minute
         );
     }
 
@@ -391,8 +391,7 @@ sub trans {
             $apache_r->print("<h1>429 Too Many Requests</h1>");
             $apache_r->print("<p>You have made too many requests. Please try again later.</p>");
             if ($retry_after) {
-                $apache_r->print(
-                    "<p>Please wait $retry_after seconds before trying again.</p>");
+                $apache_r->print("<p>Please wait $retry_after seconds before trying again.</p>");
             }
             return OK;
         }

--- a/cgi-bin/DW/API/RateLimit.pm
+++ b/cgi-bin/DW/API/RateLimit.pm
@@ -1,0 +1,74 @@
+#!/usr/bin/perl
+#
+# DW::API::RateLimit
+#
+# API-specific rate limiting wrapper that uses DW::RateLimit
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2025 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::API::RateLimit;
+
+use strict;
+use warnings;
+use JSON;
+
+use DW::RateLimit;
+use DW::Request;
+
+# Wrap a function with rate limiting
+sub wrap {
+    my ( $class, $code, %opts ) = @_;
+
+    # Validate required parameters
+    return $code unless $opts{rate};
+
+    # Create a rate limit object
+    my $limit = DW::RateLimit->get(
+        "api:" . ( $opts{name} || "unknown" ),
+        rate => $opts{rate},
+        mode => $opts{mode}
+    );
+
+    # Return a wrapped function that checks rate limits before executing
+    return sub {
+        my ( $self, $args ) = @_;
+
+        # Get the request object
+        my $r = DW::Request->get;
+        return $code->( $self, $args ) unless $r;
+
+        # Check rate limit
+        my $result = $limit->check(
+            userid => $args->{user} ? $args->{user}->userid : undef,
+            ip     => $r->connection->remote_ip
+        );
+
+        if ( $result->{exceeded} ) {
+            $r->status(429);
+            $r->headers_out->{'Retry-After'} = $result->{time_remaining};
+            $r->print(
+                to_json(
+                    {
+                        success     => 0,
+                        error       => "Rate limit exceeded",
+                        retry_after => $result->{time_remaining}
+                    }
+                )
+            );
+            return;
+        }
+
+        # Execute the original function
+        return $code->( $self, $args );
+    };
+}
+
+1;

--- a/cgi-bin/DW/Controller/API/REST.pm
+++ b/cgi-bin/DW/Controller/API/REST.pm
@@ -155,7 +155,8 @@ sub _dispatcher {
         $apikey = DW::API::Key->get_key($keystr);
     }
 
-# all paths require an API key except the spec (which informs users that they need a key and where to put it)
+    # all paths require an API key except the spec (which informs users that they need
+    # a key and where to put it)
     unless ( defined($apikey) || $self->{path}{name} eq "/spec" ) {
         $r->print( to_json( { success => 0, error => "Missing or invalid API key" } ) );
         $r->status('401');

--- a/cgi-bin/DW/Controller/API/REST/Journals.pm
+++ b/cgi-bin/DW/Controller/API/REST/Journals.pm
@@ -21,6 +21,7 @@ use warnings;
 use DW::Routing;
 use DW::Request;
 use DW::Controller;
+use DW::API::RateLimit;
 use JSON;
 use Data::Dumper;
 
@@ -30,8 +31,27 @@ use Data::Dumper;
 # Get a list of accesslists, or create a new accesslist
 ################################################
 
-my $accesslists_all = DW::Controller::API::REST->path( 'journals/accesslists_all.yaml',
-    1, { get => \&accesslists_get, post => \&accesslists_new, delete => \&accesslists_delete } );
+my $accesslists_all = DW::Controller::API::REST->path(
+    'journals/accesslists_all.yaml',
+    1,
+    {
+        get => DW::API::RateLimit->wrap(
+            \&accesslists_get,
+            name => 'accesslists_get',
+            rate => '100/60s'
+        ),
+        post => DW::API::RateLimit->wrap(
+            \&accesslists_new,
+            name => 'accesslists_post',
+            rate => '10/60s'
+        ),
+        delete => DW::API::RateLimit->wrap(
+            \&accesslists_delete,
+            name => 'accesslists_delete',
+            rate => '10/60s'
+        )
+    }
+);
 
 sub accesslists_get {
     my ( $self, $args ) = @_;
@@ -93,8 +113,22 @@ sub accesslists_delete {
 # Get details about a specific accesslist
 ################################################
 
-my $accesslists = DW::Controller::API::REST->path( 'journals/accesslists.yaml', 1,
-    { get => \&accesslist_get, post => \&accesslist_edit } );
+my $accesslists = DW::Controller::API::REST->path(
+    'journals/accesslists.yaml',
+    1,
+    {
+        get => DW::API::RateLimit->wrap(
+            \&accesslist_get,
+            name => 'accesslist_get',
+            rate => '100/60s'
+        ),
+        post => DW::API::RateLimit->wrap(
+            \&accesslist_edit,
+            name => 'accesslist_edit',
+            rate => '10/60s'
+        )
+    }
+);
 
 sub accesslist_get {
     my ( $self, $args ) = @_;
@@ -174,8 +208,27 @@ sub accesslist_delete {
 # Get a list of tags, create new tags, or delete tags
 ################################################
 
-my $tags = DW::Controller::API::REST->path( 'journals/tags.yaml', 1,
-    { get => \&tags_get, post => \&tags_post, delete => \&tags_delete } );
+my $tags = DW::Controller::API::REST->path(
+    'journals/tags.yaml',
+    1,
+    {
+        get => DW::API::RateLimit->wrap(
+            \&tags_get,
+            name => 'tags_get',
+            rate => '100/60s'
+        ),
+        post => DW::API::RateLimit->wrap(
+            \&tags_post,
+            name => 'tags_post',
+            rate => '10/60s'
+        ),
+        delete => DW::API::RateLimit->wrap(
+            \&tags_delete,
+            name => 'tags_delete',
+            rate => '10/60s'
+        )
+    }
+);
 
 sub tags_get {
     my ( $self, $args ) = @_;
@@ -248,8 +301,17 @@ sub tags_delete {
 # Get a list of crosspost accounts
 ################################################
 
-my $xpost =
-    DW::Controller::API::REST->path( 'journals/xpostaccounts.yaml', 1, { get => \&xpost_get } );
+my $xpost = DW::Controller::API::REST->path(
+    'journals/xpostaccounts.yaml',
+    1,
+    {
+        get => DW::API::RateLimit->wrap(
+            \&xpost_get,
+            name => 'xpost_get',
+            rate => '100/60s'
+        )
+    }
+);
 
 sub xpost_get {
     my ( $self, $args ) = @_;

--- a/cgi-bin/DW/RateLimit.pm
+++ b/cgi-bin/DW/RateLimit.pm
@@ -1,0 +1,186 @@
+#!/usr/bin/perl
+#
+# DW::Request::RateLimit
+#
+# Module to handle rate limiting for the site using a leaky bucket algorithm.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2025 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::RateLimit;
+
+use strict;
+use v5.10;
+use Log::Log4perl;
+my $log = Log::Log4perl->get_logger(__PACKAGE__);
+
+use LJ::MemCache;
+use LJ::User;
+use Time::HiRes qw(time);
+
+# Class to handle rate limiting
+package DW::RateLimit::Limit;
+
+use strict;
+use warnings;
+
+sub new {
+    my ( $class, %opts ) = @_;
+    my $self = bless {
+        name          => $opts{name},
+        max_count     => $opts{max_count},
+        interval_secs => $opts{per_interval_secs},
+        key_prefix    => "ratelimit:",
+        mode          => $opts{mode} || 'block',
+
+        # Calculate refill rate (tokens per second)
+        refill_rate => $opts{max_count} / $opts{per_interval_secs},
+    }, $class;
+    return $self;
+}
+
+# Check the rate limit status
+# Returns a hash containing:
+#   exceeded: 1 if they have exceeded the limit, 0 if they haven't
+#   time_remaining: seconds until the rate limit resets (0 if not exceeded)
+#   count: current count of requests
+sub check {
+    my ( $self, %opts ) = @_;
+
+    # Handle ignore mode - always return not exceeded
+    return { exceeded => 0, time_remaining => 0, count => 0 } if $self->{mode} eq 'ignore';
+
+    # Get the key to use for this rate limit
+    my $key = $self->_get_key(%opts);
+    return { exceeded => 0, time_remaining => 0, count => 0 } unless $key;
+
+    # Get the current state from memcache
+    my $state_str = LJ::MemCache::get($key);
+    my ( $level, $last_update );
+    if ($state_str) {
+        ( $level, $last_update ) = split( ':', $state_str );
+    }
+    else {
+        $level       = $self->{max_count};
+        $last_update = time();
+    }
+
+    # Calculate time elapsed since last update
+    my $now     = time();
+    my $elapsed = $now - $last_update;
+
+    # Calculate new bucket level after refill
+    my $new_level = $level + ( $elapsed * $self->{refill_rate} );
+    $new_level = $self->{max_count} if $new_level > $self->{max_count};
+
+    # Calculate current count (tokens used)
+    my $count = $self->{max_count} - $new_level;
+
+    # If we're at or over the limit
+    if ( $new_level < 1 ) {
+
+        # Log if in log mode
+        if ( $self->{mode} eq 'log' ) {
+            $log->info("RateLimit: Exceeded limit on $key");
+            return { exceeded => 0, time_remaining => 0, count => $count };
+        }
+
+        # Calculate time remaining until reset
+        # When bucket is empty, time remaining is the full interval
+        my $time_remaining = $self->{interval_secs};
+        return { exceeded => 1, time_remaining => $time_remaining, count => $count };
+    }
+
+    # Decrement the counter and update timestamp
+    $new_level -= 1;
+    my $new_state_str = "$new_level:$now";
+
+    # Store the new state
+    LJ::MemCache::set( $key, $new_state_str, $self->{interval_secs} );
+
+    # Return success with no time remaining
+    return { exceeded => 0, time_remaining => 0, count => $count + 1 };
+}
+
+# Reset the counter for this rate limit
+sub reset {
+    my ( $self, %opts ) = @_;
+
+    # In ignore mode, do nothing
+    return 1 if $self->{mode} eq 'ignore';
+
+    my $key = $self->_get_key(%opts);
+    return 0 unless $key;
+
+    # Set the state to full bucket and current time
+    my $new_state_str = "$self->{max_count}:" . time();
+
+    # Store the new state with the full interval
+    LJ::MemCache::set( $key, $new_state_str, $self->{interval_secs} );
+    return 1;
+}
+
+# Internal method to generate the memcache key
+sub _get_key {
+    my ( $self, %opts ) = @_;
+
+    my @key_parts = ( $self->{key_prefix}, $self->{name} );
+
+    # Add userid if provided
+    if ( my $userid = $opts{userid} ) {
+        push @key_parts, "user:$userid";
+    }
+
+    # Add IP if provided
+    if ( my $ip = $opts{ip} ) {
+        push @key_parts, "ip:$ip";
+    }
+
+    # Add any additional identifiers
+    if ( my $identifiers = $opts{identifiers} ) {
+        foreach my $id ( sort keys %$identifiers ) {
+            push @key_parts, "$id:$identifiers->{$id}";
+        }
+    }
+
+    return join( ":", @key_parts );
+}
+
+# Package methods for DW::RateLimit
+package DW::RateLimit;
+
+use strict;
+use warnings;
+
+# Get a rate limit object
+sub get {
+    my ( $class, $name, %opts ) = @_;
+
+    # Validate required parameters
+    return undef unless $name && $opts{max_count} && $opts{per_interval_secs};
+
+    # Check for configuration overrides
+    if ( $LJ::RATE_LIMITS{$name} ) {
+        my $config = $LJ::RATE_LIMITS{$name};
+        $opts{max_count}         = $config->{max_count} if defined $config->{max_count};
+        $opts{per_interval_secs} = $config->{per_interval_secs}
+            if defined $config->{per_interval_secs};
+        $opts{mode} = $config->{mode} if defined $config->{mode};
+    }
+
+    return DW::RateLimit::Limit->new(
+        name              => $name,
+        max_count         => $opts{max_count},
+        per_interval_secs => $opts{per_interval_secs},
+        mode              => $opts{mode},
+    );
+}
+
+1;

--- a/cgi-bin/LJ/Console/Command/Suspend.pm
+++ b/cgi-bin/LJ/Console/Command/Suspend.pm
@@ -46,7 +46,7 @@ sub execute {
     my $openid_only =
         $remote->has_priv( "suspend", "openid" ) && !$remote->has_priv( "suspend", "*" );
     my $recent_only =
-        $remote->has_priv( "suspend", "recent" )
+           $remote->has_priv( "suspend", "recent" )
         && !$remote->has_priv( "suspend", "*" )
         && !$remote->has_priv( "suspend", "openid" )
         && !$remote->has_priv( "suspend", "" );

--- a/cgi-bin/LJ/Test.pm
+++ b/cgi-bin/LJ/Test.pm
@@ -246,7 +246,7 @@ sub incr {
     my $key = _key($fkey);
     return 0 unless exists $self->{data}{$key};
     $self->{data}{$key} += $optval;
-    return 1;
+    return $self->{data}{$key};
 }
 
 sub decr {

--- a/cgi-bin/Plack/Middleware/DW/RateLimit.pm
+++ b/cgi-bin/Plack/Middleware/DW/RateLimit.pm
@@ -34,16 +34,10 @@ sub call {
     # Get the appropriate rate limit based on whether user is logged in
     my $limit;
     if ($remote) {
-        $limit = DW::RateLimit->get(
-            "authenticated_requests",
-            rate => "100/60s"
-        );
+        $limit = DW::RateLimit->get( "authenticated_requests", rate => "100/60s" );
     }
     else {
-        $limit = DW::RateLimit->get(
-            "anonymous_requests",
-            rate => "30/60s"
-        );
+        $limit = DW::RateLimit->get( "anonymous_requests", rate => "30/60s" );
     }
 
     # Check if rate limit is exceeded

--- a/cgi-bin/Plack/Middleware/DW/RateLimit.pm
+++ b/cgi-bin/Plack/Middleware/DW/RateLimit.pm
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+#
+# Plack::Middleware::DW::RateLimit
+#
+# Applies rate limiting to incoming requests. Authenticated users get a
+# higher limit than anonymous users. Ported from the rate-limit checks in
+# Apache::LiveJournal::trans().
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2025 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package Plack::Middleware::DW::RateLimit;
+
+use strict;
+use v5.10;
+
+use parent qw/ Plack::Middleware /;
+
+use DW::RateLimit;
+
+sub call {
+    my ( $self, $env ) = @_;
+
+    my $remote = LJ::get_remote();
+    my $ip     = $env->{REMOTE_ADDR};
+
+    # Get the appropriate rate limit based on whether user is logged in
+    my $limit;
+    if ($remote) {
+        $limit = DW::RateLimit->get(
+            "authenticated_requests",
+            rate => "100/60s"
+        );
+    }
+    else {
+        $limit = DW::RateLimit->get(
+            "anonymous_requests",
+            rate => "30/60s"
+        );
+    }
+
+    # Check if rate limit is exceeded
+    if ($limit) {
+        my $result = $limit->check(
+            userid => $remote ? $remote->userid : undef,
+            ip     => $remote ? undef           : $ip
+        );
+
+        if ( $result->{exceeded} ) {
+            my $retry_after = $result->{time_remaining};
+            my $body =
+                  "<h1>429 Too Many Requests</h1>"
+                . "<p>You have made too many requests. Please try again later.</p>";
+            $body .= "<p>Please wait $retry_after seconds before trying again.</p>"
+                if $retry_after;
+
+            return [
+                429,
+                [
+                    'Content-Type' => 'text/html',
+                    'Retry-After'  => $retry_after,
+                ],
+                [$body]
+            ];
+        }
+    }
+
+    return $self->app->($env);
+}
+
+1;

--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -63,6 +63,7 @@ Sys::Syscall
 Template
 Test::Code::TidyAll
 Test::MockObject
+Test::MockTime
 Test::Most
 Text::Fuzzy@0.27
 Text::Markdown

--- a/doc/raw/memcache-keys.txt
+++ b/doc/raw/memcache-keys.txt
@@ -134,3 +134,5 @@ invite_code_try_ip:<ip> = stores a value of 1 for the IP address of the person w
 profile_editors = arrayref of uids used by profile_save hook
 profile_services = arrayref of sorted hashrefs returned from profile_services table
 <uid> profile_accts:<uid> = hashref of user data from user_profile_accts table
+
+ratelimit:<key>[:<checkval>] == rate limit storage

--- a/etc/config.pl.example
+++ b/etc/config.pl.example
@@ -11,6 +11,7 @@
 # Any changes to etc/config.pl.example should be copied over by hand.
 
 {
+
     package LJ;
 
     ###
@@ -18,14 +19,14 @@
     ###
 
     $HTDOCS = "$HOME/htdocs";
-    $BIN = "$HOME/bin";
-    $TEMP = "$HOME/temp";
-    $VAR = "$HOME/var";
+    $BIN    = "$HOME/bin";
+    $TEMP   = "$HOME/temp";
+    $VAR    = "$HOME/var";
 
-    $DOMAIN_WEB = "www.$DOMAIN"; # necessary
+    $DOMAIN_WEB = "www.$DOMAIN";    # necessary
 
     # this is what gets prepended to all URLs
-    $SITEROOT = "$PROTOCOL://$DOMAIN_WEB";
+    $SITEROOT          = "$PROTOCOL://$DOMAIN_WEB";
     $RELATIVE_SITEROOT = "//$DOMAIN_WEB";
 
     # prefix for images
@@ -37,34 +38,32 @@
     $COOKIE_DOMAIN = ".$DOMAIN";
 
     # email addresses
-    $ADMIN_EMAIL = "webmaster\@$DOMAIN";
-    $ABUSE_EMAIL = "abuse\@$DOMAIN";
-    $ANTISPAM_EMAIL = "antispam\@$DOMAIN";
-    $SUPPORT_EMAIL = "support\@$DOMAIN";
+    $ADMIN_EMAIL     = "webmaster\@$DOMAIN";
+    $ABUSE_EMAIL     = "abuse\@$DOMAIN";
+    $ANTISPAM_EMAIL  = "antispam\@$DOMAIN";
+    $SUPPORT_EMAIL   = "support\@$DOMAIN";
     $COMMUNITY_EMAIL = "community_invitation\@$DOMAIN";
-    $BOGUS_EMAIL = "dw_null\@$DOMAIN";
-    $COPPA_EMAIL = "coppa\@$DOMAIN";
-    $PRIVACY_EMAIL = "privacy\@$DOMAIN";
-    $ACCOUNTS_EMAIL = "accounts\@$DOMAIN";
+    $BOGUS_EMAIL     = "dw_null\@$DOMAIN";
+    $COPPA_EMAIL     = "coppa\@$DOMAIN";
+    $PRIVACY_EMAIL   = "privacy\@$DOMAIN";
+    $ACCOUNTS_EMAIL  = "accounts\@$DOMAIN";
 
     # css proxy
     $CSSPROXY = "//cssproxy.$DOMAIN/";
 
     # setup subdomains that work
     %SUBDOMAIN_FUNCTION = (
-            community => 'journal',
-            users => 'journal',
-            syndicated => 'journal',
-            cssproxy => 'cssproxy',
-            shop => 'shop',
-            mobile => 'mobile',
-            m => 'mobile',
-            support => 'support',
-            u => 'userpics',
-            v => 'userpics',
-        );
-
-
+        community  => 'journal',
+        users      => 'journal',
+        syndicated => 'journal',
+        cssproxy   => 'cssproxy',
+        shop       => 'shop',
+        mobile     => 'mobile',
+        m          => 'mobile',
+        support    => 'support',
+        u          => 'userpics',
+        v          => 'userpics',
+    );
 
     ###
     ### Policy Options
@@ -87,12 +86,12 @@
     #   also, once you lower them, increasing them won't change anything
     #   until there are new posts numbering the difference you increased
     #   it by.
-    $MAX_HINTS_LASTN = 800;
+    $MAX_HINTS_LASTN      = 800;
     $MAX_SCROLLBACK_LASTN = 750;
 
     # do paid users get email addresses?  username@$USER_DOMAIN ?
     # (requires additional mail system configuration)
-    $USER_EMAIL  = 1;
+    $USER_EMAIL = 1;
 
     # Support URLs of the form http://username.yoursite.com/ ?
     # If so, what's the part after "username." ?
@@ -109,28 +108,27 @@
     # turns these from 0 to 1 to disable parts of the site that are
     # CPU & database intensive or that you simply don't want to use
     %DISABLED = (
-                 adult_content => 0,
-                 approvenew => 1,
-                 loggedout_support_requests => 1,
-                 'community-logins' => 0,
-                 captcha => 0,
-                 directory => 0,
-                 esn_archive => 1,
-                 eventlogrecord => 1,
-                 googlecheckout => 1,
-                 icon_renames => 0,
-                 importing => 0,
-                 'interests-findsim' => 0,
-                 memories => 0,
-                 opt_findbyemail => 1,
-                 payments => 0,
-                 payments_cmo => 0,
-                 'show-talkleft' => 0,
-                 'stats-recentupdates' => 0,
-                 'stats-newjournals' => 0,
-                 'support_request_language' => 1,
-                 tellafriend => 0,
-                 );
+        adult_content              => 0,
+        loggedout_support_requests => 1,
+        'community-logins'         => 0,
+        captcha                    => 0,
+        directory                  => 0,
+        esn_archive                => 1,
+        eventlogrecord             => 1,
+        googlecheckout             => 1,
+        icon_renames               => 0,
+        importing                  => 0,
+        'interests-findsim'        => 0,
+        memories                   => 0,
+        opt_findbyemail            => 1,
+        payments                   => 0,
+        payments_cmo               => 0,
+        'show-talkleft'            => 0,
+        'stats-recentupdates'      => 0,
+        'stats-newjournals'        => 0,
+        'support_request_language' => 1,
+        tellafriend                => 0,
+    );
 
     # allow extacct_info for all sites except LiveJournal
     #$DISABLED{extacct_info} = sub {
@@ -138,9 +136,11 @@
     #        $_[0]->{sitename} eq 'LiveJournal' ? 1 : 0 };
 
     # Maintenance messages
-    $MSG_READONLY_USER   = "This journal is in read-only mode right now while database maintenance is performed " .
-                           "on the server where the journal is located.  Try again in several minutes.";
-    $MSG_NO_POST    = "Due to hardware maintenance, you cannot post at this time.  Watch the news page for updates.";
+    $MSG_READONLY_USER =
+          "This journal is in read-only mode right now while database maintenance is performed "
+        . "on the server where the journal is located.  Try again in several minutes.";
+    $MSG_NO_POST =
+"Due to hardware maintenance, you cannot post at this time.  Watch the news page for updates.";
 
     ###
     ### Language / Scheme support
@@ -150,16 +150,13 @@
     # schemes will be displayed according to their order in the array,
     # but the first item in the array is the default scheme
     # 'title' is the printed name, while 'scheme' is the scheme name.
-    @SCHEMES = (
-                { scheme => 'blueshift', title => 'Blueshift' },
-               );
+    @SCHEMES = ( { scheme => 'blueshift', title => 'Blueshift' }, );
 
     # supported languages (defaults to qw(en) if none given)
     # First element is default language for user interface, untranslated text
     unless (@LANGS) {
-      @LANGS = qw( en_DW ) if -d "$HOME/ext/dw-nonfree";
+        @LANGS = qw( en_DW ) if -d "$HOME/ext/dw-nonfree";
     }
-
 
     ###
     ### Account Information
@@ -186,112 +183,112 @@
     # default capability limits, used only when no other
     # class-specific limit below matches.
     %CAP_DEF = (
-            'activeentries' => 0,
-            'bonus_icons' => 0,
-            'can_post' => 1,
-            'checkfriends' => 0,
-            'checkfriends_interval' => 300,
-            'directorysearch' => 0,
-            'emailpost' => 0,
-            'findsim' => 0,
-            'friendspage_per_day' => 0,
-            'friendsviewupdate' => 30,
-            'full_rss' => 1,
-            'get_comments' => 1,
-            'getselfemail' => 0,
-            'google_analytics' => 0,
-            'hide_email_after' => 60,
-            'import_comm' => 0,
-            'interests' => 150,
-            'leave_comments' => 1,
-            'makepoll' => 0,
-            'maxcomments' => 10000,
-            'maxfriends' => 500,
-            'media_file_quota' => 500, # megabytes
-            'mod_queue' => 50,
-            'mod_queue_per_poster' => 5,
-            'moodthemecreate' => 0,
-            'rateallowed-commcreate' => 3,
-            'rateallowed-failed_login' => 3,
-            'rateallowed-lostinfo' => 3,
-            'rateperiod-commcreate' => 86400*7, # 7 days / 1 week
-            'rateperiod-failed_login' => 60*5, # 5 minutes
-            'rateperiod-lostinfo' => 60*60*24, # 24 hours
-            's2layersmax' => 0,
-            's2styles' => 0,
-            's2stylesmax' => 0,
-            's2viewentry' => 1,
-            's2viewreply' => 1,
-            'staff_headicon' => 0,
-            'styles' => 0,
-            'thread_expand_all' => 0,
-            'thread_expander' => 0,
-            'track_all_comments' => 0,
-            'userdomain' => 1,
-            'useremail' => 1,
-            'userlinks' => 10,
-            'userpics' => 5,
-            'xpost_accounts' => 0,
-            );
+        'activeentries'            => 0,
+        'bonus_icons'              => 0,
+        'can_post'                 => 1,
+        'checkfriends'             => 0,
+        'checkfriends_interval'    => 300,
+        'directorysearch'          => 0,
+        'emailpost'                => 0,
+        'findsim'                  => 0,
+        'friendspage_per_day'      => 0,
+        'friendsviewupdate'        => 30,
+        'full_rss'                 => 1,
+        'get_comments'             => 1,
+        'getselfemail'             => 0,
+        'google_analytics'         => 0,
+        'hide_email_after'         => 60,
+        'import_comm'              => 0,
+        'interests'                => 150,
+        'leave_comments'           => 1,
+        'makepoll'                 => 0,
+        'maxcomments'              => 10000,
+        'maxfriends'               => 500,
+        'media_file_quota'         => 500,             # megabytes
+        'mod_queue'                => 50,
+        'mod_queue_per_poster'     => 5,
+        'moodthemecreate'          => 0,
+        'rateallowed-commcreate'   => 3,
+        'rateallowed-failed_login' => 3,
+        'rateallowed-lostinfo'     => 3,
+        'rateperiod-commcreate'    => 86400 * 7,       # 7 days / 1 week
+        'rateperiod-failed_login'  => 60 * 5,          # 5 minutes
+        'rateperiod-lostinfo'      => 60 * 60 * 24,    # 24 hours
+        's2layersmax'              => 0,
+        's2styles'                 => 0,
+        's2stylesmax'              => 0,
+        's2viewentry'              => 1,
+        's2viewreply'              => 1,
+        'staff_headicon'           => 0,
+        'styles'                   => 0,
+        'thread_expand_all'        => 0,
+        'thread_expander'          => 0,
+        'track_all_comments'       => 0,
+        'userdomain'               => 1,
+        'useremail'                => 1,
+        'userlinks'                => 10,
+        'userpics'                 => 5,
+        'xpost_accounts'           => 0,
+    );
 
     # for convenience and consistency, let's put common caps for all paid account types here:
     my %CAP_PAID = (
-            'paid' => 1,
-            'activeentries' => 1,
-            'bonus_icons' => 1,
-            'checkfriends' => 1,
-            'checkfriends_interval' => 600,
-            'directory' => 1,
-            'edit_comments' => 1,
-            'emailpost' => 1,
-            'fastserver' => 1,
-            'findsim' => 1,
-            'friendsfriendsview' => 1,
-            'friendspage_per_day' => 1,
-            'friendsviewupdate' => 1,
-            'full_rss' => 1,
-            'getselfemail' => 1,
-            'google_analytics' => 1,
-            'import_comm' => 1,
-            'makepoll' => 1,
-            'mass_privacy' => 1,
-            'mod_queue' => 100,
-            'mod_queue_per_poster' => 5,
-            'moodthemecreate' => 1,
-            'popsubscriptions' => 1,
-            's2props' => 1,
-            's2styles' => 1,
-            'security_filter' => 1,
-            'stickies' => 5,
-            'synd_create' => 1,
-            'thread_expand_all' => 1,
-            'thread_expander' => 1,
-            'track_defriended' => 1,
-            'track_pollvotes' => 1,
-            'track_thread' => 1,
-            'track_user_newuserpic' => 1,
-            'useremail' => 1,
-            'userlinks' => 50,
-            'usermessage_length' => 10000,
-            'userpicselect' => 1,
-            'viewmailqueue' => 1,
+        'paid'                  => 1,
+        'activeentries'         => 1,
+        'bonus_icons'           => 1,
+        'checkfriends'          => 1,
+        'checkfriends_interval' => 600,
+        'directory'             => 1,
+        'edit_comments'         => 1,
+        'emailpost'             => 1,
+        'fastserver'            => 1,
+        'findsim'               => 1,
+        'friendsfriendsview'    => 1,
+        'friendspage_per_day'   => 1,
+        'friendsviewupdate'     => 1,
+        'full_rss'              => 1,
+        'getselfemail'          => 1,
+        'google_analytics'      => 1,
+        'import_comm'           => 1,
+        'makepoll'              => 1,
+        'mass_privacy'          => 1,
+        'mod_queue'             => 100,
+        'mod_queue_per_poster'  => 5,
+        'moodthemecreate'       => 1,
+        'popsubscriptions'      => 1,
+        's2props'               => 1,
+        's2styles'              => 1,
+        'security_filter'       => 1,
+        'stickies'              => 5,
+        'synd_create'           => 1,
+        'thread_expand_all'     => 1,
+        'thread_expander'       => 1,
+        'track_defriended'      => 1,
+        'track_pollvotes'       => 1,
+        'track_thread'          => 1,
+        'track_user_newuserpic' => 1,
+        'useremail'             => 1,
+        'userlinks'             => 50,
+        'usermessage_length'    => 10000,
+        'userpicselect'         => 1,
+        'viewmailqueue'         => 1,
     );
 
     # for convenience and consistency, let's put common caps for all premium account types here:
     my %CAP_PREMIUM = (
-            'bookmark_max' => 1000,
-            'inbox_max' => 6000,
-            'interests' => 250,
-            'maxfriends' => 2000,
-            's2layersmax' => 300,
-            's2stylesmax' => 100,
-            'subscriptions' => 1000,
-            'tags_max' => 2000,
-            'tools_recent_comments_display' => 150,
-            'track_all_comments' => 1,
-            'userlinks' => 100,
-            'userpics' => 150,
-            'xpost_accounts' => 5,
+        'bookmark_max'                  => 1000,
+        'inbox_max'                     => 6000,
+        'interests'                     => 250,
+        'maxfriends'                    => 2000,
+        's2layersmax'                   => 300,
+        's2stylesmax'                   => 100,
+        'subscriptions'                 => 1000,
+        'tags_max'                      => 2000,
+        'tools_recent_comments_display' => 150,
+        'track_all_comments'            => 1,
+        'userlinks'                     => 100,
+        'userpics'                      => 150,
+        'xpost_accounts'                => 5,
     );
 
     # capability class limits.
@@ -301,122 +298,123 @@
     #       all users can be the same if you want, just delete all
     #       this.  the important part then is %CAP_DEF, above.
     %CAP = (
-        '0' => {  # 0x01
+        '0' => {    # 0x01
             '_name' => 'UNUSED',
-            '_key' => 'UNUSED',
+            '_key'  => 'UNUSED',
         },
-        '1' => {  # 0x02
-            '_name' => 'Free',
-            '_visible_name' => 'Free Account',
-            '_key' => 'free_user',
-            '_account_type' => 'free',
-            '_account_default' => 1,    # default account for payment system
-            'activeentries' => 0,
-            'bookmark_max' => 25,
-            'checkfriends' => 0,
-            'checkfriends_interval' => 0,
-            'directory' => 1,
-            'edit_comments' => 0,
-            'emailpost' => 1,
-            'findsim' => 0,
-            'friendsfriendsview' => 0,
-            'friendspage_per_day' => 0,
-            'friendsviewupdate' => 0,
-            'full_rss' => 1,
-            'getselfemail' => 0,
-            'google_analytics' => 0,
-            'import_comm' => 1,
-            'inbox_max' => 2000,
-            'interests' => 150,
-            'makepoll' => 0,
-            'mass_privacy' => 0,
-            'maxfriends' => 1000,
-            'mod_queue' => 50,
-            'mod_queue_per_poster' => 3,
-            'moodthemecreate' => 0,
-            'popsubscriptions' => 0,
-            's2layersmax' => 0,
-            's2props' => 0,
-            's2styles' => 0,
-            's2stylesmax' => 0,
-            'security_filter' => 0,
-            'stickies' => 2,
-            'subscriptions' => 25,
-            'synd_create' => 1,
-            'tags_max' => 1000,
-            'thread_expand_all' => 0,
-            'thread_expander' => 0,
+        '1' => {    # 0x02
+            '_name'                         => 'Free',
+            '_visible_name'                 => 'Free Account',
+            '_key'                          => 'free_user',
+            '_account_type'                 => 'free',
+            '_account_default'              => 1,               # default account for payment system
+            'activeentries'                 => 0,
+            'bookmark_max'                  => 25,
+            'checkfriends'                  => 0,
+            'checkfriends_interval'         => 0,
+            'directory'                     => 1,
+            'edit_comments'                 => 0,
+            'emailpost'                     => 1,
+            'findsim'                       => 0,
+            'friendsfriendsview'            => 0,
+            'friendspage_per_day'           => 0,
+            'friendsviewupdate'             => 0,
+            'full_rss'                      => 1,
+            'getselfemail'                  => 0,
+            'google_analytics'              => 0,
+            'import_comm'                   => 1,
+            'inbox_max'                     => 2000,
+            'interests'                     => 150,
+            'makepoll'                      => 0,
+            'mass_privacy'                  => 0,
+            'maxfriends'                    => 1000,
+            'mod_queue'                     => 50,
+            'mod_queue_per_poster'          => 3,
+            'moodthemecreate'               => 0,
+            'popsubscriptions'              => 0,
+            's2layersmax'                   => 0,
+            's2props'                       => 0,
+            's2styles'                      => 0,
+            's2stylesmax'                   => 0,
+            'security_filter'               => 0,
+            'stickies'                      => 2,
+            'subscriptions'                 => 25,
+            'synd_create'                   => 1,
+            'tags_max'                      => 1000,
+            'thread_expand_all'             => 0,
+            'thread_expander'               => 0,
             'tools_recent_comments_display' => 10,
-            'track_all_comments' => 0,
-            'track_defriended' => 0,
-            'track_pollvotes' => 0,
-            'track_thread' => 0,
-            'track_user_newuserpic' => 0,
-            'useremail' => 0,
-            'userlinks' => 10,
-            'usermessage_length' => 5000,
-            'userpics' => 6,
-            'userpicselect' => 0,
-            'viewmailqueue' => 0,
-            'xpost_accounts' => 1,
+            'track_all_comments'            => 0,
+            'track_defriended'              => 0,
+            'track_pollvotes'               => 0,
+            'track_thread'                  => 0,
+            'track_user_newuserpic'         => 0,
+            'useremail'                     => 0,
+            'userlinks'                     => 10,
+            'usermessage_length'            => 5000,
+            'userpics'                      => 6,
+            'userpicselect'                 => 0,
+            'viewmailqueue'                 => 0,
+            'xpost_accounts'                => 1,
         },
-        '2' => {  # 0x04
+        '2' => {    # 0x04
             '_name' => 'UNUSED2',
-            '_key' => 'UNUSED2',
+            '_key'  => 'UNUSED2',
         },
-        '3' => {  # 0x08
-            '_name' => 'Paid',
-            '_key' => 'paid_user', # Some things expect that key name
-            '_visible_name' => 'Paid Account',
-            '_account_type' => 'paid',
+        '3' => {    # 0x08
+            '_name'          => 'Paid',
+            '_key'           => 'paid_user',      # Some things expect that key name
+            '_visible_name'  => 'Paid Account',
+            '_account_type'  => 'paid',
             '_refund_points' => 30,
             %CAP_PAID,
-            'bookmark_max' => 500,
-            'inbox_max' => 4000,
-            'interests' => 200,
-            'maxfriends' => 1500,
-            's2layersmax' => 150,
-            's2stylesmax' => 50,
-            'subscriptions' => 500,
-            'tags_max' => 1500,
+            'bookmark_max'                  => 500,
+            'inbox_max'                     => 4000,
+            'interests'                     => 200,
+            'maxfriends'                    => 1500,
+            's2layersmax'                   => 150,
+            's2stylesmax'                   => 50,
+            'subscriptions'                 => 500,
+            'tags_max'                      => 1500,
             'tools_recent_comments_display' => 100,
-            'track_all_comments' => 0,
-            'userpics' => 75,
-            'xpost_accounts' => 3,
+            'track_all_comments'            => 0,
+            'userpics'                      => 75,
+            'xpost_accounts'                => 3,
         },
-        '4' => {  # 0x10
-            '_name' => 'Premium Paid',
-            '_key' => 'premium_user',
-            '_visible_name' => 'Premium Paid Account',
-            '_account_type' => 'premium',
+        '4' => {    # 0x10
+            '_name'          => 'Premium Paid',
+            '_key'           => 'premium_user',
+            '_visible_name'  => 'Premium Paid Account',
+            '_account_type'  => 'premium',
             '_refund_points' => 41,
             %CAP_PAID,
             %CAP_PREMIUM,
         },
+
         # a capability class with a name of "_moveinprogress" is required
         # if you want to be able to move users between clusters with the
         # provided tool.  further, this class must define 'readonly' => 1
-        '5' => {  # 0x20
-            '_name' => '_moveinprogress',
+        '5' => {    # 0x20
+            '_name'    => '_moveinprogress',
             'readonly' => 1,
         },
-        '6' => {  # 0x40
-            '_name' => 'Permanent',
-            '_key' => 'permanent_user',
+        '6' => {    # 0x40
+            '_name'         => 'Permanent',
+            '_key'          => 'permanent_user',
             '_visible_name' => 'Seed Account',
             '_account_type' => 'seed',
             %CAP_PAID,
             %CAP_PREMIUM,
         },
-        '7' => {  # 0x80
-            '_name' => 'Staff',
-            '_key' => 'staff',
-            '_visible_name' => 'Staff Account',
+        '7' => {    # 0x80
+            '_name'          => 'Staff',
+            '_key'           => 'staff',
+            '_visible_name'  => 'Staff Account',
             'staff_headicon' => 1,
             %CAP_PAID,
             %CAP_PREMIUM,
         },
-        8 => { _name => 'beta', _key => 'betafeatures' }, # 0x100
+        8 => { _name => 'beta', _key => 'betafeatures' },    # 0x100
     );
 
     # default capability class mask for new users:
@@ -425,9 +423,9 @@
 
     # by default, give users a style
     $DEFAULT_STYLE = {
-        'core' => 'core2',
+        'core'   => 'core2',
         'layout' => 'ciel/layout',
-        'theme' => 'ciel/indil',
+        'theme'  => 'ciel/indil',
     };
 
     # Setup support email address to not accept new emails.  Basically if an
@@ -446,7 +444,8 @@
     # gathered information will be appended to requests that the user opens
     # through the web interface.
     %SUPPORT_DIAGNOSTICS = (
-    #    'track_useragent' => 1,
+
+        #    'track_useragent' => 1,
     );
 
     # If you want to change the limit on how many bans a user can make, uncomment
@@ -474,13 +473,11 @@
     %USER_INIT = (
         opt_whocanreply => 'reg',
         opt_mangleemail => 'Y',
-        moodthemeid => 7,
+        moodthemeid     => 7,
     );
 
     # initial userprop settings for new users
-    %USERPROP_INIT = (
-        opt_showmutualfriends => 1,
-    );
+    %USERPROP_INIT = ( opt_showmutualfriends => 1, );
 
     # remote's safe_search prop value must be greater than or equal to the defined
     # safe_search_level value in order for users with that level's content flag to be
@@ -504,14 +501,51 @@
 
     # pages where we want to see captcha
     %CAPTCHA_FOR = (
-        create   => 0,               # account creation
-        lostinfo => 1,               # forgotten password/username
-        validate_openid => 1,        # confirming email address of openid acc
+        create              => 0,    # account creation
+        lostinfo            => 1,    # forgotten password/username
+        validate_openid     => 1,    # confirming email address of openid acc
         support_submit_anon => 0,    # support request without logged-in user
-        anonpost => 1,               # rate-limiting on anon posts
-        authpost => 0,               # rate-limiting on non-anon posts
-        comment_html_anon => 1,      # HTML comments from anon commenters?
-        comment_html_auth => 0,      # HTML comments from non-anon commenters?
+        anonpost            => 1,    # rate-limiting on anon posts
+        authpost            => 0,    # rate-limiting on non-anon posts
+        comment_html_anon   => 1,    # HTML comments from anon commenters?
+        comment_html_auth   => 0,    # HTML comments from non-anon commenters?
+    );
+
+    # Rate limit configurations
+    # Each key is the name of the rate limit, and the value is a hash containing:
+    #   max_count: Maximum number of requests allowed
+    #   per_interval_secs: Time period in seconds for the rate limit
+    #   mode: One of 'block' (default), 'ignore', or 'log'
+    #     block: Normal rate limiting behavior
+    #     ignore: No rate limiting, no memcache traffic
+    #     log: Log when limit is exceeded but don't block
+    %RATE_LIMITS = (
+
+      # Example configuration, this will configure a rate limit of 5 requests per 5 minutes
+      # and block the request when the limit is exceeded:
+      #
+      # 'failed_login' => {
+      #     max_count => 5,
+      #     per_interval_secs => 300,  # 5 minutes
+      #     mode => 'block',           # default mode
+      # },
+      #
+      # If you just want to disable a rate limit, you can set it to ignore mode:
+      #
+      # 'failed_login' => {
+      #     mode => 'ignore',
+      # },
+      #
+      # If you want to log when a rate limit is exceeded, but not block, you can set it to log mode:
+      #
+      # 'failed_login' => {
+      #     mode => 'log',
+      # },
+
+     # Put all rate limits in the RATE_LIMITS hash with an empty hashref, this will use the defaults
+     # for all settings from the code.
+        'unauthenticated_requests' => {},
+        'anonymous_requests'       => {},
     );
 }
 

--- a/etc/config.pl.example
+++ b/etc/config.pl.example
@@ -109,6 +109,7 @@
     # CPU & database intensive or that you simply don't want to use
     %DISABLED = (
         adult_content              => 0,
+        approvenew                 => 1,
         loggedout_support_requests => 1,
         'community-logins'         => 0,
         captcha                    => 0,

--- a/etc/config.pl.example
+++ b/etc/config.pl.example
@@ -521,31 +521,43 @@
     #     log: Log when limit is exceeded but don't block
     %RATE_LIMITS = (
 
-      # Example configuration, this will configure a rate limit of 5 requests per 5 minutes
-      # and block the request when the limit is exceeded:
-      #
-      # 'failed_login' => {
-      #     max_count => 5,
-      #     per_interval_secs => 300,  # 5 minutes
-      #     mode => 'block',           # default mode
-      # },
-      #
-      # If you just want to disable a rate limit, you can set it to ignore mode:
-      #
-      # 'failed_login' => {
-      #     mode => 'ignore',
-      # },
-      #
-      # If you want to log when a rate limit is exceeded, but not block, you can set it to log mode:
-      #
-      # 'failed_login' => {
-      #     mode => 'log',
-      # },
+        # Example configuration, this will configure a rate limit of 5 requests per 5 minutes
+        # and block the request when the limit is exceeded:
+        #
+        # 'failed_login' => {
+        #     max_count => 5,
+        #     per_interval_secs => 300,  # 5 minutes
+        #     mode => 'block',           # default mode
+        # },
+        #
+        # If you just want to disable a rate limit, you can set it to ignore mode:
+        #
+        # 'failed_login' => {
+        #     mode => 'ignore',
+        # },
+        #
+        # If you want to log when a rate limit is exceeded, but not block, you can set
+        # it to log mode:
+        #
+        # 'failed_login' => {
+        #     mode => 'log',
+        # },
 
-     # Put all rate limits in the RATE_LIMITS hash with an empty hashref, this will use the defaults
-     # for all settings from the code.
+        # Default site rate limits
         'unauthenticated_requests' => {},
         'anonymous_requests'       => {},
+
+        # API rate limits
+        'tags_get'           => {},
+        'tags_post'          => {},
+        'tags_delete'        => {},
+        'xpost_get'          => {},
+        'accesslists_get'    => {},
+        'accesslists_post'   => {},
+        'accesslists_delete' => {},
+        'accesslist_get'     => {},
+        'accesslist_post'    => {},
+        'accesslist_delete'  => {},
     );
 }
 

--- a/t/rate-limit.t
+++ b/t/rate-limit.t
@@ -1,0 +1,192 @@
+#!/usr/bin/perl
+#
+# DW::RateLimit tests
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2025 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+use strict;
+use warnings;
+
+use Test::More tests => 44;
+use Test::MockTime qw(set_fixed_time restore_time);
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+use LJ::Test;
+use DW::RateLimit;
+use Time::HiRes qw(time);
+
+# Test basic rate limit creation
+{
+    my $limit = DW::RateLimit->get(
+        "test_key",
+        max_count         => 10,
+        per_interval_secs => 60
+    );
+    ok( $limit, "Created rate limit object" );
+    isa_ok( $limit, "DW::RateLimit::Limit" );
+    is( $limit->{refill_rate}, 10 / 60, "Refill rate calculated correctly" );
+}
+
+# Test key generation
+{
+    my $limit = DW::RateLimit->get(
+        "test_key",
+        max_count         => 10,
+        per_interval_secs => 60
+    );
+
+    # Test key generation for user ID
+    my $key = $limit->_get_key( userid => 123 );
+    is( $key, "ratelimit::test_key:user:123", "Generated correct key for user ID" );
+
+    # Test key generation for IP
+    $key = $limit->_get_key( ip => "192.168.1.1" );
+    is( $key, "ratelimit::test_key:ip:192.168.1.1", "Generated correct key for IP" );
+
+    # Test key generation for both
+    $key = $limit->_get_key( userid => 123, ip => "192.168.1.1" );
+    is(
+        $key,
+        "ratelimit::test_key:user:123:ip:192.168.1.1",
+        "Generated correct key for user ID and IP"
+    );
+}
+
+# Test rate limit functionality
+LJ::Test::with_fake_memcache {
+    my $limit = DW::RateLimit->get(
+        "test_key",
+        max_count         => 2,
+        per_interval_secs => 60
+    );
+
+    # Test first request
+    my $result = $limit->check( userid => 123 );
+    ok( !$result->{exceeded}, "First request not exceeded" );
+    is( $result->{count},          1, "Count incremented to 1" );
+    is( $result->{time_remaining}, 0, "No time remaining when not exceeded" );
+
+    # Test second request
+    $result = $limit->check( userid => 123 );
+    ok( !$result->{exceeded}, "Second request not exceeded" );
+    is( $result->{count},          2, "Count incremented to 2" );
+    is( $result->{time_remaining}, 0, "No time remaining when not exceeded" );
+
+    # Test third request (should be exceeded)
+    $result = $limit->check( userid => 123 );
+    ok( $result->{exceeded}, "Third request exceeded" );
+    is( $result->{count}, 2, "Count remains at 2 when exceeded" );
+    ok( $result->{time_remaining} > 0, "Time remaining when exceeded" );
+};
+
+# Test leaky bucket refill behavior
+LJ::Test::with_fake_memcache {
+    my $limit = DW::RateLimit->get(
+        "test_key",
+        max_count         => 10,
+        per_interval_secs => 60
+    );
+
+    # Set initial time
+    set_fixed_time(1000);
+
+    # Use up all tokens
+    for ( 1 .. 10 ) {
+        my $result = $limit->check( userid => 123 );
+        ok( !$result->{exceeded}, "Request $_ not exceeded" );
+    }
+    my $result = $limit->check( userid => 123 );
+    ok( $result->{exceeded}, "Bucket empty, request exceeded" );
+    is( $result->{count}, 10, "Count at max when exceeded" );
+    is( $result->{time_remaining}, 60,
+        "Time remaining is exactly 60 seconds when bucket is empty" );
+
+    # Advance time by 30 seconds
+    set_fixed_time(1030);
+
+    # Should have 5 tokens available (half refilled)
+    $result = $limit->check( userid => 123 );
+    ok( !$result->{exceeded}, "Request after partial refill not exceeded" );
+    is( $result->{count},          6, "Bucket partially refilled (5 tokens + 1 from check)" );
+    is( $result->{time_remaining}, 0, "No time remaining when not exceeded" );
+
+    # Use up the refilled tokens
+    for ( 1 .. 4 ) {    # Only need 4 more since we already used one
+        $result = $limit->check( userid => 123 );
+        ok( !$result->{exceeded}, "Refilled request $_ not exceeded" );
+    }
+    $result = $limit->check( userid => 123 );
+    ok( $result->{exceeded}, "Bucket empty again" );
+    is( $result->{count}, 10, "Count at max when exceeded again" );
+    is( $result->{time_remaining},
+        60, "Time remaining is exactly 60 seconds when bucket is empty again" );
+
+    # Restore real time
+    restore_time();
+};
+
+# Test rate limit caching
+LJ::Test::with_fake_memcache {
+    my $limit1 = DW::RateLimit->get(
+        "test_key",
+        max_count         => 10,
+        per_interval_secs => 60
+    );
+    my $limit2 = DW::RateLimit->get(
+        "test_key",
+        max_count         => 10,
+        per_interval_secs => 60
+    );
+
+    # Test that we get the same object back by comparing properties
+    is( $limit1->{name},      $limit2->{name},      "Rate limit objects have same name" );
+    is( $limit1->{max_count}, $limit2->{max_count}, "Rate limit objects have same max_count" );
+    is(
+        $limit1->{interval_secs},
+        $limit2->{interval_secs},
+        "Rate limit objects have same interval_secs"
+    );
+
+    # Test that different parameters create new objects
+    my $limit3 = DW::RateLimit->get(
+        "test_key",
+        max_count         => 20,    # Different max_count
+        per_interval_secs => 60
+    );
+    isnt( $limit1->{max_count}, $limit3->{max_count},
+        "Different parameters create new rate limit objects" );
+};
+
+# Test reset functionality
+LJ::Test::with_fake_memcache {
+    my $limit = DW::RateLimit->get(
+        "test_key",
+        max_count         => 10,
+        per_interval_secs => 60
+    );
+
+    # Set initial time
+    set_fixed_time(1000);
+
+    # Use up all tokens
+    for ( 1 .. 10 ) {
+        $limit->check( userid => 123 );
+    }
+
+    # Reset the counter
+    $limit->reset( userid => 123 );
+    my $result = $limit->check( userid => 123 );
+    is( $result->{count},          1, "Count is 1 after reset (due to check consuming a token)" );
+    is( $result->{time_remaining}, 0, "No time remaining after reset" );
+
+    # Restore real time
+    restore_time();
+};

--- a/t/rate-limit.t
+++ b/t/rate-limit.t
@@ -14,7 +14,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 80;
+use Test::More tests => 91;
 use Test::MockTime qw(set_fixed_time restore_time);
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
@@ -25,23 +25,55 @@ use Time::HiRes qw(time);
 
 # Test basic rate limit creation
 {
-    my $limit = DW::RateLimit->get(
-        "test_key",
-        max_count         => 10,
-        per_interval_secs => 60
-    );
-    ok( $limit, "Created rate limit object" );
+    my $limit = DW::RateLimit->get( "test_key", rate => "10/60s" );
+    ok( $limit, "Created rate limit object with rate string" );
     isa_ok( $limit, "DW::RateLimit::Limit" );
-    is( $limit->{refill_rate}, 10 / 60, "Refill rate calculated correctly" );
+    is( $limit->{refill_rate}, 10 / 60, "Refill rate calculated correctly from rate string" );
+}
+
+# Test different rate string units
+{
+    my $limit = DW::RateLimit->get( "test_key", rate => "10/1m" );
+    ok( $limit, "Created rate limit object with minutes" );
+    is( $limit->{interval_secs}, 60, "Minutes converted to seconds correctly" );
+
+    $limit = DW::RateLimit->get( "test_key", rate => "10/1h" );
+    ok( $limit, "Created rate limit object with hours" );
+    is( $limit->{interval_secs}, 3600, "Hours converted to seconds correctly" );
+
+    $limit = DW::RateLimit->get( "test_key", rate => "10/1d" );
+    ok( $limit, "Created rate limit object with days" );
+    is( $limit->{interval_secs}, 86400, "Days converted to seconds correctly" );
+}
+
+# Test invalid rate strings
+{
+    my $limit = DW::RateLimit->get( "test_key", rate => "invalid" );
+    ok( !$limit, "Invalid rate string rejected" );
+
+    $limit = DW::RateLimit->get(
+        "test_key",
+        rate => "10/60"    # Missing unit
+    );
+    ok( !$limit, "Rate string without unit rejected" );
+
+    $limit = DW::RateLimit->get(
+        "test_key",
+        rate => "10/60x"    # Invalid unit
+    );
+    ok( !$limit, "Rate string with invalid unit rejected" );
+}
+
+# Test missing rate parameter
+{
+    my $limit = DW::RateLimit->get("test_key");
+    ok( !$limit, "Missing rate parameter rejected" );
 }
 
 # Test key generation
 {
-    my $limit = DW::RateLimit->get(
-        "test_key",
-        max_count         => 10,
-        per_interval_secs => 60
-    );
+    my $limit = DW::RateLimit->get( "test_key", rate => "10/60s" );
+    ok( $limit, "Created rate limit object for key generation test" );
 
     # Test key generation for user ID
     my $key = $limit->_get_key( userid => 123 );
@@ -62,11 +94,7 @@ use Time::HiRes qw(time);
 
 # Test rate limit functionality
 LJ::Test::with_fake_memcache {
-    my $limit = DW::RateLimit->get(
-        "test_key",
-        max_count         => 2,
-        per_interval_secs => 60
-    );
+    my $limit = DW::RateLimit->get( "test_key", rate => "2/60s" );
 
     # Test first request
     my $result = $limit->check( userid => 123 );
@@ -89,11 +117,7 @@ LJ::Test::with_fake_memcache {
 
 # Test leaky bucket refill behavior
 LJ::Test::with_fake_memcache {
-    my $limit = DW::RateLimit->get(
-        "test_key",
-        max_count         => 10,
-        per_interval_secs => 60
-    );
+    my $limit = DW::RateLimit->get( "test_key", rate => "10/60s" );
 
     # Set initial time
     set_fixed_time(1000);
@@ -135,16 +159,8 @@ LJ::Test::with_fake_memcache {
 
 # Test rate limit caching
 LJ::Test::with_fake_memcache {
-    my $limit1 = DW::RateLimit->get(
-        "test_key",
-        max_count         => 10,
-        per_interval_secs => 60
-    );
-    my $limit2 = DW::RateLimit->get(
-        "test_key",
-        max_count         => 10,
-        per_interval_secs => 60
-    );
+    my $limit1 = DW::RateLimit->get( "test_key", rate => "10/60s" );
+    my $limit2 = DW::RateLimit->get( "test_key", rate => "10/60s" );
 
     # Test that we get the same object back by comparing properties
     is( $limit1->{name},      $limit2->{name},      "Rate limit objects have same name" );
@@ -158,8 +174,7 @@ LJ::Test::with_fake_memcache {
     # Test that different parameters create new objects
     my $limit3 = DW::RateLimit->get(
         "test_key",
-        max_count         => 20,    # Different max_count
-        per_interval_secs => 60
+        rate => "20/60s"    # Different rate
     );
     isnt( $limit1->{max_count}, $limit3->{max_count},
         "Different parameters create new rate limit objects" );
@@ -167,11 +182,7 @@ LJ::Test::with_fake_memcache {
 
 # Test reset functionality
 LJ::Test::with_fake_memcache {
-    my $limit = DW::RateLimit->get(
-        "test_key",
-        max_count         => 10,
-        per_interval_secs => 60
-    );
+    my $limit = DW::RateLimit->get( "test_key", rate => "10/60s" );
 
     # Set initial time
     set_fixed_time(1000);
@@ -196,16 +207,14 @@ LJ::Test::with_fake_memcache {
 
     # Set up test configuration
     $LJ::RATE_LIMITS{test_override} = {
-        max_count         => 5,
-        per_interval_secs => 30,
-        mode              => 'ignore'
+        rate => "5/30s",
+        mode => 'ignore'
     };
 
     # Test that configuration is applied
     my $limit = DW::RateLimit->get(
         "test_override",
-        max_count         => 10,    # Should be overridden
-        per_interval_secs => 60     # Should be overridden
+        rate => "10/60s"    # Should be overridden
     );
     ok( $limit, "Created rate limit object with overrides" );
     is( $limit->{max_count},     5,        "max_count overridden correctly" );
@@ -227,11 +236,7 @@ LJ::Test::with_fake_memcache {
     }
 
     # Test block mode (default)
-    my $block_limit = DW::RateLimit->get(
-        "test_block",
-        max_count         => 2,
-        per_interval_secs => 60
-    );
+    my $block_limit = DW::RateLimit->get( "test_block", rate => "2/60s" );
     is( $block_limit->{mode}, 'block', "Default mode is block" );
 
     # Test block mode behavior


### PR DESCRIPTION
CODE TOUR: This adds basic rate limiting functionality that will leverage memcached to enable us to keep track of how frequently certain things are happening and then return the appropriate error code. This is primarily being built for the API, but will probably be useful in other contexts as well, or could be? Maybe?

Still WIP, don't merge yet.