### PR TITLE
Fix checkbox state on en masse interests form (#3478)

### DIFF
--- a/views/interests/enmasse.tt
+++ b/views/interests/enmasse.tt
@@ -40,7 +40,7 @@
     [%- FOREACH int = enmasse_data -%]
         <div>
             <label>
-            <input type='checkbox' [% "checked='checked'" IF cell.is_checked %]
+            <input type='checkbox' [% "checked='checked'" IF int.is_checked %]
                 name='[% int.checkid %]' id='[% int.checkid %]' value='1' class="inline" />
 
             [%- "<strong>" IF int.is_checked %]


### PR DESCRIPTION
The Foundation conversion in #3418 changed the loop variable in `enmasse.tt` from `cell` to `int` but missed updating the `checked` attribute condition — it still referenced `cell.is_checked` instead of `int.is_checked`. Since `cell` is undefined, this made all checkboxes render unchecked regardless of state. Fixed by updating the reference to `int.is_checked`.

CODE TOUR: Fixed a bug on the "add/remove interests" page where all checkboxes appeared unchecked. The page shows your interests (or another user's interests) as a list of checkboxes — checked means you want to keep (or add) the interest, unchecked means remove it. A typo from a previous update broke the checkboxes so they always started unchecked, which meant submitting the form without changes would remove all displayed interests.

Fixes #3478