### PR TITLE
Preserve empty form fields in DW::Request arg parsing

### DIFF
--- a/cgi-bin/DW/Request/Base.pm
+++ b/cgi-bin/DW/Request/Base.pm
@@ -237,6 +237,10 @@ sub _string_to_multivalue {
     foreach my $key ( keys %gets ) {
 
         my @parts = defined $gets{$key} ? split( /\0/, $gets{$key} ) : '';
+
+        # split() on '' returns (), dropping the key; keep an empty field as ''
+        @parts = ('') unless @parts;
+
         push @out, map { $opts{lowercase} ? lc $key : $key => $_ } @parts;
     }
 

--- a/cgi-bin/DW/Request/Base.pm
+++ b/cgi-bin/DW/Request/Base.pm
@@ -236,9 +236,9 @@ sub _string_to_multivalue {
     my @out;
     foreach my $key ( keys %gets ) {
 
-        my @parts = defined $gets{$key} ? split( /\0/, $gets{$key} ) : '';
-
-        # split() on '' returns (), dropping the key; keep an empty field as ''
+        # -1 keeps trailing empties (repeated params); split('') returns (), so
+        # guard the all-empty case too. Both would otherwise drop empty fields.
+        my @parts = defined $gets{$key} ? split( /\0/, $gets{$key}, -1 ) : ('');
         @parts = ('') unless @parts;
 
         push @out, map { $opts{lowercase} ? lc $key : $key => $_ } @parts;

--- a/t/request-multi.t
+++ b/t/request-multi.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2;
+use Test::More tests => 4;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use DW::Request::Standard;
@@ -54,6 +54,37 @@ check_post(
         is( 'baz', $args->{bar} );
         is( 'baz', $args->get('bar') );
         is_deeply( ['baz'], [ $args->get_all('bar') ] );
+    }
+);
+
+# A submitted-but-empty field (foo=) must round-trip as '', not be dropped.
+# Pre-Plack, BML pages parsed args without _string_to_multivalue and kept the
+# empty; DW::Request must preserve the same behavior.
+check_get(
+    "empty=&filled=x",
+    sub {
+        plan tests => 4;
+
+        my $args = DW::Request->get->get_args;
+
+        ok( exists $args->{empty}, "empty GET field is present, not dropped" );
+        is( $args->{empty}, '', "empty GET field round-trips as ''" );
+        is_deeply( [ $args->get_all('empty') ], [''], "empty GET field is a single ''" );
+        is( $args->{filled}, 'x', "filled GET field unaffected" );
+    }
+);
+
+check_post(
+    "empty=&filled=x",
+    sub {
+        plan tests => 4;
+
+        my $args = DW::Request->get->post_args;
+
+        ok( exists $args->{empty}, "empty POST field is present, not dropped" );
+        is( $args->{empty}, '', "empty POST field round-trips as ''" );
+        is_deeply( [ $args->get_all('empty') ], [''], "empty POST field is a single ''" );
+        is( $args->{filled}, 'x', "filled POST field unaffected" );
     }
 );
 

--- a/t/request-multi.t
+++ b/t/request-multi.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More tests => 6;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use DW::Request::Standard;
@@ -85,6 +85,34 @@ check_post(
         is( $args->{empty}, '', "empty POST field round-trips as ''" );
         is_deeply( [ $args->get_all('empty') ], [''], "empty POST field is a single ''" );
         is( $args->{filled}, 'x', "filled POST field unaffected" );
+    }
+);
+
+# A repeated param whose last value is empty (multi=x&multi=) must keep the
+# trailing '' -- split(/\0/) drops trailing empties without a negative limit.
+check_get(
+    "multi=x&multi=",
+    sub {
+        plan tests => 1;
+        my $args = DW::Request->get->get_args;
+        is_deeply(
+            [ $args->get_all('multi') ],
+            [ 'x', '' ],
+            "trailing empty value in a repeated GET param is preserved"
+        );
+    }
+);
+
+check_post(
+    "multi=x&multi=",
+    sub {
+        plan tests => 1;
+        my $args = DW::Request->get->post_args;
+        is_deeply(
+            [ $args->get_all('multi') ],
+            [ 'x', '' ],
+            "trailing empty value in a repeated POST param is preserved"
+        );
     }
 );
 


### PR DESCRIPTION
A submitted-but-empty form field (`foo=`) was coming back as `undef` instead of `""`. In `DW::Request::Base::_string_to_multivalue`, `LJ::parse_args` correctly yields `foo => ""`, but `split( /\0/, "" )` returns `()`, so the key produced no pairs and was dropped from the `Hash::MultiValue`. The fix keeps a single `""` when the split is empty.

This is a BML→Plack regression: the old `Apache::BML::parse_inputs` populated `%GET`/`%POST`/`%FORM` directly and kept empty fields, but BML pages now read form data through `$r->get_args`/`$r->post_args` → `_string_to_multivalue`. Added GET/POST cases to `t/request-multi.t` (they fail without the fix, pass with it).

Diagnosis by @momijizukamori.

CODE TOUR: When you submitted a form and left a field blank, the site was quietly throwing that blank away instead of remembering you cleared it — which broke the customize page (and any form that needs to know a field was emptied). This makes an empty field come through as an actual empty value again, the way it did before the move to the new web server. Comes with a test so it stays fixed.

Fixes #3628
