### PR TITLE
Rename request-latency metric to dw.request.duration_seconds

### DIFF
--- a/cgi-bin/Plack/Middleware/DW/AccessLog.pm
+++ b/cgi-bin/Plack/Middleware/DW/AccessLog.pm
@@ -71,10 +71,14 @@ sub _log {
     # Per-request metrics for Grafana (volume counter + latency timing). No-op when
     # %LJ::STATS is unset (dev container, tests), so no behavior change locally.
     # Note: for streaming/code-ref responses _log runs at time-to-first-byte, so
-    # duration_ms reflects that rather than full body-stream time.
+    # the latency captured reflects that rather than full body-stream time.
+    #
+    # We send the value in milliseconds (statsd "ms" timer type), but the Prometheus
+    # statsd_exporter converts "ms" timers to base-unit seconds -- so the metric is
+    # named dw.request.duration_seconds to match the unit it actually stores.
     my $tags = $self->_request_tags( $env, $res->[0] );
     DW::Stats::increment( 'dw.request', 1, $tags );
-    DW::Stats::timing( 'dw.request.duration_ms', $duration_ms, $tags );
+    DW::Stats::timing( 'dw.request.duration_seconds', $duration_ms, $tags );
 
     # Content-Length from the response headers (may be undef for streaming)
     my $bytes;

--- a/t/access-log.t
+++ b/t/access-log.t
@@ -93,6 +93,6 @@ is(
 );
 like(
     recv_packet(),
-    qr{^dw\.request\.duration_ms:[0-9.]+\|ms\|#auth:anon,ratelimit:allowed,status:200,method:GET$},
-    'call() emits the dw.request.duration_ms timing with tags'
+qr{^dw\.request\.duration_seconds:[0-9.]+\|ms\|#auth:anon,ratelimit:allowed,status:200,method:GET$},
+    'call() emits the dw.request.duration_seconds timing with tags'
 );

--- a/t/stats.t
+++ b/t/stats.t
@@ -42,10 +42,10 @@ sub recv_packet {
 DW::Stats::setup( '127.0.0.1', $server->sockport );
 
 # Timing with tags.
-DW::Stats::timing( 'dw.request.duration_ms', 12.5, [ 'auth:anon', 'status:200' ] );
+DW::Stats::timing( 'dw.request.duration_seconds', 12.5, [ 'auth:anon', 'status:200' ] );
 is(
     recv_packet(),
-    'dw.request.duration_ms:12.5|ms|#auth:anon,status:200',
+    'dw.request.duration_seconds:12.5|ms|#auth:anon,status:200',
     'timing emits |ms type with tags'
 );
 


### PR DESCRIPTION
The per-request latency metric added in #3550 was named `dw.request.duration_ms`, but the
Prometheus `statsd_exporter` (behind Grafana Alloy's statsd integration) converts `ms` timer
observations to base-unit **seconds** — so the stored series actually holds seconds, and the
`_ms` name (and a `ms` dashboard unit) misrepresents it by 1000× (observed avg ~0.42 = 420ms,
which as `ms` looked like an impossible 0.42ms).

This renames the emitted metric to `dw.request.duration_seconds`. We still send the value in
milliseconds with the statsd `ms` timer type (the correct statsd convention) — only the metric
*name* changes, so it matches the seconds the exporter stores and follows the Prometheus
`_seconds` naming convention. No emission/value change; `DW::Stats` is still a no-op when
`%LJ::STATS` is unset. Comment added documenting the conversion; `t/access-log.t` and `t/stats.t`
updated.

CODE TOUR: A monitoring metric we recently added for request timing was labelled in
milliseconds, but our metrics backend automatically stores timings in seconds — so the name was
off by a factor of 1000 and made the site look 1000× faster than it is. This just renames the
metric so its name matches the real unit (seconds); nothing about the site's behaviour changes.

Follow-up to #3550.
🤖 Generated with [Claude Code](https://claude.com/claude-code)