### PR TITLE
Ensure that the "find by email" error message says what's invalid

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -3258,7 +3258,7 @@ settings.error.year.notenoughdigits=Invalid birthday year. Enter a 4-digit year.
 
 settings.error.year.outofrange=Invalid birthday year.
 
-settings.findbyemail.error.invalid=Invalid Option
+settings.findbyemail.error.invalid=Invalid option for find by email
 
 settings.findbyemail.helper=This setting will allow you to have your email address searchable without having to display it anywhere on [[sitename]]. You can also choose whether or not you want your [[siteabbrev]] identity to be shared in the search results.
 


### PR DESCRIPTION
While it's difficult for users to end up in a situation where their "find by email" settings are invalid, it is possible (at least, in dev environments). Prior to this change, the message that would appear if this happened was vague and cryptic and the best way to figure out what the site was complaining about was to grep en.dat for the error text (ask me how I know).

The new message makes it explicit that "find by email" is the setting that has an invalid option attached to it in the error surfaced to the user, hopefully saving people from wild goose chases of this nature in the future.

CODE TOUR: If you edit your profile and your "find by email" settings are in an invalid state, Dreamwidth will now make it clear that this is what went wrong rather than merely informing you that something is invalid. This is mostly useful to developers, who may have created tests accounts through unusual means.