### PR TITLE
Send notifications when screened comments are unscreened (#3487)

### DIFF
--- a/cgi-bin/LJ/Event/JournalNewComment/Reply.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment/Reply.pm
@@ -175,6 +175,16 @@ sub matches_filter {
     # Do not send on own comments
     return 0 unless $comment->visible_to($watcher);
 
+    # For unscreen events, skip users who were already notified
+    # when the comment was screened (they could already see it).
+    if ( $self->is_unscreen_event ) {
+        return 0 if $watcher->can_manage( $comment->journal );
+        return 0
+            if $comment->entry
+            && $comment->entry->poster
+            && $watcher->equals( $comment->entry->poster );
+    }
+
     # Do not send if opt_noemail applies
     return 0 if $self->apply_noemail( $watcher, $comment, $subscr->method );
 

--- a/cgi-bin/LJ/Event/JournalNewComment/TopLevel.pm
+++ b/cgi-bin/LJ/Event/JournalNewComment/TopLevel.pm
@@ -40,6 +40,15 @@ sub matches_filter {
     my $watcher = $subscr->owner;
     return 0 unless $comment->visible_to($watcher);
 
+    # For unscreen events, skip users who were already notified
+    # when the comment was screened (they could already see it).
+    if ( $self->is_unscreen_event ) {
+        return 0 if $watcher->can_manage( $comment->journal );
+        return 0
+            if $entry->poster
+            && $watcher->equals( $entry->poster );
+    }
+
     # check that event's entry is the entry we're interested in (subscribed to)
     my $wanted_ditemid = $subscr->arg1;
     return 0 if $wanted_ditemid && $entry->ditemid != $wanted_ditemid;

--- a/cgi-bin/LJ/Event/UserMessageRecvd.pm
+++ b/cgi-bin/LJ/Event/UserMessageRecvd.pm
@@ -49,8 +49,9 @@ sub as_email_subject {
 sub _as_email {
     my ( $self, $u, $is_html ) = @_;
 
-    my $msg         = $self->load_message;
-    my $compose_url = LJ::BetaFeatures->user_in_beta( $u => "inbox" )
+    my $msg = $self->load_message;
+    my $compose_url =
+        LJ::BetaFeatures->user_in_beta( $u => "inbox" )
         ? "$LJ::SITEROOT/inbox/new/compose"
         : "$LJ::SITEROOT/inbox/compose";
     my $replyurl = "$compose_url?mode=reply&msgid=" . $msg->msgid;
@@ -140,7 +141,8 @@ sub as_html_actions {
     my $u       = LJ::want_user( $msg->journalid );
     my $other_u = $msg->other_u;
 
-    my $compose_url = LJ::BetaFeatures->user_in_beta( $u => "inbox" )
+    my $compose_url =
+        LJ::BetaFeatures->user_in_beta( $u => "inbox" )
         ? "$LJ::SITEROOT/inbox/new/compose"
         : "$LJ::SITEROOT/inbox/compose";
     my $ret = "<div class='actions'>";


### PR DESCRIPTION
When a comment is posted but screened, ESN fires a JournalNewComment event, but `matches_filter` skips users who can't see it (via `visible_to`). When the comment is later unscreened, `unscreen_comment` updated the DB state but never fired a new event, so those users were never notified.

This adds event firing to `LJ::Talk::unscreen_comment` using a new `new_for_unscreen` constructor that sets arg2 as a flag. `matches_filter` in `JournalNewComment`, `Reply`, and `TopLevel` checks this flag and skips users who could already see the comment while screened (journal managers, entry posters), preventing duplicate notifications. Also updates in-memory LJ::Comment singletons after unscreening so the new state is immediately visible within the same process.

Tests added covering both the positive case (watcher notified after unscreen) and the dedup case (journal owner not notified twice).

CODE TOUR: When someone replies to your comment but their reply gets screened (because the journal screens comments from people not on their access list), you previously never found out about that reply — even after the journal owner unscreened it. Now, when a journal owner unscreens a comment, everyone who would normally have been notified about that comment will receive their notification. People who were already notified when the comment was screened (like the journal owner) won't get a duplicate.

Fixes #3487