### PR TITLE
Fix journal search hiding all access-locked entries

### DIFF
--- a/cgi-bin/DW/Search.pm
+++ b/cgi-bin/DW/Search.pm
@@ -215,11 +215,21 @@ sub _journal_where {
         # Manticore rejects MVA filters passed as bind params (they get typed
         # as 'stringlist' and the MVA side errors out), so interpolate the
         # integers directly. Safe because bit_breakdown only returns ints.
+        #
+        # security_bits encoding (see DW::Task::SearchCopier): public entries
+        # carry 102, private carry 101, and usemask entries carry
+        # bit_breakdown(allowmask) with no discriminator bit. bit_breakdown(1)
+        # is (0), so a plain access-list-locked entry is stored as [0] -- 0 is
+        # a legitimate security bit (the default access group), not garbage.
+        # We therefore include it whenever the viewer's own mask covers it, and
+        # do NOT exclude it: this is only a coarse pre-filter. Every hit is
+        # re-checked authoritatively with $entry->visible_to in _enrich_journal,
+        # which redacts anything the viewer may not see, so an over-broad match
+        # here can never leak content -- but an over-narrow filter (the old
+        # "NOT IN (0)" exclude) silently hid every access-locked entry from the
+        # trusted readers entitled to it.
         my @bits = ( 102, LJ::bit_breakdown( $args->{allowmask} ) );
         push @c, 'security_bits IN (' . join( ',', map { int $_ } @bits ) . ')';
-
-        # Defensive exclude: drop any rows with a stray 0 security bit.
-        push @c, 'security_bits NOT IN (0)';
     }
 
     return ( 'AND ' . join( ' AND ', @c ), @b );

--- a/cgi-bin/DW/Task/SearchCopier.pm
+++ b/cgi-bin/DW/Task/SearchCopier.pm
@@ -253,21 +253,7 @@ sub copy_comment {
         $log->logcroak( $dbfrom->errstr ) if $dbfrom->err;
 
         foreach my $row ( values %$entries ) {
-
-            # Auto-convert usemask-with-no-groups to private.
-            $row->{security} = 'private'
-                if $row->{security} eq 'usemask' && $row->{allowmask} == 0;
-
-            # We need extra security bits for some metadata. We have to do
-            # this this way because it makes it easier to later do searches
-            # on various combinations of things at the same time. Also, even
-            # though these are bits, we're not going to ever use them as
-            # actual bits.
-            my @extrabits;
-            push @extrabits, 101 if $row->{security} eq 'private';
-            push @extrabits, 102 if $row->{security} eq 'public';
-
-            $row->{bits} = [ LJ::bit_breakdown( $row->{allowmask} ), @extrabits ];
+            $row->{bits} = _security_bits( $row->{security}, $row->{allowmask} );
         }
     }
 
@@ -463,15 +449,7 @@ sub copy_entry {
         # Just make sure, in case we don't have a corresponding logtext2 row.
         next unless $row;
 
-        # Auto-convert usemask-with-no-groups to private.
-        $row->{security} = 'private'
-            if $row->{security} eq 'usemask' && $row->{allowmask} == 0;
-
-        # Security bits as described in copy_comment above.
-        my @extrabits;
-        push @extrabits, 101 if $row->{security} eq 'private';
-        push @extrabits, 102 if $row->{security} eq 'public';
-        my $bits = [ LJ::bit_breakdown( $row->{allowmask} ), @extrabits ];
+        my $bits = _security_bits( $row->{security}, $row->{allowmask} );
 
         # Very important, the search engine can't index compressed crap...
         foreach (qw/ subject event /) {
@@ -598,6 +576,42 @@ sub copy_supportlog {
 
 sub _mva {
     return '(' . join( ',', @{ $_[0] } ) . ')';
+}
+
+# -----------------------------------------------------------------------------
+# Compute the security_bits MVA for an entry/comment from its log2 (security,
+# allowmask). This is the sole encoder; the DW::Search query side must match it.
+#
+#   public                     -> [102]
+#   private                    -> [101]
+#   usemask, allowmask == 0    -> [101]   (auto-converted to private: no groups)
+#   usemask, allowmask == 1    -> [0]     (bit_breakdown(1); the access list)
+#   usemask, custom filter     -> [<bits>=1] (bit_breakdown; groups live at bit>=1)
+#
+# usemask entries carry NO 101/102 discriminator -- their bits are purely
+# bit_breakdown(allowmask). 0 is therefore a legitimate bit (the default access
+# group), which is why DW::Search must not treat a stored 0 as garbage.
+#
+# Takes ($security, $allowmask), returns an arrayref of int bits. Pure: no DB,
+# no side effects on its arguments.
+# -----------------------------------------------------------------------------
+
+sub _security_bits {
+    my ( $security, $allowmask ) = @_;
+    $allowmask += 0;
+
+    # Auto-convert usemask-with-no-groups to private.
+    $security = 'private' if $security eq 'usemask' && $allowmask == 0;
+
+    # We need extra security bits for some metadata. We have to do this this
+    # way because it makes it easier to later do searches on various
+    # combinations of things at the same time. Also, even though these are
+    # bits, we're not going to ever use them as actual bits.
+    my @extrabits;
+    push @extrabits, 101 if $security eq 'private';
+    push @extrabits, 102 if $security eq 'public';
+
+    return [ LJ::bit_breakdown($allowmask), @extrabits ];
 }
 
 1;

--- a/t/search-copier.t
+++ b/t/search-copier.t
@@ -1,0 +1,56 @@
+# t/search-copier.t
+#
+# Unit tests for DW::Task::SearchCopier::_security_bits, the sole encoder that
+# turns a log2 (security, allowmask) into the security_bits MVA stored in
+# Manticore. The DW::Search query side (t/search.t) depends on this encoding,
+# so pinning it here keeps the encode and query sides from silently drifting.
+#
+# Pure function: no DB, no Manticore, so this runs everywhere.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+use DW::Task::SearchCopier;
+
+sub bits { return DW::Task::SearchCopier::_security_bits(@_); }
+
+# public / private carry a discriminator bit and no allowmask bits.
+is_deeply( bits( 'public',  0 ), [102], 'public -> [102]' );
+is_deeply( bits( 'private', 0 ), [101], 'private -> [101]' );
+
+# usemask with no groups is auto-converted to private.
+is_deeply( bits( 'usemask', 0 ), [101], 'usemask/allowmask=0 auto-converts to private [101]' );
+
+# The crux: a plain access-list lock (allowmask=1) encodes to a lone [0].
+# 0 is bit_breakdown(1) -- the default access group -- NOT garbage.
+is_deeply( bits( 'usemask', 1 ), [0], 'usemask/allowmask=1 (access list) -> [0]' );
+
+# Custom access filters live at bit >= 1 and carry no discriminator.
+is_deeply( bits( 'usemask', 2 ), [1], 'usemask/allowmask=2 -> [1] (one custom group)' );
+is_deeply( bits( 'usemask', 6 ), [ 1, 2 ], 'usemask/allowmask=6 -> [1,2] (two custom groups)' );
+
+# 0 appears in the output ONLY for access-list entries: public/private never
+# emit it, so DW::Search can treat a stored 0 as "access list" unambiguously.
+ok( !( grep { $_ == 0 } @{ bits( 'public',  0 ) } ), 'public output never contains 0' );
+ok( !( grep { $_ == 0 } @{ bits( 'private', 0 ) } ), 'private output never contains 0' );
+
+# Encoder is pure: a numeric-string allowmask works and args are untouched.
+my $mask = '1';
+is_deeply( bits( 'usemask', $mask ), [0], 'numeric-string allowmask is handled' );
+is( $mask, '1', 'argument not mutated' );
+
+done_testing();

--- a/t/search.t
+++ b/t/search.t
@@ -178,12 +178,14 @@ ins(
     body          => 'chronology test newest'
 );
 
-# Defensive exclusion: has public bit *and* a stray 0.
+# Access-list-locked entry. usemask/allowmask=1 encodes to security_bits=[0]
+# (bit 0 is the default access group, see DW::Task::SearchCopier). 0 is a
+# legitimate bit, not garbage: a reader on the access list must see this.
 ins(
     journalid     => 401,
     jitemid       => 1,
-    security_bits => [ 102, 0 ],
-    body          => 'penguin defensively filtered'
+    security_bits => [0],
+    body          => 'penguin locked to the access list'
 );
 
 $dbh->do("FLUSH RAMCHUNK $TABLE");
@@ -294,13 +296,20 @@ subtest 'sort_by date_posted' => sub {
     is_deeply( $desc, [ '301/3/0', '301/2/0', '301/1/0' ], 'sort_by=new yields newest-first' );
 };
 
-subtest 'defensive security_bits=0 exclusion' => sub {
+subtest 'access-list-locked entry visible to trusted reader, hidden from stranger' => sub {
 
-    # Doc 401/1 has security_bits=[102, 0]. _journal_where emits both
-    # `IN (102, ...)` and `NOT IN (0)`, so the 0 bit should shoot the doc
-    # down even though its public bit would otherwise match.
-    my $k = keys_for( query => 'penguin', userid => 401 );
-    is( scalar @$k, 0, 'doc with stray 0 bit is excluded' );
+    # Doc 401/1 has security_bits=[0] (usemask/allowmask=1). A reader on the
+    # journal's access list arrives with a mask whose bit 0 is set, so
+    # bit_breakdown yields (0) and the `IN (102, 0)` pre-filter admits the doc.
+    # A stranger has allowmask=0 -> `IN (102)` only, so the [0] doc is filtered
+    # out. (This is the pre-filter only; production also re-checks each hit
+    # with $entry->visible_to in _enrich_journal, not exercised here.)
+    my $trusted = keys_for( query => 'penguin', userid => 401, allowmask => 1 );
+    is_deeply( $trusted, ['401/1/0'],
+        'reader whose mask covers bit 0 sees the access-locked entry' );
+
+    my $stranger = keys_for( query => 'penguin', userid => 401, allowmask => 0 );
+    is( scalar @$stranger, 0, 'stranger (no matching bits) does not see it' );
 };
 
 subtest 'CALL SNIPPETS builds highlighted excerpts' => sub {


### PR DESCRIPTION
`DW::Search::_journal_where` filtered candidates with `security_bits IN (102, bit_breakdown(allowmask))` and then, redundantly, `security_bits NOT IN (0)` — a clause carried over from the retired Sphinx daemon. An access-list-locked entry (`usemask`/`allowmask=1`) encodes to `security_bits = [0]`, where `0` is the legitimate default-access-group bit, so the exclude silently dropped every default-access-locked entry from search results for precisely the trusted readers entitled to see them (owners bypass via `ignore_security`). The positive `IN` filter already gates security, and each hit is re-checked authoritatively by `$entry->visible_to` in `_enrich_journal`, so removing the exclude cannot leak content. This is query-side only — no reindex. Also extracts the duplicated `security_bits` encoding in `DW::Task::SearchCopier` into one pure `_security_bits()` helper, and adds tests pinning both the encoder (`t/search-copier.t`) and the access-list query behavior (`t/search.t`) so the two sides can't drift apart again.

CODE TOUR: If you locked entries to your access list and someone you'd granted access to tried to search your journal, they'd get nothing back — no matter what they searched — because search was quietly throwing away every access-locked post before it ever checked whether the reader was allowed to see it. This fixes that so access-list-locked entries show up in search for the people you've actually given access to, while everyone else still can't see them.