### PR TITLE
Add mysql-client to dependencies-system.

### DIFF
--- a/doc/dependencies-system
+++ b/doc/dependencies-system
@@ -19,3 +19,4 @@ libdatetime-perl
 libio-aio-perl
 libssl-dev
 apache2
+mysql-client

--- a/etc/docker/dev/Dockerfile
+++ b/etc/docker/dev/Dockerfile
@@ -16,7 +16,6 @@ ENV PERL5LIB /dw/extlib/lib/perl5
 # Install some packages we need in workers only.
 RUN echo $COMMIT && \
     apt-get update && \
-    apt-get install -y mysql-client && \
     curl https://raw.githubusercontent.com/dreamwidth/dreamwidth/main/doc/dependencies-system | \
         xargs apt-get -y install && \
     curl https://raw.githubusercontent.com/dreamwidth/dreamwidth/main/doc/dependencies-dev | \

--- a/etc/docker/web/Dockerfile
+++ b/etc/docker/web/Dockerfile
@@ -14,7 +14,7 @@ ENV LJHOME /dw
 # Install some packages we need in web only.
 RUN echo $COMMIT && \
     apt-get update && \
-    apt-get install -y mysql-client varnish
+    apt-get install -y varnish
 
 
 # Actually check out the source code now & install branch dependencies.

--- a/etc/docker/web22/Dockerfile
+++ b/etc/docker/web22/Dockerfile
@@ -14,7 +14,7 @@ ENV LJHOME /dw
 # Install some packages we need in web only.
 RUN echo $COMMIT && \
     apt-get update && \
-    apt-get install -y mysql-client varnish
+    apt-get install -y varnish
 
 
 # Actually check out the source code now & install branch dependencies.

--- a/etc/docker/worker/Dockerfile
+++ b/etc/docker/worker/Dockerfile
@@ -14,7 +14,6 @@ ENV LJHOME /dw
 # Install some packages we need in workers only.
 RUN echo $COMMIT && \
     apt-get update && \
-    apt-get install -y mysql-client && \
     curl https://raw.githubusercontent.com/dreamwidth/dreamwidth/main/doc/dependencies-system | \
     xargs apt-get -y install && \
     curl https://raw.githubusercontent.com/dreamwidth/dreamwidth/main/doc/dependencies-cpanm | \

--- a/etc/docker/worker22/Dockerfile
+++ b/etc/docker/worker22/Dockerfile
@@ -14,7 +14,6 @@ ENV LJHOME /dw
 # Install some packages we need in workers only.
 RUN echo $COMMIT && \
     apt-get update && \
-    apt-get install -y mysql-client && \
     curl https://raw.githubusercontent.com/dreamwidth/dreamwidth/main/doc/dependencies-system | \
     xargs apt-get -y install && \
     curl https://raw.githubusercontent.com/dreamwidth/dreamwidth/main/doc/dependencies-cpanm | \


### PR DESCRIPTION
It turns out that almost every container pulls in mysql-client as an "exclusive dependency". And if everyone's doing it, it's not exclusive, and it should be added to the global dependency list.

CODE TOUR: no-impact. added mysql-client to the list of dependencies needed to install dreamwidth, since it seems that it's required in all cases anyways.

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
