### PR TITLE
Instrument byte size of in-process web caches

### DIFF
--- a/cgi-bin/DW/CacheStats.pm
+++ b/cgi-bin/DW/CacheStats.pm
@@ -62,7 +62,7 @@ sub _rss_bytes {
     return undef unless $line;
 
     my ( undef, $rss_pages ) = split /\s+/, $line;
-    return undef unless $rss_pages;
+    return undef unless defined $rss_pages;
     return $rss_pages * _page_size();
 }
 
@@ -77,9 +77,8 @@ sub report {
     return unless $rate && DW::Stats::enabled();
     return unless rand() < $rate;
 
-    if ( my $rss = _rss_bytes() ) {
-        DW::Stats::timing( 'dw.process.rss_bytes', $rss );
-    }
+    my $rss = _rss_bytes();
+    DW::Stats::timing( 'dw.process.rss_bytes', $rss ) if defined $rss;
 
     foreach my $name ( keys %CACHES ) {
         my $ref = eval { $CACHES{$name}->() };

--- a/cgi-bin/DW/CacheStats.pm
+++ b/cgi-bin/DW/CacheStats.pm
@@ -1,0 +1,127 @@
+#!/usr/bin/perl
+#
+# DW::CacheStats
+#
+# Instruments the size (in bytes) of the various in-process caches the web
+# process maintains, so we can track memory growth. Measurement is expensive
+# (it deep-walks each cache with Devel::Size), so it is sampled: nothing is
+# measured unless $LJ::CACHE_STATS_SAMPLE_RATE is set and a stats sink is
+# configured. The cheap process RSS gauge is emitted on the same sampled path.
+#
+# Caches register themselves by name with a coderef that returns a reference to
+# the underlying data structure. Package-global caches (the %LJ::CACHE_* family)
+# are registered centrally below; caches held in file-scoped lexicals (e.g.
+# %LJ::Lang::TXT_CACHE, the per-class singleton registries) self-register from
+# their own module, after their declaration, so the closure can see them.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+package DW::CacheStats;
+
+use strict;
+use warnings;
+
+use Devel::Size qw( total_size );
+
+use DW::Stats;
+
+# name -> coderef returning a reference to the cache structure to measure
+our %CACHES;
+
+# Usage: DW::CacheStats::register( 'some_cache', sub { \%Some::cache } )
+#
+# Registers a cache for size instrumentation. The coderef is called at report
+# time and must return a reference (hashref/arrayref); anything else is skipped.
+sub register {
+    my ( $name, $getref ) = @_;
+    $CACHES{$name} = $getref;
+    return 1;
+}
+
+my $page_size;
+
+sub _page_size {
+    return $page_size if defined $page_size;
+    $page_size = eval { require POSIX; POSIX::sysconf( POSIX::_SC_PAGESIZE() ) } || 4096;
+    return $page_size;
+}
+
+# Resident set size of this process, in bytes, from /proc (Linux). Returns
+# undef where /proc/self/statm is unavailable.
+sub _rss_bytes {
+    open my $fh, '<', '/proc/self/statm' or return undef;
+    my $line = <$fh>;
+    close $fh;
+    return undef unless $line;
+
+    my ( undef, $rss_pages ) = split /\s+/, $line;
+    return undef unless $rss_pages;
+    return $rss_pages * _page_size();
+}
+
+# Usage: DW::CacheStats::report()
+#
+# Sampled at $LJ::CACHE_STATS_SAMPLE_RATE (0..1). When it fires, emits the
+# process RSS and the byte size of every registered cache as timing metrics, so
+# the stats backend aggregates them into histograms across workers. A no-op
+# unless a stats sink is configured and the sample rate is positive.
+sub report {
+    my $rate = $LJ::CACHE_STATS_SAMPLE_RATE;
+    return unless $rate && DW::Stats::enabled();
+    return unless rand() < $rate;
+
+    if ( my $rss = _rss_bytes() ) {
+        DW::Stats::timing( 'dw.process.rss_bytes', $rss );
+    }
+
+    foreach my $name ( keys %CACHES ) {
+        my $ref = eval { $CACHES{$name}->() };
+        next unless ref $ref;
+
+        DW::Stats::timing( 'dw.cache.bytes', total_size($ref), ["cache:$name"] );
+    }
+
+    return 1;
+}
+
+# Built-in registrations for the package-global caches. These are always
+# reachable as symbols, so we can reference them directly here rather than
+# touching the owning code. The per-request caches are measured at the top of
+# LJ::start_request, just before they are cleared, so we capture each request's
+# peak. The rest persist for the life of the process.
+#
+# Persistent process-global caches (the unbounded memory-growth suspects):
+register( 'cache_userid',     sub { \%LJ::CACHE_USERID } );
+register( 'cache_username',   sub { \%LJ::CACHE_USERNAME } );
+register( 'cache_mood_theme', sub { \%LJ::CACHE_MOOD_THEME } );
+register( 'cache_moods',      sub { \%LJ::CACHE_MOODS } );
+register( 'cache_prop',       sub { \%LJ::CACHE_PROP } );
+register( 'cache_propid',     sub { \%LJ::CACHE_PROPID } );
+register( 'cache_codes',      sub { \%LJ::CACHE_CODES } );
+register( 'cache_encodings',  sub { \%LJ::CACHE_ENCODINGS } );
+register( 'cache_userprop',   sub { \%LJ::CACHE_USERPROP } );
+register( 'cache_style',      sub { \%LJ::CACHE_STYLE } );
+
+# Per-request caches (cleared every request; measured just before the clear):
+register( 'req_cache_user_name',     sub { \%LJ::REQ_CACHE_USER_NAME } );
+register( 'req_cache_user_id',       sub { \%LJ::REQ_CACHE_USER_ID } );
+register( 'req_cache_rel',           sub { \%LJ::REQ_CACHE_REL } );
+register( 'req_cache_usertags',      sub { \%LJ::REQ_CACHE_USERTAGS } );
+register( 'cache_userpic',           sub { \%LJ::CACHE_USERPIC } );
+register( 'cache_userpic_info',      sub { \%LJ::CACHE_USERPIC_INFO } );
+register( 'cache_s2theme',           sub { \%LJ::CACHE_S2THEME } );
+register( 'paid_status',             sub { \%LJ::PAID_STATUS } );
+register( 'request_cache',           sub { \%LJ::REQUEST_CACHE } );
+register( 'req_global',              sub { \%LJ::REQ_GLOBAL } );
+register( 's2_req_cache_style_id',   sub { \%LJ::S2::REQ_CACHE_STYLE_ID } );
+register( 's2_req_cache_layer_id',   sub { \%LJ::S2::REQ_CACHE_LAYER_ID } );
+register( 's2_req_cache_layer_info', sub { \%LJ::S2::REQ_CACHE_LAYER_INFO } );
+
+1;

--- a/cgi-bin/DW/Stats.pm
+++ b/cgi-bin/DW/Stats.pm
@@ -39,6 +39,14 @@ sub setup {
     );
 }
 
+# Usage: DW::Stats::enabled()
+#
+# Returns true if a stats sink has been configured via setup(). Useful for
+# guarding expensive measurement work that would otherwise be discarded.
+sub enabled {
+    return defined $sock ? 1 : 0;
+}
+
 # Usage: DW::Stats::increment( 'my.metric', $incrby, $tags, $sample_rate )
 #
 # Metric must be a string. $incrby must be a number or undef. $tags must be an

--- a/cgi-bin/LJ/Comment.pm
+++ b/cgi-bin/LJ/Comment.pm
@@ -20,6 +20,7 @@ package LJ::Comment;
 
 use strict;
 use Carp qw/ croak /;
+use DW::CacheStats;
 use Log::Log4perl;
 my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
@@ -66,6 +67,9 @@ LJ::Comment
 #    _loaded_childids:  loaded childids
 
 my %singletons = ();    # journalid->jtalkid->singleton
+
+# instrument this per-request cache's byte size for memory metrics
+DW::CacheStats::register( 'comment_singletons', sub { \%singletons } );
 
 # singletons still to be loaded
 my %unloaded_singletons      = ();

--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -26,6 +26,7 @@ my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
 our $AUTOLOAD;
 use Carp qw/ croak confess /;
+use DW::CacheStats;
 use DW::Task::DeleteEntry;
 use DW::Task::SearchCopier;
 use DW::Search;
@@ -67,6 +68,9 @@ LJ::Entry
 #    _loaded_talkdata: loaded talkdata
 
 my %singletons = ();    # journalid->jitemid->singleton
+
+# instrument this per-request cache's byte size for memory metrics
+DW::CacheStats::register( 'entry_singletons', sub { \%singletons } );
 
 sub reset_singletons {
     %singletons = ();

--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -172,6 +172,11 @@ no strict "vars";
     # block size is used in stats generation code that gets n rows from the db at a time
     $STATS_BLOCK_SIZE ||= 10_000;
 
+    # fraction (0..1) of requests on which DW::CacheStats measures the byte size
+    # of in-process caches. Measurement is expensive, so this defaults off; set
+    # it in config-private (e.g. 0.01) once a stats sink (%STATS) is configured.
+    $CACHE_STATS_SAMPLE_RATE //= 0;
+
     # Maximum number of comments to display on Recent Comments page
     $TOOLS_RECENT_COMMENTS_MAX ||= 150;
 

--- a/cgi-bin/LJ/Lang.pm
+++ b/cgi-bin/LJ/Lang.pm
@@ -14,6 +14,7 @@
 package LJ::Lang;
 use strict;
 use LJ::LangDatFile;
+use DW::CacheStats;
 
 use constant MAXIMUM_ITCODE_LENGTH => 120;
 
@@ -137,6 +138,9 @@ my %LN_ID     = ();    # id -> { ..., ..., 'children' => [ $ids, .. ] }
 my %LN_CODE   = ();    # $code -> ^^^^
 my $LAST_ERROR;
 my %TXT_CACHE;
+
+# instrument this persistent translation cache's byte size for memory metrics
+DW::CacheStats::register( 'lang_txt_cache', sub { \%TXT_CACHE } );
 
 sub last_error {
     return $LAST_ERROR;

--- a/cgi-bin/LJ/Message.pm
+++ b/cgi-bin/LJ/Message.pm
@@ -15,8 +15,12 @@ package LJ::Message;
 use strict;
 use Carp qw/ croak /;
 use LJ::Typemap;
+use DW::CacheStats;
 
 my %singletons = ();    # journalid-msgid
+
+# instrument this per-request cache's byte size for memory metrics
+DW::CacheStats::register( 'message_singletons', sub { \%singletons } );
 
 sub new {
     my ( $class, $opts ) = @_;

--- a/cgi-bin/LJ/Userpic.pm
+++ b/cgi-bin/LJ/Userpic.pm
@@ -19,6 +19,7 @@ use Log::Log4perl;
 my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
 use Digest::MD5;
+use DW::CacheStats;
 use Storable;
 
 use DW::BlobStore;
@@ -62,6 +63,9 @@ my %MimeTypeMap = (
 # all LJ::Userpics in memory
 # userid -> picid -> LJ::Userpic
 my %singletons;
+
+# instrument this per-request cache's byte size for memory metrics
+DW::CacheStats::register( 'userpic_singletons', sub { \%singletons } );
 
 sub reset_singletons {
     %singletons = ();

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -118,6 +118,7 @@ use LJ::Global::Img;        # defines LJ::Img
 use LJ::Global::Secrets;    # defines LJ::Secrets
 use DW::Media;
 use DW::Stats;
+use DW::CacheStats;
 use DW::Proxy;
 use DW::TaskQueue;
 use DW::BlobStore;
@@ -476,7 +477,9 @@ sub handle_caches {
 sub start_request {
     handle_caches();
 
-    # TODO: check process growth size
+    # Sample the size of our in-process caches (and process RSS) before we clear
+    # the per-request ones below, so each measurement reflects a request's peak.
+    DW::CacheStats::report();
 
     # clear per-request caches
     LJ::unset_remote();    # clear cached remote

--- a/doc/dependencies-cpanm
+++ b/doc/dependencies-cpanm
@@ -13,6 +13,7 @@ Convert::Base32
 CryptX@0.080
 Danga::Socket
 Data::ObjectDriver
+Devel::Size
 Digest::HMAC_SHA1
 Digest::SHA1
 File::Type

--- a/etc/config-private.pl.example
+++ b/etc/config-private.pl.example
@@ -153,6 +153,12 @@ use Net::Subnet;
     #     port => 8125,
     # );
 
+    # Fraction (0..1) of requests on which DW::CacheStats measures the byte size
+    # of the web process's in-memory caches (and reports process RSS), emitting
+    # them as timing/histogram metrics via %STATS above. Measurement deep-walks
+    # each cache, so keep this low; it defaults to 0 (disabled).
+    # $CACHE_STATS_SAMPLE_RATE = 0.01;
+
     # If you are going to be using the external content proxy system, you should
     # define a file here that contains your private salt.
     # $PROXY_URL = "https://proxy.myhost.net";


### PR DESCRIPTION
Adds `DW::CacheStats`, which samples the byte size of the web process's in-memory caches (via `Devel::Size::total_size`) plus process RSS, and emits them as `timing` metrics through the existing `DW::Stats` statsd path so the backend renders histograms across Starman workers. `report()` is called at the top of `LJ::start_request` (`cgi-bin/ljlib.pl`), before per-request caches are cleared, so each measurement captures a request's peak. The `%LJ::CACHE_*` package globals register centrally inside `DW::CacheStats`; caches kept in file-scoped lexicals (the `LJ::Entry`/`Comment`/`Userpic`/`Message` singleton registries and `%LJ::Lang::TXT_CACHE`) self-register a closure from their own module. Sampling is gated by a new `$CACHE_STATS_SAMPLE_RATE` config knob (default `0`) and skipped entirely unless a stats sink is configured; `Devel::Size` is added to `doc/dependencies-cpanm`.

CODE TOUR: We've been chasing memory growth in the web servers, and the first step to fixing it is being able to see it. This adds lightweight, sampled instrumentation that periodically measures how much memory each of our internal caches is using and reports those numbers to our metrics dashboards, so we can spot which cache is ballooning. It's off by default and only kicks in on a small fraction of requests when enabled, so it won't slow the site down.

🌒 Run on Niteshift: [View Task](https://niteshift.dev/repo/dreamwidth/dreamwidth/task_km3ncfnbmpn29ydf)