### PR TITLE
Require opening angle bracket when sniffing embed tags in parse_module_embed

### DIFF
--- a/cgi-bin/LJ/EmbedModule.pm
+++ b/cgi-bin/LJ/EmbedModule.pm
@@ -175,7 +175,7 @@ sub parse_module_embed {
     return unless LJ::is_enabled('embed_module');
 
     # fast track out if we don't have to expand anything
-    return unless $$postref =~ /(lj|site)\-embed|embed|object|iframe/i;
+    return unless $$postref =~ /<((lj|site)\-embed|embed|object|iframe)/i;
 
     # do we want to replace with the lj-embed tags or iframes?
     my $expand = $opts{expand};


### PR DESCRIPTION
Since this early-exit condition was only checking for _any mention of the word_ "object" (or iframe or embed) rather than a relevant html tag, it was running the embed reprocessing on a bunch of posts unnecessarily.

This function happens to be involved in an actual correctness bug around the handling of user text in Markdown. I'm not able to address that right now, but this early-exit fix makes it meaningfully more difficult to trigger that bug.

Anyway, "angle bracket then tag name" is used for an identical regex early-exit in `LJ::Poll::contains_new_poll`, so it should be ok here too.

CODE TOUR: This was a fun party trick: Make a post in Markdown format that contains an `<UppercaseWord>` in angle brackets, inside a pair of backticks (a Markdown character-escaping code span), and then, somewhere in the post, say the word "object". This would cause any of those uppercase-in-angle-brackets-in-code-span instances to get lowercased. Well -- now you can at least _say the word_ "object" and your text is safe, but it'll still get lowercased if you, say, embed a youtube video, because that's a harder version of this bug to fix. Pretty cursed. 