### PR TITLE
Make jbackup.pl resilient to throttling and interruptions

### DIFF
--- a/src/jbackup/jbackup.pl
+++ b/src/jbackup/jbackup.pl
@@ -116,7 +116,12 @@ $opts{verbose} = $opts{quiet} ? 0 : 1;
 
 # set some constants that should never need to change.
 my $COMMENTS_FETCH_META = 10000;   # up to 10000 comments, the maximum for comment_meta
-my $COMMENTS_FETCH_BODY = 1000;    # up to 1000 comments, the maximum for comment_body
+# comment_body batch size: the server max is 1000, but heavy windows (big threads) can blow
+# past DW's gateway timeout and 504. Lower this (e.g. comment_body_fetch=250 in ~/.jbackup)
+# to make each request lighter and far less likely to time out, at the cost of more requests.
+my $COMMENTS_FETCH_BODY = defined $opts{comment_body_fetch} ? $opts{comment_body_fetch}+0 : 1000;
+$COMMENTS_FETCH_BODY = 1000 if $COMMENTS_FETCH_BODY > 1000;   # server ceiling
+$COMMENTS_FETCH_BODY = 1    if $COMMENTS_FETCH_BODY < 1;
 
 # --- resilience knobs (override in ~/.jbackup, e.g. a line "xmlrpc_delay=3") ---
 my $XMLRPC_DELAY      = defined $opts{xmlrpc_delay} ? $opts{xmlrpc_delay}+0 : 2;   # sec before each XML-RPC call

--- a/src/jbackup/jbackup.pl
+++ b/src/jbackup/jbackup.pl
@@ -141,7 +141,7 @@ my $ADAPT_DELAY       = 0;   # current carried-over delay (state)
 my $ADAPT_OK          = 0;   # consecutive clean windows (state)
 
 # now figure out what we're doing
-if ($opts{help} || !($opts{sync} || $opts{dumptype} || $opts{alter_security})) {
+if ($opts{help} || !($opts{sync} || $opts{dumptype} || $opts{alter_security} || $opts{backfill})) {
     print <<HELP;
 jbackup.pl -- journal database generator and formatter
 

--- a/src/jbackup/jbackup.pl
+++ b/src/jbackup/jbackup.pl
@@ -124,6 +124,14 @@ my $FETCH_DELAY       = defined $opts{fetch_delay}  ? $opts{fetch_delay}+0  : 1;
 my $HTTP_TIMEOUT      = defined $opts{http_timeout} ? $opts{http_timeout}+0 : 120; # sec per request before it's an error (not a hang)
 my $MAX_BACKOFF_TRIES = defined $opts{max_tries}    ? $opts{max_tries}+0    : 6;   # retries w/ exponential backoff before giving up/skipping
 
+# adaptive pacing: extra delay carried across comment windows, ramps up on errors, decays
+# only after a clean streak -- so a struggling server gets sustained relief, not fresh poking.
+my $ADAPT_STEP        = defined $opts{adapt_step}  ? $opts{adapt_step}+0  : 5;   # first bump (sec) on the first error
+my $ADAPT_MAX         = defined $opts{adapt_max}   ? $opts{adapt_max}+0   : 60;  # ceiling for the carried-over delay
+my $ADAPT_DECAY_AFTER = defined $opts{adapt_decay} ? $opts{adapt_decay}+0 : 10;  # clean windows needed before easing off
+my $ADAPT_DELAY       = 0;   # current carried-over delay (state)
+my $ADAPT_OK          = 0;   # consecutive clean windows (state)
+
 # now figure out what we're doing
 if ($opts{help} || !($opts{sync} || $opts{dumptype} || $opts{alter_security})) {
     print <<HELP;
@@ -515,7 +523,10 @@ sub load_comment {
 sub do_authed_fetch {
     my ($mode, $startid, $numitems, $sess, $tries) = @_;
     $tries ||= 0;
-    sleep $FETCH_DELAY if $FETCH_DELAY;
+    # adaptive pacing: $ADAPT_DELAY is extra delay carried ACROSS windows. It ramps up when
+    # the server is unhappy (504s/etc) and decays only after a run of clean successes, so we
+    # stay slowed for a while instead of slamming a struggling server fresh on every window.
+    sleep($FETCH_DELAY + $ADAPT_DELAY) if ($FETCH_DELAY + $ADAPT_DELAY) > 0;
     d("do_authed_fetch: mode = $mode, startid = $startid, numitems = $numitems, sess = $sess");
 
     # hit up the server with the specified information and return the raw content.
@@ -532,14 +543,28 @@ sub do_authed_fetch {
 
     if ($response->is_error()) {
         my $code = $response->code;
+        # an error means the server is struggling: bump the carried-over delay (capped) and
+        # reset the clean-streak counter so it doesn't decay back immediately.
+        $ADAPT_DELAY = $ADAPT_DELAY < $ADAPT_MAX ? ($ADAPT_DELAY ? $ADAPT_DELAY * 2 : $ADAPT_STEP) : $ADAPT_MAX;
+        $ADAPT_DELAY = $ADAPT_MAX if $ADAPT_DELAY > $ADAPT_MAX;
+        $ADAPT_OK = 0;
         if ($tries < $MAX_BACKOFF_TRIES) {
             my $wait = 15 * (2 ** $tries);   # 15,30,60,120,240,480s
-            d("do_authed_fetch: HTTP $code; backing off ${wait}s (try " . ($tries+1) . "/$MAX_BACKOFF_TRIES)");
+            d("do_authed_fetch: HTTP $code; backing off ${wait}s (try " . ($tries+1) . "/$MAX_BACKOFF_TRIES); pace now ${ADAPT_DELAY}s");
             sleep $wait;
             return do_authed_fetch($mode, $startid, $numitems, $sess, $tries + 1);
         }
         warn "do_authed_fetch: giving up on $mode startid=$startid after repeated HTTP $code; skipping this window\n";
         return '__SKIP__';
+    }
+
+    # success: only decay the carried-over delay after several clean windows in a row.
+    if ($ADAPT_DELAY > 0) {
+        if (++$ADAPT_OK >= $ADAPT_DECAY_AFTER) {
+            $ADAPT_OK = 0;
+            $ADAPT_DELAY = int($ADAPT_DELAY / 2);
+            d("do_authed_fetch: clean streak; easing pace to ${ADAPT_DELAY}s");
+        }
     }
 
     my $xml = $response->content();

--- a/src/jbackup/jbackup.pl
+++ b/src/jbackup/jbackup.pl
@@ -90,7 +90,8 @@ exit 1 unless
                "md5pass=s" => \$opts{md5password},
                "alter-security=s" => \$opts{alter_security},
                "confirm-alter" => \$opts{confirm_alter},
-               "no-comments" => \$opts{no_comments},);
+               "no-comments" => \$opts{no_comments},
+               "backfill" => \$opts{backfill},);
 
 # hit up .jbackup for other options
 if (-e "$ENV{HOME}/.jbackup") {
@@ -128,6 +129,8 @@ my $XMLRPC_DELAY      = defined $opts{xmlrpc_delay} ? $opts{xmlrpc_delay}+0 : 2;
 my $FETCH_DELAY       = defined $opts{fetch_delay}  ? $opts{fetch_delay}+0  : 1;   # sec before each comment HTTP fetch
 my $HTTP_TIMEOUT      = defined $opts{http_timeout} ? $opts{http_timeout}+0 : 120; # sec per request before it's an error (not a hang)
 my $MAX_BACKOFF_TRIES = defined $opts{max_tries}    ? $opts{max_tries}+0    : 6;   # retries w/ exponential backoff before giving up/skipping
+my $META_MAX_TRIES    = defined $opts{meta_max_tries} ? $opts{meta_max_tries}+0 : 9; # meta windows get more patience (a meta skip is high-stakes)
+my $MAX_BACKOFF_WAIT  = defined $opts{max_backoff}   ? $opts{max_backoff}+0   : 300; # cap on a single backoff sleep (sec)
 
 # adaptive pacing: extra delay carried across comment windows, ramps up on errors, decays
 # only after a clean streak -- so a struggling server gets sustained relief, not fresh poking.
@@ -222,7 +225,7 @@ my $tied = do_tie();
 
 # do something
 do_alter_security($opts{alter_security}, $opts{confirm_alter}) if $opts{alter_security};
-do_sync() if $opts{sync};
+do_sync() if $opts{sync} || $opts{backfill};
 do_dump($opts{dumptype}) if $opts{dumptype};
 
 # clean up before we exit
@@ -236,8 +239,50 @@ sub d {
     print STDERR shift(@_) . "\n";
 }
 
+# --- skipped-window accounting -------------------------------------------------
+# Skips are recorded durably in the database under a single key, "skipped:windows",
+# as a comma list of "mode:startid:numitems" so a gap survives the run ending, is
+# reported at the end, and can be recovered with --backfill. numitems gives the exact
+# id range and an upper bound on how many comments the window could hold.
+sub parse_skips {
+    my %w;
+    foreach my $e (split /,/, ($bak{"skipped:windows"} || '')) {
+        my ($mode, $startid, $numitems) = split /:/, $e;
+        next unless defined $numitems;
+        $w{"$mode:$startid"} = $numitems;
+    }
+    return %w;
+}
+
+sub record_skip {
+    my ($mode, $startid, $numitems) = @_;
+    my %w = parse_skips();
+    $w{"$mode:$startid"} = $numitems;
+    $bak{"skipped:windows"} = join(',', map { "$_:$w{$_}" } sort keys %w);
+}
+
+sub remove_skip {
+    my ($mode, $startid) = @_;
+    my %w = parse_skips();
+    delete $w{"$mode:$startid"};
+    $bak{"skipped:windows"} = join(',', map { "$_:$w{$_}" } sort keys %w);
+}
+
+sub report_skipped {
+    my %w = parse_skips();
+    return unless %w;
+    my $total = 0; $total += $_ for values %w;
+    print STDERR "\n*** WARNING: " . (scalar keys %w) . " window(s) skipped; up to $total comment(s) missing:\n";
+    foreach my $k (sort keys %w) {
+        my ($mode, $startid) = split /:/, $k;
+        print STDERR "      $mode startid=$startid numitems=$w{$k}\n";
+    }
+    print STDERR "    Re-run with --backfill (set a lower comment_body_fetch first) to recover them.\n\n";
+}
+
 sub do_sync {
 ### ENTRY DOWNLOADING ###
+  unless ($opts{backfill}) {   # --backfill skips the entry sweep; it only re-pulls comment gaps
     # see if we have any sync data saved
     my %sync;
     my $lastsync = $bak{"event:lastsync"};
@@ -315,6 +360,8 @@ sub do_sync {
         last unless $count && $lastgrab;
     }
 
+  }  # end entry sweep (skipped in --backfill mode)
+
 ### COMMENT DOWNLOADING ###
     # see if we shouldn't be doing this
     return if $opts{no_comments};
@@ -363,17 +410,38 @@ sub do_sync {
         $server_next_id = $_[1] + 0 if ($lasttag eq 'nextid');
     };
 
-    # hit up the server for metadata
+    # hit up the server for metadata. A skipped meta window is NOT safe to continue past: it
+    # would leave %meta incomplete and a wrong $server_max_id, corrupting/truncating the body
+    # sweep. So we stop the comment phase cleanly and let a re-run rebuild the (in-memory,
+    # uncheckpointed, cheap) meta pass from scratch.
     while (defined $server_next_id  && $server_next_id =~ /^\d+$/) {
         my $content = do_authed_fetch('comment_meta', $server_next_id, $COMMENTS_FETCH_META, $ljsession);
         die "Some sort of error fetching metadata from server" unless $content;
 
+        if ($content eq '__SKIP__') {
+            print STDERR "\n*** A comment-metadata window failed after $META_MAX_TRIES retries.\n";
+            print STDERR "    Stopping the comment phase WITHOUT running the body sweep, because an\n";
+            print STDERR "    incomplete metadata pass would corrupt and truncate saved comments.\n";
+            print STDERR "    Your entries and any previously-saved comments are intact. Wait for the\n";
+            print STDERR "    server to recover, then re-run --sync -- the metadata pass rebuilds from\n";
+            print STDERR "    scratch (it is not checkpointed), so nothing here needs --backfill.\n\n";
+            report_skipped();
+            return;
+        }
+
         $server_next_id = undef;
 
         # now we want to XML parse this
-        unless ($content eq '__SKIP__') {
-            my $parser = new XML::Parser(Handlers => { Start => $meta_handler, Char => $meta_content, End => $meta_closer });
-            $parser->parse($content);
+        my $parser = new XML::Parser(Handlers => { Start => $meta_handler, Char => $meta_content, End => $meta_closer });
+        $parser->parse($content);
+    }
+    # the metadata pass completed in full, so any comment_meta skip marker from a prior aborted
+    # run is now stale -- clear it.
+    {
+        my %w = parse_skips();
+        foreach my $k (grep { /^comment_meta:/ } keys %w) {
+            my (undef, $sid) = split /:/, $k;
+            remove_skip('comment_meta', $sid);
         }
     }
     $bak{"comment:ids"} = join ',', keys %meta;
@@ -415,7 +483,47 @@ sub do_sync {
         # gotten some data
     };
 
-    # at this point we have a fully regenerated metadata cache and we want to grab a block of comments
+    # at this point we have a fully regenerated metadata cache and we want to grab comment bodies
+    if ($opts{backfill}) {
+        # --backfill: re-pull only the windows recorded as skipped (reusing the meta rebuilt
+        # above), splitting each into sub-windows of the current comment_body_fetch size -- so a
+        # window that 504'd at 1000 can come through at e.g. 250. Recovered comments are saved;
+        # any sub-window that still fails re-records a finer skip marker for a later attempt.
+        my %w = parse_skips();
+        my @windows = sort grep { /^comment_body:/ } keys %w;
+        unless (@windows) {
+            print "No skipped comment_body windows to backfill.\n";
+            report_skipped();
+            return;
+        }
+        print scalar(@windows) . " skipped window(s) to backfill (sub-batch = $COMMENTS_FETCH_BODY).\n";
+        my $recovered = 0;
+        foreach my $k (@windows) {
+            my (undef, $startid) = split /:/, $k;
+            my $numitems = $w{$k};
+            remove_skip('comment_body', $startid);   # drop the wide marker; sub-failures re-mark finer
+            $tied->sync();
+            for (my $s = $startid; $s < $startid + $numitems; $s += $COMMENTS_FETCH_BODY) {
+                my $n = ($s + $COMMENTS_FETCH_BODY > $startid + $numitems) ? ($startid + $numitems - $s) : $COMMENTS_FETCH_BODY;
+                @window_ids = ();
+                my $content = do_authed_fetch('comment_body', $s, $n, $ljsession);
+                next if !$content || $content eq '__SKIP__';   # finer marker auto-recorded on re-skip
+                my $parser = new XML::Parser(Handlers => { Start => $body_handler, Char => $body_content, End => $body_closer });
+                $parser->parse($content);
+                foreach my $id (@window_ids) {
+                    next unless $meta{$id}{jitemid};
+                    $recovered++;
+                    save_comment($meta{$id});
+                }
+                $tied->sync();
+            }
+            print "backfill: processed window startid=$startid numitems=$numitems.\n";
+        }
+        print "Backfill done: recovered $recovered comment bodies.\n";
+        report_skipped();   # report any finer gaps that still remain
+        return;
+    }
+
     my $count = 0;
     while (1) {
         @window_ids = ();
@@ -444,6 +552,7 @@ sub do_sync {
         last unless $lastid < $server_max_id;
     }
     print "$count new comments downloaded.\n";
+    report_skipped();   # surface any windows skipped during this sweep
 }
 
 # save an event that we get
@@ -553,13 +662,20 @@ sub do_authed_fetch {
         $ADAPT_DELAY = $ADAPT_DELAY < $ADAPT_MAX ? ($ADAPT_DELAY ? $ADAPT_DELAY * 2 : $ADAPT_STEP) : $ADAPT_MAX;
         $ADAPT_DELAY = $ADAPT_MAX if $ADAPT_DELAY > $ADAPT_MAX;
         $ADAPT_OK = 0;
-        if ($tries < $MAX_BACKOFF_TRIES) {
-            my $wait = 15 * (2 ** $tries);   # 15,30,60,120,240,480s
-            d("do_authed_fetch: HTTP $code; backing off ${wait}s (try " . ($tries+1) . "/$MAX_BACKOFF_TRIES); pace now ${ADAPT_DELAY}s");
+        # metadata windows get more retry patience than body windows: a skipped meta window is
+        # high-stakes (it truncates the meta pass), whereas a skipped body window is a clean,
+        # backfillable gap.
+        my $cap = ($mode eq 'comment_meta') ? $META_MAX_TRIES : $MAX_BACKOFF_TRIES;
+        if ($tries < $cap) {
+            my $wait = 15 * (2 ** $tries);
+            $wait = $MAX_BACKOFF_WAIT if $wait > $MAX_BACKOFF_WAIT;   # don't let a single backoff run away
+            d("do_authed_fetch: HTTP $code; backing off ${wait}s (try " . ($tries+1) . "/$cap); pace now ${ADAPT_DELAY}s");
             sleep $wait;
             return do_authed_fetch($mode, $startid, $numitems, $sess, $tries + 1);
         }
         warn "do_authed_fetch: giving up on $mode startid=$startid after repeated HTTP $code; skipping this window\n";
+        record_skip($mode, $startid, $numitems);   # persist the gap for end-of-run report + --backfill
+        $tied->sync();
         return '__SKIP__';
     }
 

--- a/src/jbackup/jbackup.pl
+++ b/src/jbackup/jbackup.pl
@@ -118,6 +118,12 @@ $opts{verbose} = $opts{quiet} ? 0 : 1;
 my $COMMENTS_FETCH_META = 10000;   # up to 10000 comments, the maximum for comment_meta
 my $COMMENTS_FETCH_BODY = 1000;    # up to 1000 comments, the maximum for comment_body
 
+# --- resilience knobs (override in ~/.jbackup, e.g. a line "xmlrpc_delay=3") ---
+my $XMLRPC_DELAY      = defined $opts{xmlrpc_delay} ? $opts{xmlrpc_delay}+0 : 2;   # sec before each XML-RPC call
+my $FETCH_DELAY       = defined $opts{fetch_delay}  ? $opts{fetch_delay}+0  : 1;   # sec before each comment HTTP fetch
+my $HTTP_TIMEOUT      = defined $opts{http_timeout} ? $opts{http_timeout}+0 : 120; # sec per request before it's an error (not a hang)
+my $MAX_BACKOFF_TRIES = defined $opts{max_tries}    ? $opts{max_tries}+0    : 6;   # retries w/ exponential backoff before giving up/skipping
+
 # now figure out what we're doing
 if ($opts{help} || !($opts{sync} || $opts{dumptype} || $opts{alter_security})) {
     print <<HELP;
@@ -352,8 +358,10 @@ sub do_sync {
         $server_next_id = undef;
 
         # now we want to XML parse this
-        my $parser = new XML::Parser(Handlers => { Start => $meta_handler, Char => $meta_content, End => $meta_closer });
-        $parser->parse($content);
+        unless ($content eq '__SKIP__') {
+            my $parser = new XML::Parser(Handlers => { Start => $meta_handler, Char => $meta_content, End => $meta_closer });
+            $parser->parse($content);
+        }
     }
     $bak{"comment:ids"} = join ',', keys %meta;
     $bak{"usermap:userids"} = join ',', @userids;
@@ -362,6 +370,7 @@ sub do_sync {
     my $lastid = $bak{"comment:lastid"}+0;
     my $curid = 0;
     my @tags;
+    my @window_ids;   # ids whose bodies arrived in the current window (for incremental save)
     my $body_handler = sub {
         # this sub actually processes incoming body information
         $lasttag = $_[1];
@@ -373,6 +382,7 @@ sub do_sync {
             $curid = $temp{id};
             $meta{$curid}{parentid} = $temp{parentid}+0;
             $meta{$curid}{jitemid} = $temp{jitemid}+0;
+            push @window_ids, $curid;   # for incremental per-window save
             # line below commented out because we shouldn't be trying to be clever like this ;p
             # $lastid = $curid if $curid > $lastid;
         }
@@ -393,31 +403,34 @@ sub do_sync {
     };
 
     # at this point we have a fully regenerated metadata cache and we want to grab a block of comments
+    my $count = 0;
     while (1) {
+        @window_ids = ();
         my $content = do_authed_fetch('comment_body', $lastid+1, $COMMENTS_FETCH_BODY, $ljsession);
         die "Some sort of error fetching body data from server" unless $content;
 
         # now we want to XML parse this
-        my $parser = new XML::Parser(Handlers => { Start => $body_handler, Char => $body_content, End => $body_closer });
-        $parser->parse($content);
+        unless ($content eq '__SKIP__') {
+            my $parser = new XML::Parser(Handlers => { Start => $body_handler, Char => $body_content, End => $body_closer });
+            $parser->parse($content);
+        }
 
-        # now at this point what we have to decide whether we should loop again for more metadata
+        # INCREMENTAL SAVE: persist this window's comments, advance the checkpoint, and flush
+        # to disk immediately. This turns the comment phase from all-or-nothing into resumable:
+        # if the server blocks us mid-run, everything pulled so far is already saved, and the
+        # next --sync picks up from comment:lastid instead of restarting bodies from scratch.
+        foreach my $id (@window_ids) {
+            next unless $meta{$id}{jitemid}; # jitemid == 0 means we didn't get body info
+            $count++;
+            save_comment($meta{$id});
+        }
         $lastid += $COMMENTS_FETCH_BODY;
+        $bak{"comment:lastid"} = $lastid;   # checkpoint advances EVERY window (even empty ones)
+        $tied->sync();                       # flush so progress survives an interruption
+
         last unless $lastid < $server_max_id;
     }
-
-    # at this point we should have a set of fully formed comments, so let's save everything
-    my $count = 0;
-    foreach my $id (keys %meta) {
-        next unless $meta{$id}{jitemid}; # jitemid == 0 means we didn't get body info on this comment
-        $count++;
-        save_comment($meta{$id});
-    }
     print "$count new comments downloaded.\n";
-
-    # update our lastid.  we want this to always point to the last comment we downloaded, because
-    # comment ids will never go backwards, and we can always count on the next one being > lastid
-    $bak{"comment:lastid"} = $lastid if $count;
 }
 
 # save an event that we get
@@ -500,7 +513,9 @@ sub load_comment {
 }
 
 sub do_authed_fetch {
-    my ($mode, $startid, $numitems, $sess) = @_;
+    my ($mode, $startid, $numitems, $sess, $tries) = @_;
+    $tries ||= 0;
+    sleep $FETCH_DELAY if $FETCH_DELAY;
     d("do_authed_fetch: mode = $mode, startid = $startid, numitems = $numitems, sess = $sess");
 
     # hit up the server with the specified information and return the raw content.
@@ -508,18 +523,31 @@ sub do_authed_fetch {
     # (e.g. dreamwidth.org -> www.dreamwidth.org)
     my $ua = LWP::UserAgent->new;
     $ua->agent('JBackup/1.0');
+    $ua->timeout($HTTP_TIMEOUT);   # a stalled connection becomes an error instead of a forever-hang
     $ua->cookie_jar({});
     $ua->cookie_jar->set_cookie(0, 'ljsession', $sess, '/', $opts{server}, undef, 0, 0, 86400, 0);
     my $authas = $opts{usejournal} ? "&authas=$opts{usejournal}" : '';
     my $request = HTTP::Request->new(GET => "$opts{baseurl}/export_comments.bml?get=$mode&startid=$startid&numitems=$numitems$authas");
     my $response = $ua->request($request);
-    return if $response->is_error();
+
+    if ($response->is_error()) {
+        my $code = $response->code;
+        if ($tries < $MAX_BACKOFF_TRIES) {
+            my $wait = 15 * (2 ** $tries);   # 15,30,60,120,240,480s
+            d("do_authed_fetch: HTTP $code; backing off ${wait}s (try " . ($tries+1) . "/$MAX_BACKOFF_TRIES)");
+            sleep $wait;
+            return do_authed_fetch($mode, $startid, $numitems, $sess, $tries + 1);
+        }
+        warn "do_authed_fetch: giving up on $mode startid=$startid after repeated HTTP $code; skipping this window\n";
+        return '__SKIP__';
+    }
+
     my $xml = $response->content();
     return $xml if $xml;
 
-    # blah
-    d("do_authed_fetch: failure! retrying");
-    return do_authed_fetch($mode, $startid, $numitems, $sess);
+    # 200 but empty body: transient, retry (no try increment, matches original intent)
+    d("do_authed_fetch: empty response; retrying");
+    return do_authed_fetch($mode, $startid, $numitems, $sess, $tries);
 }
 
 sub do_dump {
@@ -914,21 +942,39 @@ sub dump_xml {
 sub xmlrpc_call_helper {
     # helper function that makes life easier on folks that call xmlrpc stuff.  this handles
     # running the actual request and checking for errors, as well as handling the cases where
-    # we hit a problem and need to do something about it.  (abort or retry.)
-    my ($xmlrpc, $method, $req, $mode, $hash) = @_;
+    # we hit a problem and need to do something about it.  (back off, retry, skip or abort.)
+    my ($xmlrpc, $method, $req, $mode, $hash, $tries) = @_;
+    $tries ||= 0;
+    sleep $XMLRPC_DELAY if $XMLRPC_DELAY;
     d("\t\txmlrpc_call_helper: $method");
     my $res;
     eval { $res = $xmlrpc->call($method, $req); };
     if ($res && $res->fault) {
+        # a server-side fault (e.g. throttle/abuse "Denied access to method"). Back off and
+        # retry a few times in case it's transient; only abort if it persists.
+        if ($tries < $MAX_BACKOFF_TRIES) {
+            my $wait = 30 * (2 ** $tries);   # 30,60,120,240,480,960s
+            print STDERR "xmlrpc_call_helper: fault '" . $res->faultstring . "'; backing off ${wait}s (try " . ($tries+1) . "/$MAX_BACKOFF_TRIES)\n";
+            sleep $wait;
+            return call_xmlrpc($mode, $hash, $tries + 1);
+        }
         # fatal error, so don't use d() as we want to print even in case of non-verbosity
         print STDERR "xmlrpc_call_helper error:\n\tString: " . $res->faultstring . "\n\tCode: " . $res->faultcode . "\n";
+        print STDERR "\t(persisted after $MAX_BACKOFF_TRIES backoffs -- you are likely rate/abuse blocked; wait and re-run --sync)\n";
         do_abort();
         exit 1;
     }
     unless ($res) {
-        # when server times out
-        d("\t\txmlrpc_call_helper: timeout... retrying.");
-        return call_xmlrpc($mode, $hash);
+        # no response: server timeout / transport error. back off and retry (bounded).
+        if ($tries < $MAX_BACKOFF_TRIES) {
+            my $wait = 15 * (2 ** $tries);
+            d("\t\txmlrpc_call_helper: no response; backing off ${wait}s (try " . ($tries+1) . "/$MAX_BACKOFF_TRIES)");
+            sleep $wait;
+            return call_xmlrpc($mode, $hash, $tries + 1);
+        }
+        print STDERR "xmlrpc_call_helper: giving up after repeated timeouts on $method\n";
+        do_abort();
+        exit 1;
     }
     return $res->result;
 }
@@ -937,14 +983,16 @@ sub call_xmlrpc {
     # also a way to help people do xmlrpc stuff easily.  this method actually does the
     # challenge response stuff so we never send the user's password or md5 digest over
     # the intarweb.  of course, we say nothing about the user's password security anyway...
-    my ($mode, $hash) = @_;
+    my ($mode, $hash, $tries) = @_;
     $hash ||= {};
+    $tries ||= 0;
 
     my $xmlrpc = new XMLRPC::Lite;
     $xmlrpc->proxy("$opts{baseurl}/interface/xmlrpc");
+    eval { $xmlrpc->transport->timeout($HTTP_TIMEOUT); };   # don't hang forever on a dead socket
     my $chal;
     while (!$chal) {
-        my $get_chal = xmlrpc_call_helper($xmlrpc, 'LJ.XMLRPC.getchallenge');
+        my $get_chal = xmlrpc_call_helper($xmlrpc, 'LJ.XMLRPC.getchallenge', undef, $mode, $hash, $tries);
         $chal = $get_chal->{'challenge'};
     }
     #d("\tcall_xmlrpc: challenge obtained: $chal");
@@ -957,7 +1005,7 @@ sub call_xmlrpc {
         'auth_challenge' => $chal,
         'auth_response' => $response,
         %$hash, # interpolate $hash into our hash here...isn't Perl great?
-    }, $mode, $hash);
+    }, $mode, $hash, $tries);
     return $res;
 }
 


### PR DESCRIPTION
CODE TOUR: Allow backing up of larger communities, while being more resilient to being throttled and allowing the user to continue from where they left off if throttled.

Full disclosure. This was mostly written by Claude as I walked through trying to get a backup made, but is tested and functional. I ran into a lot of troubles trying to backup an extremely large community, and this made the job much easier.

# Make `jbackup.pl` resilient to throttling and interruptions on large journals

## Summary

Hardens `src/jbackup/jbackup.pl` for large communities (tens of thousands of
entries, hundreds of thousands of comments). Adds request timeouts, exponential
backoff, polite rate-limiting, adaptive pacing, incremental comment saving, a
tunable comment batch size, durable accounting of skipped windows with an
end-of-run report, a `--backfill` mode to recover them, and safe handling of
metadata-window failures. Together these let a long backup survive server-side
throttling and interruptions without hanging, escalating into a harder block,
silently dropping data, or discarding hours of downloaded comments.

All new behavior is on by default with conservative values; every knob is
optional and overridable via `~/.jbackup`.

## Motivation

On a community with ~31k entries and 300k+ comments, the current script has
several failure modes that compound:

1. **No request timeout.** `do_authed_fetch` and the XML-RPC transport have no
   timeout, so a stalled connection (a throttle that drops the socket rather than
   returning a status) hangs the process indefinitely.
2. **No backoff.** On a timeout, `xmlrpc_call_helper` retries *immediately* and
   unbounded; on an HTTP error, `do_authed_fetch` returns undef and the caller
   `die`s. Neither waits. Sustained immediate retries against a throttling server
   escalate a soft rate-limit into a hard `Denied access to method` block.
3. **No rate-limiting.** There's no delay between calls, and the XML-RPC path
   re-fetches a challenge before every call (two round trips each), so a large
   sync is a high sustained request rate.
4. **All-or-nothing comment save.** Comment bodies accumulate in `%meta` and are
   only written to the database (`save_comment`) after the *entire* body loop
   completes; `comment:lastid` advances only at the end. Any failure during the
   comment phase discards every downloaded body and leaves the checkpoint
   unmoved, forcing a full re-download on the next run.
5. **A skipped window is silent and unrecoverable.** Even once skipping is
   possible, a skip is a transient stderr line with no durable record and no way
   to recover just the gap.
6. **A metadata-window failure is catastrophic, not bounded.** The body fetcher
   can tolerate a skipped window (a localized gap), but the metadata pass cannot:
   a skipped `comment_meta` window leaves `%meta` incomplete and `$server_max_id`
   wrong, which corrupts the saved state of comments in that range and can
   silently truncate the body sweep.

## Changes

### Tunable knobs (overridable via `~/.jbackup`, e.g. `xmlrpc_delay=3`)

| Knob | Default | Purpose |
|------|---------|---------|
| `xmlrpc_delay` | 2s | delay before each XML-RPC call |
| `fetch_delay` | 1s | delay before each comment HTTP fetch |
| `http_timeout` | 120s | per-request timeout (a stall becomes an error) |
| `max_tries` | 6 | backoff retries for body/XML-RPC before skip/abort |
| `meta_max_tries` | 9 | backoff retries for metadata windows (higher stakes) |
| `max_backoff` | 300s | cap on a single backoff sleep |
| `comment_body_fetch` | 1000 | comment bodies per request (lower to dodge 504s) |
| `adapt_step` / `adapt_max` / `adapt_decay` | 5s / 60s / 10 | adaptive pacing |

### Request timeouts, backoff, and rate-limiting

`do_authed_fetch` (comment HTTP fetcher):

- Sets `$ua->timeout($http_timeout)` so a stalled socket becomes a catchable
  error instead of a hang.
- Sleeps `fetch_delay` (plus the adaptive delay, below) before each request.
- On HTTP error, retries with exponential backoff (15·2ⁿ s, capped at
  `max_backoff`) up to the relevant try cap, then records and skips the window
  (see *Skip accounting*) rather than aborting the whole run.

`xmlrpc_call_helper` / `call_xmlrpc` (XML-RPC path):

- Sleeps `xmlrpc_delay` before each call; sets the transport timeout.
- Threads a `$tries` counter through both subs.
- On a fault (previously an immediate abort), backs off (30·2ⁿ s) and retries up
  to `max_tries` before aborting, with a clearer message that a persistent fault
  likely means a rate/abuse block.
- On no response (previously an immediate, unbounded retry), uses bounded
  exponential backoff.
- The `getchallenge` helper call now receives `$mode`/`$hash`, so a retry after a
  challenge failure restarts the intended call correctly rather than calling
  `call_xmlrpc(undef, undef)`.

### Adaptive pacing (comment fetch)

The per-window backoff resets its try-counter for each new window, so after
surviving a rough patch the fetcher returns to full speed and re-discovers the
throttle from scratch on the next window. On a server returning sustained `504`s
(a slow backend rather than a hard rate-limit) this wastes time and keeps poking
a struggling server. `do_authed_fetch` therefore maintains a small amount of
state that *carries across windows*:

- A persistent extra delay is added to every request, on top of `fetch_delay`.
- On any HTTP error it ramps up multiplicatively (`adapt_step`, then doubling,
  capped at `adapt_max`) and the clean-streak counter resets.
- On success it decays — but only after `adapt_decay` consecutive clean windows,
  and only by halving — so the slowdown is *sustained* through and after a rough
  patch rather than snapping back instantly.

With the defaults, a burst of errors ramps the carried-over delay 5→10→20→40s
and eases off over ~30–40 clean windows. It is self-tuning, bounded, and adds no
delay once a backup is running cleanly.

### Incremental comment saving

- The body loop now calls `save_comment` for the current window's comments,
  advances `comment:lastid`, and `$tied->sync()`s the database **every window**,
  instead of saving everything after the loop.
- A small `@window_ids` list (populated by `body_handler`) lets each iteration
  save only that window.
- **Result:** the comment phase is resumable. An interruption keeps everything
  already pulled, and the next `--sync` resumes from `comment:lastid` instead of
  re-downloading bodies from the start.

The lighter `comment_meta` pass still re-runs from scratch each comment phase, as
before, since it's held in memory (~10k IDs/request, not the bottleneck).

### Tunable comment batch size

`comment_body` requests default to the server maximum of 1000, but a heavy window
(a large thread) can exceed the server's gateway timeout and `504`. The batch
size is now read from `comment_body_fetch` (clamped 1–1000), so it can be lowered
(e.g. 250) to make each request lighter and far less likely to time out, at the
cost of more requests. The checkpoint is in absolute comment-ID units, so the
value can be changed between runs without re-downloading anything.

### Skip accounting and `--backfill`

A skipped window is now recorded durably in the database under a single
`skipped:windows` key as a comma list of `mode:startid:numitems`, so a gap
survives the run ending, carries its exact ID range and an upper-bound comment
count, and can be recovered later. At the end of the comment phase the run prints
a summary of any skipped windows and the upper-bound number of missing comments.

A new `--backfill` mode (run like `--sync`, e.g.
`jbackup.pl --backfill --user=U --journal=J`) skips the entry sweep, rebuilds the
comment metadata, and re-pulls **only** the recorded skipped `comment_body`
windows — splitting each into sub-windows of the current `comment_body_fetch`
size, so a window that `504`d at 1000 can come through at, say, 250. Recovered
comments are saved and their markers cleared; any sub-window that still fails
re-records a *finer* marker, so successive backfill passes (at progressively
smaller batch sizes) narrow the gaps rather than restarting them.

### Metadata-window failure is now safe

A skipped `comment_meta` window is high-stakes — continuing past it would leave
`%meta` incomplete and `$server_max_id` wrong, corrupting and truncating the body
sweep. So:

- Metadata windows get more retry patience than body windows (`meta_max_tries`,
  default 9, vs `max_tries` default 6).
- If a metadata window still fails, the comment phase **stops cleanly before the
  body sweep**, with a clear message, rather than truncating. Entries and any
  previously-saved comments are intact, and a re-run rebuilds the in-memory,
  uncheckpointed metadata pass from scratch — so no `--backfill` is needed for
  metadata.
- When the metadata pass completes in full, any stale `comment_meta` marker from
  a prior aborted run is cleared automatically.

## Compatibility

- One new CLI flag, `--backfill`; all other behavior is on by default with
  conservative values, and every knob is optional.
- Database schema is unchanged. It reuses the existing `comment:lastid`
  checkpoint key (written more frequently) and adds one new bookkeeping key,
  `skipped:windows`, so existing `.jbak` files remain compatible.
- The only behavioral change to a *successful, unthrottled* run is the added
  per-call delays (seconds of overhead) and more frequent DB flushes.

## Testing

- `perl -c` clean under `use strict`.
- Skip accounting (record / parse / remove / report, including finer re-marking
  after a partial backfill and body-only window selection) validated via a
  serialization round-trip harness.
- Adaptive-pacing ramp-up/decay and the capped backoff schedule validated via
  simulation.
- Metadata-marker cleanup validated to clear only `comment_meta` markers and
  leave `comment_body` markers intact.
- The incremental-save path exercises the existing `comment:lastid` checkpoint
  that the script already read but never advanced incrementally.

## Notes for reviewers

These are three logically separable concerns and could be split into separate
PRs if preferred:

1. **Network resilience** — timeouts, backoff, rate-limiting, adaptive pacing,
   tunable batch size. Keeps a long run from escalating a throttle into a block.
2. **Incremental comment saving** — makes the comment phase resumable. The
   highest-impact change for large journals.
3. **Skip accounting, `--backfill`, and metadata-skip safety** — makes data loss
   visible, bounded, and recoverable instead of silent.
