### PR TITLE
Auto-deploy web-canary on every web22 build from main

### DIFF
--- a/.github/workflows/web22-build.yml
+++ b/.github/workflows/web22-build.yml
@@ -30,6 +30,9 @@ jobs:
     permissions:
       packages: write
 
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -41,6 +44,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Push image
+        id: push
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 
@@ -65,6 +69,7 @@ jobs:
           # Get sha256 for later
           IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE_NAME | cut -d@ -f2)
           echo "IMAGE_DIGEST=$IMAGE_DIGEST" >> $GITHUB_ENV
+          echo "digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Notify Discord
         uses: sarisia/actions-status-discord@v1
@@ -72,3 +77,15 @@ jobs:
         with:
           description: "Package digest: `${{ env.IMAGE_DIGEST }}`\n\nDeploy here: https://github.com/dreamwidth/dreamwidth/actions/workflows/web22-deploy.yml"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
+
+  # Auto-deploy every new main build to the web-canary tier (canary only; promote
+  # the other tiers by hand). Pins the exact digest just built. Only pushes to
+  # main trigger this — canary-branch builds and manual rebuilds do not.
+  deploy-canary:
+    needs: build
+    if: github.repository == 'dreamwidth/dreamwidth' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/web22-deploy.yml
+    with:
+      service: web-canary
+      tag: ${{ needs.build.outputs.digest }}
+    secrets: inherit

--- a/.github/workflows/web22-deploy.yml
+++ b/.github/workflows/web22-deploy.yml
@@ -15,6 +15,14 @@ on:
         type: string
         description: SHA256 to deploy (include "sha256:" prefix)
         required: true
+  workflow_call:
+    inputs:
+      service:
+        type: string
+        required: true
+      tag:
+        type: string
+        required: true
 
 env:
   REGION: us-east-1
@@ -43,23 +51,23 @@ jobs:
         id: render-web-container
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
-          task-definition: ".github/workflows/tasks/${{ github.event.inputs.service }}-service.json"
+          task-definition: ".github/workflows/tasks/${{ inputs.service }}-service.json"
           container-name: ${{ env.CONTAINER_NAME }}
-          image: "${{ env.IMAGE_BASE }}@${{ github.event.inputs.tag }}"
+          image: "${{ env.IMAGE_BASE }}@${{ inputs.tag }}"
 
       - name: Deploy to Amazon ECS service
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.render-web-container.outputs.task-definition }}
           cluster: ${{ env.ECS_CLUSTER }}
-          service: "${{ github.event.inputs.service }}-service"
+          service: "${{ inputs.service }}-service"
 
       - name: Notify Discord
         uses: sarisia/actions-status-discord@v1
         if: always()
         with:
-          title: "${{ github.event.inputs.service }} DEPLOY STARTED"
-          description: "Deploying `${{ github.event.inputs.tag }}` to `${{ github.event.inputs.service }}`\n\nClick the header above to watch the deployment progress."
-          url: "https://${{ env.REGION }}.console.aws.amazon.com/ecs/v2/clusters/dreamwidth/services/${{ github.event.inputs.service }}-service/deployments?region=${{ env.REGION }}"
+          title: "${{ inputs.service }} DEPLOY STARTED"
+          description: "Deploying `${{ inputs.tag }}` to `${{ inputs.service }}`\n\nClick the header above to watch the deployment progress."
+          url: "https://${{ env.REGION }}.console.aws.amazon.com/ecs/v2/clusters/dreamwidth/services/${{ inputs.service }}-service/deployments?region=${{ env.REGION }}"
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           nocontext: true


### PR DESCRIPTION
Makes `web22-deploy.yml` a reusable workflow (adds a `workflow_call` trigger and references `inputs.service`/`inputs.tag`, so manual dispatch is unchanged). `web22-build.yml` now exposes the pushed image digest as a build-job output and adds a `deploy-canary` job (`needs: build`) that calls the reusable deploy with `service: web-canary` and that exact digest. It's gated to **push events on `main`** (`github.event_name == 'push' && github.ref == 'refs/heads/main'`), so canary-branch builds and manual rebuilds don't auto-deploy, and only the **web-canary** tier is touched — shop/unauth/stable stay manual.

CODE TOUR: When new site code lands on the main branch and its web container finishes building, it now automatically ships to the "canary" tier — the small slice of opt-in test traffic — so we catch problems there before promoting to everyone. Nothing else deploys automatically; the rest of the site is still rolled out by hand.