### PR TITLE
Add syn_delete console command to delete/undelete feed accounts

### DIFF
--- a/cgi-bin/LJ/Console/Command/SynDelete.pm
+++ b/cgi-bin/LJ/Console/Command/SynDelete.pm
@@ -1,0 +1,96 @@
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+
+package LJ::Console::Command::SynDelete;
+
+use strict;
+use base qw(LJ::Console::Command);
+use Carp qw(croak);
+
+sub cmd { "syn_delete" }
+
+sub desc {
+    "Deletes a syndicated (RSS/Atom feed) account, marking it for purging and stopping the "
+        . "syndication system from refreshing it. Pass 'undelete' to reverse this and resume "
+        . "feed checking. Requires priv: syn_edit.";
+}
+
+sub args_desc {
+    [
+        'user'   => "The username of the syndicated account.",
+        'action' => "Either 'delete' (the default) or 'undelete' to restore a deleted feed.",
+    ]
+}
+
+sub usage { '<user> [ delete | undelete ]' }
+
+sub can_execute {
+    my $remote = LJ::get_remote();
+    return $remote && $remote->has_priv("syn_edit");
+}
+
+sub execute {
+    my ( $self, $user, $action, @args ) = @_;
+
+    $action ||= 'delete';
+
+    return $self->error("This command takes one or two arguments. Consult the reference.")
+        unless $user && scalar(@args) == 0;
+
+    return $self->error("Invalid action: must be 'delete' or 'undelete'.")
+        unless $action eq 'delete' || $action eq 'undelete';
+
+    my $u = LJ::load_user($user);
+
+    return $self->error("Invalid user $user")
+        unless $u;
+    return $self->error("Not a syndicated account")
+        unless $u->is_syndicated;
+    return $self->error("Cannot modify a purged account.")
+        if $u->is_expunged;
+
+    my $remote = LJ::get_remote();
+
+    if ( $action eq 'delete' ) {
+        return $self->error("Account is already deleted.")
+            if $u->is_deleted;
+
+        $u->set_deleted;
+
+        LJ::statushistory_add( $u, $remote, 'synd_delete',
+            "Feed account deleted; syndication checking stopped." );
+
+        return $self->print( "Feed account $user marked as deleted; "
+                . "the syndication system will stop refreshing it." );
+    }
+    else {
+        return $self->error("Account is not deleted.")
+            unless $u->is_deleted;
+
+        $u->set_visible;
+
+        # nudge the scheduler to pick the feed up promptly and clear any
+        # accumulated failures from before it was deleted.
+        my $dbh = LJ::get_db_writer();
+        $dbh->do( "UPDATE syndicated SET checknext=NOW(), failcount=0 WHERE userid=?",
+            undef, $u->id );
+
+        LJ::statushistory_add( $u, $remote, 'synd_delete',
+            "Feed account undeleted; syndication checking restored." );
+
+        return $self->print(
+            "Feed account $user restored; " . "the syndication system will resume refreshing it." );
+    }
+}
+
+1;

--- a/cgi-bin/LJ/Console/Command/SynUndelete.pm
+++ b/cgi-bin/LJ/Console/Command/SynUndelete.pm
@@ -1,11 +1,11 @@
 #!/usr/bin/perl
 #
-# LJ::Console::Command::SynDelete
+# LJ::Console::Command::SynUndelete
 #
-# Console command to delete a syndicated (RSS/Atom feed) account. Marks
-# the account as deleted so the syndication system stops refreshing it
-# and it eventually gets purged like any other deleted account. Use
-# syn_undelete to reverse this.
+# Console command to undelete a syndicated (RSS/Atom feed) account that
+# was previously deleted with syn_delete. Restores the account to visible
+# and resets the check schedule so the syndication system resumes
+# refreshing the feed.
 #
 # Authors:
 #      Mark Smith <mark@dreamwidth.org>
@@ -17,22 +17,21 @@
 # 'perldoc perlartistic' or 'perldoc perlgpl'.
 #
 
-package LJ::Console::Command::SynDelete;
+package LJ::Console::Command::SynUndelete;
 
 use strict;
 use base qw(LJ::Console::Command);
 use Carp qw(croak);
 
-sub cmd { "syn_delete" }
+sub cmd { "syn_undelete" }
 
 sub desc {
-    "Deletes a syndicated (RSS/Atom feed) account, marking it for purging and stopping the "
-        . "syndication system from refreshing it. Use syn_undelete to reverse this. "
-        . "Requires priv: syn_edit.";
+    "Undeletes a syndicated (RSS/Atom feed) account that was deleted with syn_delete, "
+        . "restoring it and resuming syndication checking. Requires priv: syn_edit.";
 }
 
 sub args_desc {
-    [ 'user' => "The username of the syndicated account to delete.", ]
+    [ 'user' => "The username of the syndicated account to undelete.", ]
 }
 
 sub usage { '<user>' }
@@ -56,17 +55,22 @@ sub execute {
         unless $u->is_syndicated;
     return $self->error("Cannot modify a purged account.")
         if $u->is_expunged;
-    return $self->error("Account is already deleted.")
-        if $u->is_deleted;
+    return $self->error("Account is not deleted.")
+        unless $u->is_deleted;
 
-    $u->set_deleted;
+    $u->set_visible;
+
+    # nudge the scheduler to pick the feed up promptly and clear any
+    # accumulated failures from before it was deleted.
+    my $dbh = LJ::get_db_writer();
+    $dbh->do( "UPDATE syndicated SET checknext=NOW(), failcount=0 WHERE userid=?", undef, $u->id );
 
     my $remote = LJ::get_remote();
     LJ::statushistory_add( $u, $remote, 'synd_delete',
-        "Feed account deleted; syndication checking stopped." );
+        "Feed account undeleted; syndication checking restored." );
 
     return $self->print(
-        "Feed account $user marked as deleted; the syndication system will stop refreshing it.");
+        "Feed account $user restored; the syndication system will resume refreshing it.");
 }
 
 1;

--- a/t/console-syndelete.t
+++ b/t/console-syndelete.t
@@ -1,0 +1,113 @@
+# t/console-syndelete.t
+#
+# Test LJ::Console syn_delete command (delete and undelete of feed accounts).
+#
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+
+use strict;
+use warnings;
+
+use Test::More tests => 13;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+use LJ::Console;
+use LJ::Test qw (temp_user temp_feed);
+local $LJ::T_NO_COMMAND_PRINT = 1;
+
+my $u    = temp_user();
+my $feed = temp_feed();
+LJ::set_remote($u);
+
+my $run = sub {
+    my $cmd = shift;
+    return LJ::Console->run_commands_text($cmd);
+};
+
+# requires the syn_edit priv
+is(
+    $run->( "syn_delete " . $feed->user ),
+    "error: You are not authorized to run this command.",
+    "Command requires syn_edit priv."
+);
+$u->grant_priv("syn_edit");
+$u = LJ::load_user( $u->user );
+
+# can only operate on syndicated accounts
+my $reguser = temp_user();
+is(
+    $run->( "syn_delete " . $reguser->user ),
+    "error: Not a syndicated account",
+    "Refuses non-syndicated accounts."
+);
+
+is(
+    $run->( "syn_delete " . $feed->user . " bogus" ),
+    "error: Invalid action: must be 'delete' or 'undelete'.",
+    "Rejects an unknown action."
+);
+
+# undelete on a non-deleted feed should fail
+is(
+    $run->( "syn_delete " . $feed->user . " undelete" ),
+    "error: Account is not deleted.",
+    "Cannot undelete a feed that is not deleted."
+);
+
+# delete it
+is(
+    $run->( "syn_delete " . $feed->user ),
+    "success: Feed account "
+        . $feed->user
+        . " marked as deleted; the syndication system will stop refreshing it.",
+    "Deletes the feed."
+);
+$feed = LJ::load_user( $feed->user );
+ok( $feed->is_deleted, "Feed account is now marked deleted." );
+
+# deleting again should fail
+is(
+    $run->( "syn_delete " . $feed->user ),
+    "error: Account is already deleted.",
+    "Cannot delete an already-deleted feed."
+);
+
+# undelete it
+is(
+    $run->( "syn_delete " . $feed->user . " undelete" ),
+    "success: Feed account "
+        . $feed->user
+        . " restored; the syndication system will resume refreshing it.",
+    "Undeletes the feed."
+);
+$feed = LJ::load_user( $feed->user );
+ok( $feed->is_visible, "Feed account is visible again." );
+
+# undelete resets the schedule so syndication picks it back up
+my $dbh = LJ::get_db_reader();
+my ( $checknext, $failcount ) =
+    $dbh->selectrow_array( "SELECT checknext, failcount FROM syndicated WHERE userid=?",
+    undef, $feed->id );
+is( $failcount, 0, "failcount reset on undelete." );
+ok( defined $checknext, "checknext is set on undelete." );
+
+# explicit 'delete' action works too
+is(
+    $run->( "syn_delete " . $feed->user . " delete" ),
+    "success: Feed account "
+        . $feed->user
+        . " marked as deleted; the syndication system will stop refreshing it.",
+    "Explicit 'delete' action works."
+);
+$feed = LJ::load_user( $feed->user );
+ok( $feed->is_deleted, "Feed account deleted via explicit action." );

--- a/t/console-syndelete.t
+++ b/t/console-syndelete.t
@@ -1,24 +1,21 @@
 # t/console-syndelete.t
 #
-# Test LJ::Console syn_delete command (delete and undelete of feed accounts).
+# Test LJ::Console syn_delete and syn_undelete commands.
 #
-# This code was forked from the LiveJournal project owned and operated
-# by Live Journal, Inc. The code has been modified and expanded by
-# Dreamwidth Studios, LLC. These files were originally licensed under
-# the terms of the license supplied by Live Journal, Inc, which can
-# currently be found at:
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
 #
-# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
 #
-# In accordance with the original license, this code and all its
-# modifications are provided under the GNU General Public License.
-# A copy of that license can be found in the LICENSE file included as
-# part of this distribution.
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
 
 use strict;
 use warnings;
 
-use Test::More tests => 13;
+use Test::More tests => 14;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Console;
@@ -34,11 +31,16 @@ my $run = sub {
     return LJ::Console->run_commands_text($cmd);
 };
 
-# requires the syn_edit priv
+# both commands require the syn_edit priv
 is(
     $run->( "syn_delete " . $feed->user ),
     "error: You are not authorized to run this command.",
-    "Command requires syn_edit priv."
+    "syn_delete requires syn_edit priv."
+);
+is(
+    $run->( "syn_undelete " . $feed->user ),
+    "error: You are not authorized to run this command.",
+    "syn_undelete requires syn_edit priv."
 );
 $u->grant_priv("syn_edit");
 $u = LJ::load_user( $u->user );
@@ -48,18 +50,12 @@ my $reguser = temp_user();
 is(
     $run->( "syn_delete " . $reguser->user ),
     "error: Not a syndicated account",
-    "Refuses non-syndicated accounts."
-);
-
-is(
-    $run->( "syn_delete " . $feed->user . " bogus" ),
-    "error: Invalid action: must be 'delete' or 'undelete'.",
-    "Rejects an unknown action."
+    "syn_delete refuses non-syndicated accounts."
 );
 
 # undelete on a non-deleted feed should fail
 is(
-    $run->( "syn_delete " . $feed->user . " undelete" ),
+    $run->( "syn_undelete " . $feed->user ),
     "error: Account is not deleted.",
     "Cannot undelete a feed that is not deleted."
 );
@@ -84,7 +80,7 @@ is(
 
 # undelete it
 is(
-    $run->( "syn_delete " . $feed->user . " undelete" ),
+    $run->( "syn_undelete " . $feed->user ),
     "success: Feed account "
         . $feed->user
         . " restored; the syndication system will resume refreshing it.",
@@ -101,13 +97,20 @@ my ( $checknext, $failcount ) =
 is( $failcount, 0, "failcount reset on undelete." );
 ok( defined $checknext, "checknext is set on undelete." );
 
-# explicit 'delete' action works too
+# undeleting a live feed fails
 is(
-    $run->( "syn_delete " . $feed->user . " delete" ),
+    $run->( "syn_undelete " . $feed->user ),
+    "error: Account is not deleted.",
+    "Cannot undelete a feed that is already visible."
+);
+
+# delete then undelete a second time, to confirm it round-trips
+is(
+    $run->( "syn_delete " . $feed->user ),
     "success: Feed account "
         . $feed->user
         . " marked as deleted; the syndication system will stop refreshing it.",
-    "Explicit 'delete' action works."
+    "Deletes the feed a second time."
 );
 $feed = LJ::load_user( $feed->user );
-ok( $feed->is_deleted, "Feed account deleted via explicit action." );
+ok( $feed->is_deleted, "Feed account deleted again." );


### PR DESCRIPTION
Adds two console commands (priv: `syn_edit`) for managing syndicated (RSS/Atom feed) accounts: `LJ::Console::Command::SynDelete` (`syn_delete <feed>`) and `LJ::Console::Command::SynUndelete` (`syn_undelete <feed>`). Previously the only options were `syn_merge` (which requires a merge target) or a direct DB purge. Delete calls `set_deleted` (statusvis `D`); undelete calls `set_visible` and resets `checknext`/`failcount` so checking resumes promptly. No scheduler change is needed because `bin/worker/schedule-synsuck` already only picks up feeds where `statusvis='V'`, so a deleted feed stops refreshing and then gets purged through the normal expunge lifecycle. Test coverage in `t/console-syndelete.t`.

CODE TOUR: Site admins can now cleanly retire an RSS/Atom feed account from the admin console with `syn_delete <feed>`. This marks the feed as deleted so the site stops fetching new posts for it, and it eventually gets cleaned up like any other deleted account. If it was deleted by mistake, `syn_undelete <feed>` brings it back and resumes feed checking.

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/dreamwidth/dreamwidth/task_j9kgeatgpkfn04yd)