### PR TITLE
Convert /manage/subscriptions/filters from BML to Template Toolkit

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -4211,3 +4211,5 @@ general /mobile/login.bml.login.header
 general /mobile/login.bml.login.invalid_username
 general /mobile/login.bml.login.ip_banned
 general /mobile/login.bml.page.title
+
+general /manage/subscriptions/filters.bml.accessfilters

--- a/cgi-bin/DW/Controller/Manage/Subscriptions/Filters.pm
+++ b/cgi-bin/DW/Controller/Manage/Subscriptions/Filters.pm
@@ -1,0 +1,41 @@
+#!/usr/bin/perl
+#
+# DW::Controller::Manage::Subscriptions::Filters
+#
+# Page to manage your subscription filters. The page is mostly a static
+# shell driven by js/subfilters.js, which talks to the __rpc_contentfilters
+# endpoint over AJAX.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2009-2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::Controller::Manage::Subscriptions::Filters;
+
+use strict;
+
+use DW::Controller;
+use DW::Routing;
+use DW::Template;
+
+DW::Routing->register_string( "/manage/subscriptions/filters", \&filters_handler, app => 1 );
+
+sub filters_handler {
+    my ( $ok, $rv ) = controller( anonymous => 0 );
+    return $rv unless $ok;
+
+    # custom CSS/JS for the filter-editing interface
+    LJ::set_active_resource_group('jquery');
+    LJ::need_res( { priority => $LJ::OLD_RES_PRIORITY }, 'stc/subfilters.css' );
+    LJ::need_res( { group => 'jquery' }, 'js/subfilters.js' );
+
+    return DW::Template->render_template( 'manage/subscriptions/filters.tt', $rv );
+}
+
+1;

--- a/htdocs/manage/subscriptions/filters.bml.text
+++ b/htdocs/manage/subscriptions/filters.bml.text
@@ -1,3 +1,0 @@
-;; -*- coding: utf-8 -*-
-.accessfilters=You are currently managing your subscription filters.  <a [[aopts]]>Manage your access filters?</a>
-

--- a/views/manage/subscriptions/filters.tt
+++ b/views/manage/subscriptions/filters.tt
@@ -1,47 +1,27 @@
-<?_c
-#
-# manage/subscriptions/filters.bml
-#
-# Page to manage your subscription filters.
-#
-# Authors:
-#      Mark Smith <mark@dreamwidth.org>
-#
-# Copyright (c) 2009 by Dreamwidth Studios, LLC.
-#
-# This program is free software; you may redistribute it and/or modify it under
-# the same terms as Perl itself. For a copy of the license, please reference
-# 'perldoc perlartistic' or 'perldoc perlgpl'.
-#
-_c?><?page
-body<=
-<?_code
-{
-    use strict;
-    use vars qw/ %GET %POST $title $windowtitle $headextra @errors @warnings /;
+[%# manage/subscriptions/filters.tt
+  #
+  # Page to manage your subscription filters. Mostly a static shell driven by
+  # js/subfilters.js (resources are loaded by the controller).
+  #
+  # Authors:
+  #     Mark Smith <mark@dreamwidth.org>
+  #
+  # Copyright (c) 2009-2026 by Dreamwidth Studios, LLC.
+  #
+  # This program is free software; you may redistribute it and/or modify it under
+  # the same terms as Perl itself.  For a copy of the license, please reference
+  # 'perldoc perlartistic' or 'perldoc perlgpl'.
+  #
+%]
+[%- sections.title = '.title' | ml -%]
 
-    # this is how you include custom CSS/JS/etc
-    LJ::set_active_resource_group( 'jquery' );
-    LJ::need_res( { priority => $LJ::OLD_RES_PRIORITY }, qw# stc/subfilters.css # );
-    LJ::need_res( { group => 'jquery' }, qw# js/subfilters.js # );
+[%# subfilters.js reads these globals to build its __rpc_contentfilters calls %]
+<script type="text/javascript">
+DW.currentUser = '[% remote.user %]';
+DW.userIsPaid = [% remote.is_paid ? 'true' : 'false' %];
+</script>
 
-    # for pages that require authentication
-    my $remote = LJ::get_remote();
-    return "<?needlogin?>" unless $remote;
-
-    # stick in some JS to set the current user
-    # FIXME: this should be done automatically as part of the templates!
-    my $ret = "<script type='text/javascript'>\n" .
-              "DW.currentUser = '" . $remote->user . "';\n" .
-              "DW.userIsPaid = " . ( $remote->is_paid ? 'true' : 'false' ) . ";\n" .
-              "</script>\n";
-
-    # redirect to managing access filters
-    $ret .= "<div class='highlight-box'>" . BML::ml( '.accessfilters', { aopts => "href='$LJ::SITEROOT/manage/circle/editfilters'" } ) . "</div>\n\n"; 
-
-    # and now the main page HTML
-    my $img = LJ::img( 'hourglass', '', { id => 'cf-hourglass' } );
-    $ret .= <<EOF;
+<div class='highlight-box'>[% '.accessfilters' | ml( aopts => "href='" _ site.root _ "/manage/circle/editfilters'" ) %]</div>
 
 <div id='cf-select'>
     <div id='cf-select-filter'>
@@ -51,7 +31,7 @@ body<=
         </select>
     </div>
     <div id='cf-save'>
-        $img
+        [% dw.img( 'hourglass', '', { id => 'cf-hourglass' } ) %]
         <span id='cf-unsaved'>Saving in N seconds...</span>
     </div>
     <div id='cf-make-new'>
@@ -64,7 +44,7 @@ body<=
 </div>
 
 <div id='cf-filtopts'>
-    <h4>Options for "<span id='cf-foname'>selected filter</span>"</h4> 
+    <h4>[% '.foptions' | ml %] "<span id='cf-foname'>selected filter</span>"</h4>
 
     <p><label for='cf-public'>Visibility:</label>
     <select id='cf-public'>
@@ -78,11 +58,9 @@ body<=
 </div>
 
 <div id='cf-intro'>
-    <p>Hello!</p>
-    <p>Welcome to the Dreamwidth Subscription Filters editing page.  If you have already created a filter,
-    you may select it in the dropdown above.</p>
-    <p>If this is your first time here, you should click the New button in the top right to make a new
-    subscription filter.</p>
+    <p>[% '.intro.hello' | ml %]</p>
+    <p>[% '.intro.welcome' | ml %]</p>
+    <p>[% '.intro.firsttime' | ml %]</p>
 </div>
 
 <div id='cf-edit'>
@@ -100,7 +78,7 @@ body<=
                 </select>
             </div>
         </div>
-    
+
         <div id='cf-in'>
             In filter:<br />
             <select id='cf-in-list' size='20' multiple></select><br />
@@ -114,13 +92,11 @@ body<=
         Options:<br />
         <div id='cf-opts-box'>
             <div id='cf-free-warning'>
-                Your account type does not permit the use of advanced subscription filters.  These options
-                are not active.  If you would like to use these options, please consider supporting the
-                site and upgrading your account.
+                [% '.freewarning' | ml %]
             </div>
-            Show only content that ...
+            [% '.opts.showonly' | ml %]
             <div id='cf-ac-box'>
-                ... is rated
+                [% '.opts.rated' | ml %]
                 <select id='cf-adultcontent'>
                     <option value='any'>anything (show all content)</option>
                     <option value='nonexplicit'>safe or non-explicit</option>
@@ -128,7 +104,7 @@ body<=
                 </select>
             </div>
             <div id='cf-pt-box'>
-                ... and the poster is
+                [% '.opts.poster' | ml %]
                 <select id='cf-postertype'>
                     <option value='any'>anybody</option>
                     <option value='moderator'>a moderator or maintainer</option>
@@ -136,18 +112,18 @@ body<=
                 </select>
             </div>
             <div id='cf-t-box'>
-                ... and the entry is tagged with
+                [% '.opts.tagged' | ml %]
                 <select id='cf-tagmode'>
                     <option value='any_of'>any</option>
                     <option value='all_of'>all</option>
                     <option value='none_of'>none</option>
                 </select>
-                of the selected tags:
-                <div id='cf-notagssel'>(no tags selected)</div>
+                [% '.opts.ofselected' | ml %]
+                <div id='cf-notagssel'>[% '.opts.notagssel' | ml %]</div>
                 <div id='cf-t-box3'>
                 </div>
-                Available tags (click to select):
-                <div id='cf-notagsavail'>(no tags available)</div>
+                [% '.opts.availabletags' | ml %]
+                <div id='cf-notagsavail'>[% '.opts.notagsavail' | ml %]</div>
                 <div id='cf-t-box2'>
                 </div>
             </div>
@@ -156,12 +132,3 @@ body<=
 
     <div style='clear: both;'></div>
 </div>
-
-EOF
-
-    return $ret;
-}
-_code?>
-<=body
-title=>Manage Subscription Filters
-page?>

--- a/views/manage/subscriptions/filters.tt.text
+++ b/views/manage/subscriptions/filters.tt.text
@@ -1,0 +1,30 @@
+;; -*- coding: utf-8 -*-
+.accessfilters=You are currently managing your subscription filters.  <a [[aopts]]>Manage your access filters?</a>
+
+.foptions=Options for
+
+.freewarning=Your account type does not permit the use of advanced subscription filters.  These options are not active.  If you would like to use these options, please consider supporting the site and upgrading your account.
+
+.intro.firsttime=If this is your first time here, you should click the New button in the top right to make a new subscription filter.
+
+.intro.hello=Hello!
+
+.intro.welcome=Welcome to the Dreamwidth Subscription Filters editing page.  If you have already created a filter, you may select it in the dropdown above.
+
+.opts.availabletags=Available tags (click to select):
+
+.opts.notagsavail=(no tags available)
+
+.opts.notagssel=(no tags selected)
+
+.opts.ofselected=of the selected tags:
+
+.opts.poster=... and the poster is
+
+.opts.rated=... is rated
+
+.opts.showonly=Show only content that ...
+
+.opts.tagged=... and the entry is tagged with
+
+.title=Manage Subscription Filters


### PR DESCRIPTION
Converts `/manage/subscriptions/filters` from BML to the `DW::Controller` + Template Toolkit architecture. This page is a mostly-static shell that `js/subfilters.js` drives over AJAX (`__rpc_contentfilters`), so the conversion is primarily structural rather than logic-heavy.

**Controller (`cgi-bin/DW/Controller/Manage/Subscriptions/Filters.pm`):**
- Registers `/manage/subscriptions/filters` via `register_string`, requires login (`controller( anonymous => 0 )`).
- Keeps resource loading in Perl so it can use `$LJ::OLD_RES_PRIORITY`: `LJ::set_active_resource_group('jquery')` + `LJ::need_res` for `stc/subfilters.css` and `js/subfilters.js`.

**Template (`views/manage/subscriptions/filters.tt`):**
- Reproduces the markup verbatim — every `cf-*` element id is preserved because `subfilters.js` hooks them by id.
- Emits the `DW.currentUser` / `DW.userIsPaid` globals the JS depends on, from `remote.user` / `remote.is_paid`.

**Strings:** prose (intro text, free-account warning, the filter-option explanatory phrases, the page title) is extracted into `views/manage/subscriptions/filters.tt.text` as ML keys; short control labels (Filter:/Delete/View/New/…) and dropdown option values are left hardcoded as they were in BML. The old `/manage/subscriptions/filters.bml.accessfilters` key is retired in `deadphrases.dat`.

Verified live under Starman as a logged-in user: HTTP 200, correct title, both resources loaded, all prose ML strings resolved, the `DW.currentUser`/`DW.userIsPaid` injection correct (confirmed `userIsPaid` flips to `true` after granting paid time), the access-filters link points to `/manage/circle/editfilters`, and all `cf-*` ids intact. `t/02-tidy.t` and `t/00-compile.t` pass.

CODE TOUR: The subscription-filters editor page was written in BML, the old format that mixes Perl and HTML in one file. This rebuilds it the modern way — page logic in one file, layout in another — with no visible change for anyone using the page; the interactive filter editor works exactly as before. Some of the on-page text is now translatable where it previously was not.
