### PR TITLE
Auto-load ML strings from files on demand; make texttool load non-destructive

### DIFF
--- a/bin/upgrading/texttool.pl
+++ b/bin/upgrading/texttool.pl
@@ -54,13 +54,9 @@ sub help {
 Where <command> is one of:
   load         Runs the following five commands in order:
     popstruct  Populate lang data from text[-local].dat into db
-    poptext    Populate text from en.dat, etc into database. This will also
-               delete any text items listed in deadphrases[-local].dat. If
-               texttool.pl is run on a production server ($LJ::IS_DEV_SERVER is
-               false), the text items will be dumped first (as if by dumptext)
-               for all languages except en and the local root language
-               ($LJ::DEFAULT_LANG or $LJ::LANGS[0]), but existing text files
-               will be appended, not overwritten.
+    poptext    Populate text from en.dat, etc into database. This only adds and
+               updates text items; it does NOT delete. To retire dead keys, run
+               the separate "deadphrases" command (below).
     copyfaq    If site is translating FAQ, copy FAQ data into trans area
     makeusable Setup internal indexes necessary after loading text
   dumptext     Dump lang text based on text[-local].dat information
@@ -70,6 +66,13 @@ Where <command> is one of:
   wipedb       Remove all language/text data from database.
   remove       takes two extra arguments: domain name and code, and removes
                that code and its text in all languages
+  deadphrases  Delete the text items listed in deadphrases[-local].dat from the
+               database. Intentionally NOT run by "load", so keys a migration
+               moved (e.g. foo.bml.text -> foo.tt.text) survive on hosts still
+               running the old code; run it explicitly once the new keys are live
+               everywhere. On a production server ($LJ::IS_DEV_SERVER false) all
+               languages except en and the local root language ($LJ::DEFAULT_LANG
+               or $LJ::LANGS[0]) are dumped first (as if by dumptext, appending).
 
 ';
 }
@@ -193,15 +196,16 @@ my $out   = sub {
 };
 
 my @good = qw(load popstruct poptext dumptext dumptextcvs wipedb
-    makeusable copyfaq remove);
+    makeusable copyfaq remove deadphrases);
 
 popstruct()    if $mode eq "popstruct"  or $mode eq "load";
 poptext(@ARGV) if $mode eq "poptext"    or $mode eq "load";
 copyfaq()      if $mode eq "copyfaq"    or $mode eq "load";
 makeusable()   if $mode eq "makeusable" or $mode eq "load";
 dumptext( 0, @ARGV ) if $mode =~ /^dumptext?$/;
-wipedb() if $mode eq "wipedb";
-remove(@ARGV) if $mode eq "remove" and scalar(@ARGV) == 2;
+wipedb()           if $mode eq "wipedb";
+remove(@ARGV)      if $mode eq "remove" and scalar(@ARGV) == 2;
+deadphrases(@ARGV) if $mode eq "deadphrases";
 help() unless grep { $mode eq $_ } @good;
 exit 0;
 
@@ -462,8 +466,19 @@ sub poptext {
         $out->( "added: $addcount", '-' );
     }
     $out->( "-", "done." );
+}
 
-    # dead phrase removal
+# Remove the text items listed in deadphrases[-local].dat from the database.
+# This is intentionally NOT part of 'load'/'poptext' (which now only add/update
+# text): when a migration moves keys (e.g. foo.bml.text -> foo.tt.text), the old
+# keys must survive on hosts still running the old code (stable/BML) until the new
+# code is everywhere. Run this explicitly once that's true to retire them.
+sub deadphrases {
+    my @langs = @_;
+    push @langs, ( keys %lang_code ) unless @langs;
+
+    # before removing on production, dump translated text (with append) so a
+    # mistaken/early deadphrase doesn't lose existing translations
     unless ($LJ::IS_DEV_SERVER) {
         my @trans = grep { $_ ne "en" && $_ ne $LJ::DEFAULT_LANG } @LJ::LANGS;
         if (@trans) {

--- a/cgi-bin/LJ/Lang.pm
+++ b/cgi-bin/LJ/Lang.pm
@@ -429,7 +429,13 @@ sub set_text {
     $dbh->do( "REPLACE INTO ml_latest (lnid, dmid, itid, txtid, chgtime, staleness) "
             . "VALUES ($lnid, $dmid, $itid, $txtid, NOW(), $staleness)" );
     return set_error( "Error inserting ml_latest: " . $dbh->errstr ) if $dbh->err;
-    LJ::MemCache::set( "ml.${lncode}.${dmid}.${itcode}", $text ) if defined $text;
+    if ( defined $text ) {
+        LJ::MemCache::set( "ml.${lncode}.${dmid}.${itcode}", $text );
+
+        # keep the in-process cache in step with memcache, else a worker that
+        # already cached this code as missing would keep serving the stale miss
+        $TXT_CACHE{"ml.${lncode}.${dmid}.${itcode}"} = $text;
+    }
 
     my $langids;
     {
@@ -447,6 +453,7 @@ sub set_text {
                 $langids .= "," if $langids;
                 $langids .= $cid + 0;
                 LJ::MemCache::delete("ml.$clid->{'lncode'}.${dmid}.${itcode}");
+                delete $TXT_CACHE{"ml.$clid->{'lncode'}.${dmid}.${itcode}"};
                 $rec->( $clid, $rec );
             }
         };
@@ -606,13 +613,40 @@ sub get_text {
 
     my $gen_mld     = LJ::Lang::get_dom('general');
     my $is_gen_dmid = defined $dmid ? $dmid == $gen_mld->{dmid} : 1;
-    my $text =
-        (
-        $LJ::IS_DEV_SERVER && $is_gen_dmid && ( $lang eq "en"
-            || $lang eq $LJ::DEFAULT_LANG )
-        )
-        ? $from_files->()
-        : $from_db->();
+    my $is_src_lang = ( $lang eq "en" || $lang eq $LJ::DEFAULT_LANG );
+
+    my $text;
+    if ( $LJ::IS_DEV_SERVER && $is_gen_dmid && $is_src_lang ) {
+
+        # dev server: read the source files directly (no DB writes) so edits to
+        # .text/.dat files show up immediately without a `texttool.pl load`.
+        $text = $from_files->();
+    }
+    else {
+        $text = $from_db->();
+
+        # production auto-load: general-domain strings live in .text/.dat files
+        # that ship with the code. If a string isn't in the DB yet, pull it from
+        # the file and persist it as the source language -- propagating to every
+        # language as an untranslated fallback (childrenlatest) -- so deploying
+        # the files is enough and no separate `texttool.pl load` step is needed.
+        # Best-effort: a failure here must never break rendering.
+        if ( $is_gen_dmid && !$LJ::IS_DEV_SERVER && LJ::Lang::is_missing_string($text) ) {
+            my $srcval = $from_files->();
+            unless ( LJ::Lang::is_missing_string($srcval) ) {
+
+                # the shipped .text/.dat files are the "en" root source (this is
+                # how `texttool.pl poptext` loads them); persisting under "en"
+                # with childrenlatest gives every other language a fallback row.
+                eval {
+                    LJ::Lang::set_text( $gen_mld->{dmid}, 'en', $code, $srcval,
+                        { childrenlatest => 1 } );
+                    1;
+                } or warn "ML auto-load failed for [$code]: $@";
+                $text = $srcval;
+            }
+        }
+    }
 
     if ( defined $vars && ref $vars eq 'HASH' ) {
         $text =~ s/\[\[\?([\w\-]+)\|(.+?)\]\]/resolve_plural($lang, $vars, $1, $2)/eg;

--- a/t/ml.t
+++ b/t/ml.t
@@ -1,0 +1,177 @@
+# t/ml.t
+#
+# Tests the basics of the multilang (ML) string system: LJ::Lang::set_text /
+# get_text / get_text_multi, the in-process + memcache caching, parent-language
+# fallback, and the production "auto-load strings from the source files on a DB
+# miss" behavior.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+my $gen  = eval { LJ::Lang::get_dom('general') };
+my $dmid = $gen ? $gen->{dmid} : undef;
+plan skip_all => "ML general domain not loaded in test DB" unless $dmid;
+
+my $fixture = "$ENV{LJHOME}/views/dev/t_ml_autoload.tt.text";
+my @cleanup;
+
+# clear the in-process + memcache copies of a code across every language
+sub flush_code {
+    my $code = shift;
+    my $lc   = lc $code;
+    LJ::MemCache::delete("ml.$_.$dmid.$lc") for ( 'en', @LJ::LANGS );
+}
+
+# force a real DB read of a code (bypassing %TXT_CACHE and memcache)
+sub db_value {
+    my ( $lang, $code ) = @_;
+    flush_code($code);
+    local $LJ::NO_ML_CACHE = 1;
+    return LJ::Lang::get_text_multi( $lang, $dmid, [$code] )->{$code};
+}
+
+# start each code from a clean slate
+sub fresh_code {
+    my $code = shift;
+    push @cleanup, $code;
+    eval { LJ::Lang::remove_text( $dmid, $code ); };
+    flush_code($code);
+    return $code;
+}
+
+# find a child language of en so we can exercise parent fallback
+my $child;
+{
+    my $en = LJ::Lang::get_lang('en');
+    if ($en) {
+        my $dbr = LJ::get_db_reader();
+        ($child) = $dbr->selectrow_array(
+            "SELECT lncode FROM ml_langs WHERE parentlnid = ? AND lncode <> 'en' LIMIT 1",
+            undef, $en->{lnid} );
+    }
+}
+diag( "child language for fallback tests: " . ( $child // "(none found)" ) );
+
+# ---------------------------------------------------------------------------
+# is_missing_string
+# ---------------------------------------------------------------------------
+ok( LJ::Lang::is_missing_string(''),                     "empty string is missing" );
+ok( LJ::Lang::is_missing_string('[missing string foo]'), "[missing ...] is missing" );
+ok( !LJ::Lang::is_missing_string('a real value'),        "a real value is not missing" );
+
+# ---------------------------------------------------------------------------
+# basic round trip: set_text -> get_text_multi (DB) -> get_text (prod)
+# ---------------------------------------------------------------------------
+{
+    my $code = fresh_code("zzz.mltest.basic");
+    ok( LJ::Lang::is_missing_string( db_value( 'en', $code ) ), "unset code is missing in the DB" );
+
+    ok( LJ::Lang::set_text( $dmid, 'en', $code, "Hello World", {} ), "set_text stores a string" );
+    is( db_value( 'en', $code ), "Hello World", "get_text_multi reads it back from the DB" );
+
+    local $LJ::IS_DEV_SERVER = 0;
+    is( LJ::Lang::get_text( 'en', $code, $dmid ),
+        "Hello World", "get_text (prod) returns the stored string" );
+}
+
+# ---------------------------------------------------------------------------
+# cache coherence: a set_text must clear a previously-cached miss
+# (this is what lets an auto-load be seen by a long-lived worker)
+# ---------------------------------------------------------------------------
+{
+    local $LJ::IS_DEV_SERVER = 0;
+    my $code = fresh_code("zzz.mltest.cache");
+
+    LJ::Lang::get_text( 'en', $code, $dmid );    # caches the empty miss
+    LJ::Lang::set_text( $dmid, 'en', $code, "Now Set", {} );
+    is( LJ::Lang::get_text( 'en', $code, $dmid ),
+        "Now Set", "set_text invalidates the cached miss (no stale empty)" );
+}
+
+# ---------------------------------------------------------------------------
+# parent/child fallback: setting en with childrenlatest materializes a row
+# for each descendant language
+# ---------------------------------------------------------------------------
+SKIP: {
+    skip "no child language available", 2 unless $child;
+    my $code = fresh_code("zzz.mltest.fallback");
+    LJ::Lang::set_text( $dmid, 'en', $code, "Parent Text", { childrenlatest => 1 } );
+    is( db_value( 'en',   $code ), "Parent Text", "en has the row" );
+    is( db_value( $child, $code ), "Parent Text", "child language falls back to the en source" );
+}
+
+# ---------------------------------------------------------------------------
+# our change: auto-load a general-domain string from the source files
+# ---------------------------------------------------------------------------
+{
+    my $code = fresh_code("/dev/t_ml_autoload.tt.auto");
+
+    open my $fh, '>', $fixture or die "can't write fixture $fixture: $!";
+    print $fh ";; -*- coding: utf-8 -*-\n.auto=Autoloaded Value\n";
+    close $fh;
+
+    ok(
+        LJ::Lang::is_missing_string( db_value( 'en', $code ) ),
+        "fixture code is absent from the DB before any request"
+    );
+
+    # dev: reads straight from the file, must NOT persist to the DB
+    {
+        local $LJ::IS_DEV_SERVER = 1;
+        is(
+            LJ::Lang::get_text( 'en', $code, $dmid ),
+            "Autoloaded Value",
+            "dev get_text reads the value from the file"
+        );
+    }
+    ok(
+        LJ::Lang::is_missing_string( db_value( 'en', $code ) ),
+        "dev did not persist the string to the DB"
+    );
+
+    # prod: auto-loads from the file AND persists it
+    {
+        local $LJ::IS_DEV_SERVER = 0;
+        is(
+            LJ::Lang::get_text( 'en', $code, $dmid ),
+            "Autoloaded Value",
+            "prod get_text auto-loads the value from the file"
+        );
+    }
+    is( db_value( 'en', $code ), "Autoloaded Value", "prod auto-load persisted the string" );
+
+SKIP: {
+        skip "no child language available", 1 unless $child;
+        is(
+            db_value( $child, $code ),
+            "Autoloaded Value",
+            "auto-load materialized the child-language fallback row"
+        );
+    }
+
+    unlink $fixture;
+}
+
+END {
+    if ($dmid) {
+        foreach my $code (@cleanup) {
+            eval { LJ::Lang::remove_text( $dmid, $code ); };
+        }
+    }
+    unlink $fixture if $fixture;
+}
+
+done_testing();


### PR DESCRIPTION
Makes the translation system populate itself from the shipped `.text`/`.dat` files on demand, so deploying a web container is enough to make new strings live — no separate `texttool.pl load` step. This removes the failure mode where, after a BML→TT migration moves strings from `foo.bml.text` to `foo.tt.text`, canary (on TT) shows missing strings until `load` is run, but running `load` deletes those keys out from under stable (still on BML).

**`LJ::Lang::get_text` — auto-load + persist (production):**
- When a general-domain string isn't in the DB yet, read it from the source file (which already ships with the code) and persist it as the `en` root via `set_text(..., { childrenlatest => 1 })`. That materializes a fallback `ml_latest` row for every language — exactly what `texttool.pl makeusable` does at load time, just on demand for a single string. The write is `eval`-guarded so a failure can never break rendering.
- Dev servers are unchanged: they read straight from the files (no DB writes) so `.text`/`.dat` edits show up immediately.
- All ML lookups funnel through `get_text` — the TT `| ml` filter calls it directly, and BML / `$ML{}` / `error_ml` reach it via the registered `ml_getter` hook — so this one change covers every page.

**`LJ::Lang::set_text` — cache coherence:**
- Keep the in-process `%TXT_CACHE` in step with memcache (set it for the written language, delete it for each child language the propagation walks), so a long-lived worker that had already cached a code as missing won't keep serving the stale miss after an auto-load.

**`bin/upgrading/texttool.pl` — non-destructive load:**
- Split dead-phrase removal out of `poptext`/`load` into a new explicit `deadphrases` command. `load`/`poptext` now only add and update text; they never delete. Retire old keys with `texttool.pl deadphrases` once the new code is live everywhere.

Verified in a prod-simulated harness (`$LJ::IS_DEV_SERVER` forced off): a string removed from the DB is auto-loaded from its file on first request, persists so that both `en` and the served `en_DW` resolve from the DB afterward, a genuinely-missing code degrades to empty without crashing or persisting, and the dev path still reads from files. `t/02-tidy.t` and `t/00-compile.t` pass.

CODE TOUR: Dreamwidth keeps all its user-facing text ("translation strings") in files, but historically a manual database-load step had to run after deploying for new or changed text to appear. This makes the site load that text from the files automatically the first time it's needed and remember it, so shipping the code is all that's required. It also stops that load step from deleting old text, which previously could remove strings still in use by servers running the previous version during a rollout.
