### PR TITLE
Ship access logs for web-shop and web-unauthenticated

### DIFF
--- a/etc/docker/web22/fluent-bit/README.md
+++ b/etc/docker/web22/fluent-bit/README.md
@@ -7,8 +7,13 @@ image — the operator copies them onto the per-class EFS roots:
 | Repo file     | EFS destination                       | Used by                       |
 |---------------|---------------------------------------|-------------------------------|
 | `canary.conf` | `/etc-canary/fluent-bit/web.conf`     | web-canary (error + access)   |
-| `parsers.conf`| `/etc-canary/fluent-bit/parsers.conf` | web-canary (access JSON parse)|
-| `stable.conf` | `/etc-stable/fluent-bit/web.conf`     | web-shop, web-unauthenticated (error only) |
+| `stable.conf` | `/etc-stable/fluent-bit/web.conf`     | web-shop, web-unauthenticated (error + access) |
+| `parsers.conf`| `/etc-canary/fluent-bit/parsers.conf` **and** `/etc-stable/fluent-bit/parsers.conf` | all of the above (access JSON parse) |
+
+Both `web.conf` variants tail `error.log` + `access.log`, so `parsers.conf` must be
+present on **both** EFS roots. After updating a conf on EFS, restart (force a new
+deployment of) the affected services — the sidecar reads its config only at startup
+(no hot reload configured).
 
 Inside the container the `dw-config` EFS volume is mounted at `/dw/etc`, so the
 sidecar runs `fluent-bit -c /dw/etc/fluent-bit/web.conf`.

--- a/etc/docker/web22/fluent-bit/stable.conf
+++ b/etc/docker/web22/fluent-bit/stable.conf
@@ -1,13 +1,23 @@
 [SERVICE]
-    Flush      5
-    Daemon     Off
-    Log_Level  info
+    Flush        5
+    Daemon       Off
+    Log_Level    info
+    Parsers_File /dw/etc/fluent-bit/parsers.conf
 
 [INPUT]
     Name             tail
     Alias            error_tail
     Path             /var/log/starman/error.log
     Tag              error
+    Read_from_Head   true
+    Refresh_Interval 5
+
+[INPUT]
+    Name             tail
+    Alias            access_tail
+    Path             /var/log/starman/access.log
+    Tag              access
+    Parser           dw_access_json
     Read_from_Head   true
     Refresh_Interval 5
 
@@ -22,3 +32,15 @@
     Http_Passwd ${LOKI_PASSWORD}
     Labels      source=dreamwidth, service=${DW_LOKI_SERVICE}, stream=error
     line_format key_value
+
+[OUTPUT]
+    Name        loki
+    Match       access
+    Host        logs-prod-042.grafana.net
+    Port        443
+    tls         On
+    tls.verify  On
+    Http_User   ${LOKI_USER}
+    Http_Passwd ${LOKI_PASSWORD}
+    Labels      source=dreamwidth, service=${DW_LOKI_SERVICE}, stream=access
+    line_format json


### PR DESCRIPTION
`stable.conf` (the Fluent Bit sidecar config shared by `web-shop` and `web-unauthenticated`)
shipped only the `error` stream. This adds the `access` tail input, the `access` Loki output, and
the `Parsers_File` reference — making it tail `/var/log/starman/access.log` and ship it as
`stream=access`. The result is byte-identical to the already-in-production `canary.conf`. The web
containers already write `access.log` (same `startup-prod.sh` + read-write `log-share` mount as
canary), so **no task-definition change is needed**. `web-stable` is intentionally left alone (it
has no `log_router` sidecar).

**Operator steps to deploy** (the configs are delivered via EFS, not the image, so merging this
alone changes nothing):
1. Copy `stable.conf` → `/etc-stable/fluent-bit/web.conf` on the `dw-config` EFS.
2. Copy `parsers.conf` → `/etc-stable/fluent-bit/parsers.conf` on EFS (newly required for the
   `dw_access_json` parser on the stable root).
3. Force a new deployment of `web-shop` and `web-unauthenticated` (the sidecar reads its config
   only at startup — no hot reload).
4. Verify in Loki: `{service_name=~"web-shop|web-unauthenticated", stream="access"}`.

Heads up on volume/cost: this turns on the access stream for the high-traffic unauthenticated tier
(~200+ req/s). Rough estimate ~$60/month of additional Loki ingest+30-day-retention at current
traffic; shop is small. Intent is to run it ~a day, see how the logs look, then optimize (drop
health checks / static assets / sample) at the Fluent Bit layer.

CODE TOUR: This turns on detailed web request logging for the shop and logged-out web tiers (the
logged-in "canary" tier already had it). It lets the team see real traffic in our log dashboards
for a day to understand what's there before deciding what to trim.

Fixes nothing / follow-up to #3548.
🤖 Generated with [Claude Code](https://claude.com/claude-code)