### PR TITLE
Fix spurious entry text markup validation errors on markdown

### DIFF
--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -764,15 +764,18 @@ sub _form_to_backend {
     $errors->add( undef, ".error.noentry" )
         if $errors && $req->{event} eq "" && !$opts{allow_empty};
 
+    # Sort out the markup format ("editor"), which is used for both detecting
+    # markup errors and constructing the protocol request.
+    my $validated_editor = DW::Formats::validate( $post->{editor} )
+
     # warn the user of any bad markup errors
     my $clean_event = $post->{event};
     my $errref;
 
-    my $editor = undef;
     my $verbose_err;
 
     LJ::CleanHTML::clean_event( \$clean_event,
-        { errref => \$errref, editor => $editor, verbose_err => \$verbose_err } );
+        { errref => \$errref, editor => $validated_editor, verbose_err => \$verbose_err } );
 
     if ( $errors && $verbose_err ) {
         if ( ref($verbose_err) eq 'HASH' ) {
@@ -797,7 +800,7 @@ sub _form_to_backend {
 
     # This form always uses the editor prop instead of opt_preformatted.
     $props->{opt_preformatted} = 0;
-    $props->{editor}           = DW::Formats::validate( $post->{editor} );
+    $props->{editor}           = $validated_editor;
 
     # old implementation of comments
     # FIXME: remove this before taking the page out of beta

--- a/cgi-bin/DW/Controller/Entry.pm
+++ b/cgi-bin/DW/Controller/Entry.pm
@@ -766,7 +766,7 @@ sub _form_to_backend {
 
     # Sort out the markup format ("editor"), which is used for both detecting
     # markup errors and constructing the protocol request.
-    my $validated_editor = DW::Formats::validate( $post->{editor} )
+    my $validated_editor = DW::Formats::validate( $post->{editor} );
 
     # warn the user of any bad markup errors
     my $clean_event = $post->{event};


### PR DESCRIPTION
We weren't passing the markup format name ("editor") to the `clean_event` call in `_form_to_backend`. (We actually throw away the cleaned output from this cleaner invocation; it's only used to detect markup problems. This step was added sometime since the last time I was in this zone, see https://github.com/dreamwidth/dreamwidth/commit/54992a1d95c549c1e39119d012fc454f0ecbdbdc)

CODE TOUR: Markdown formatting has a "code span" syntax (using the backtick character) that automatically escapes any html-unfriendly characters inside it, like turning angle brackets (`<`) into entities (`&lt;`). On the beta create entries page, the code that checks for broken HTML wasn't taking that escaping into account, so it was raising unnecessary markup errors (and blocking posting) for Markdown posts that discussed HTML tags by putting them inside auto-escaping code spans. That's fixed. 

## TESTING:

On the beta create entries page:

- If you set format to raw html or casual html, the following entry body text should fail to post with an "unclosed tag" warning:

```
Random <unknown-tag> with no closer.
```

- If you set format to markdown, the entry body text above should STILL fail to post!
- If you set the format to markdown and post the _following_ entry body text, it should (correctly) succeed to post:

```
Markdown with `<unknown-tag>` inside a code span, which auto-escapes the angle brackets.
```