### PR TITLE
Remove useless rand_chars imports

### DIFF
--- a/cgi-bin/DW/API/Key.pm
+++ b/cgi-bin/DW/API/Key.pm
@@ -22,7 +22,7 @@ use strict;
 use warnings;
 use Carp;
 
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 
 # Usage: new_for_user ( user )
 # Creates a new API key for a given user, saves it to DB,

--- a/cgi-bin/DW/Auth/Challenge.pm
+++ b/cgi-bin/DW/Auth/Challenge.pm
@@ -25,7 +25,7 @@ use Log::Log4perl;
 use Digest::MD5;
 my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 
 ################################################################################
 #

--- a/cgi-bin/DW/EmailPost/Comment.pm
+++ b/cgi-bin/DW/EmailPost/Comment.pm
@@ -20,7 +20,7 @@ use strict;
 
 use Digest::SHA;
 
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 use LJ::Protocol;
 use DW::CleanEmail;
 use LJ::Comment;

--- a/cgi-bin/DW/OAuth.pm
+++ b/cgi-bin/DW/OAuth.pm
@@ -18,7 +18,7 @@ package DW::OAuth;
 use strict;
 use warnings;
 
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 use DW::Request;
 use Net::OAuth;
 

--- a/cgi-bin/DW/OAuth/Request.pm
+++ b/cgi-bin/DW/OAuth/Request.pm
@@ -17,7 +17,7 @@ package DW::OAuth::Request;
 use strict;
 use warnings;
 
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 use Digest::SHA qw/sha1 sha256/;
 use MIME::Base64::URLSafe;
 

--- a/cgi-bin/LJ/Console/Command/ChangeJournalType.pm
+++ b/cgi-bin/LJ/Console/Command/ChangeJournalType.pm
@@ -16,7 +16,7 @@ package LJ::Console::Command::ChangeJournalType;
 use strict;
 use base qw(LJ::Console::Command);
 use Carp qw(croak);
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 
 sub cmd { "change_journal_type" }
 

--- a/cgi-bin/LJ/Session.pm
+++ b/cgi-bin/LJ/Session.pm
@@ -15,7 +15,7 @@ package LJ::Session;
 use strict;
 use Carp qw(croak);
 use Digest::HMAC_SHA1 qw(hmac_sha1 hmac_sha1_hex);
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 
 use constant VERSION => 1;
 

--- a/cgi-bin/LJ/SynSuck.pm
+++ b/cgi-bin/LJ/SynSuck.pm
@@ -17,7 +17,7 @@ use HTTP::Status;
 use Log::Log4perl;
 my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
-use LJ::Utils qw(md5_struct);
+use LJ::Utils;
 use LJ::Protocol;
 use LJ::ParseFeed;
 use LJ::CleanHTML;

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -27,7 +27,7 @@ use DW::Task::SphinxCopier;
 use DW::Captcha;
 use DW::EmailPost::Comment;
 use DW::Formats;
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 use LJ::Comment;
 use LJ::Event::JournalNewComment;
 use LJ::Event::JournalNewComment::Edited;

--- a/cgi-bin/LJ/Test.pm
+++ b/cgi-bin/LJ/Test.pm
@@ -21,7 +21,7 @@ use DW::Request::Standard;
 use HTTP::Request;
 
 use DBI;
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 use LJ::ModuleCheck;
 our @ISA    = qw(Exporter);
 our @EXPORT = qw(memcache_stress with_fake_memcache temp_user temp_comm temp_feed routing_request);

--- a/cgi-bin/LJ/UniqCookie.pm
+++ b/cgi-bin/LJ/UniqCookie.pm
@@ -16,7 +16,7 @@ package LJ::UniqCookie;
 
 use strict;
 use Carp qw(croak);
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 
 my %req_cache_uid2uniqs = ();    # uid  => [ uniq1, uniq2, ... ]
 my %req_cache_uniq2uids = ();    # uniq => [  uid1,  uid2, ... ]

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -25,7 +25,7 @@ use DW::Auth::Challenge;
 use DW::External::Site;
 use DW::Request;
 use DW::Formats;
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 use LJ::Global::Constants;
 use LJ::Event;
 use LJ::Subscription::Pending;

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -77,7 +77,7 @@ use Carp;
 use DBI;
 use DBI::Role;
 use HTTP::Date ();
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 use LJ::Hooks;
 use LJ::MemCache;
 use LJ::Error;

--- a/cgi-bin/modperl_subs.pl
+++ b/cgi-bin/modperl_subs.pl
@@ -46,7 +46,7 @@ use Time::HiRes ();
 use Image::Size ();
 use POSIX       ();
 
-use LJ::Utils qw(urandom_int);
+use LJ::Utils;
 use LJ::Hooks;
 use LJ::Faq;
 use DW::BusinessRules::InviteCodes;

--- a/t/comment.t
+++ b/t/comment.t
@@ -21,7 +21,7 @@ use warnings;
 use Test::More tests => 405;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 use LJ::Protocol;
 use LJ::Comment;
 use LJ::Talk;

--- a/t/content-filters.t
+++ b/t/content-filters.t
@@ -20,7 +20,7 @@ use Test::More tests => 15;
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Test qw ( temp_user temp_comm );
 
-use LJ::Utils qw(rand_chars);
+use LJ::Utils;
 use LJ::Community;
 
 my $u1 = temp_user();


### PR DESCRIPTION
`use LJ::Utils qw/rand_chars/` and similar constructs with other functions previously appeared in a number of files. Because LJ::Utils->import does not exist, this is exactly equivalent to `use LJ::Utils` on its own. Moreover, because the functions passed as arguments are always referred to in these files fully-qualified (eg `LJ::rand_chars`), this would be useless even if it did do what it was supposed to. This becomes a warning in newer versions of perl, and since we'll eventually upgrade and can eliminate it now very easily we might as well do it.

CODE TOUR: Removed some things that did nothing but gave very irritating warning messages in newer versions of Perl

CODE TOUR: summarize here.

<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
