### PR TITLE
Redirect expired/needed-login to /login instead of the homepage

### DIFF
--- a/cgi-bin/DW/Controller.pm
+++ b/cgi-bin/DW/Controller.pm
@@ -41,7 +41,7 @@ sub needlogin {
     }
     $uri = LJ::eurl($uri);
 
-    $r->header_out( Location => "$LJ::SITEROOT/?returnto=$uri" );
+    $r->header_out( Location => "$LJ::SITEROOT/login?returnto=$uri" );
     return $r->REDIRECT;
 }
 

--- a/cgi-bin/DW/Controller/Login.pm
+++ b/cgi-bin/DW/Controller/Login.pm
@@ -41,7 +41,13 @@ sub login_handler {
 
     my $vars = {
         continue_to => $get->{continue_to},
-        return_to   => $get->{return_to}
+        return_to   => $get->{return_to},
+
+        # forwarded into the login form (components/login.tt) as a hidden field
+        # so that, after a successful login, we send the user back to the page
+        # they were trying to reach when they got bounced here by needlogin().
+        # Sourced from POST too so a failed login attempt keeps the destination.
+        returnto => $post->{returnto} || $get->{returnto},
     };
 
     my @errors = ();

--- a/cgi-bin/DW/Controller/Login.pm
+++ b/cgi-bin/DW/Controller/Login.pm
@@ -41,7 +41,6 @@ sub login_handler {
 
     my $vars = {
         continue_to => $get->{continue_to},
-        return_to   => $get->{return_to},
 
         # forwarded into the login form (components/login.tt) as a hidden field
         # so that, after a successful login, we send the user back to the page

--- a/cgi-bin/DW/Controller/Login.pm
+++ b/cgi-bin/DW/Controller/Login.pm
@@ -39,14 +39,21 @@ sub login_handler {
     # '.error.notuser') resolve correctly before render_template runs.
     $r->note( ml_scope => '/login.tt' );
 
+    # The page to send the user back to after a successful login. Prefer the
+    # POSTed value (form resubmission) over the GET value so a failed login
+    # attempt keeps the destination. Strip CR/LF up front so the value can't be
+    # used for header injection when it later builds a Location header on
+    # redirect.
+    my $returnto = $post->{returnto} // $get->{returnto};
+    $returnto =~ tr/\r\n//d if defined $returnto;
+
     my $vars = {
         continue_to => $get->{continue_to},
 
         # forwarded into the login form (components/login.tt) as a hidden field
         # so that, after a successful login, we send the user back to the page
         # they were trying to reach when they got bounced here by needlogin().
-        # Sourced from POST too so a failed login attempt keeps the destination.
-        returnto => $post->{returnto} || $get->{returnto},
+        returnto => $returnto,
     };
 
     my @errors = ();
@@ -224,11 +231,11 @@ sub login_handler {
 # In both cases, we need to validate the URL before we redirect to it, to prevent XSS and similar attacks
 
                 my $redirect_url;
-                if ( $post->{returnto} ) {
+                if ($returnto) {
 
                     # this passes in the URI of the page to redirect to on success, eg:
                     # /manage/profile/index?authas=test or whatever
-                    $redirect_url = $post->{returnto};
+                    $redirect_url = $returnto;
                     if ( $redirect_url =~ /^\// ) {
                         $redirect_url = $LJ::SITEROOT . $redirect_url;
                     }

--- a/cgi-bin/lj-bml-blocks.pl
+++ b/cgi-bin/lj-bml-blocks.pl
@@ -46,7 +46,7 @@ BML::register_block(
         }
         $uri = LJ::eurl($uri);
 
-        return BML::redirect("$LJ::SITEROOT/?returnto=$uri");
+        return BML::redirect("$LJ::SITEROOT/login?returnto=$uri");
     }
 );
 


### PR DESCRIPTION
When a logged-out user hit a login-required page (e.g. `/inbox/`), both the legacy BML `<?needlogin?>` block (`cgi-bin/lj-bml-blocks.pl`) and the modern `DW::Controller::needlogin` redirected to the site homepage (`/?returnto=...`), where the only login affordance is an easy-to-miss button in the upper right. Both gates now redirect to the dedicated `/login` page, and `DW::Controller::Login::login_handler` forwards the `returnto` value into the login form (as a hidden field) so users land back on their original destination after authenticating.

CODE TOUR: If your login quietly expires and you click on something that needs you to be logged in — like your inbox — Dreamwidth used to drop you on the front page, where the login box is a small thing tucked in the top corner that's easy to miss. Now it takes you to the regular log-in page with the big, obvious login form, and once you sign in it sends you right back to the page you were trying to reach.

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/dreamwidth/dreamwidth/task_iuhrx5t5edyztwuw)
