### PR TITLE
Emit per-task lifecycle stats from DW::TaskQueue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Code is edited on the host, but **all commands must be run inside the devcontain
 Build and start the devcontainer from the repo root:
 
 ```bash
-npx devcontainer up --workspace-folder .
+npx @devcontainers/cli up --workspace-folder .
 ```
 
 Find the running container ID for your workspace:
@@ -77,7 +77,7 @@ Each worktree is an isolated git worktree with its own devcontainer, so many ses
 **Start a devcontainer for the worktree:**
 
 ```bash
-npx devcontainer up --workspace-folder <worktree-path>
+npx @devcontainers/cli up --workspace-folder <worktree-path>
 ```
 
 This works because `devcontainer.json` uses `workspaceMount` to always mount at `/workspaces/dreamwidth` (matching `$LJHOME`) regardless of the host folder name, and each worktree gets its own MySQL volume (`dreamwidth-mysql-<foldername>`).

--- a/cgi-bin/DW/TaskQueue.pm
+++ b/cgi-bin/DW/TaskQueue.pm
@@ -219,7 +219,7 @@ sub start_work {
             if ($@) {
                 DW::Stats::increment( 'dw.task.processed', 1,
                     [ "task_class:$class", 'outcome:died' ] );
-                DW::Stats::timing( 'dw.task.work_time', $work_ms,
+                DW::Stats::timing( 'dw.task.duration_seconds', $work_ms,
                     [ "task_class:$class", 'outcome:died' ] );
                 die;
             }
@@ -230,7 +230,7 @@ sub start_work {
             if ($abort) {
                 DW::Stats::increment( 'dw.task.processed', 1,
                     [ "task_class:$class", 'outcome:timeout' ] );
-                DW::Stats::timing( 'dw.task.work_time', $work_ms,
+                DW::Stats::timing( 'dw.task.duration_seconds', $work_ms,
                     [ "task_class:$class", 'outcome:timeout' ] );
                 return;
             }
@@ -280,9 +280,15 @@ sub start_work {
 
             # Per-job stats, tagged by result state so a slow/failing class shows
             # up on its own series and failures don't skew the success timing.
+            #
+            # The timing VALUE is milliseconds (statsd "ms" type), but the
+            # Prometheus statsd_exporter converts "ms" timers to base-unit
+            # seconds -- so the metric is named *_seconds to match what it
+            # actually stores. (Same convention as dw.request.duration_seconds
+            # in Plack::Middleware::DW::AccessLog.)
             my @stat_tags = ( "task_class:$class", "outcome:$outcome" );
             DW::Stats::increment( 'dw.task.processed', 1, \@stat_tags );
-            DW::Stats::timing( 'dw.task.work_time', $work_ms, \@stat_tags );
+            DW::Stats::timing( 'dw.task.duration_seconds', $work_ms, \@stat_tags );
         }
 
         $log->debug(

--- a/cgi-bin/DW/TaskQueue.pm
+++ b/cgi-bin/DW/TaskQueue.pm
@@ -18,6 +18,7 @@ package DW::TaskQueue;
 
 use strict;
 use v5.10;
+use Time::HiRes ();
 use Log::Log4perl;
 my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
@@ -184,6 +185,8 @@ sub start_work {
             )
         );
 
+        DW::Stats::increment( 'dw.task.received', scalar(@$messages), ["task_class:$class"] );
+
         my ( @completed,       @failed );
         my ( $work_start_time, $work_end_time );
         foreach my $message_pair (@$messages) {
@@ -195,6 +198,7 @@ sub start_work {
                 if $local_start_time < $work_start_time || !defined $work_start_time;
 
             my ( $res, $abort );
+            my $job_start = Time::HiRes::time();
             eval {
                 local $SIG{ALRM} = sub {
                     $log->error(
@@ -209,12 +213,27 @@ sub start_work {
                 $res = $message->work($handle);
             };
             alarm 0;
-            die if $@;    # Reraise if the work call died.
+            my $work_ms = ( Time::HiRes::time() - $job_start ) * 1000;
+
+            # The work call died: record it as its own result state, then reraise.
+            if ($@) {
+                DW::Stats::increment( 'dw.task.processed', 1,
+                    [ "task_class:$class", 'outcome:died' ] );
+                DW::Stats::timing( 'dw.task.work_time', $work_ms,
+                    [ "task_class:$class", 'outcome:died' ] );
+                die;
+            }
 
             # Clear out MDC so we don't continue to log with whatever the worker might
             # have put into context
             Log::Log4perl::MDC->remove;
-            return if $abort;
+            if ($abort) {
+                DW::Stats::increment( 'dw.task.processed', 1,
+                    [ "task_class:$class", 'outcome:timeout' ] );
+                DW::Stats::timing( 'dw.task.work_time', $work_ms,
+                    [ "task_class:$class", 'outcome:timeout' ] );
+                return;
+            }
 
             $messages_done++;
 
@@ -223,8 +242,10 @@ sub start_work {
             $work_end_time = $local_end_time
                 if $local_end_time > $work_end_time || !defined $work_end_time;
 
+            my $outcome;
             if ( $res == DW::Task::COMPLETED ) {
                 push @completed, $handle;
+                $outcome = 'completed';
 
                 # Release dedup key on successful completion
                 if ( my $uniqkey = $message->uniqkey ) {
@@ -242,10 +263,12 @@ sub start_work {
                         )
                     );
                     push @completed, $handle;
+                    $outcome = 'failed_abandoned';
                 }
                 else {
                     $log->warn( sprintf( '[%s] Message "%s" failed', $class, $handle ) );
                     push @failed, $handle;
+                    $outcome = 'failed_retry';
                 }
 
                 # Release dedup key on failure so the task can be
@@ -254,6 +277,12 @@ sub start_work {
                     DW::TaskQueue::Dedup->release_unique( ref($message), $uniqkey );
                 }
             }
+
+            # Per-job stats, tagged by result state so a slow/failing class shows
+            # up on its own series and failures don't skew the success timing.
+            my @stat_tags = ( "task_class:$class", "outcome:$outcome" );
+            DW::Stats::increment( 'dw.task.processed', 1, \@stat_tags );
+            DW::Stats::timing( 'dw.task.work_time', $work_ms, \@stat_tags );
         }
 
         $log->debug(


### PR DESCRIPTION
Adds job-lifecycle metrics to the central execution loop in `DW::TaskQueue::start_work`, so every `DW::Task` subclass is instrumented at once with no per-task code:

- `dw.task.received` (counter) — messages pulled from the queue; tag `task_class`.
- `dw.task.processed` (counter) — one per job; tags `task_class`, `outcome`.
- `dw.task.duration_seconds` (timing) — per-job duration; tags `task_class`, `outcome`.

`outcome` is one of `completed`, `failed_retry`, `failed_abandoned` (the max-retries give-up branch that pushes a failed message onto `@completed` to dodge the DLQ), `timeout` (work exceeded `message_timeout_secs`), or `died` (`work()` threw). The `timeout` and `died` states were previously invisible to metrics. The timing is tagged by `outcome` so failed/timed-out/died jobs form their own series and never skew success latency.

Notes:
- Timing uses `Time::HiRes` for sub-second resolution. The emitted **value is milliseconds** (statsd `ms` type), but the Prometheus statsd_exporter stores `ms` timers as base-unit **seconds**, so the metric is named `…_seconds` to match what it stores — same convention as `dw.request.duration_seconds` (#3551).
- All stat emission happens *before* the existing `die`/`return`, so control flow is unchanged. `DW::Stats` calls are no-ops until `DW::Stats::setup` runs, matching the existing pattern in `DW::Task`.

Also fixes a stale `npx devcontainer up` → `npx @devcontainers/cli up` in CLAUDE.md (the former errors with "could not determine executable to run").

CODE TOUR: Dreamwidth runs lots of background jobs — crossposting, imports, feed fetching, sending email, and more. Until now there was no consistent way to see, across all of them, how many jobs each worker received, how many succeeded or failed, and how long they took. This adds that bookkeeping in one shared place so every kind of job is counted automatically — including jobs that time out, crash, or get given up on after too many retries, which were invisible before. Timings are kept separate by result, so a burst of failures can't make the "successful" numbers look slow. It's metrics only; it doesn't change how any job runs.