### PR TITLE
Serve real error pages under Plack, mirroring Apache's ErrorDocument handling

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -204,13 +204,25 @@ sub _render_error_document {
             # overrides the base one). It's padded so browsers don't swap in
             # their own "friendly" error page.
             my $file = LJ::resolve_file('htdocs/500-error.html');
+            my $body;
             if ( $file && open my $fh, '<', $file ) {
                 local $/;
-                my $body = <$fh>;
+                $body = <$fh>;
                 close $fh;
-                $r->content_type('text/html; charset=utf-8');
-                $r->print($body);
             }
+            else {
+
+                # Never leave a blank 500 (the very symptom this code avoids).
+                # Log the resolution failure and fall back to a small inline page.
+                warn "Could not serve htdocs/500-error.html"
+                    . ( defined $file ? " ($file): $!" : " (not found)" );
+                $body =
+                      "<h1>Oops!</h1>\n<p>If you've gotten this error, it means "
+                    . "that something is currently (and, with luck, temporarily) "
+                    . "broken. Please wait five minutes and try again.</p>\n";
+            }
+            $r->content_type('text/html; charset=utf-8');
+            $r->print($body);
         }
         1;
     } or warn "Failed to render error document for status $status: $@";
@@ -263,6 +275,12 @@ builder {
     # Also writes to $ENV{DW_ACCESS_LOG} on disk when set (e.g. via bin/starman --log).
     enable 'DW::AccessLog',
         ( $ENV{DW_ACCESS_LOG} ? ( log_file => $ENV{DW_ACCESS_LOG} ) : () );
+
+    # Strip the response body from HEAD requests while leaving headers intact.
+    # Apache does this automatically; under Plack we must opt in or handlers
+    # (including the error documents below) would send a body on HEAD. Enabled
+    # outside ContentLength so Content-Length still reflects the GET body.
+    enable 'Head';
 
     # Set Content-Length on responses so Starman doesn't fall back to chunked
     # transfer encoding when the app doesn't set it itself

--- a/app.psgi
+++ b/app.psgi
@@ -141,8 +141,25 @@ my $app = sub {
         }
     }
 
+    # If we settled on a 404 but no handler produced a body, render the stock
+    # error page so the client gets a real "we can't find that page" document
+    # instead of an empty response (which browsers replace with their own
+    # generic error page). Mirrors Apache::LiveJournal's ErrorDocument handling.
+    _render_error_document($r) if $r->status == 404 && !$r->response_bytes_written;
+
     return $r->res;
 };
+
+# Render the internal 404 error page into the current response, preserving the
+# 404 status (the error templates return OK on success, so we restore it after).
+sub _render_error_document {
+    my $r = $_[0];
+
+    my $status = $r->status;
+    my $ret = DW::Routing->call( uri => "/internal/local/404" );
+    $ret //= DW::Routing->call( uri => "/internal/404" );
+    $r->status($status) if defined $ret;
+}
 
 # Apply the middleware. Ordering is important!
 builder {

--- a/app.psgi
+++ b/app.psgi
@@ -57,13 +57,48 @@ my $app = sub {
         $srand_pid = $$;
     }
 
-    my $r   = DW::Request->get;
+    my $r = DW::Request->get;
 
-    # Main request dispatch; this will determine what kind of request we're getting
-    # and then pass it to the appropriate handler. In the future, this should just
-    # be a call to DW::Routing and let it sort it out with all the controllers and
-    # such, but until then, we're having to dispatch between various generations
-    # of systems ourselves.
+    # Run the actual dispatch. A finalized Plack response (arrayref) is returned
+    # directly; anything else means the status/body now live on $r.
+    my $response = eval { _handle_request( $r, $env ) };
+    if ( my $err = $@ ) {
+
+        # In dev, re-throw so the StackTrace middleware can render the trace in
+        # the browser. In production, turn it into a 500 and fall through to the
+        # error-document handling below — this mirrors mod_perl translating a
+        # died handler into a 500 and Apache then serving ErrorDocument 500.
+        die $err if $LJ::IS_DEV_SERVER;
+
+        warn "Unhandled request exception: $err";
+        $r->status(500);
+        $response = undef;
+    }
+
+    # A finalized response already carries its own body/headers (e.g. redirects).
+    return $response if ref $response;
+
+    # If we settled on an error status but no handler produced a body, render
+    # the matching error document so the client gets a real page instead of an
+    # empty response (which browsers replace with their own generic error page).
+    # Mirrors the ErrorDocument directives Apache::LiveJournal sets up.
+    _render_error_document($r) if $r->status >= 400 && !$r->response_bytes_written;
+
+    return $r->res;
+};
+
+# Main request dispatch; this will determine what kind of request we're getting
+# and then pass it to the appropriate handler. In the future, this should just
+# be a call to DW::Routing and let it sort it out with all the controllers and
+# such, but until then, we're having to dispatch between various generations
+# of systems ourselves.
+#
+# Returns a finalized Plack response (arrayref) for responses that carry their
+# own headers/body (redirects, etc.); otherwise returns undef after setting the
+# status (and possibly body) on $r, leaving finalization to the caller.
+sub _handle_request {
+    my ( $r, $env ) = @_;
+
     # If this is the embed module domain, force routing to embedcontent handler
     # regardless of the requested path (matches Apache::LiveJournal::trans behavior)
     my $host = $r->host;
@@ -71,12 +106,13 @@ my $app = sub {
         ( $LJ::EMBED_MODULE_DOMAIN && $host =~ /$LJ::EMBED_MODULE_DOMAIN$/ )
         ? '/journal/embedcontent'
         : $r->path;
+
     # Handle legacy RPC URIs (/__rpc_delcomment, /__rpc_talkscreen) that
     # Apache routes via LJ::URI->handle() to BML files
     if ( my ($rpc) = $uri =~ m!^.*/__rpc_(\w+)$! ) {
         if ( my $bml_file = $LJ::AJAX_URI_MAP{$rpc} ) {
             DW::BML->render( "$LJ::HTDOCS/$bml_file", $uri );
-            return $r->res;
+            return;
         }
     }
 
@@ -141,24 +177,47 @@ my $app = sub {
         }
     }
 
-    # If we settled on a 404 but no handler produced a body, render the stock
-    # error page so the client gets a real "we can't find that page" document
-    # instead of an empty response (which browsers replace with their own
-    # generic error page). Mirrors Apache::LiveJournal's ErrorDocument handling.
-    _render_error_document($r) if $r->status == 404 && !$r->response_bytes_written;
+    return;
+}
 
-    return $r->res;
-};
-
-# Render the internal 404 error page into the current response, preserving the
-# 404 status (the error templates return OK on success, so we restore it after).
+# Render the error document configured for the current (error) status into the
+# response, preserving that status. Mirrors the ErrorDocument directives that
+# Apache::LiveJournal sets up (see modperl_subs.pl): only 404 and 500 have
+# custom documents; any other status keeps its empty body, exactly as Apache
+# would (it defines no ErrorDocument for them).
 sub _render_error_document {
     my $r = $_[0];
 
     my $status = $r->status;
-    my $ret = DW::Routing->call( uri => "/internal/local/404" );
-    $ret //= DW::Routing->call( uri => "/internal/404" );
-    $r->status($status) if defined $ret;
+
+    eval {
+        if ( $status == 404 ) {
+
+            # Apache renders /internal/local/404 (site-specific, with quips)
+            # and falls back to the stock /internal/404 page.
+            my $ret = DW::Routing->call( uri => "/internal/local/404" );
+            $ret //= DW::Routing->call( uri => "/internal/404" );
+        }
+        elsif ( $status == 500 ) {
+
+            # Apache serves the static htdocs/500-error.html (a site-local copy
+            # overrides the base one). It's padded so browsers don't swap in
+            # their own "friendly" error page.
+            my $file = LJ::resolve_file('htdocs/500-error.html');
+            if ( $file && open my $fh, '<', $file ) {
+                local $/;
+                my $body = <$fh>;
+                close $fh;
+                $r->content_type('text/html; charset=utf-8');
+                $r->print($body);
+            }
+        }
+        1;
+    } or warn "Failed to render error document for status $status: $@";
+
+    # The error templates return OK on success without touching the status, but
+    # restore it explicitly so a rendered document can never downgrade the code.
+    $r->status($status);
 }
 
 # Apply the middleware. Ordering is important!

--- a/cgi-bin/DW/Request/Plack.pm
+++ b/cgi-bin/DW/Request/Plack.pm
@@ -179,6 +179,14 @@ sub print {
     $self->{res_length} += length($data);
 }
 
+# number of body bytes appended via print() so far; lets callers tell whether a
+# handler has actually produced any output (e.g. to decide whether to render a
+# stock error page over an otherwise-empty 404 response)
+sub response_bytes_written {
+    my DW::Request::Plack $self = $_[0];
+    return $self->{res_length};
+}
+
 # flatten out the body and return the response
 sub res {
     my DW::Request::Plack $self = $_[0];

--- a/t/plack-error-pages.t
+++ b/t/plack-error-pages.t
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+# t/plack-error-pages.t
+#
+# Tests that error HTTP statuses render real error-document bodies through the
+# full Plack stack, rather than the empty responses browsers replace with their
+# own generic error page. Mirrors Apache's ErrorDocument handling.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2025 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use warnings;
+use v5.10;
+
+use Test::More;
+use HTTP::Request::Common;
+use Plack::Test;
+
+BEGIN {
+    $LJ::_T_CONFIG = 1;
+    require "$ENV{LJHOME}/cgi-bin/ljlib.pl";
+}
+
+# Load the Plack app
+my $app_file = "$ENV{LJHOME}/app.psgi";
+my $app      = do $app_file;
+die "Failed to load app.psgi: $@" if $@;
+die "app.psgi did not return a code reference" unless $app && ref $app eq 'CODE';
+
+# Test: a missing page returns a non-empty 404 body (not a blank response).
+test_psgi $app, sub {
+    my $cb  = shift;
+    my $res = $cb->( GET "http://localhost/nonexistent-page-xyz-12345" );
+
+    is( $res->code, 404, "Missing page returns 404" );
+    like( $res->header('Content-Type'), qr{text/html}, "404 body is HTML" );
+    ok( length( $res->content ), "404 response has a non-empty body" );
+    like( $res->content, qr/find that page/i, "404 body is the stock error page" );
+};
+
+# Test: HEAD on a missing page returns 404 with no body but a non-zero
+# Content-Length (the Head middleware strips the body but, sitting outside
+# ContentLength, leaves the header reflecting what GET would have returned).
+# (An exact match against GET's length would be flaky: the stock 404 page
+# embeds a randomly chosen quip, so its length varies between requests.)
+test_psgi $app, sub {
+    my $cb   = shift;
+    my $head = $cb->( HEAD "http://localhost/nonexistent-page-xyz-12345" );
+
+    is( $head->code,    404, "HEAD of missing page returns 404" );
+    is( $head->content, "",  "HEAD response has no body" );
+    cmp_ok( $head->header('Content-Length'), '>', 0, "HEAD keeps a non-zero Content-Length" );
+};
+
+done_testing;


### PR DESCRIPTION
Under Plack, when journal/BML routing settled on an error status, `app.psgi` set the status but never rendered a body — so clients got an empty response that the browser replaced with its own generic error page (the reported 404 symptom on entry URLs like `style-system.dreamwidth.org/168082.html`). This adds a general error-document path mirroring the `ErrorDocument` directives `Apache::LiveJournal` configures in `modperl_subs.pl`: **404** → the internal "not found" page (`/internal/local/404`, falling back to `/internal/404`), **500** → the static `htdocs/500-error.html` maintenance page (the dw-nonfree copy overrides the base one). Dispatch is factored into `_handle_request` and wrapped in an `eval` — in dev an uncaught exception is re-thrown so the StackTrace middleware still shows the trace, while in production it becomes a 500 routed through the same handling, matching mod_perl turning a died handler into ErrorDocument 500. After dispatch, any error status (≥ 400) with no handler-produced body renders its configured document; statuses Apache left without an ErrorDocument keep their empty body. A new `DW::Request::Plack::response_bytes_written` lets us detect whether a handler already wrote output so we never clobber a handler-supplied error body.

CODE TOUR: When you hit a page that doesn't exist — like a deleted entry — Dreamwidth's newer web server was returning a blank page, so your browser showed its own ugly error screen instead of our friendly "We can't find that page" message. Now it shows the proper page again, and if the site itself hits a temporary error you'll get the normal "Oops!" maintenance message rather than a blank screen.

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/dreamwidth/dreamwidth/task_a54viag40biied54)