### PR TITLE
Mark beta-superseded inbox BML pages as deprecated

### DIFF
--- a/htdocs/inbox/compose.bml
+++ b/htdocs/inbox/compose.bml
@@ -1,4 +1,9 @@
 <?_c
+# DEPRECATED: This page has been migrated to the new Template Toolkit inbox
+# (DW::Controller::Inbox), served at /inbox/new/compose. It is kept only while
+# the new inbox is in beta and will be removed once the new inbox leaves beta.
+_c?>
+<?_c
 # This code was forked from the LiveJournal project owned and operated
 # by Live Journal, Inc. The code has been modified and expanded by
 # Dreamwidth Studios, LLC. These files were originally licensed under

--- a/htdocs/inbox/index.bml
+++ b/htdocs/inbox/index.bml
@@ -1,4 +1,9 @@
 <?_c
+# DEPRECATED: This page has been migrated to the new Template Toolkit inbox
+# (DW::Controller::Inbox), served at /inbox/new. It is kept only while the new
+# inbox is in beta and will be removed once the new inbox leaves beta.
+_c?>
+<?_c
 # This code was forked from the LiveJournal project owned and operated
 # by Live Journal, Inc. The code has been modified and expanded by
 # Dreamwidth Studios, LLC. These files were originally licensed under

--- a/htdocs/inbox/markspam.bml
+++ b/htdocs/inbox/markspam.bml
@@ -1,4 +1,9 @@
 <?_c
+# DEPRECATED: This page has been migrated to the new Template Toolkit inbox
+# (DW::Controller::Inbox), served at /inbox/new/markspam. It is kept only while
+# the new inbox is in beta and will be removed once the new inbox leaves beta.
+_c?>
+<?_c
 # This code was forked from the LiveJournal project owned and operated
 # by Live Journal, Inc. The code has been modified and expanded by
 # Dreamwidth Studios, LLC. These files were originally licensed under


### PR DESCRIPTION
The new Template Toolkit inbox (`DW::Controller::Inbox`, served under `/inbox/new/*`) already reimplements the legacy `/inbox/{index,compose,markspam}.bml` pages. Rather than re-migrate them (which would collide with the existing `views/inbox/markspam.tt` and duplicate the controller logic), this adds a `<?_c … _c?>` deprecation note to the top of each legacy BML pointing at its new route. The files keep serving production until the new inbox leaves beta, at which point they get deleted.

CODE TOUR: The inbox is mid-rewrite — a newer version lives at `/inbox/new` while the classic one still runs the site. This just leaves a clear note at the top of the three old inbox page files saying "this has moved to the new inbox, and this file goes away once the new inbox is no longer in beta," so nobody mistakes them for live code to edit. No behavior changes.