### PR TITLE
Scale web22 Starman workers to vCPUs and enable --preload-app

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -42,8 +42,21 @@ BEGIN {
     srand( LJ::urandom_int() );
 }
 
+# Track the worker PID we last seeded the RNG for. With --preload-app the
+# srand() in the BEGIN block above runs once in the master, so every forked
+# worker would otherwise inherit an identical random sequence. Reseed once per
+# worker on its first request. (DW's security-sensitive randomness uses
+# /dev/urandom, not rand(); this just keeps rand() well-distributed.)
+my $srand_pid = 0;
+
 my $app = sub {
     my $env = $_[0];
+
+    if ( $srand_pid != $$ ) {
+        srand( LJ::urandom_int() );
+        $srand_pid = $$;
+    }
+
     my $r   = DW::Request->get;
 
     # Main request dispatch; this will determine what kind of request we're getting

--- a/bin/starman
+++ b/bin/starman
@@ -14,6 +14,7 @@
 #   --workers COUNT  Number of workers to run in parallel
 #   --log DIR        Directory for access and error logs (default: none)
 #   --daemonize      Fork into background (writes PID to log dir)
+#   --preload-app    Load the app in the master before forking (CoW memory)
 #
 # Authors:
 #      Mark Smith <mark@dreamwidth.org>
@@ -42,14 +43,17 @@ my $host    = '0.0.0.0';
 my $workers = 3;
 my $log_dir;
 my $daemonize;
+my $preload_app;
 
 GetOptions(
-    'port=i'    => \$port,
-    'host=s'    => \$host,
-    'workers=i' => \$workers,
-    'log=s'     => \$log_dir,
-    'daemonize' => \$daemonize,
-) or die "Usage: $0 [--port PORT] [--host HOST] [--workers COUNT] [--log DIR] [--daemonize]\n";
+    'port=i'      => \$port,
+    'host=s'      => \$host,
+    'workers=i'   => \$workers,
+    'log=s'       => \$log_dir,
+    'daemonize'   => \$daemonize,
+    'preload-app' => \$preload_app,
+) or die
+    "Usage: $0 [--port PORT] [--host HOST] [--workers COUNT] [--log DIR] [--daemonize] [--preload-app]\n";
 
 my $app_psgi = "$ENV{LJHOME}/app.psgi";
 die "Cannot find $app_psgi\n" unless -f $app_psgi;
@@ -68,6 +72,12 @@ my @opts = (
     '--app',     $app_psgi,
     '--no-default-middleware',
 );
+
+# Preload the app in the master so forked workers share compiled code via
+# copy-on-write (far lower memory per worker). Safe because nothing opens
+# DB/memcache sockets at load time — connections are made lazily per worker on
+# first request; see the per-worker srand() reseed in app.psgi.
+push @opts, '--preload-app' if $preload_app;
 
 if ($log_dir) {
     mkdir $log_dir unless -d $log_dir;

--- a/etc/docker/web22/scripts/startup-prod.sh
+++ b/etc/docker/web22/scripts/startup-prod.sh
@@ -8,7 +8,13 @@ perl -I$LJHOME/extlib/ $LJHOME/bin/checkconfig.pl || sleep infinity
 
 # Starman on port 8080 (Varnish sits in front on 6081)
 mkdir -p /var/log/starman
-perl $LJHOME/bin/starman --port 8080 --workers 10 --log /var/log/starman --daemonize
+
+# Scale workers to the task's vCPU allocation (on Fargate, nproc reflects the
+# task's vCPUs). ~8 workers/vCPU balances CPU-bound rendering against DB/memcache
+# I/O wait. --preload-app shares compiled code across workers via copy-on-write,
+# so the higher worker count doesn't inflate memory.
+WORKERS=$(( $(nproc) * 8 ))
+perl $LJHOME/bin/starman --port 8080 --workers "$WORKERS" --preload-app --log /var/log/starman --daemonize
 
 # Kick off Varnish
 service varnish start


### PR DESCRIPTION
web22's Starman ran a fixed 10 workers on a 1-vCPU task with no app preload, so the workers oversubscribed the single core (CPU pegged at 100%) and each held its own copy of the codebase (memory near 100%), making logged-in pages slow. `etc/docker/web22/scripts/startup-prod.sh` now sizes workers to the task's vCPUs (`nproc * 8`) and passes `--preload-app` (new passthrough in `bin/starman`) so workers share compiled code via copy-on-write. Preload runs `app.psgi`'s `BEGIN` (including `srand`) only in the master, so `app.psgi` reseeds the RNG once per worker; nothing opens DB/memcache handles at load, so preload is fork-safe. Pairs with a dw-terraform change bumping the stable task to 2 vCPU.

CODE TOUR: Logged-in pages had gotten slow because the web servers were trying to run too many request handlers on too little CPU, while also using more memory than they needed. This change lets each server right-size how many handlers it runs and share program code between them, so pages load faster — without having to throw bigger servers at the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
