### PR TITLE
Fix mobile folder toggle breaking after inbox actions (#3480)

### DIFF
--- a/htdocs/js/jquery.inbox.js
+++ b/htdocs/js/jquery.inbox.js
@@ -235,7 +235,7 @@ if ($('#msg_to').length) {
 }
 $('.folders').removeClass('no-js');
 $("#folder_btn").removeClass('no-js');
-$("#folder_btn").click(function(){
+$("#inbox_folders").on("click", "#folder_btn", function(){
     var folders = $('#folder_list');
     var img = $(this).children();
 


### PR DESCRIPTION
The folder button's click handler on the beta inbox was bound directly to `#folder_btn` using
`$("#folder_btn").click(...)`. After any AJAX action (mark read, mark unread, delete, etc.),
the success handler replaces the entire `#inbox_folders` inner HTML with fresh server-rendered
content. This destroys the original `#folder_btn` DOM element and its attached click handler,
so the folder toggle button stops responding to clicks until the page is reloaded.

Fixed by switching to jQuery event delegation: `$("#inbox_folders").on("click", "#folder_btn", ...)`.
The handler is now attached to `#inbox_folders` (which survives the `.html()` replacement) and
delegates to `#folder_btn`, so it works on both the original and any replacement elements.

CODE TOUR: On mobile, the beta inbox has a "Folders" button that expands and collapses the
folder list. After using any action button (like marking a message as read), the folder button
would stop working until you refreshed the page. This was because the action updated the folder
area's HTML behind the scenes, and the new button lost its connection to the toggle behavior.
Now the toggle works reliably even after actions are performed.

Fixes #3480