### PR TITLE
update AO3 userhead to use https

### DIFF
--- a/cgi-bin/DW/External/Site/ArchiveofOurOwn.pm
+++ b/cgi-bin/DW/External/Site/ArchiveofOurOwn.pm
@@ -45,7 +45,7 @@ sub badge_image {
         unless $u && ref $u eq 'DW::External::User';
 
     return {
-        url    => 'http://archiveofourown.org/favicon.ico',
+        url    => 'https://archiveofourown.org/favicon.ico',
         width  => 16,
         height => 16,
     };


### PR DESCRIPTION
CODE TOUR: This updates the link for the AO3 user profile icon to use https instead of http. The http link is being proxied, and the proxy apparently doesn't understand the `.ico` image format.

Reported in support: https://www.dreamwidth.org/support/see_request?id=50559