### PR TITLE
Tag request metrics and occupancy counters by web tier

### DIFF
--- a/cgi-bin/DW/WorkerOccupancy.pm
+++ b/cgi-bin/DW/WorkerOccupancy.pm
@@ -41,7 +41,7 @@ sub __reset {
     return;
 }
 
-sub _svc { return $ENV{DW_LOKI_SERVICE} }
+sub _svc { return $LJ::WEB_TIER }
 
 sub _key {
     my ($kind) = @_;

--- a/cgi-bin/LJ/Global/Defaults.pm
+++ b/cgi-bin/LJ/Global/Defaults.pm
@@ -48,6 +48,13 @@ no strict "vars";
 
     $SERVER_NAME ||= Sys::Hostname::hostname();
 
+    # Which web pool/tier this process serves (e.g. web-stable,
+    # web-unauthenticated). Used as the "tier" dimension on request metrics and
+    # as the memcached namespace the occupancy autoscaler reads. Production sets
+    # this from its environment in config-private-prod.pl; every other install
+    # shares a single 'default' tier.
+    $WEB_TIER ||= 'default';
+
     @LANGS = ("en") unless @LANGS;
     $DEFAULT_LANG ||= $LANGS[0];
 

--- a/cgi-bin/Plack/Middleware/DW/AccessLog.pm
+++ b/cgi-bin/Plack/Middleware/DW/AccessLog.pm
@@ -124,6 +124,7 @@ sub _log {
 sub _request_tags {
     my ( $self, $env, $status ) = @_;
     return [
+        'tier:' .      ( $LJ::WEB_TIER                // 'default' ),
         'auth:' .      ( $env->{'dw.stats.auth'}      // 'anon' ),
         'ratelimit:' . ( $env->{'dw.stats.ratelimit'} // 'skipped' ),
         'status:' . $status,

--- a/etc/config-private.pl.example
+++ b/etc/config-private.pl.example
@@ -295,11 +295,18 @@ use Net::Subnet;
     #    private_key => ,
     #);
 
+    # Which web pool/tier this install serves. Defaults to 'default'; production
+    # sets it per pool from the deploy environment. This is the ONLY place a
+    # production environment variable should appear -- app code reads
+    # $LJ::WEB_TIER, never the environment directly. It becomes the "tier" label
+    # on request metrics and the memcached namespace the autoscaler reads.
+    #$WEB_TIER = $ENV{DW_LOKI_SERVICE};
+
     # Occupancy-based web-tier autoscaler (bin/worker/web-autoscaler). Region and
-    # ecs_cluster are required. Each key under 'services' MUST equal the workers'
-    # DW_LOKI_SERVICE for that pool -- it's the memcached namespace the autoscaler
-    # reads -- while ecs_service is the ECS service it scales. Set dry_run to log
-    # decisions without touching ECS.
+    # ecs_cluster are required. Each key under 'services' MUST equal that pool's
+    # $WEB_TIER -- it's the memcached namespace the autoscaler reads -- while
+    # ecs_service is the ECS service it scales. Set dry_run to log decisions
+    # without touching ECS.
     #%AUTOSCALER = (
     #    region      => 'us-east-1',
     #    ecs_cluster => 'dreamwidth',

--- a/t/worker-occupancy.t
+++ b/t/worker-occupancy.t
@@ -26,7 +26,7 @@ use DW::WorkerOccupancy;
 # Controllable clock
 my $t = 1000.0;
 local $DW::WorkerOccupancy::CLOCK = sub { $t };
-local $ENV{DW_LOKI_SERVICE} = 'web-test';
+local $LJ::WEB_TIER               = 'web-test';
 
 my $shard    = $$ % 64;
 my $busy_key = "dw:sched:busy_ms:web-test:$shard";
@@ -61,11 +61,10 @@ with_fake_memcache {
     is( LJ::MemCache::get($busy_key), 850, 'busy accumulates to 850ms' );
 };
 
-# No service env => total no-op (dev / non-ECS)
+# Empty tier => total no-op (dev / unconfigured)
 with_fake_memcache {
     DW::WorkerOccupancy::__reset();
-    local $ENV{DW_LOKI_SERVICE};
-    delete $ENV{DW_LOKI_SERVICE};
+    local $LJ::WEB_TIER = '';
     DW::WorkerOccupancy::request_start();
     $t = 1003.6;
     DW::WorkerOccupancy::request_end();


### PR DESCRIPTION
Adds `$LJ::WEB_TIER` (default `'default'`, set in `LJ::Global::Defaults`) so we can break metrics down by web pool. `AccessLog` now puts a `tier` label on `dw.request` / `dw.request.duration_seconds`, and `DW::WorkerOccupancy` namespaces its memcached counters by `$LJ::WEB_TIER` rather than reading `$ENV{DW_LOKI_SERVICE}` — keeping the production-ism out of app code. Production bridges the env into config: `$LJ::WEB_TIER = $ENV{DW_LOKI_SERVICE};` in `config-private-prod.pl` (documented in `etc/config-private.pl.example`).

**Deploy ordering:** the prod config bridge must be set before/with this deploy. Otherwise web tasks fall back to tier `default`, the occupancy counters move to `dw:sched:…:default:*`, and the autoscaler (which reads per-tier) sees empty counters for `web-unauthenticated`.

CODE TOUR: Lets us slice request graphs (QPS, latency) by which set of web servers handled them, instead of one undifferentiated total — handy for spotting which pool a traffic or spam spike is hitting. No change for non-production installs (they just get one `default` tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)