### PR TITLE
Add bin/dev/screenshot dev-server screenshot tool + skill

### DIFF
--- a/.claude/skills/screenshot-dev-page/SKILL.md
+++ b/.claude/skills/screenshot-dev-page/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: screenshot-dev-page
+description: Capture a screenshot of a page rendered by the local Dreamwidth dev server, to visually check how a change looks. Use when asked to screenshot, "show me", or visually verify how a page/view/.tt renders (e.g. after a BML→TT migration or a CSS/template change). Runs headless Chrome inside the devcontainer via bin/dev/screenshot.
+---
+
+# Screenshot a dev-server page
+
+`bin/dev/screenshot` renders a page from the local Starman dev server (port 8080)
+to a PNG using headless Google Chrome. Use it to *see* how a change looks rather
+than only reading the HTML.
+
+## Prerequisites
+
+- The page's devcontainer must be running (`docker ps --filter
+  label=devcontainer.local_folder=<worktree-path>`). The script runs **inside**
+  the container (as root) and talks to Starman on `127.0.0.1:8080`.
+- First run installs Google Chrome (Google's signed apt repo) and `puppeteer-core`
+  into `/opt/dw-screenshot` — ~1–2 min once per container, then cached.
+
+## Run it
+
+```bash
+CID=$(docker ps --filter label=devcontainer.local_folder=<worktree-path> --format '{{.ID}}')
+
+# public page
+docker exec -w /workspaces/dreamwidth $CID bin/dev/screenshot /login
+
+# logged-in page (most pages): pass a user + password
+docker exec -w /workspaces/dreamwidth $CID \
+  bin/dev/screenshot --user someuser --password somepass /manage/tags
+```
+
+Options: `--user`/`--password` (log in first), `--out FILE`, `--size WxH`
+(default `1280x1400`), `--restart`. See `bin/dev/screenshot --help`.
+
+The PNG is written **inside the container** (default `/tmp/dw-screenshot.png`).
+Copy it out, then look at it and/or send it to the user:
+
+```bash
+docker cp $CID:/tmp/dw-screenshot.png /tmp/shot.png
+```
+
+Then `Read` `/tmp/shot.png` to inspect it yourself, and/or `SendUserFile` it.
+
+## Gotchas
+
+- **A running Starman does not pick up a new controller/route** (it globs the FS
+  at startup). After adding or changing a route, pass `--restart`, or you'll get
+  a 404 for the new page.
+- **Auth:** logged-in pages need `--user`/`--password`. If you don't already have
+  a usable account in the container's DB, make a throwaway one:
+  ```bash
+  docker exec -w /workspaces/dreamwidth $CID perl -e '
+    require "$ENV{LJHOME}/cgi-bin/ljlib.pl";
+    my $u = LJ::load_user("shotuser") || LJ::User->create_personal(
+      user=>"shotuser", email=>"shot\@example.com", password=>"Testpass123", name=>"Shot User");
+    $u->update_self({status=>"A", statusvis=>"V"});
+    LJ::update_user($u, { password=>"Testpass123" });'
+  # then: bin/dev/screenshot --user shotuser --password Testpass123 <path>
+  ```
+- It captures the **full page** (`fullPage: true`); pass `--size` to change the
+  viewport width.

--- a/bin/dev/screenshot
+++ b/bin/dev/screenshot
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# bin/dev/screenshot -- screenshot a page on the local dev server, to visually
+# check how a change renders. Runs INSIDE the devcontainer (as root).
+#
+# Usage:
+#   bin/dev/screenshot [options] <path>
+#
+# Options:
+#   --user U       log in as user U (via /mobile/login) before capturing
+#   --password P   password for --user (default: $DW_SCREENSHOT_PASSWORD)
+#   --out FILE     output PNG (default: /tmp/dw-screenshot.png)
+#   --size WxH     viewport, width x height (default: 1280x1400)
+#   --restart      restart Starman first -- needed after adding/changing a route
+#                  (a running Starman won't pick up a new controller)
+#
+# Examples:
+#   bin/dev/screenshot /login
+#   bin/dev/screenshot --user shotuser --password s3cret /manage/tags
+#
+# On first run it installs Google Chrome (Google's signed apt repo) and
+# puppeteer-core into /opt/dw-screenshot; later runs reuse them.
+
+set -eu
+
+DEPDIR=/opt/dw-screenshot
+PORT=8080
+BASE="http://127.0.0.1:$PORT"
+OUT=/tmp/dw-screenshot.png
+SIZE=1280x1400
+LOGIN_USER=""
+PASSWORD="${DW_SCREENSHOT_PASSWORD:-}"
+RESTART=0
+TARGET=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --user)     LOGIN_USER="$2"; shift 2 ;;
+        --password) PASSWORD="$2";   shift 2 ;;
+        --out)      OUT="$2";        shift 2 ;;
+        --size)     SIZE="$2";       shift 2 ;;
+        --restart)  RESTART=1;       shift ;;
+        -h|--help)  sed -n '3,28p' "$0"; exit 0 ;;
+        -*)         echo "unknown option: $1" >&2; exit 1 ;;
+        *)          TARGET="$1";     shift ;;
+    esac
+done
+
+if [ -z "$TARGET" ]; then
+    echo "usage: bin/dev/screenshot [options] <path>   (try --help)" >&2
+    exit 1
+fi
+
+# 1. Google Chrome -- signed apt repo, per the packaging policy. First run only.
+if ! command -v google-chrome-stable >/dev/null 2>&1; then
+    echo "[screenshot] installing google-chrome-stable (first run)..." >&2
+    curl -fsSL https://dl.google.com/linux/linux_signing_key.pub |
+        gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+        >/etc/apt/sources.list.d/google-chrome.list
+    apt-get update -qq
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq google-chrome-stable >/dev/null
+fi
+
+# 2. puppeteer-core -- drives the system Chrome (no bundled browser). First run only.
+if [ ! -d "$DEPDIR/node_modules/puppeteer-core" ]; then
+    echo "[screenshot] installing puppeteer-core (first run)..." >&2
+    mkdir -p "$DEPDIR"
+    ( cd "$DEPDIR" && npm init -y >/dev/null 2>&1 &&
+        npm install --no-audit --no-fund puppeteer-core@23 >/dev/null 2>&1 )
+fi
+
+# 3. Starman on :8080 (restart on request, else just make sure it's up)
+if [ "$RESTART" = 1 ]; then
+    fuser -k "$PORT/tcp" 2>/dev/null || true
+    sleep 1
+fi
+if ! curl -sf -o /dev/null "$BASE/"; then
+    echo "[screenshot] starting starman..." >&2
+    ( cd "$LJHOME" && nohup perl bin/starman --port "$PORT" >/tmp/dw-starman.log 2>&1 & )
+    for _ in $(seq 1 30); do curl -sf -o /dev/null "$BASE/" && break; sleep 1; done
+fi
+
+# 4. Optional login -> session cookies for authenticated pages
+MASTER=""
+LOGGEDIN=""
+if [ -n "$LOGIN_USER" ]; then
+    JAR=$(mktemp)
+    TOK=$(curl -s -c "$JAR" "$BASE/mobile/login" |
+        grep -o 'lj_form_auth" value="[^"]*' | sed 's/.*value="//' || true)
+    curl -s -c "$JAR" -b "$JAR" -o /dev/null \
+        -d "lj_form_auth=$TOK" \
+        --data-urlencode "user=$LOGIN_USER" \
+        --data-urlencode "password=$PASSWORD" \
+        "$BASE/mobile/login"
+    MASTER=$(awk '/ljmastersession/{print $NF}' "$JAR" || true)
+    LOGGEDIN=$(awk '/ljloggedin/{print $NF}' "$JAR" || true)
+    rm -f "$JAR"
+    if [ -z "$MASTER" ]; then
+        echo "[screenshot] warning: login as '$LOGIN_USER' set no session (wrong password?)" >&2
+    fi
+fi
+
+# 5. Capture
+node "$LJHOME/bin/dev/screenshot.js" "$TARGET" "$OUT" "$SIZE" "$MASTER" "$LOGGEDIN"
+echo "$OUT"

--- a/bin/dev/screenshot.js
+++ b/bin/dev/screenshot.js
@@ -1,0 +1,37 @@
+// bin/dev/screenshot.js
+//
+// Capture a full-page screenshot of a local dev-server URL with headless
+// Chrome. Invoked by bin/dev/screenshot (which installs the deps and handles
+// login); not normally run directly.
+//
+// Args: <path> <outfile> <WxH> [ljmastersession] [ljloggedin]
+
+const puppeteer = require("/opt/dw-screenshot/node_modules/puppeteer-core");
+
+const [, , path, outfile, size, master, loggedin] = process.argv;
+const [w, h] = (size || "1280x1400").split("x").map(Number);
+const BASE = "http://127.0.0.1:8080";
+
+(async () => {
+    const browser = await puppeteer.launch({
+        executablePath: "/usr/bin/google-chrome-stable",
+        args: ["--no-sandbox", "--disable-gpu", "--hide-scrollbars"],
+        defaultViewport: { width: w, height: h },
+    });
+    const page = await browser.newPage();
+
+    if (master) {
+        await page.setCookie(
+            { name: "ljmastersession", value: master, domain: "127.0.0.1", path: "/" },
+            { name: "ljloggedin", value: loggedin || "", domain: "127.0.0.1", path: "/" }
+        );
+    }
+
+    const resp = await page.goto(BASE + path, { waitUntil: "networkidle2", timeout: 30000 });
+    await page.screenshot({ path: outfile, fullPage: true });
+    await browser.close();
+    process.stderr.write("rendered " + path + " -> HTTP " + (resp && resp.status()) + "\n");
+})().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
Adds `bin/dev/screenshot`, a small tool to capture a screenshot of a page rendered by the local Starman dev server, so changes can be checked *visually* (not just by reading HTML) — e.g. after a BML→TT migration or a template/CSS change.

**`bin/dev/screenshot`** (bash) runs inside the devcontainer and self-bootstraps on first use:
- installs Google Chrome from Google's **signed apt repo** (per the packaging policy) and `puppeteer-core` into `/opt/dw-screenshot` (~1–2 min once per container, then cached);
- ensures Starman is up (`--restart` to pick up a newly-added route — a running Starman won't see a new controller);
- optionally logs in via `/mobile/login` (`--user`/`--password`) so authenticated pages render logged-in;
- writes a full-page PNG (`--out`, `--size`).

**`bin/dev/screenshot.js`** is the `puppeteer-core` driver (headless Chrome, cookie injection, full-page capture). Neither file is `.pl`/`.pm`/`.t`, so they're outside `tidyall`/`t/00-compile.t`.

**`.claude/skills/screenshot-dev-page/`** — the project's first skill: documents the workflow (run via `docker exec`, copy the PNG out, the Starman-restart and auth gotchas) so future sessions know how to use it on demand.

Verified end-to-end from a clean devcontainer: first-run bootstrap → Starman start → login → `/manage/tags` rendered HTTP 200 to a 1280×1400 PNG.

CODE TOUR: This adds a developer convenience for taking a picture of a page on your local test site, which makes it easy to eyeball whether a change looks right. It sets itself up the first time you run it and can log in so it can capture pages that require an account.
