### PR TITLE
Repoint plack-bml.t off login.bml ahead of #3585

### DIFF
--- a/t/plack-bml.t
+++ b/t/plack-bml.t
@@ -40,10 +40,10 @@ die "app.psgi did not return a code reference" unless $app && ref $app eq 'CODE'
 # Test 1: DW::BML module loads
 use_ok('DW::BML');
 
-# Test 2: resolve_path finds a known BML file (login.bml exists in htdocs)
+# Test 2: resolve_path finds a known BML file (imgpreview.bml exists in htdocs)
 {
-    my ( $redirect, $uri, $file ) = DW::BML->resolve_path('/login');
-    ok( defined $file && $file =~ /login\.bml$/, "resolve_path finds login.bml" );
+    my ( $redirect, $uri, $file ) = DW::BML->resolve_path('/imgpreview');
+    ok( defined $file && $file =~ /imgpreview\.bml$/, "resolve_path finds imgpreview.bml" );
 }
 
 # Test 3: resolve_path returns undef for nonexistent path
@@ -78,19 +78,19 @@ test_psgi $app, sub {
     is( $res->code, 403, "Direct access to _config.bml returns 403" );
 };
 
-# Test 7: GET /login returns 200 with HTML content
+# Test 7: GET /imgpreview returns 200 with HTML content
 test_psgi $app, sub {
     my $cb  = shift;
-    my $res = $cb->( GET "/login" );
+    my $res = $cb->( GET "/imgpreview" );
 
-    # login.bml should render successfully
-    is( $res->code, 200, "GET /login returns 200" );
+    # imgpreview.bml is served by DW::BML (not shadowed by a controller route)
+    is( $res->code, 200, "GET /imgpreview returns 200" );
 };
 
 # Test 8: BML response has text/html content type
 test_psgi $app, sub {
     my $cb  = shift;
-    my $res = $cb->( GET "/login" );
+    my $res = $cb->( GET "/imgpreview" );
 
     like( $res->content_type, qr{text/html}, "BML response has text/html content type" );
 };


### PR DESCRIPTION
`t/plack-bml.t` used `login.bml` as its fixture in Tests 2, 7, and 8. PR #3585 deletes `htdocs/login.bml`, which would make Test 2's `resolve_path('/login')` return undef and fail in CI (`prove t/plack-*.t`). Tests 7/8 GET `/login` expecting BML to render, but that path is already served by `DW::Controller::Login` (routing shadows the BML file), so they never actually exercised BML. This repoints all three at `/imgpreview` → `imgpreview.bml`, a public page genuinely served by `DW::BML` with no shadowing controller route. Verified 10/10 pass with `login.bml` and `tools/index.bml` removed (simulating #3585's state).

CODE TOUR: A behind-the-scenes test was pinned to the old login page, which is about to be deleted in another cleanup. This swaps it onto a different internal page so the test keeps working — and actually checks the thing it was meant to check. Nothing user-facing changes.

Note: this should land together with (or be folded into) #3585 — on its own #3585 turns CI red, and on its own this PR is a harmless test-robustness improvement.

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/dreamwidth/dreamwidth/task_uqdbw9xr4sypytb5)