### PR TITLE
Remove ICQ from other sites

### DIFF
--- a/bin/upgrading/base-data.sql
+++ b/bin/upgrading/base-data.sql
@@ -357,8 +357,6 @@ INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_form
 UPDATE profile_services SET userprop='github', imgfile='github.png', title_ml='profile.service.github', url_format='//github.com/%s', maxlen=39 WHERE name='github';
 INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('google_chat', 'google_talk', 'google_hangouts.png', 'profile.service.hangouts', NULL, 60);
 UPDATE profile_services SET userprop='google_talk', imgfile='google_hangouts.png', title_ml='profile.service.hangouts', url_format=NULL, maxlen=60 WHERE name='google_chat';
-INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('icq', 'icq', 'icq.gif', 'profile.service.icq', '//wwp.icq.com/%s', 12);
-UPDATE profile_services SET userprop='icq', imgfile='icq.gif', title_ml='profile.service.icq', url_format='//wwp.icq.com/%s', maxlen=12 WHERE name='icq';
 INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('insanejournal', 'insanejournal', 'insanejournal.png', 'profile.service.insanejournal', '//%s.insanejournal.com', 15);
 UPDATE profile_services SET userprop='insanejournal', imgfile='insanejournal.png', title_ml='profile.service.insanejournal', url_format='//%s.insanejournal.com', maxlen=15 WHERE name='insanejournal';
 INSERT IGNORE INTO profile_services (name, userprop, imgfile, title_ml, url_format, maxlen) VALUES ('instagram', 'instagram', 'instagram.png', 'profile.service.instagram', '//www.instagram.com/%s', 30);

--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2313,8 +2313,6 @@ profile.service.github=GitHub
 
 profile.service.hangouts=Google Chat
 
-profile.service.icq=ICQ
-
 profile.service.insanejournal=InsaneJournal
 
 profile.service.instagram=Instagram

--- a/bin/upgrading/proplists.dat
+++ b/bin/upgrading/proplists.dat
@@ -510,14 +510,6 @@ userproplist.iconbrowser_smallicons:
   multihomed: 0
   prettyname: Icon browser small icons
 
-userproplist.icq:
-  cldversion: 0
-  datatype: char
-  des: ICQ Number
-  indexed: 1
-  multihomed: 1
-  prettyname: ICQ (legacy value)
-
 userproplist.import_job:
   cldversion: 4
   datatype: char

--- a/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/LiveJournal.pm
@@ -558,7 +558,6 @@ sub get_foaf_from {
     my @schools;
     my %wanted_text_items = (
         'foaf:name'          => 'name',
-        'foaf:icqChatID'     => 'icq',
         'foaf:jabberID'      => 'jabber',
         'ya:bio'             => 'bio',
         'lj:journaltitle'    => 'journaltitle',

--- a/cgi-bin/DW/Worker/ContentImporter/Local/Bio.pm
+++ b/cgi-bin/DW/Worker/ContentImporter/Local/Bio.pm
@@ -59,7 +59,7 @@ sub merge_bio_items {
 
     $u->set_bio( $items->{'bio'} ) if defined( $items->{'bio'} );
 
-    foreach my $prop (qw/ icq jabber journaltitle journalsubtitle /) {
+    foreach my $prop (qw/ jabber journaltitle journalsubtitle /) {
         $u->set_prop( $prop => $items->{$prop} )
             if defined $items->{$prop};
     }


### PR DESCRIPTION
CODE TOUR: Pour one out for ICQ.

Removes ICQ from other sites list on profiles, since it no longer exists. Closes #3372 