### PR TITLE
Add per-request metrics (volume + latency) via DW::Stats

### DIFF
--- a/cgi-bin/DW/Stats.pm
+++ b/cgi-bin/DW/Stats.pm
@@ -70,4 +70,21 @@ sub gauge {
     $sock->send("$metric:$gauge|g$tags");
 }
 
+# Usage: DW::Stats::timing( 'my.metric', $value_ms, $tags, $sample_rate )
+#
+# Metric must be a string. $value_ms must be a number (milliseconds). $tags must be
+# an arrayref or undef. $sample_rate must be undef or a number 0..1.
+sub timing {
+    return unless $sock;
+
+    my ( $metric, $value, $tags, $sample_rate ) = @_;
+    return unless defined $value;
+
+    if ( !defined $sample_rate || rand() < $sample_rate ) {
+        $sample_rate = defined $sample_rate ? "|\@$sample_rate" : "";
+        $tags = ref $tags eq 'ARRAY' ? '|#' . join( ',', @$tags ) : '';
+        $sock->send("$metric:$value|ms$sample_rate$tags");
+    }
+}
+
 1;

--- a/cgi-bin/Plack/Middleware/DW/AccessLog.pm
+++ b/cgi-bin/Plack/Middleware/DW/AccessLog.pm
@@ -27,6 +27,8 @@ use LJ::JSON;
 use POSIX qw( strftime );
 use Time::HiRes qw( gettimeofday tv_interval );
 
+use DW::Stats;
+
 sub prepare_app {
     my $self = shift;
 
@@ -63,7 +65,16 @@ sub call {
 sub _log {
     my ( $self, $env, $t0, $res ) = @_;
 
-    my $duration = tv_interval($t0) * 1000;    # milliseconds
+    my $duration    = tv_interval($t0) * 1000;            # milliseconds
+    my $duration_ms = sprintf( '%.1f', $duration ) + 0;
+
+    # Per-request metrics for Grafana (volume counter + latency timing). No-op when
+    # %LJ::STATS is unset (dev container, tests), so no behavior change locally.
+    # Note: for streaming/code-ref responses _log runs at time-to-first-byte, so
+    # duration_ms reflects that rather than full body-stream time.
+    my $tags = $self->_request_tags( $env, $res->[0] );
+    DW::Stats::increment( 'dw.request', 1, $tags );
+    DW::Stats::timing( 'dw.request.duration_ms', $duration_ms, $tags );
 
     # Content-Length from the response headers (may be undef for streaming)
     my $bytes;
@@ -83,7 +94,7 @@ sub _log {
         method      => $env->{REQUEST_METHOD},
         path        => $env->{PATH_INFO} || '/',
         status      => $res->[0],
-        duration_ms => sprintf( '%.1f', $duration ) + 0,
+        duration_ms => $duration_ms,
     );
 
     # Optional fields — omit rather than logging placeholder values
@@ -100,6 +111,20 @@ sub _log {
     else {
         $env->{'psgi.errors'}->print($line);
     }
+}
+
+# Build the DogStatsD tag arrayref for a request from the PSGI env and final HTTP
+# status. Reads the auth / rate-limit hints stashed in the env by downstream
+# middleware (DW::RateLimit), defaulting for requests that never reached them
+# (static files, redirects, early exits): auth -> anon, ratelimit -> skipped.
+sub _request_tags {
+    my ( $self, $env, $status ) = @_;
+    return [
+        'auth:' .      ( $env->{'dw.stats.auth'}      // 'anon' ),
+        'ratelimit:' . ( $env->{'dw.stats.ratelimit'} // 'skipped' ),
+        'status:' . $status,
+        'method:' . ( $env->{REQUEST_METHOD} // 'GET' ),
+    ];
 }
 
 1;

--- a/cgi-bin/Plack/Middleware/DW/RateLimit.pm
+++ b/cgi-bin/Plack/Middleware/DW/RateLimit.pm
@@ -31,11 +31,16 @@ sub call {
     my $remote = LJ::get_remote();
     my $ip     = LJ::get_remote_ip();
 
+    # Stash the auth state for the per-request metrics tags (read by DW::AccessLog).
+    $env->{'dw.stats.auth'} = $remote ? 'user' : 'anon';
+
     # Internal infrastructure (e.g. load-balancer health checks) connects without a
     # trusted X-Forwarded-For, so its resolved IP is private. Skip rate limiting for
     # those entirely, regardless of auth state.
-    return $self->app->($env)
-        if $ip && DW::RateLimit->ip_is_excluded($ip);
+    if ( $ip && DW::RateLimit->ip_is_excluded($ip) ) {
+        $env->{'dw.stats.ratelimit'} = 'excluded';
+        return $self->app->($env);
+    }
 
     # Get the appropriate rate limit based on whether user is logged in
     my $limit;
@@ -52,6 +57,8 @@ sub call {
             userid => $remote ? $remote->userid : undef,
             ip     => $remote ? undef           : $ip
         );
+
+        $env->{'dw.stats.ratelimit'} = $result->{exceeded} ? 'blocked' : 'allowed';
 
         if ( $result->{exceeded} ) {
             my $retry_after = $result->{time_remaining};

--- a/t/access-log.t
+++ b/t/access-log.t
@@ -1,0 +1,98 @@
+#!/usr/bin/perl
+#
+# Plack::Middleware::DW::AccessLog tests
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+use Plack::Middleware::DW::AccessLog;
+
+my $mw = Plack::Middleware::DW::AccessLog->new;
+
+# Full hints from downstream middleware produce all four tags, in order.
+is_deeply(
+    $mw->_request_tags(
+        {
+            'dw.stats.auth'      => 'user',
+            'dw.stats.ratelimit' => 'blocked',
+            REQUEST_METHOD       => 'POST',
+        },
+        429
+    ),
+    [ 'auth:user', 'ratelimit:blocked', 'status:429', 'method:POST' ],
+    'full hints produce all four tags'
+);
+
+# Missing hints (request never reached Auth/RateLimit) fall back to defaults.
+is_deeply(
+    $mw->_request_tags( {}, 200 ),
+    [ 'auth:anon', 'ratelimit:skipped', 'status:200', 'method:GET' ],
+    'missing hints default to anon/skipped/GET'
+);
+
+# Partial hints: method present but no auth/ratelimit hints (defaults still apply).
+is_deeply(
+    $mw->_request_tags( { REQUEST_METHOD => 'DELETE' }, 204 ),
+    [ 'auth:anon', 'ratelimit:skipped', 'status:204', 'method:DELETE' ],
+    'partial env: method present but auth/ratelimit hints absent'
+);
+
+# Integration: call() through to _log emits a counter + a timing to the configured
+# DogStatsD socket, both carrying the request tags.
+use DW::Stats;
+use IO::Socket::INET;
+use IO::Select;
+
+my $server = IO::Socket::INET->new(
+    Proto     => 'udp',
+    LocalAddr => '127.0.0.1',
+    LocalPort => 0,
+) or die "cannot create udp listener: $!";
+my $select = IO::Select->new($server);
+
+sub recv_packet {
+    return undef unless $select->can_read(2);
+    my $data = '';
+    $server->recv( $data, 1024 );
+    return $data;
+}
+
+DW::Stats::setup( '127.0.0.1', $server->sockport );
+
+my $emit_mw = Plack::Middleware::DW::AccessLog->new;
+$emit_mw->app( sub { [ 200, [ 'Content-Type' => 'text/plain' ], ['ok'] ] } );
+
+open my $errfh, '>', \my $errbuf or die "cannot open in-memory errors handle: $!";
+my %env = (
+    REQUEST_METHOD       => 'GET',
+    PATH_INFO            => '/',
+    'dw.stats.auth'      => 'anon',
+    'dw.stats.ratelimit' => 'allowed',
+    'psgi.errors'        => $errfh,
+);
+$emit_mw->call( \%env );
+
+# Two packets, order preserved on a single loopback socket: counter then timing.
+is(
+    recv_packet(),
+    'dw.request:1|c|#auth:anon,ratelimit:allowed,status:200,method:GET',
+    'call() emits the dw.request counter with tags'
+);
+like(
+    recv_packet(),
+    qr{^dw\.request\.duration_ms:[0-9.]+\|ms\|#auth:anon,ratelimit:allowed,status:200,method:GET$},
+    'call() emits the dw.request.duration_ms timing with tags'
+);

--- a/t/rate-limit.t
+++ b/t/rate-limit.t
@@ -14,7 +14,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 105;
+use Test::More tests => 111;
 use Test::MockTime qw(set_fixed_time restore_time);
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
@@ -282,3 +282,65 @@ LJ::Test::with_fake_memcache {
     ok( DW::RateLimit->ip_is_excluded("8.8.8.8"),   "override: 8.8.8.8 excluded" );
     ok( !DW::RateLimit->ip_is_excluded("10.1.2.3"), "override: default range no longer applies" );
 }
+
+# Test that the rate-limit middleware stashes auth + outcome hints in the PSGI env
+# for the request-metrics tags.
+LJ::Test::with_fake_memcache {
+    require Plack::Middleware::DW::RateLimit;
+
+    my $build_mw = sub {
+        my $mw = Plack::Middleware::DW::RateLimit->new;
+        $mw->app( sub { [ 200, [], ['ok'] ] } );
+        return $mw;
+    };
+
+    no warnings 'redefine', 'once';
+
+    # Anonymous request from an internal IP -> excluded; auth anon; limiter skipped.
+    {
+        local *LJ::get_remote    = sub { undef };
+        local *LJ::get_remote_ip = sub { '10.0.0.5' };
+        my %env;
+        $build_mw->()->call( \%env );
+        is( $env{'dw.stats.auth'},      'anon',     'excluded: auth tagged anon' );
+        is( $env{'dw.stats.ratelimit'}, 'excluded', 'internal IP tagged excluded' );
+    }
+
+    # Anonymous request from a public IP, under the limit -> allowed.
+    # reset() before checking so any earlier call in this block doesn't consume
+    # a token and make the "allowed" assertion flaky.
+    {
+        local *LJ::get_remote    = sub { undef };
+        local *LJ::get_remote_ip = sub { '203.0.113.7' };
+        local $LJ::RATE_LIMITS{anonymous_requests} = { rate => '5/60s' };
+        DW::RateLimit->get( 'anonymous_requests', rate => '5/60s' )->reset( ip => '203.0.113.7' );
+        my %env;
+        $build_mw->()->call( \%env );
+        is( $env{'dw.stats.ratelimit'}, 'allowed', 'public IP under limit tagged allowed' );
+    }
+
+    # Anonymous request from a public IP, over the limit -> blocked + 429.
+    {
+        local *LJ::get_remote    = sub { undef };
+        local *LJ::get_remote_ip = sub { '203.0.113.8' };
+        local $LJ::RATE_LIMITS{anonymous_requests} = { rate => '1/60s' };
+        DW::RateLimit->get( 'anonymous_requests', rate => '1/60s' )->reset( ip => '203.0.113.8' );
+        my $mw = $build_mw->();
+        $mw->call( {} );    # first request consumes the single token
+        my %env2;
+        my $res = $mw->call( \%env2 );    # second request is blocked
+        is( $env2{'dw.stats.ratelimit'}, 'blocked', 'over limit tagged blocked' );
+        is( $res->[0],                   429,       'blocked request returns 429' );
+    }
+
+    # Authenticated request -> auth tagged user.
+    {
+        my $fake_user = bless { userid => 42 }, 'LJ::User';
+        local *LJ::get_remote    = sub { $fake_user };
+        local *LJ::get_remote_ip = sub { '203.0.113.9' };
+        local $LJ::RATE_LIMITS{authenticated_requests} = { rate => '5/60s' };
+        my %env;
+        $build_mw->()->call( \%env );
+        is( $env{'dw.stats.auth'}, 'user', 'authenticated request tagged user' );
+    }
+};

--- a/t/stats.t
+++ b/t/stats.t
@@ -1,0 +1,63 @@
+#!/usr/bin/perl
+#
+# DW::Stats tests
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+use DW::Stats;
+use IO::Socket::INET;
+use IO::Select;
+
+# Loopback UDP listener that DW::Stats will send to.
+my $server = IO::Socket::INET->new(
+    Proto     => 'udp',
+    LocalAddr => '127.0.0.1',
+    LocalPort => 0,
+) or die "cannot create udp listener: $!";
+my $select = IO::Select->new($server);
+
+# Receive one packet, or undef if nothing arrives within 2s (so a missing emit
+# fails the test instead of hanging it).
+sub recv_packet {
+    return undef unless $select->can_read(2);
+    my $data = '';
+    $server->recv( $data, 1024 );
+    return $data;
+}
+
+DW::Stats::setup( '127.0.0.1', $server->sockport );
+
+# Timing with tags.
+DW::Stats::timing( 'dw.request.duration_ms', 12.5, [ 'auth:anon', 'status:200' ] );
+is(
+    recv_packet(),
+    'dw.request.duration_ms:12.5|ms|#auth:anon,status:200',
+    'timing emits |ms type with tags'
+);
+
+# Timing without tags.
+DW::Stats::timing( 'dw.timer', 7 );
+is( recv_packet(), 'dw.timer:7|ms', 'timing emits |ms type without tags' );
+
+# Sample rate is serialized as |@rate before the tags.
+DW::Stats::timing( 'dw.sampled', 3, ['x:y'], 1 );
+is( recv_packet(), 'dw.sampled:3|ms|@1|#x:y', 'timing serializes sample rate' );
+
+# Undefined value emits nothing; a following emit confirms the undef one was skipped.
+DW::Stats::timing( 'dw.skipped', undef );
+DW::Stats::timing( 'dw.after',   1 );
+is( recv_packet(), 'dw.after:1|ms', 'timing with undef value emits nothing' );


### PR DESCRIPTION
Adds per-HTTP-request observability through the existing DogStatsD client (`DW::Stats`), emitting
two metrics so Grafana can show request volume, flow breakdown, and latency percentiles:

- `dw.request` — counter, +1 per request
- `dw.request.duration_ms` — timing (`|ms`), wall-clock latency

Both carry the same deliberately low-cardinality tag set: `auth` (anon|user), `ratelimit`
(excluded|allowed|blocked|skipped), `status` (full HTTP code), `method`. No path, user, or host
tags, so series count stays bounded (~hundreds, not unbounded).

Implementation:
- `DW::Stats` gains a `timing()` method mirroring `increment()`/`gauge()` (DogStatsD `|ms`,
  same no-op-when-unconfigured and tag/sample-rate serialization).
- `Plack::Middleware::DW::RateLimit::call` stashes the auth state and its decision in the PSGI
  `$env` (`dw.stats.auth`; `dw.stats.ratelimit` = `excluded` on the internal-IP skip path,
  `allowed`/`blocked` after the leaky-bucket check).
- `Plack::Middleware::DW::AccessLog` — which already runs once per request and measures duration —
  reads those hints via a pure, unit-tested `_request_tags($env, $status)` helper (defaulting to
  `anon`/`skipped` for requests that never reach the limiter, e.g. static files and redirects) and
  emits both metrics from `_log`. The rounded `$duration_ms` is shared with the JSON access log, so
  Loki and Grafana report the same value. For streaming/code-ref responses `_log` fires at
  time-to-first-byte (documented inline).

`DW::Stats` is a no-op when `%LJ::STATS` is unset (dev container, tests), so there is no behavior
change locally. The production receiver is Grafana Alloy's statsd receiver, which maps `|ms`
timings into histograms for percentiles. Tests use real loopback UDP sockets and drive the
middleware end-to-end (`t/stats.t`, `t/access-log.t`, additions to `t/rate-limit.t`).

CODE TOUR: This adds lightweight monitoring so the team can see, in our dashboards, how many
requests the site is handling and how fast they are — broken down by whether the visitor was
logged in, whether the request was rate-limited, the response code, and the HTTP method. It
deliberately avoids recording anything per-page or per-user, so it gives a useful big-picture view
without becoming noisy or expensive. There is no visible change for people using the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)