### PR TITLE
Log HTTP status and redirects on comment-fetch failures

### DIFF
--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Comments.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal/Comments.pm
@@ -679,14 +679,47 @@ sub do_authed_comment_fetch {
     # if we don't have a session, then let's generate one
     $data->{_session} ||= $class->get_lj_session($data);
 
-    # hit up the server with the specified information and return the raw content
-    my $ua      = LWP::UserAgent->new;
+    # hit up the server with the specified information and return the raw content.
+    # don't auto-follow redirects: a successful export returns XML directly, so any
+    # 3xx means we were bounced (typically to login.bml when the source rejects our
+    # session) -- we want to see that explicitly rather than silently fetching the
+    # login page and failing the is-it-XML check below.
+    my $ua = LWP::UserAgent->new;
+    $ua->max_redirect(0);
     my $request = HTTP::Request->new( GET => $url );
     $request->push_header( Cookie => "ljsession=$data->{_session}" );
 
     # try to get the response
     my $response = $ua->request($request);
-    return if $response->is_error;
+
+    # a redirect almost always means the source didn't accept our session and is
+    # bouncing us to login -- log where it sent us so this is diagnosable from the logs.
+    if ( $response->is_redirect ) {
+        my $location = $response->header('Location') || '';
+        $log->(
+            'comment fetch (%s, startid=%d) from %s redirected: HTTP %s -> %s%s',
+            $mode,
+            $startid,
+            $data->{hostname},
+            $response->code,
+            $location,
+            ( $location =~ m!/login\.bml! ? ' (session not accepted)' : '' )
+        );
+        return undef;
+    }
+
+    # HTTP-level failure (4xx/5xx): log the status and any throttling hint so blocks
+    # or rate-limiting on the bulk export endpoint are visible in the import logs.
+    if ( $response->is_error ) {
+        my $retry = $response->header('Retry-After') || '';
+        $log->(
+            'comment fetch (%s, startid=%d) from %s failed: HTTP %s %s%s', $mode,
+            $startid,                                                      $data->{hostname},
+            $response->code,                                               $response->message,
+            ( length $retry ? " (Retry-After: $retry)" : '' )
+        );
+        return undef;
+    }
 
     # now get the content, ensure it's actually XML
     my $xml = $response->content;
@@ -699,7 +732,20 @@ sub do_authed_comment_fetch {
         return $xml;
     }
 
-    # total failure...
+    # 2xx but the body isn't XML (e.g. an error or login page) -- log enough to tell
+    # what came back instead of comment metadata.
+    my $snippet = substr( $xml || '', 0, 200 );
+    $snippet =~ s/\s+/ /g;
+    $log->(
+'comment fetch (%s, startid=%d) from %s returned non-XML: HTTP %s, ctype=%s, %d bytes; starts: %s',
+        $mode,
+        $startid,
+        $data->{hostname},
+        $response->code,
+        $response->content_type || '?',
+        length( $xml || '' ),
+        $snippet
+    );
     return undef;
 }
 


### PR DESCRIPTION
When LiveJournal/InsaneJournal comment import fails, `do_authed_comment_fetch` (cgi-bin/DW/Worker/ContentImporter/LiveJournal/Comments.pm) returned `undef` for *any* non-XML response, so the only log line was the generic "Error fetching comment metadata from server." — with no status, no redirect target, nothing to act on. This disables LWP auto-redirect following and logs the HTTP status, the redirect `Location` (flagging a bounce to `login.bml` as a rejected session), any `Retry-After`, and a snippet of a non-XML body. No behavioral change to successful fetches.

Motivation: LJ comment imports have been failing site-wide for weeks (entries import fine via XML-RPC; the `export_comments.bml` cookie-session path fails) and the current logging makes it impossible to tell whether the cause is a login redirect, a 4xx/5xx, or rate-limiting. This makes the next failure self-explanatory in the logs.

CODE TOUR: When importing comments from another site stops working, our logs now record exactly what the other site said — for example "you were sent to the login page" or "too many requests, try later" — instead of a vague "could not fetch comments" message. That makes it much faster to figure out why an import is stuck on comments.