### PR TITLE
Fix blank page when saving /manage/profile

### DIFF
--- a/cgi-bin/DW/Controller/Manage/Profile.pm
+++ b/cgi-bin/DW/Controller/Manage/Profile.pm
@@ -262,13 +262,26 @@ sub profile_handler {
             $errors->add( 'bio', "$scope.error.bio.toolong" );
         }
 
-        # FIXME: validation AND POSTING are handled by widgets' handle_post() methods
-        # (introduce validate_post() ?)
+        # Field validation is done; bail before any saving if it failed. The
+        # Location widget below both validates AND persists immediately, so
+        # running it after a validation error would partially save.
+        if ( $errors->exist ) {
+            $vars->{errors} = $errors;
+            return DW::Template->render_template( 'manage/profile.tt', $vars );
+        }
+
+        # FIXME: validation AND POSTING are handled by widgets' handle_post()
+        # methods (introduce validate_post()?). The Location widget's own errors
+        # accumulate in @BMLCodeBlock::errors rather than being returned, so
+        # capture them and surface them through $errors.
+        @BMLCodeBlock::errors = ();
         my $save_search_index = $POST->{'opt_showlocation'} =~ /^[YR]$/;
         LJ::Widget->handle_post( $POST, 'Location' => { save_search_index => $save_search_index } );
-
-        # validation failed: re-render the form with the errors shown, no save
-        if ( $errors->exist ) {
+        if (@BMLCodeBlock::errors) {
+            foreach my $e (@BMLCodeBlock::errors) {
+                my $eo = LJ::errobj($e);
+                $errors->add_string( '', $eo ? $eo->as_string : "$e" );
+            }
             $vars->{errors} = $errors;
             return DW::Template->render_template( 'manage/profile.tt', $vars );
         }
@@ -316,9 +329,9 @@ sub profile_handler {
 
         my $save_rv = LJ::Setting->save_all( $u, $POST, \@settings );
         if ( LJ::Setting->save_had_errors($save_rv) ) {
-            for ( keys %$save_rv ) {
-                my $e = $save_rv->{$_}->{save_errors} or next;
-                $errors->add_string( $_, $e->{ ( keys %$e )[0] } );
+            for my $setting ( keys %$save_rv ) {
+                my $e = $save_rv->{$setting}->{save_errors} or next;
+                $errors->add_string( $_, $e->{$_} ) foreach keys %$e;
             }
             $vars->{errors} = $errors;
             return DW::Template->render_template( 'manage/profile.tt', $vars );

--- a/cgi-bin/DW/Controller/Manage/Profile.pm
+++ b/cgi-bin/DW/Controller/Manage/Profile.pm
@@ -64,7 +64,6 @@ sub profile_handler {
         }->{ $u->opt_showcontact };
 
     my $errors = DW::FormErrors->new;
-    my @errors;
 
     return DW::Template->render_template( 'error.tt', { message => $LJ::MSG_READONLY_USER } )
         if $u->is_readonly;
@@ -245,15 +244,15 @@ sub profile_handler {
             $errors->add( 'day', "$scope.error.day.outofrange" );
         }
 
-        if (   @errors == 0
+        if (  !$errors->exist
             && $POST->{'day'}
             && $POST->{'day'} > LJ::days_in_month( $POST->{'month'}, $POST->{'year'} ) )
         {
             $errors->add( 'day', "$scope.error.day.notinmonth" );
         }
 
-        if ( $POST->{'LJ__Setting__FindByEmail_opt_findbyemail'}
-            && !$POST->{'LJ__Setting__FindByEmail_opt_findbyemail'} =~ /^[HNY]$/ )
+        if (   $POST->{'LJ__Setting__FindByEmail_opt_findbyemail'}
+            && $POST->{'LJ__Setting__FindByEmail_opt_findbyemail'} !~ /^[HNY]$/ )
         {
             $errors->add( undef, "$scope.error.findbyemail" );
         }
@@ -268,7 +267,11 @@ sub profile_handler {
         my $save_search_index = $POST->{'opt_showlocation'} =~ /^[YR]$/;
         LJ::Widget->handle_post( $POST, 'Location' => { save_search_index => $save_search_index } );
 
-        return LJ::error_list(@errors) if @errors;
+        # validation failed: re-render the form with the errors shown, no save
+        if ( $errors->exist ) {
+            $vars->{errors} = $errors;
+            return DW::Template->render_template( 'manage/profile.tt', $vars );
+        }
 
         ### no errors
 
@@ -313,12 +316,12 @@ sub profile_handler {
 
         my $save_rv = LJ::Setting->save_all( $u, $POST, \@settings );
         if ( LJ::Setting->save_had_errors($save_rv) ) {
-            my @save_errors;
             for ( keys %$save_rv ) {
-                my $e = $save_rv->{$_}->{save_errors};
-                push @save_errors, $e->{ ( keys %$e )[0] };
+                my $e = $save_rv->{$_}->{save_errors} or next;
+                $errors->add_string( $_, $e->{ ( keys %$e )[0] } );
             }
-            return LJ::error_list(@save_errors);
+            $vars->{errors} = $errors;
+            return DW::Template->render_template( 'manage/profile.tt', $vars );
         }
 
         $u->update_self( \%update );
@@ -473,6 +476,14 @@ sub profile_handler {
                 . LJ::Lang::ml("$scope.success.editicons")
                 . "</a></li></ul>";
         }
+
+        # interest validation (above) can add errors after the main save; if so,
+        # re-render with them instead of reporting success
+        if ( $errors->exist ) {
+            $vars->{errors} = $errors;
+            return DW::Template->render_template( 'manage/profile.tt', $vars );
+        }
+
         return $r->msg_redirect( $success_msg, $r->SUCCESS, $profile_url );
     }
 

--- a/views/manage/profile.tt
+++ b/views/manage/profile.tt
@@ -27,6 +27,7 @@
 
 <form method='post' action="[% dw.create_url('/manage/profile', keep_args => ["authas"]) %]">
     [%- dw.form_auth %]
+    [%- INCLUDE components/errors.tt errors = errors -%]
     <table summary='' width='100%' style='margin: 1em 0;'>
 
         [%# personal information %]
@@ -93,7 +94,7 @@
             <td class='field_name' role="cell">[% dw.ml('.fn.birthday') %]</td>
             <td class='bday_field' role="cell">
                 [%- form.select( name => 'month', title => dw.ml('.fn.birthday.month'),
-                                 selected => ( bdpart.month + 0 ),
+                                 selected => ( bdpart.month ? bdpart.month + 0 : 0 ),
                                 items => month_select,
                                 class => 'inline'
                                  ) -%]


### PR DESCRIPTION
Saving `/manage/profile` returned a **blank page** and logged `Argument "<?errorbar <strong>There was an error processing your re..." isn't numeric in numeric eq (==) at app.psgi line 80` whenever a setting failed to save — e.g. leaving find-by-email at its default on a dev server (where `opt_findbyemail` is enabled).

**Root cause** (introduced in the original BML→TT conversion, `122355df5` / #3320, Dec 2024 — `git blame` puts both error returns on that commit): the controller returned `LJ::error_list(...)` / `bad_input(...)` on error, which produce a BML `<?errorbar?>` **string**. Under DW::Routing a handler must return a numeric status / Plack response, so the string fell through to `app.psgi:80` (`$ret == 0`) → the "isn't numeric" warning + a blank page. The page's error handling was broken several ways at once:

- the save gate checked an always-empty `@errors` array instead of the `$errors` `DW::FormErrors` object, so field validation never actually blocked the save;
- `views/manage/profile.tt` never rendered `$errors`;
- an operator-precedence bug (`!$x =~ /re/` parses as `(!$x) =~ /re/`) made the findbyemail check a no-op;
- post-save interest-validation errors still reported success.

**Fix:**
- Render errors through `DW::FormErrors` + `components/errors.tt` and re-render the form (no save) when `$errors->exist`.
- Route `LJ::Setting->save_all` errors into `$errors` instead of returning a string.
- Fix the gate (`@errors` → `$errors->exist`) and the findbyemail precedence bug.
- Guard the success redirect so interest-validation errors re-render instead of falsely reporting success.
- Silence a pre-existing `"" + 0` numeric warning in `profile.tt` (empty birth month).

**Verified** in the devcontainer (as the seeded `test_user`): invalid input now re-renders the form with the error shown (HTTP 200, no blank page); a valid save redirects (303 → profile); and there are **no more "isn't numeric" warnings**. `t/02-tidy.t` passes.

CODE TOUR: Editing your profile and hitting save would sometimes just show a blank page instead of telling you what went wrong. This fixes it so the page properly shows the error message and lets you correct it, and so a valid save goes through cleanly.

Fixes the blank-page-on-profile-save report.
