### PR TITLE
Fix icon upload failures and rename-keywords checkbox under Plack

### DIFF
--- a/cgi-bin/DW/Request/Plack.pm
+++ b/cgi-bin/DW/Request/Plack.pm
@@ -30,8 +30,7 @@ use Plack::Request;
 use Plack::Response;
 use URI;
 
-use fields ( 'env', 'req', 'req_addr', 'res', 'res_body', 'res_length', 'notes', 'pnotes',
-    'read_offset' );
+use fields ( 'env', 'req', 'req_addr', 'res', 'res_body', 'res_length', 'notes', 'pnotes' );
 
 $DW::Request::PLACK_AVAILABLE = 1;
 
@@ -250,30 +249,24 @@ sub content {
 }
 
 # read: copy up to $_[2] bytes of the request body into the buffer $_[1] (at the
-# optional offset $_[3]), returning the number of bytes read or 0 at EOF. This
-# mirrors Apache2's $r->read so streaming body parsers -- notably the large
-# icon-upload path in DW::Controller::EditIcons -- work under Plack/Starman.
+# optional offset $_[3]), returning the number of bytes read or 0 at EOF. Reads
+# straight from the PSGI input stream rather than slicing $self->content, so a
+# large body isn't pre-materialized into a scalar -- this mirrors Apache2's
+# $r->read and preserves the streaming intent of callers like the large
+# icon-upload parser in DW::Controller::EditIcons.
 # IMPORTANT: Do not pull out $_[1] to a variable in this sub.
 sub read {
     my DW::Request::Plack $self = $_[0];
-    die "missing required arguments" if scalar(@_) < 3;
+    die "missing required arguments"   if scalar(@_) < 3;
+    die "Length cannot be negative"    if $_[2] < 0;
+    die "Negative offsets not allowed" if defined $_[3] && $_[3] < 0;
 
-    my $prefix = '';
-    if ( exists $_[3] ) {
-        die "Negative offsets not allowed" if $_[3] < 0;
-        $prefix = substr( $_[1], 0, $_[3] );
-    }
+    my $input = $self->{env}->{'psgi.input'};
+    return 0 unless $input;
 
-    die "Length cannot be negative" if $_[2] < 0;
-    $self->{read_offset} ||= 0;
-    my $ov = substr( $self->content, $self->{read_offset}, $_[2] );
-
-    # Given $_[1] and whatever was passed in as the first argument are the
-    # same exact scalar this will set *that* variable too.
-    $_[1] = $prefix . $ov;
-
-    $self->{read_offset} += length($ov);
-    return length($ov);
+    # CORE::read writes into the caller's buffer (via the $_[1] alias) at the
+    # given offset, growing it as needed, and returns the bytes read (0 at EOF).
+    return CORE::read( $input, $_[1], $_[2], $_[3] // 0 ) // 0;
 }
 
 # pnote: per-request notes hash (used by routing)

--- a/cgi-bin/DW/Request/Plack.pm
+++ b/cgi-bin/DW/Request/Plack.pm
@@ -30,7 +30,8 @@ use Plack::Request;
 use Plack::Response;
 use URI;
 
-use fields ( 'env', 'req', 'req_addr', 'res', 'res_body', 'res_length', 'notes', 'pnotes' );
+use fields ( 'env', 'req', 'req_addr', 'res', 'res_body', 'res_length', 'notes', 'pnotes',
+    'read_offset' );
 
 $DW::Request::PLACK_AVAILABLE = 1;
 
@@ -246,6 +247,33 @@ sub content_type {
 sub content {
     my DW::Request::Plack $self = $_[0];
     return $self->{req}->content;
+}
+
+# read: copy up to $_[2] bytes of the request body into the buffer $_[1] (at the
+# optional offset $_[3]), returning the number of bytes read or 0 at EOF. This
+# mirrors Apache2's $r->read so streaming body parsers -- notably the large
+# icon-upload path in DW::Controller::EditIcons -- work under Plack/Starman.
+# IMPORTANT: Do not pull out $_[1] to a variable in this sub.
+sub read {
+    my DW::Request::Plack $self = $_[0];
+    die "missing required arguments" if scalar(@_) < 3;
+
+    my $prefix = '';
+    if ( exists $_[3] ) {
+        die "Negative offsets not allowed" if $_[3] < 0;
+        $prefix = substr( $_[1], 0, $_[3] );
+    }
+
+    die "Length cannot be negative" if $_[2] < 0;
+    $self->{read_offset} ||= 0;
+    my $ov = substr( $self->content, $self->{read_offset}, $_[2] );
+
+    # Given $_[1] and whatever was passed in as the first argument are the
+    # same exact scalar this will set *that* variable too.
+    $_[1] = $prefix . $ov;
+
+    $self->{read_offset} += length($ov);
+    return length($ov);
 }
 
 # pnote: per-request notes hash (used by routing)

--- a/htdocs/js/editicons.js
+++ b/htdocs/js/editicons.js
@@ -52,18 +52,18 @@ function addNewUpload(uploadType) {
   var labels = ep_config().labels || {};
   updateMakeDefaultType(true);
 
-  insertIntoTag = document.getElementById("multi_insert");
-  insertElement = document.createElement("p");
+  var insertIntoTag = document.getElementById("multi_insert");
+  var insertElement = document.createElement("p");
   insertElement.setAttribute("id", "additional_upload_" + counter);
   insertElement.setAttribute("class", "pkg");
 
-  newPicHTML = "<input type='button' value='" + labels.remove + "' onclick='javascript:removeAdditionalUpload(" + counter + ");' /><br/>\n";
+  var newPicHTML = "<input type='button' value='" + labels.remove + "' onclick='javascript:removeAdditionalUpload(" + counter + ");' /><br/>\n";
 
   if (uploadType == 'file') {
     newPicHTML += "<label class='left' for='userpic_" + counter + "'>From <u>F</u>ile:</label>";
     newPicHTML += "<input type='file' class='file' name='userpic_" + counter + "' id='userpic_" + counter + "' size='22' />";
   } else if (uploadType == 'url') {
-    newPicHTML += "<label class='left' for='urlpic_'" + counter + ">";
+    newPicHTML += "<label class='left' for='urlpic_" + counter + "'>";
     newPicHTML += labels.fromurl + '</label>';
     newPicHTML += '<input type="text" name="urlpic_' + counter + '" id="urlpic_' + counter + '" class="text" />';
   }
@@ -95,8 +95,8 @@ function removeAdditionalUpload(removeIndex) {
     updateMakeDefaultType(false);
   }
 
-  removeFromTag = document.getElementById("multi_insert");
-  removeElement = document.getElementById("additional_upload_" + removeIndex);
+  var removeFromTag = document.getElementById("multi_insert");
+  var removeElement = document.getElementById("additional_upload_" + removeIndex);
   removeFromTag.removeChild(removeElement);
   maxcounter++;
   if (counter < maxcounter) {
@@ -106,30 +106,27 @@ function removeAdditionalUpload(removeIndex) {
 }
 
 function hideUploadButtons() {
-  buttonsElement = document.getElementById("multi_insert_buttons");
-  buttonsElement.style.display = 'none';
+  document.getElementById("multi_insert_buttons").style.display = 'none';
 }
 
 function unhideUploadButtons() {
-  buttonsElement = document.getElementById("multi_insert_buttons");
-  buttonsElement.style.display = 'block';
+  document.getElementById("multi_insert_buttons").style.display = 'block';
 }
 
 function addNoDefaultButton() {
   var labels = ep_config().labels || {};
-  buttonsElement = document.getElementById("no_default_insert");
-  insertElement = document.createElement("p");
+  var buttonsElement = document.getElementById("no_default_insert");
+  var insertElement = document.createElement("p");
   insertElement.setAttribute("id", "make_default_none");
   insertElement.setAttribute("class", "pkg");
 
-  newPicHTML = "<input type='radio' accesskey='" + labels.makedefaultkey +"' value='-1' name='make_default' id='make_default_button_none' /><label for='make_default_button_none'>" + labels.keepdefault + "</label>\n";
-  insertElement.innerHTML = newPicHTML;
+  insertElement.innerHTML = "<input type='radio' accesskey='" + labels.makedefaultkey +"' value='-1' name='make_default' id='make_default_button_none' /><label for='make_default_button_none'>" + labels.keepdefault + "</label>\n";
   buttonsElement.appendChild(insertElement);
 }
 
 function removeNoDefaultButton() {
-  removeFromTag = document.getElementById("no_default_insert");
-  removeElement = document.getElementById("make_default_none");
+  var removeFromTag = document.getElementById("no_default_insert");
+  var removeElement = document.getElementById("make_default_none");
   removeFromTag.removeChild(removeElement);
 }
 
@@ -161,7 +158,7 @@ function updateMakeDefaultType(multi) {
     if ((multi && makeDefaultInput.type != "radio") || (! multi && makeDefaultInput.type != "checkbox")) {
       var containerElement = document.getElementById('main_make_default');
 
-      value = makeDefaultInput.checked;
+      var value = makeDefaultInput.checked;
       if (multi) {
         containerElement.innerHTML = containerElement.innerHTML.replace(/checkbox/, "radio");
       } else {

--- a/htdocs/js/editicons.js
+++ b/htdocs/js/editicons.js
@@ -1,34 +1,55 @@
-function setup () {
-  DOM.addEventListener($("radio_url"), "click", selectUrlUpload);
-  DOM.addEventListener($("radio_file"), "click", selectFileUpload);
-  DOM.addEventListener($("urlpic_0"), "keypress", keyPressUrlUpload);
-  DOM.addEventListener($("userpic_0"), "change", keyPressFileUpload);
+// Icon management page (/manage/icons): upload-form behaviors.
+//
+// Uses plain DOM APIs only. This is a Foundation page, where the global $ is
+// jQuery and the legacy 6alib helpers (DOM, the getElementById-style $, etc.)
+// are not loaded -- the previous helper-based version of this file silently
+// failed to initialize there, breaking the file/URL toggles and the
+// "add another upload" buttons.
+//
+// The page supplies its labels and upload limit via an inline <script> that
+// sets window.editiconsConfig before this file runs at the end of the body.
+
+// counter: how many extra upload slots we've created so far.
+// maxcounter: the maximum number of upload slots allowed (from config).
+var counter = 1;
+var maxcounter;
+
+function ep_config() {
+    return window.editiconsConfig || { labels: {} };
+}
+
+function ep_bind(id, eventName, fn) {
+    var el = document.getElementById(id);
+    if (el) el.addEventListener(eventName, fn);
+}
+
+function setup() {
+    maxcounter = ep_config().maxcounter;
+
+    ep_bind("radio_url", "click", selectUrlUpload);
+    ep_bind("radio_file", "click", selectFileUpload);
+    ep_bind("urlpic_0", "keypress", keyPressUrlUpload);
+    ep_bind("userpic_0", "change", keyPressFileUpload);
+
+    editiconsInit();
 }
 
 function editiconsInit() {
-    if ($("upload_desc_link")) {
-        $("upload_desc_link").style.display = 'block';
-        $("upload_desc").style.display = 'none';
+    var link = document.getElementById("upload_desc_link");
+    if (link) {
+        link.style.display = 'block';
+        document.getElementById("upload_desc").style.display = 'none';
     }
 }
 
 function toggleElement(elementId) {
-    var el = $(elementId);
-    if (el && el.style.display == 'block') {
-        el.style.display = 'none';
-    } else {
-        el.style.display = 'block';
-    }
+    var el = document.getElementById(elementId);
+    if (!el) return;
+    el.style.display = (el.style.display == 'block') ? 'none' : 'block';
 }
 
-// keeps track of maximum number of uploads alowed
-var counter = 1;
-var maxcounter;
-var ep_labels = {};
-var allowComments = false;
-var allowDescriptions = false;
-
 function addNewUpload(uploadType) {
+  var labels = ep_config().labels || {};
   updateMakeDefaultType(true);
 
   insertIntoTag = document.getElementById("multi_insert");
@@ -36,24 +57,24 @@ function addNewUpload(uploadType) {
   insertElement.setAttribute("id", "additional_upload_" + counter);
   insertElement.setAttribute("class", "pkg");
 
-  newPicHTML = "<input type='button' value='" + ep_labels.remove + "' onclick='javascript:removeAdditionalUpload(" + counter + ");' /><br/>\n";
+  newPicHTML = "<input type='button' value='" + labels.remove + "' onclick='javascript:removeAdditionalUpload(" + counter + ");' /><br/>\n";
 
   if (uploadType == 'file') {
     newPicHTML += "<label class='left' for='userpic_" + counter + "'>From <u>F</u>ile:</label>";
     newPicHTML += "<input type='file' class='file' name='userpic_" + counter + "' id='userpic_" + counter + "' size='22' />";
   } else if (uploadType == 'url') {
     newPicHTML += "<label class='left' for='urlpic_'" + counter + ">";
-    newPicHTML += ep_labels.fromurl + '</label>';
+    newPicHTML += labels.fromurl + '</label>';
     newPicHTML += '<input type="text" name="urlpic_' + counter + '" id="urlpic_' + counter + '" class="text" />';
   }
-  newPicHTML += "<label class='left' for='keywords_" + counter + "'>" + ep_labels.keywords + "</label><input type='text' name='keywords_" + counter + "' id='keywords_" + counter + "' class='text' />";
-  if (allowComments) {
-    newPicHTML += "<label class='left' for='comments_" + counter + "'>" + ep_labels.comment + "</label><input type='text' maxlength='120' name='comments_" + counter + "' id='comments_" + counter + "' class='text' />";
+  newPicHTML += "<label class='left' for='keywords_" + counter + "'>" + labels.keywords + "</label><input type='text' name='keywords_" + counter + "' id='keywords_" + counter + "' class='text' />";
+  if (ep_config().allowComments) {
+    newPicHTML += "<label class='left' for='comments_" + counter + "'>" + labels.comment + "</label><input type='text' maxlength='120' name='comments_" + counter + "' id='comments_" + counter + "' class='text' />";
   }
-  if (allowDescriptions) {
-    newPicHTML += "<label class='left' for='descriptions_" + counter + "'>" + ep_labels.description +"</label><input type='text' maxlength='120' name='descriptions_" + counter + "' id='descriptions_" + counter + "' class='text' />";
+  if (ep_config().allowDescriptions) {
+    newPicHTML += "<label class='left' for='descriptions_" + counter + "'>" + labels.description +"</label><input type='text' maxlength='120' name='descriptions_" + counter + "' id='descriptions_" + counter + "' class='text' />";
   }
-  newPicHTML += "<br/><input type='radio' accesskey='" + ep_labels.makedefaultkey + "' value='" + counter + "' name='make_default' id='make_default_" + counter + "' /><label for='make_default_" + counter + "'>" + ep_labels.makedefault + "</label>\n";
+  newPicHTML += "<br/><input type='radio' accesskey='" + labels.makedefaultkey + "' value='" + counter + "' name='make_default' id='make_default_" + counter + "' /><label for='make_default_" + counter + "'>" + labels.makedefault + "</label>\n";
 
   insertElement.innerHTML = newPicHTML;
   insertIntoTag.appendChild(insertElement);
@@ -95,12 +116,13 @@ function unhideUploadButtons() {
 }
 
 function addNoDefaultButton() {
+  var labels = ep_config().labels || {};
   buttonsElement = document.getElementById("no_default_insert");
   insertElement = document.createElement("p");
   insertElement.setAttribute("id", "make_default_none");
   insertElement.setAttribute("class", "pkg");
 
-  newPicHTML = "<input type='radio' accesskey='" + ep_labels.makedefaultkey +"' value='-1' name='make_default' id='make_default_button_none' /><label for='make_default_button_none'>" + ep_labels.keepdefault + "</label>\n";
+  newPicHTML = "<input type='radio' accesskey='" + labels.makedefaultkey +"' value='-1' name='make_default' id='make_default_button_none' /><label for='make_default_button_none'>" + labels.keepdefault + "</label>\n";
   insertElement.innerHTML = newPicHTML;
   buttonsElement.appendChild(insertElement);
 }
@@ -112,32 +134,32 @@ function removeNoDefaultButton() {
 }
 
 function selectUrlUpload() {
-  $("userpic_0").disabled = true;
-  $("urlpic_0").disabled = false;
+  document.getElementById("userpic_0").disabled = true;
+  document.getElementById("urlpic_0").disabled = false;
 }
 
 function selectFileUpload() {
-  $("urlpic_0").disabled = true;
-  $("userpic_0").disabled = false;
+  document.getElementById("urlpic_0").disabled = true;
+  document.getElementById("userpic_0").disabled = false;
 }
 
 function keyPressUrlUpload() {
-  $("radio_url").checked =true;
+  document.getElementById("radio_url").checked = true;
   selectUrlUpload();
 }
 
 function keyPressFileUpload() {
-  $("radio_file").checked =true;
+  document.getElementById("radio_file").checked = true;
   selectFileUpload();
 }
 
 function updateMakeDefaultType(multi) {
-  var makeDefaultInput = $('make_default_0');
+  var makeDefaultInput = document.getElementById('make_default_0');
 
   if (makeDefaultInput != null) {
     // see if we're already correct
     if ((multi && makeDefaultInput.type != "radio") || (! multi && makeDefaultInput.type != "checkbox")) {
-      var containerElement = $('main_make_default');
+      var containerElement = document.getElementById('main_make_default');
 
       value = makeDefaultInput.checked;
       if (multi) {
@@ -145,9 +167,16 @@ function updateMakeDefaultType(multi) {
       } else {
         containerElement.innerHTML = containerElement.innerHTML.replace(/radio/, "checkbox");
       }
-      $('make_default_0').checked = value;
+      document.getElementById('make_default_0').checked = value;
     }
   }
 }
 
-document.addEventListener("DOMContentLoaded", setup);
+// This file loads at the end of the body, so the DOM is normally still parsing
+// when it runs; register for DOMContentLoaded. Guard against the already-loaded
+// case so initialization is robust regardless of where the file ends up.
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", setup);
+} else {
+  setup();
+}

--- a/htdocs/js/editicons.js
+++ b/htdocs/js/editicons.js
@@ -60,7 +60,7 @@ function addNewUpload(uploadType) {
   var newPicHTML = "<input type='button' value='" + labels.remove + "' onclick='javascript:removeAdditionalUpload(" + counter + ");' /><br/>\n";
 
   if (uploadType == 'file') {
-    newPicHTML += "<label class='left' for='userpic_" + counter + "'>From <u>F</u>ile:</label>";
+    newPicHTML += "<label class='left' for='userpic_" + counter + "'>" + labels.fromfile + "</label>";
     newPicHTML += "<input type='file' class='file' name='userpic_" + counter + "' id='userpic_" + counter + "' size='22' />";
   } else if (uploadType == 'url') {
     newPicHTML += "<label class='left' for='urlpic_" + counter + "'>";

--- a/t/plack-request.t
+++ b/t/plack-request.t
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use v5.10;
 
-use Test::More tests => 25;
+use Test::More tests => 26;
 
 BEGIN {
     require "$ENV{LJHOME}/cgi-bin/ljlib.pl";
@@ -284,6 +284,45 @@ subtest 'content returns raw request body' => sub {
     # empty body on GET
     my $r2 = make_request();
     is( $r2->content, '', 'content returns empty string for bodyless GET' );
+};
+
+###########################################################################
+# 8b. read — chunked body reads for streaming parsers.
+#     The large icon-upload path (DW::Controller::EditIcons) drives the
+#     request body through $r->read($buf, $count, $offset), appending each
+#     chunk at the current length of $buf.  Plack used to lack this method
+#     entirely, so that path silently produced "No data from client".
+###########################################################################
+
+subtest 'read returns body in chunks and appends at offset' => sub {
+    plan tests => 6;
+
+    my $body = 'abcdefghij';    # 10 bytes
+    my $r    = make_request(
+        'REQUEST_METHOD' => 'POST',
+        'CONTENT_TYPE'   => 'application/octet-stream',
+        _body            => $body,
+    );
+
+    # Read the whole body the way parse_multipart_interactive does: in fixed
+    # windows, passing the current buffer length as the offset so each chunk
+    # is appended rather than overwriting what came before.
+    my $window = '';
+    my $got    = $r->read( $window, 4, length($window) );
+    is( $got,    4,      'first read returns 4 bytes' );
+    is( $window, 'abcd', 'first chunk copied into buffer' );
+
+    $got = $r->read( $window, 4, length($window) );
+    is( $window, 'abcdefgh', 'second chunk appended at offset' );
+
+    # Ask for more than remains: only the tail comes back.
+    $got = $r->read( $window, 4, length($window) );
+    is( $got,    2,            'short final read returns remaining byte count' );
+    is( $window, 'abcdefghij', 'buffer holds the full body' );
+
+    # At EOF, read returns 0 (the loop-termination signal the parser relies on).
+    $got = $r->read( $window, 4, length($window) );
+    is( $got, 0, 'read returns 0 at EOF' );
 };
 
 ###########################################################################

--- a/views/edit/icons.tt
+++ b/views/edit/icons.tt
@@ -27,10 +27,10 @@
   [%- END -%]
 [%- END -%]
 
-[%- IF num_icons >= max_icons -%]
-  <div id='limit'>[% '.error.icon.quota' | ml( num = max_icons ) %]</div>
-[%- ELSE -%]
 <div class="row">
+[%- IF num_icons >= max_icons -%]
+  <div id='limit' class="columns large-4">[% '.error.icon.quota' | ml( num = max_icons ) %]</div>
+[%- ELSE -%]
   <div id='uploadBox' class='highlight-box box pkg columns large-4'>
   <div id='uploadBox-inner' class="small-left">
   <form enctype="multipart/form-data" action="[% selflink() %]" method='post'
@@ -146,8 +146,10 @@
 [%- END -%]
 
 [%- IF ! num_icons -%]
+  <div class="columns large-8">
   <h2>[% '.edit.nopics.header' | ml %]</h2>
   <p>[% '.edit.nopics.desc' | ml %]</p>
+  </div>
 [%- ELSE -%]
   <div id='current_userpics' class="columns large-8">
   <form method='post' action='[% selflink() %]'>
@@ -278,5 +280,5 @@
                             name = 'action:save' ) %]</div>
   </form>
   </div><!-- end #current_userpics -->
-  </div>
 [%- END -%]
+</div><!-- end .row -->

--- a/views/edit/icons.tt
+++ b/views/edit/icons.tt
@@ -122,15 +122,15 @@
                 allowComments: true,
                 allowDescriptions: true,
                 labels: {
-                    comment: "[% '.upload.label.comment' | ml %]",
-                    description: "[% '.upload.label.description' | ml %]",
-                    fromfile: "[% '.fromfile' | ml %]",
-                    fromurl: "[% '.fromurl' | ml %]",
-                    keepdefault: "[% '.keepdefault' | ml %]",
-                    keywords: "[% '.upload.label.keywords' | ml %]",
-                    makedefault: "[% '.makedefault' | ml %]",
-                    makedefaultkey: "[% '.makedefault.key' | ml %]",
-                    remove: "[% '.upload.btn.remove' | ml %]"
+                    comment: [% '.upload.label.comment' | ml | js %],
+                    description: [% '.upload.label.description' | ml | js %],
+                    fromfile: [% '.fromfile' | ml | js %],
+                    fromurl: [% '.fromurl' | ml | js %],
+                    keepdefault: [% '.keepdefault' | ml | js %],
+                    keywords: [% '.upload.label.keywords' | ml | js %],
+                    makedefault: [% '.makedefault' | ml | js %],
+                    makedefaultkey: [% '.makedefault.key' | ml | js %],
+                    remove: [% '.upload.btn.remove' | ml | js %]
                 }
             };
         </script>

--- a/views/edit/icons.tt
+++ b/views/edit/icons.tt
@@ -13,7 +13,7 @@
 [%- CALL dw.active_resource_group( "foundation" ) -%]
 [%- sections.title = '.title' | ml -%]
 
-[%- dw.need_res( "stc/editicons.css", "js/editicons.js" ) -%]
+[%- dw.need_res( { group => "foundation" }, "stc/editicons.css", "js/editicons.js" ) -%]
 
 [%- USE Scalar; # needed to force scalar return context for keywords -%]
 
@@ -117,19 +117,22 @@
         <input class="button" type='button secondary' value="[% '.upload.btn.addurl' | ml %]"
                onclick='javascript:addNewUpload("url");' />
         <script type='text/javascript'>
-            maxcounter = [% num_remaining %];
-            allowComments = true;
-            allowDescriptions = true;
-
-            ep_labels.comment = "[% '.upload.label.comment' | ml %]";
-            ep_labels.description = "[% '.upload.label.description' | ml %]";
-            ep_labels.fromfile = "[% '.fromfile' | ml %]";
-            ep_labels.fromurl = "[% '.fromurl' | ml %]";
-            ep_labels.keepdefault = "[% '.keepdefault' | ml %]";
-            ep_labels.keywords = "[% '.upload.label.keywords' | ml %]";
-            ep_labels.makedefault = "[% '.makedefault' | ml %]";
-            ep_labels.makedefaultkey = "[% '.makedefault.key' | ml %]";
-            ep_labels.remove = "[% '.upload.btn.remove' | ml %]";
+            window.editiconsConfig = {
+                maxcounter: [% num_remaining %],
+                allowComments: true,
+                allowDescriptions: true,
+                labels: {
+                    comment: "[% '.upload.label.comment' | ml %]",
+                    description: "[% '.upload.label.description' | ml %]",
+                    fromfile: "[% '.fromfile' | ml %]",
+                    fromurl: "[% '.fromurl' | ml %]",
+                    keepdefault: "[% '.keepdefault' | ml %]",
+                    keywords: "[% '.upload.label.keywords' | ml %]",
+                    makedefault: "[% '.makedefault' | ml %]",
+                    makedefaultkey: "[% '.makedefault.key' | ml %]",
+                    remove: "[% '.upload.btn.remove' | ml %]"
+                }
+            };
         </script>
       </p>
     [%- END -%]
@@ -276,7 +279,4 @@
   </form>
   </div><!-- end #current_userpics -->
   </div>
-  <script type='text/javascript'>
-    editiconsInit();
-  </script>
 [%- END -%]

--- a/views/edit/icons.tt
+++ b/views/edit/icons.tt
@@ -190,7 +190,7 @@
               <div class="columns small-9">
               [% form.textbox( name = "kw_$pid", id = "kw_$pid", class = "text",
                                value = pic.scalar.keywords, disabled = pic.inactive,
-                               onfocus = display_rename ? "\$(\'rename_div_$pid\').style.display = \'block\';" : "" ) %]
+                               onfocus = display_rename ? "document.getElementById(\'rename_div_$pid\').style.display = \'block\';" : "" ) %]
               [% form.hidden( name = "kw_orig_$pid", value = pic.scalar.keywords ) %]
               </div>
               [%- IF display_rename -%]


### PR DESCRIPTION
Four issues on `/manage/icons`, surfaced once web traffic moved to Plack/Starman.

**1. "Couldn't parse upload: No data from client."** The streaming multipart parser in `DW::Controller::EditIcons` (POST bodies over ~63KB) reads the request body via `$r->read(...)`, but `DW::Request::Plack` never implemented `read()` — only `Apache2`/`Standard` did. Under Plack the call died inside an `eval`, leaving the error unset and the upload list empty, which fell through to the "no data" message. Added `read()` to `DW::Request::Plack` (streaming from `psgi.input` via `CORE::read`, so large bodies aren't pre-buffered), plus a regression test in `t/plack-request.t`.

**2. Missing "Rename Keywords" checkbox.** It rendered but stuck at `display:none`. Its reveal-on-focus handler called `$('rename_div_N')`, but on this Foundation page `$` is jQuery, so the lookup returned an empty set and `.style` threw. Switched the inline `onfocus` to `document.getElementById(...)`.

**3. `editicons.js` never loaded.** Registered with no resource group, it landed in the legacy `default` JS group while the page renders the `foundation` group, so it was never sent to the browser — the file/URL toggles and "add another upload" buttons were dead. Registered it in the foundation group and rewrote it to plain DOM APIs (no legacy `DOM`/`$`); page labels arrive via a self-contained, JS-escaped `window.editiconsConfig`, and it self-initializes on `DOMContentLoaded`.

**4. Broken layout at/over the icon limit.** The Foundation `<div class="row">` wrapper was opened only in the under-limit branch but closed only in the has-icons branch. A user at/over their limit who still had icons (e.g. after paid time expired) got a stray `</div>` that prematurely closed an ancestor — collapsing the page chrome (nav above the logo, missing headers). The row is now opened/closed unconditionally with each branch as a self-contained grid column.

CODE TOUR: A handful of things on the icon-upload page had quietly broken. Larger icons failed with a confusing "No data from client" error; the "Rename Keywords" checkbox (which renames a keyword without breaking entries that use it) stopped appearing when you clicked the keyword box; the buttons for adding several icons at once and the file/URL switch stopped responding; and if you were over your icon limit (say your paid time lapsed), the whole page layout fell apart with the menu jumping above the logo. All four are fixed.

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/dreamwidth/dreamwidth/task_v44ciryuqns8y326)