### PR TITLE
Build JS for ES6, not ES2020

### DIFF
--- a/bin/build-static-modern.sh
+++ b/bin/build-static-modern.sh
@@ -127,7 +127,7 @@ do
 
                 if [[ "$ext" = "js" ]]; then
                     # Minify JS with esbuild
-                    $compressor --minify "$synced_file" --outfile="$final/$modified_file" 2>/dev/null \
+                    $compressor --target=es6 --minify "$synced_file" --outfile="$final/$modified_file" 2>/dev/null \
                         || cp -p "$synced_file" "$final/$modified_file"
                 else
                     # CSS is already minified by Dart Sass; other files copy as-is


### PR DESCRIPTION
CODE TOUR: We updated our script that gets all the CSS and Javascript files ready to be served to use tools that are actually still updated. Unfortunately, we didn't realize that that the Javascript minifier by default tries to save as much space as possible by using shorter modern Javascript syntax, which causes it to break in older browsers. This tells the minifier to not do that.

----
**Note**: this will require deleting the existing unminified js build dir to get force a rebuild. Also if both this and #3531 get merged, use the code tour text from just that one - I'm splitting off the uncontroversial bit that /needs/ to get merged here.