### PR TITLE
Allow rubytext in comments

### DIFF
--- a/cgi-bin/LJ/CleanHTML.pm
+++ b/cgi-bin/LJ/CleanHTML.pm
@@ -1636,6 +1636,7 @@ my @comment_all = qw(
     area map form textarea
     img br hr p col
     summary details
+    ruby rt rp
 );
 
 my $event_eat    = $subject_eat;


### PR DESCRIPTION
CODE TOUR: lets people use `<ruby>`, `<rp>` and `<rt>` in comments for posting furigana (or doing elaborate HTML-based bits)

Closes #3481.