### PR TITLE
Rename autoscaler task role to match the ECS PassRole wildcard

### DIFF
--- a/.github/workflows/tasks/worker-web-autoscaler-service.json
+++ b/.github/workflows/tasks/worker-web-autoscaler-service.json
@@ -79,7 +79,7 @@
         }
     ],
     "family": "worker-web-autoscaler",
-    "taskRoleArn": "arn:aws:iam::194396987458:role/dreamwidth-autoscaler-taskRole",
+    "taskRoleArn": "arn:aws:iam::194396987458:role/dreamwidth-ecs-autoscaler-taskRole",
     "executionRoleArn": "arn:aws:iam::194396987458:role/dreamwidth-ecsTaskExecutionRole",
     "networkMode": "awsvpc",
     "volumes": [

--- a/config/workers.json
+++ b/config/workers.json
@@ -17,7 +17,7 @@
       "min_count": 1,
       "max_count": 1,
       "target_cpu": 50,
-      "task_role": "dreamwidth-autoscaler-taskRole"
+      "task_role": "dreamwidth-ecs-autoscaler-taskRole"
     },
     "change-poster-id": {
       "cpu": 256,


### PR DESCRIPTION
The worker deploy failed with `iam:PassRole` denied: the `dw-github-actions` user is only allowed to pass `arn:aws:iam::*:role/dreamwidth-ecs*`, but the autoscaler role was named `dreamwidth-autoscaler-taskRole`, which does not match. Rename it to `dreamwidth-ecs-autoscaler-taskRole` (in `config/workers.json` and the generated task def) so the existing wildcard covers it — no IAM policy change needed. The matching terraform rename is applied separately in dw-terraform.

CODE TOUR: A one-name fix so the new autoscaler service is allowed to deploy — no behavior change.