### PR TITLE
Mark /login no-cache to fix "Invalid form submission" on login

### DIFF
--- a/cgi-bin/DW/Controller/Login.pm
+++ b/cgi-bin/DW/Controller/Login.pm
@@ -24,7 +24,12 @@ use DW::Template;
 use DW::Controller;
 use DW::FormErrors;
 
-DW::Routing->register_string( '/login', \&login_handler, app => 1 );
+# no_cache: the login form embeds a form_auth (CSRF) token that, for logged-out
+# users, is bound to their per-browser ljuniq cookie. If a shared proxy caches
+# this page, everyone is served one user's token and their login POST fails with
+# "Invalid form submission". (The pre-TT login.bml set nocache=>1 for the same
+# reason; /register and /openid carry no_cache => 1 likewise.)
+DW::Routing->register_string( '/login', \&login_handler, app => 1, no_cache => 1 );
 
 sub login_handler {
     my ( $ok, $rv ) = controller( form_auth => 1, anonymous => 1 );

--- a/t/plack-controller.t
+++ b/t/plack-controller.t
@@ -39,6 +39,11 @@ test_psgi $app, sub {
 
     is( $res->code, 200, "GET /login returns 200" );
     like( $res->content, qr/<form/i, "Response contains a login form" );
+
+    # /login must be marked no-cache: the form embeds a uniq-bound form_auth
+    # token, so a shared cache serving one user's page to another would break
+    # login with "Invalid form submission".
+    like( $res->header('Cache-Control'), qr/no-cache/, "GET /login is marked no-cache" );
 };
 
 done_testing;


### PR DESCRIPTION
The `/login` route was registered as an `app`-role page with no `Cache-Control` header, so a shared proxy (Cloudfront) could cache the page. The login form embeds a `form_auth` (CSRF) token that, for logged-out users, is bound to their per-browser `ljuniq` cookie — so a cached page serves one user's token to everyone else, and their login POST fails the check with "Invalid form submission". The pre-TT `login.bml` set `nocache=>1` for this reason; the BML→TT conversion dropped it. This restores it via `no_cache => 1` on the route (matching `/register` and `/openid`). The recent needlogin→`/login` redirect (#3597) funneled far more logged-out traffic to `/login`, which is what made the cached stale-token page start failing.

CODE TOUR: Some people were getting an "Invalid form submission" error when logging in — the login page had been getting cached and shared between visitors, so the hidden security token in the login form didn't match the person actually trying to log in. This tells caches never to share the login page, so everyone gets their own fresh form and can log in normally.

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/dreamwidth/dreamwidth/task_uotmwdwq8mqrhb9m)