### PR TITLE
add .module-customtext ul to styling for module lists on abstractia

### DIFF
--- a/styles/abstractia/layout.s2
+++ b/styles/abstractia/layout.s2
@@ -1045,7 +1045,8 @@ q {
 .module-tags_list ul,
 .module-tags_multilevel ul,
 .module-pagesummary ul,
-.module-credit ul {
+.module-credit ul,
+.module-customtext ul {
     padding-left: 1.15em;
 }
 .module-tags_cloud ul {


### PR DESCRIPTION
CODE TOUR: Unordered lists in the body of a customtext module should now get the expected left-hand padding.

Closes #3477.