### PR TITLE
Ship web22 Starman logs to Grafana Cloud Loki

### DIFF
--- a/.github/workflows/tasks/web-canary-service.json
+++ b/.github/workflows/tasks/web-canary-service.json
@@ -21,27 +21,80 @@
                 "bash",
                 "/opt/startup-prod.sh"
             ],
-            "environment": [],
+            "environment": [
+                {
+                    "name": "DW_LOKI_SERVICE",
+                    "value": "web-canary"
+                }
+            ],
             "mountPoints": [
                 {
                     "sourceVolume": "dw-config",
                     "containerPath": "/dw/etc",
                     "readOnly": true
+                },
+                {
+                    "sourceVolume": "log-share",
+                    "containerPath": "/var/log/starman",
+                    "readOnly": false
                 }
             ],
             "volumesFrom": [],
             "linuxParameters": {
                 "initProcessEnabled": true
-            },
+            }
+        },
+        {
+            "name": "log_router",
+            "image": "194396987458.dkr.ecr.us-east-1.amazonaws.com/dreamwidth-fluent-bit:3",
+            "essential": false,
+            "entryPoint": [
+                "/fluent-bit/bin/fluent-bit"
+            ],
+            "command": [
+                "-c",
+                "/dw/etc/fluent-bit/web.conf"
+            ],
+            "environment": [
+                {
+                    "name": "DW_LOKI_SERVICE",
+                    "value": "web-canary"
+                }
+            ],
+            "secrets": [
+                {
+                    "name": "LOKI_USER",
+                    "valueFrom": "arn:aws:ssm:us-east-1:194396987458:parameter/dreamwidth/grafana-cloud/loki-username"
+                },
+                {
+                    "name": "LOKI_PASSWORD",
+                    "valueFrom": "arn:aws:ssm:us-east-1:194396987458:parameter/dreamwidth/grafana-cloud/loki-password"
+                }
+            ],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dw-config",
+                    "containerPath": "/dw/etc",
+                    "readOnly": true
+                },
+                {
+                    "sourceVolume": "log-share",
+                    "containerPath": "/var/log/starman",
+                    "readOnly": true
+                }
+            ],
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {
                     "awslogs-create-group": "true",
-                    "awslogs-group": "/dreamwidth/web/canary",
+                    "awslogs-group": "/dreamwidth/fluent-bit",
                     "awslogs-region": "us-east-1",
-                    "awslogs-stream-prefix": "canary"
+                    "awslogs-stream-prefix": "web-canary"
                 }
-            }
+            },
+            "portMappings": [],
+            "volumesFrom": [],
+            "systemControls": []
         }
     ],
     "family": "web-canary",
@@ -56,6 +109,9 @@
                 "rootDirectory": "/etc-canary",
                 "transitEncryption": "DISABLED"
             }
+        },
+        {
+            "name": "log-share"
         }
     ],
     "requiresCompatibilities": [

--- a/.github/workflows/tasks/web-shop-service.json
+++ b/.github/workflows/tasks/web-shop-service.json
@@ -21,27 +21,80 @@
                 "bash",
                 "/opt/startup-prod.sh"
             ],
-            "environment": [],
+            "environment": [
+                {
+                    "name": "DW_LOKI_SERVICE",
+                    "value": "web-shop"
+                }
+            ],
             "mountPoints": [
                 {
                     "sourceVolume": "dw-config",
                     "containerPath": "/dw/etc",
                     "readOnly": true
+                },
+                {
+                    "sourceVolume": "log-share",
+                    "containerPath": "/var/log/starman",
+                    "readOnly": false
                 }
             ],
             "volumesFrom": [],
             "linuxParameters": {
                 "initProcessEnabled": true
-            },
+            }
+        },
+        {
+            "name": "log_router",
+            "image": "194396987458.dkr.ecr.us-east-1.amazonaws.com/dreamwidth-fluent-bit:3",
+            "essential": false,
+            "entryPoint": [
+                "/fluent-bit/bin/fluent-bit"
+            ],
+            "command": [
+                "-c",
+                "/dw/etc/fluent-bit/web.conf"
+            ],
+            "environment": [
+                {
+                    "name": "DW_LOKI_SERVICE",
+                    "value": "web-shop"
+                }
+            ],
+            "secrets": [
+                {
+                    "name": "LOKI_USER",
+                    "valueFrom": "arn:aws:ssm:us-east-1:194396987458:parameter/dreamwidth/grafana-cloud/loki-username"
+                },
+                {
+                    "name": "LOKI_PASSWORD",
+                    "valueFrom": "arn:aws:ssm:us-east-1:194396987458:parameter/dreamwidth/grafana-cloud/loki-password"
+                }
+            ],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dw-config",
+                    "containerPath": "/dw/etc",
+                    "readOnly": true
+                },
+                {
+                    "sourceVolume": "log-share",
+                    "containerPath": "/var/log/starman",
+                    "readOnly": true
+                }
+            ],
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {
                     "awslogs-create-group": "true",
-                    "awslogs-group": "/dreamwidth/web/shop",
+                    "awslogs-group": "/dreamwidth/fluent-bit",
                     "awslogs-region": "us-east-1",
-                    "awslogs-stream-prefix": "shop"
+                    "awslogs-stream-prefix": "web-shop"
                 }
-            }
+            },
+            "portMappings": [],
+            "volumesFrom": [],
+            "systemControls": []
         }
     ],
     "family": "web-shop",
@@ -56,6 +109,9 @@
                 "rootDirectory": "/etc-stable",
                 "transitEncryption": "DISABLED"
             }
+        },
+        {
+            "name": "log-share"
         }
     ],
     "requiresCompatibilities": [

--- a/.github/workflows/tasks/web-unauthenticated-service.json
+++ b/.github/workflows/tasks/web-unauthenticated-service.json
@@ -21,27 +21,80 @@
                 "bash",
                 "/opt/startup-prod.sh"
             ],
-            "environment": [],
+            "environment": [
+                {
+                    "name": "DW_LOKI_SERVICE",
+                    "value": "web-unauthenticated"
+                }
+            ],
             "mountPoints": [
                 {
                     "sourceVolume": "dw-config",
                     "containerPath": "/dw/etc",
                     "readOnly": true
+                },
+                {
+                    "sourceVolume": "log-share",
+                    "containerPath": "/var/log/starman",
+                    "readOnly": false
                 }
             ],
             "volumesFrom": [],
             "linuxParameters": {
                 "initProcessEnabled": true
-            },
+            }
+        },
+        {
+            "name": "log_router",
+            "image": "194396987458.dkr.ecr.us-east-1.amazonaws.com/dreamwidth-fluent-bit:3",
+            "essential": false,
+            "entryPoint": [
+                "/fluent-bit/bin/fluent-bit"
+            ],
+            "command": [
+                "-c",
+                "/dw/etc/fluent-bit/web.conf"
+            ],
+            "environment": [
+                {
+                    "name": "DW_LOKI_SERVICE",
+                    "value": "web-unauthenticated"
+                }
+            ],
+            "secrets": [
+                {
+                    "name": "LOKI_USER",
+                    "valueFrom": "arn:aws:ssm:us-east-1:194396987458:parameter/dreamwidth/grafana-cloud/loki-username"
+                },
+                {
+                    "name": "LOKI_PASSWORD",
+                    "valueFrom": "arn:aws:ssm:us-east-1:194396987458:parameter/dreamwidth/grafana-cloud/loki-password"
+                }
+            ],
+            "mountPoints": [
+                {
+                    "sourceVolume": "dw-config",
+                    "containerPath": "/dw/etc",
+                    "readOnly": true
+                },
+                {
+                    "sourceVolume": "log-share",
+                    "containerPath": "/var/log/starman",
+                    "readOnly": true
+                }
+            ],
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {
                     "awslogs-create-group": "true",
-                    "awslogs-group": "/dreamwidth/web/unauthenticated",
+                    "awslogs-group": "/dreamwidth/fluent-bit",
                     "awslogs-region": "us-east-1",
-                    "awslogs-stream-prefix": "unauthenticated"
+                    "awslogs-stream-prefix": "web-unauthenticated"
                 }
-            }
+            },
+            "portMappings": [],
+            "volumesFrom": [],
+            "systemControls": []
         }
     ],
     "family": "web-unauthenticated",
@@ -56,6 +109,9 @@
                 "rootDirectory": "/etc-stable",
                 "transitEncryption": "DISABLED"
             }
+        },
+        {
+            "name": "log-share"
         }
     ],
     "requiresCompatibilities": [

--- a/cgi-bin/DW/Search.pm
+++ b/cgi-bin/DW/Search.pm
@@ -374,11 +374,24 @@ sub _enrich_support {
         }
         next unless $visible;
 
-        $match->{url}      = "$LJ::SITEROOT/support/see_request?id=$spid";
-        $match->{type}     = $type;
-        $match->{spid}     = $spid;
-        $match->{category} = $sp->{_cat}->{catname};
-        $match->{subject}  = $sp->{subject};
+        # supportlog messages are stored as raw HTML. Strip it before
+        # excerpting: CALL SNIPPETS echoes its input back verbatim apart from
+        # the highlight tags, and the results template prints the excerpt
+        # unfiltered, so unstripped markup in a request body injects arbitrary
+        # HTML into the page. Mirrors the journal entry path in _enrich_journal.
+        $content =~ s#<(?:br|p)\s*/?># #gi;
+        $content = LJ::strip_html($content);
+        $content ||= '(this support entry only contains html content)';
+
+        $match->{url}  = "$LJ::SITEROOT/support/see_request?id=$spid";
+        $match->{type} = $type;
+        $match->{spid} = $spid;
+
+        # category and subject are likewise printed unfiltered by the
+        # template; entity-escape them here since neither is run through
+        # SNIPPETS (the subject is operator-uncontrolled request text).
+        $match->{category} = LJ::ehtml( $sp->{_cat}->{catname} );
+        $match->{subject}  = LJ::ehtml( $sp->{subject} );
         $match->{content}  = $content;
         push @out, $match;
     }

--- a/etc/docker/web22/fluent-bit/README.md
+++ b/etc/docker/web22/fluent-bit/README.md
@@ -1,0 +1,22 @@
+# web22 Fluent Bit configs
+
+Source-of-truth copies of the Fluent Bit sidecar (`log_router`) configs used by
+the web22 ECS tasks. These are **delivered via EFS**, not by the application
+image — the operator copies them onto the per-class EFS roots:
+
+| Repo file     | EFS destination                       | Used by                       |
+|---------------|---------------------------------------|-------------------------------|
+| `canary.conf` | `/etc-canary/fluent-bit/web.conf`     | web-canary (error + access)   |
+| `parsers.conf`| `/etc-canary/fluent-bit/parsers.conf` | web-canary (access JSON parse)|
+| `stable.conf` | `/etc-stable/fluent-bit/web.conf`     | web-shop, web-unauthenticated (error only) |
+
+Inside the container the `dw-config` EFS volume is mounted at `/dw/etc`, so the
+sidecar runs `fluent-bit -c /dw/etc/fluent-bit/web.conf`.
+
+`${LOKI_USER}` / `${LOKI_PASSWORD}` come from the task's ECS `secrets` (the
+shared Grafana Cloud SSM params). `${DW_LOKI_SERVICE}` is set per service in the
+task def `environment` and becomes the Loki `service` label, so the shared
+`stable.conf` labels shop vs. unauthenticated correctly.
+
+Validate locally (on a host with Docker) with `fluent-bit ... --dry-run`; see
+`docs/superpowers/plans/2026-05-24-web22-loki-logging.md`.

--- a/etc/docker/web22/fluent-bit/canary.conf
+++ b/etc/docker/web22/fluent-bit/canary.conf
@@ -1,0 +1,46 @@
+[SERVICE]
+    Flush        5
+    Daemon       Off
+    Log_Level    info
+    Parsers_File /dw/etc/fluent-bit/parsers.conf
+
+[INPUT]
+    Name             tail
+    Alias            error_tail
+    Path             /var/log/starman/error.log
+    Tag              error
+    Read_from_Head   true
+    Refresh_Interval 5
+
+[INPUT]
+    Name             tail
+    Alias            access_tail
+    Path             /var/log/starman/access.log
+    Tag              access
+    Parser           dw_access_json
+    Read_from_Head   true
+    Refresh_Interval 5
+
+[OUTPUT]
+    Name        loki
+    Match       error
+    Host        logs-prod-042.grafana.net
+    Port        443
+    tls         On
+    tls.verify  On
+    Http_User   ${LOKI_USER}
+    Http_Passwd ${LOKI_PASSWORD}
+    Labels      source=dreamwidth, service=${DW_LOKI_SERVICE}, stream=error
+    line_format key_value
+
+[OUTPUT]
+    Name        loki
+    Match       access
+    Host        logs-prod-042.grafana.net
+    Port        443
+    tls         On
+    tls.verify  On
+    Http_User   ${LOKI_USER}
+    Http_Passwd ${LOKI_PASSWORD}
+    Labels      source=dreamwidth, service=${DW_LOKI_SERVICE}, stream=access
+    line_format json

--- a/etc/docker/web22/fluent-bit/parsers.conf
+++ b/etc/docker/web22/fluent-bit/parsers.conf
@@ -1,0 +1,10 @@
+# Parses DW::AccessLog lines (one JSON object per line). The `ts` field is
+# always ISO8601 with milliseconds + Z (e.g. 2026-05-24T12:34:56.789Z), built
+# by AccessLog.pm as strftime('%Y-%m-%dT%H:%M:%S') . sprintf('.%03dZ', ...),
+# so Time_Format below always matches.
+[PARSER]
+    Name        dw_access_json
+    Format      json
+    Time_Key    ts
+    Time_Format %Y-%m-%dT%H:%M:%S.%LZ
+    Time_Keep   On

--- a/etc/docker/web22/fluent-bit/stable.conf
+++ b/etc/docker/web22/fluent-bit/stable.conf
@@ -1,0 +1,24 @@
+[SERVICE]
+    Flush      5
+    Daemon     Off
+    Log_Level  info
+
+[INPUT]
+    Name             tail
+    Alias            error_tail
+    Path             /var/log/starman/error.log
+    Tag              error
+    Read_from_Head   true
+    Refresh_Interval 5
+
+[OUTPUT]
+    Name        loki
+    Match       error
+    Host        logs-prod-042.grafana.net
+    Port        443
+    tls         On
+    tls.verify  On
+    Http_User   ${LOKI_USER}
+    Http_Passwd ${LOKI_PASSWORD}
+    Labels      source=dreamwidth, service=${DW_LOKI_SERVICE}, stream=error
+    line_format key_value


### PR DESCRIPTION
Adds a Fluent Bit `log_router` sidecar (`essential: false`) to the three web22 ECS task defs (web-canary, web-shop, web-unauthenticated). It tails `/var/log/starman/{error,access}.log` off a new ephemeral `log-share` volume and ships to Grafana Cloud Loki, reusing the worker Loki endpoint, SSM secrets, and execution-role access. Error logs ship for all three services; access logs for web-canary only. The per-service difference and the shop-vs-unauthenticated split (shared `/etc-stable`) are handled by EFS-delivered Fluent Bit configs plus a `DW_LOKI_SERVICE` env var used as the Loki `service` label, with an `error`/`access` `stream` label. The web container's `awslogs` `logConfiguration` is removed (Loki-only).

The sidecar runs the stock `aws-for-fluent-bit` image as a plain file-tailing sidecar via an `entryPoint`/`command` override (`fluent-bit -c /dw/etc/fluent-bit/web.conf`), not FireLens. Fluent Bit configs live under `etc/docker/web22/fluent-bit/` as source of truth and are copied onto EFS operationally (`canary.conf` → `/etc-canary/fluent-bit/web.conf`, `stable.conf` → `/etc-stable/fluent-bit/web.conf`, plus `parsers.conf` on canary for the access-log JSON parser). No Terraform, no application code, and no CI generator changes — the web task defs are hand-maintained and `ignore_changes = [task_definition]`.

Validated locally: both configs pass `fluent-bit --dry-run`, and a stdout smoke test confirmed error lines ship raw while access lines parse into structured JSON. Two things only verifiable on AWS — the `entryPoint` override launching against the private `dreamwidth-fluent-bit:3` image, and `${DW_LOKI_SERVICE}` expanding to a real Loki label — are covered by deploying web-canary first; a FireLens fallback is documented if the plain-sidecar launch fails.

CODE TOUR: Dreamwidth's web servers now send their logs to our Grafana dashboards instead of AWS CloudWatch, matching how the background workers already report. This makes it easier to search and graph web errors and (for the canary server) per-request access logs in one place.
