### PR TITLE
Handle multiple dc:creator elements in feed entries (#3476)

### DIFF
--- a/cgi-bin/LJ/ParseFeed.pm
+++ b/cgi-bin/LJ/ParseFeed.pm
@@ -131,7 +131,10 @@ sub parse_feed {
 
         # Dublin Core
         if ( $_->{dc} && ref $_->{dc} eq "HASH" ) {
-            $author = $_->{dc}->{creator} if $_->{dc}->{creator};
+            if ( $_->{dc}->{creator} ) {
+                my $creator = $_->{dc}->{creator};
+                $author = ref $creator eq 'ARRAY' ? join( ', ', @$creator ) : $creator;
+            }
             $time = w3cdtf_to_time( $_->{dc}->{date} ) if $_->{dc}->{date};
         }
 

--- a/t/parsefeed-authors.t
+++ b/t/parsefeed-authors.t
@@ -18,7 +18,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 10;
+use Test::More tests => 11;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -79,6 +79,16 @@ xmlns:dc='http://purl.org/dc/elements/1.1/'>
 <dw:poster>example-dw-poster</dw:poster>
 <dw:security>public</dw:security>
 <dw:reply-count>0</dw:reply-count>
+</item>
+
+<item>
+<guid isPermaLink='true'>http://examplecomm.dream.fu/789.html</guid>
+<pubDate>Mon, 07 Feb 2011 12:00:00 GMT</pubDate>
+<title>yo</title>
+<link>http://examplecomm.dream.fu/789.html</link>
+<description>yo</description>
+<dc:creator>First Author</dc:creator>
+<dc:creator>Second Author</dc:creator>
 </item>
 
 </channel>
@@ -158,6 +168,11 @@ SKIP: {
     is( $parse_rss->{items}->[0]->{author}, "example-dc-creator", "<dc:creator> tag" );
     is( $parse_rss->{items}->[1]->{author}, "example-lj-poster",  "<lj:poster> tag" );
     is( $parse_rss->{items}->[2]->{author}, "example-dw-poster",  "<dw:poster> tag" );
+    is(
+        $parse_rss->{items}->[3]->{author},
+        "First Author, Second Author",
+        "multiple <dc:creator> tags"
+    );
 }
 
 my ( $parse_atom, $atom_error ) = LJ::ParseFeed::parse_feed( $feed_atom, "atom" );


### PR DESCRIPTION
When an RSS feed item has multiple `<dc:creator>` elements, the XML parser returns an array ref instead of a string. `LJ::ParseFeed` passed this through as-is, which resulted in `LJ::SynSuck` stringifying it as `ARRAY(0x...)` in the "Posted by" line. Fixed by joining multiple creators with commas in the RSS parsing path. Added a test case for this scenario.

CODE TOUR: Feed entries with multiple authors (which is allowed by the RSS spec) used to display "Posted by ARRAY(0x...)" instead of the actual author names. Now they correctly show something like "Posted by First Author, Second Author".

Fixes #3476