### PR TITLE
Mark the legacy entry-post page and its image popup as deprecated

### DIFF
--- a/htdocs/imgupload.bml
+++ b/htdocs/imgupload.bml
@@ -1,4 +1,11 @@
 <?_c
+# DEPRECATED: This is the "Insert Image" popup for the legacy entry editor
+# (htdocs/update.bml and htdocs/editjournal.bml, via entry.js / InOb). The new
+# Template Toolkit entry editor (DW::Controller::Entry, /entry/new) does not use
+# it. It will be removed together with the legacy editor once the new entry
+# editor leaves beta.
+_c?>
+<?_c
 # This code was forked from the LiveJournal project owned and operated
 # by Live Journal, Inc. The code has been modified and expanded by
 # Dreamwidth Studios, LLC. These files were originally licensed under

--- a/htdocs/update.bml
+++ b/htdocs/update.bml
@@ -1,4 +1,10 @@
 <?_c
+# DEPRECATED: This entry-posting page has been superseded by the new Template
+# Toolkit entry editor (DW::Controller::Entry), served at /entry/new. It is kept
+# only while the new editor is in beta (gated by the "updatepage" beta) and will
+# be removed once the new editor leaves beta.
+_c?>
+<?_c
 # This code was forked from the LiveJournal project owned and operated
 # by Live Journal, Inc. The code has been modified and expanded by
 # Dreamwidth Studios, LLC. These files were originally licensed under


### PR DESCRIPTION
Adds a `DEPRECATED:` note to the top of `htdocs/update.bml` (the legacy post form) and `htdocs/imgupload.bml` (the "Insert Image" popup reachable only from the legacy editor's `entry.js`/`InOb` flow). The new Template Toolkit editor (`DW::Controller::Entry`, `/entry/new`) supersedes them for users in the `updatepage` beta, and neither is referenced by the modern flow. Comment-only; both pages keep working until the beta graduates. `editjournal.bml` is intentionally left alone — its entry-picker view is still live and linked from the nav, and only its per-entry edit form redirects to the new editor.

CODE TOUR: No user-facing change — these are just signposts in the code. We left notes on the old "post an entry" page and its image-insert popup saying they've been replaced by the new entry editor and can be removed once that editor is rolled out to everyone, so whoever does that cleanup later knows what's safe to delete.