### PR TITLE
Redesign /manage/icons for density and a mobile-friendly layout

### DIFF
--- a/bin/upgrading/deadphrases.dat
+++ b/bin/upgrading/deadphrases.dat
@@ -192,6 +192,13 @@ general /create.bml.tos.p1.2
 general /create.bml.username.charsallowed
 general /create.bml.username.text
 
+general /edit/icons.tt.fromfile
+general /edit/icons.tt.fromfile.key
+general /edit/icons.tt.fromurl
+general /edit/icons.tt.fromurl.key
+general /edit/icons.tt.upload.btn.addfile
+general /edit/icons.tt.upload.btn.addurl
+general /edit/icons.tt.upload.formats.desc
 general /editinfo.bml.allowshocontact.email.if_domainaddy
 general /editinfo.bml.allowshowcontact.email.reason
 general /editinfo.bml.allowshowcontact.email.withdomainaddr

--- a/cgi-bin/DW/Controller/EditIcons.pm
+++ b/cgi-bin/DW/Controller/EditIcons.pm
@@ -575,10 +575,11 @@ sub parse_post_uploads {
         }
 
         # uploaded pics
-        if ( $userpic_key =~ /userpic_.*/ ) {
+        if ( $userpic_key =~ /^userpic_(\d+)$/ ) {
 
-            # only use userpic_0 if we selected file for the source
-            next if $userpic_key eq "userpic_0" && $POST->{"src"} ne "file";
+            # each upload row carries its own source selector (src_N); only use
+            # the file input for a row whose source is "file"
+            next if ( $POST->{"src_$1"} // "file" ) ne "file";
 
             # Some callers to the function pass data, others pass
             # a reference to data.  Figure out which type we got.
@@ -698,10 +699,10 @@ sub parse_post_uploads {
             push @uploads, \%current_upload;
 
         }
-        elsif ( $userpic_key =~ /urlpic_.*/ ) {
+        elsif ( $userpic_key =~ /^urlpic_(\d+)$/ ) {
 
-            # go through the URL uploads
-            next if $userpic_key eq "urlpic_0" && $POST->{src} ne "url";
+            # only use the URL input for a row whose source is "url"
+            next if ( $POST->{"src_$1"} // "url" ) ne "url";
 
             if ( !$POST->{$userpic_key} ) {
                 $current_upload{error} = LJ::Lang::ml('error.editicons.empty.url');

--- a/htdocs/js/editicons.js
+++ b/htdocs/js/editicons.js
@@ -1,13 +1,12 @@
 // Icon management page (/manage/icons): upload-form behaviors.
 //
 // Uses plain DOM APIs only. This is a Foundation page, where the global $ is
-// jQuery and the legacy 6alib helpers (DOM, the getElementById-style $, etc.)
-// are not loaded -- the previous helper-based version of this file silently
-// failed to initialize there, breaking the file/URL toggles and the
-// "add another upload" buttons.
+// jQuery and the legacy 6alib helpers are not loaded.
 //
-// The page supplies its labels and upload limit via an inline <script> that
-// sets window.editiconsConfig before this file runs at the end of the body.
+// Each upload row has a "Upload file" button (which opens a hidden file input)
+// and an "or enter URL" text field. A hidden src_N field records which source
+// the row uses; the server processes only the matching input per row. The page
+// supplies its labels and upload limit via window.editiconsConfig.
 
 // counter: how many extra upload slots we've created so far.
 // maxcounter: the maximum number of upload slots allowed (from config).
@@ -18,26 +17,15 @@ function ep_config() {
     return window.editiconsConfig || { labels: {} };
 }
 
-function ep_bind(id, eventName, fn) {
-    var el = document.getElementById(id);
-    if (el) el.addEventListener(eventName, fn);
-}
-
 function setup() {
     maxcounter = ep_config().maxcounter;
-
-    ep_bind("radio_url", "click", selectUrlUpload);
-    ep_bind("radio_file", "click", selectFileUpload);
-    ep_bind("urlpic_0", "keypress", keyPressUrlUpload);
-    ep_bind("userpic_0", "change", keyPressFileUpload);
-
+    bindUploadRow(0);
     editiconsInit();
 }
 
 function editiconsInit() {
     var link = document.getElementById("upload_desc_link");
     if (link) {
-        link.style.display = 'block';
         document.getElementById("upload_desc").style.display = 'none';
     }
 }
@@ -48,132 +36,139 @@ function toggleElement(elementId) {
     el.style.display = (el.style.display == 'block') ? 'none' : 'block';
 }
 
-function addNewUpload(uploadType) {
-  var labels = ep_config().labels || {};
-  updateMakeDefaultType(true);
+// Wire up a row's file-button + URL field so they keep the row's src_N in sync.
+function bindUploadRow(n) {
+    var file = document.getElementById("userpic_" + n);
+    var url = document.getElementById("urlpic_" + n);
+    if (file) file.addEventListener("change", function () { selectFile(n); });
+    if (url) {
+        url.addEventListener("focus", function () { selectUrl(n); });
+        url.addEventListener("input", function () { selectUrl(n); });
+    }
+}
 
-  var insertIntoTag = document.getElementById("multi_insert");
-  var insertElement = document.createElement("p");
-  insertElement.setAttribute("id", "additional_upload_" + counter);
-  insertElement.setAttribute("class", "pkg");
+// Open the (hidden) file picker for a row.
+function chooseFile(n) {
+    var file = document.getElementById("userpic_" + n);
+    if (file) file.click();
+}
 
-  var newPicHTML = "<input type='button' value='" + labels.remove + "' onclick='javascript:removeAdditionalUpload(" + counter + ");' /><br/>\n";
+// A file was chosen: mark the row as a file upload and show the filename.
+function selectFile(n) {
+    var file = document.getElementById("userpic_" + n);
+    var src = document.getElementById("src_" + n);
+    var name = document.getElementById("filename_" + n);
+    if (src) src.value = "file";
+    if (name && file && file.files && file.files.length) {
+        name.textContent = file.files[0].name;
+    }
+}
 
-  if (uploadType == 'file') {
-    newPicHTML += "<label class='left' for='userpic_" + counter + "'>" + labels.fromfile + "</label>";
-    newPicHTML += "<input type='file' class='file' name='userpic_" + counter + "' id='userpic_" + counter + "' size='22' />";
-  } else if (uploadType == 'url') {
-    newPicHTML += "<label class='left' for='urlpic_" + counter + "'>";
-    newPicHTML += labels.fromurl + '</label>';
-    newPicHTML += '<input type="text" name="urlpic_' + counter + '" id="urlpic_' + counter + '" class="text" />';
-  }
-  newPicHTML += "<label class='left' for='keywords_" + counter + "'>" + labels.keywords + "</label><input type='text' name='keywords_" + counter + "' id='keywords_" + counter + "' class='text' />";
-  if (ep_config().allowComments) {
-    newPicHTML += "<label class='left' for='comments_" + counter + "'>" + labels.comment + "</label><input type='text' maxlength='120' name='comments_" + counter + "' id='comments_" + counter + "' class='text' />";
-  }
-  if (ep_config().allowDescriptions) {
-    newPicHTML += "<label class='left' for='descriptions_" + counter + "'>" + labels.description +"</label><input type='text' maxlength='120' name='descriptions_" + counter + "' id='descriptions_" + counter + "' class='text' />";
-  }
-  newPicHTML += "<br/><input type='radio' accesskey='" + labels.makedefaultkey + "' value='" + counter + "' name='make_default' id='make_default_" + counter + "' /><label for='make_default_" + counter + "'>" + labels.makedefault + "</label>\n";
+// The URL field is being used: mark the row as a URL upload.
+function selectUrl(n) {
+    var src = document.getElementById("src_" + n);
+    var name = document.getElementById("filename_" + n);
+    if (src) src.value = "url";
+    if (name) name.textContent = "";
+}
 
-  insertElement.innerHTML = newPicHTML;
-  insertIntoTag.appendChild(insertElement);
-  counter++;
-  if (counter >= maxcounter) {
-    hideUploadButtons();
-  }
+function addNewUpload() {
+    var labels = ep_config().labels || {};
+    updateMakeDefaultType(true);
+    var n = counter;
 
-  if (document.forms.uploadPic.make_default.length == 2) {
-    addNoDefaultButton();
-  }
+    var block = document.createElement("div");
+    block.setAttribute("id", "additional_upload_" + n);
+    block.setAttribute("class", "additional_upload");
 
+    var html = "<hr class='hr' />";
+    html += "<div class='upload_source'>";
+    html += "<button type='button' class='button secondary upload_file_btn' onclick='chooseFile(" + n + ")'>" + labels.file + "</button>";
+    html += "<input type='file' class='upload_file_input' name='userpic_" + n + "' id='userpic_" + n + "' />";
+    html += "<span class='upload_filename' id='filename_" + n + "'></span>";
+    html += "<label class='upload_or' for='urlpic_" + n + "'>" + labels.orurl + "</label>";
+    html += "<input type='text' class='text upload_url' name='urlpic_" + n + "' id='urlpic_" + n + "' />";
+    html += "<input type='hidden' name='src_" + n + "' id='src_" + n + "' value='file' />";
+    html += "<button type='button' class='button tiny secondary additional_remove' onclick='removeAdditionalUpload(" + n + ")'>" + labels.remove + "</button>";
+    html += "</div>";
+    html += fieldRow("keywords", n, labels.keywords, 0);
+    if (ep_config().allowComments) html += fieldRow("comments", n, labels.comment, 120);
+    if (ep_config().allowDescriptions) html += fieldRow("descriptions", n, labels.description, 300);
+    html += "<p class='pkg additional_default'><input type='radio' value='" + n + "' name='make_default' id='make_default_" + n + "' /> <label class='inline' for='make_default_" + n + "'>" + labels.makedefault + "</label></p>";
+
+    block.innerHTML = html;
+    document.getElementById("multi_insert").appendChild(block);
+    bindUploadRow(n);
+
+    counter++;
+    if (counter >= maxcounter) hideUploadButtons();
+    if (document.forms.uploadPic.make_default.length == 2) addNoDefaultButton();
+}
+
+function fieldRow(name, n, label, maxlen) {
+    var ml = maxlen ? " maxlength='" + maxlen + "'" : "";
+    return "<p class='pkg additional_field'>"
+        + "<label class='inline' for='" + name + "_" + n + "'>" + label + "</label> "
+        + "<input type='text'" + ml + " class='text' name='" + name + "_" + n + "' id='" + name + "_" + n + "' />"
+        + "</p>";
 }
 
 function removeAdditionalUpload(removeIndex) {
-  if (document.forms.uploadPic.make_default.length == 3) {
-    removeNoDefaultButton();
-    updateMakeDefaultType(false);
-  }
-
-  var removeFromTag = document.getElementById("multi_insert");
-  var removeElement = document.getElementById("additional_upload_" + removeIndex);
-  removeFromTag.removeChild(removeElement);
-  maxcounter++;
-  if (counter < maxcounter) {
-    unhideUploadButtons();
-  }
-
+    if (document.forms.uploadPic.make_default.length == 3) {
+        removeNoDefaultButton();
+        updateMakeDefaultType(false);
+    }
+    var wrap = document.getElementById("multi_insert");
+    var el = document.getElementById("additional_upload_" + removeIndex);
+    if (el) wrap.removeChild(el);
+    maxcounter++;
+    if (counter < maxcounter) unhideUploadButtons();
 }
 
 function hideUploadButtons() {
-  document.getElementById("multi_insert_buttons").style.display = 'none';
+    document.getElementById("multi_insert_buttons").style.display = 'none';
 }
 
 function unhideUploadButtons() {
-  document.getElementById("multi_insert_buttons").style.display = 'block';
+    document.getElementById("multi_insert_buttons").style.display = 'inline-block';
 }
 
 function addNoDefaultButton() {
-  var labels = ep_config().labels || {};
-  var buttonsElement = document.getElementById("no_default_insert");
-  var insertElement = document.createElement("p");
-  insertElement.setAttribute("id", "make_default_none");
-  insertElement.setAttribute("class", "pkg");
-
-  insertElement.innerHTML = "<input type='radio' accesskey='" + labels.makedefaultkey +"' value='-1' name='make_default' id='make_default_button_none' /><label for='make_default_button_none'>" + labels.keepdefault + "</label>\n";
-  buttonsElement.appendChild(insertElement);
+    var labels = ep_config().labels || {};
+    var buttonsElement = document.getElementById("no_default_insert");
+    var insertElement = document.createElement("p");
+    insertElement.setAttribute("id", "make_default_none");
+    insertElement.setAttribute("class", "pkg");
+    insertElement.innerHTML = "<input type='radio' accesskey='" + labels.makedefaultkey + "' value='-1' name='make_default' id='make_default_button_none' /> <label class='inline' for='make_default_button_none'>" + labels.keepdefault + "</label>";
+    buttonsElement.appendChild(insertElement);
 }
 
 function removeNoDefaultButton() {
-  var removeFromTag = document.getElementById("no_default_insert");
-  var removeElement = document.getElementById("make_default_none");
-  removeFromTag.removeChild(removeElement);
-}
-
-function selectUrlUpload() {
-  document.getElementById("userpic_0").disabled = true;
-  document.getElementById("urlpic_0").disabled = false;
-}
-
-function selectFileUpload() {
-  document.getElementById("urlpic_0").disabled = true;
-  document.getElementById("userpic_0").disabled = false;
-}
-
-function keyPressUrlUpload() {
-  document.getElementById("radio_url").checked = true;
-  selectUrlUpload();
-}
-
-function keyPressFileUpload() {
-  document.getElementById("radio_file").checked = true;
-  selectFileUpload();
+    var removeFromTag = document.getElementById("no_default_insert");
+    var removeElement = document.getElementById("make_default_none");
+    if (removeElement) removeFromTag.removeChild(removeElement);
 }
 
 function updateMakeDefaultType(multi) {
-  var makeDefaultInput = document.getElementById('make_default_0');
-
-  if (makeDefaultInput != null) {
-    // see if we're already correct
-    if ((multi && makeDefaultInput.type != "radio") || (! multi && makeDefaultInput.type != "checkbox")) {
-      var containerElement = document.getElementById('main_make_default');
-
-      var value = makeDefaultInput.checked;
-      if (multi) {
-        containerElement.innerHTML = containerElement.innerHTML.replace(/checkbox/, "radio");
-      } else {
-        containerElement.innerHTML = containerElement.innerHTML.replace(/radio/, "checkbox");
-      }
-      document.getElementById('make_default_0').checked = value;
+    var makeDefaultInput = document.getElementById('make_default_0');
+    if (makeDefaultInput != null) {
+        if ((multi && makeDefaultInput.type != "radio") || (!multi && makeDefaultInput.type != "checkbox")) {
+            var containerElement = document.getElementById('main_make_default');
+            var value = makeDefaultInput.checked;
+            if (multi) {
+                containerElement.innerHTML = containerElement.innerHTML.replace(/checkbox/, "radio");
+            } else {
+                containerElement.innerHTML = containerElement.innerHTML.replace(/radio/, "checkbox");
+            }
+            document.getElementById('make_default_0').checked = value;
+        }
     }
-  }
 }
 
-// This file loads at the end of the body, so the DOM is normally still parsing
-// when it runs; register for DOMContentLoaded. Guard against the already-loaded
-// case so initialization is robust regardless of where the file ends up.
+// This file loads at the end of the body; register for DOMContentLoaded, but
+// guard against the already-loaded case so init is robust.
 if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", setup);
+    document.addEventListener("DOMContentLoaded", setup);
 } else {
-  setup();
+    setup();
 }

--- a/htdocs/js/editicons.js
+++ b/htdocs/js/editicons.js
@@ -45,6 +45,10 @@ function bindUploadRow(n) {
         url.addEventListener("focus", function () { selectUrl(n); });
         url.addEventListener("input", function () { selectUrl(n); });
     }
+    // Sync src_N to any value already present (form re-render after a
+    // validation error, or browser autofill) so it isn't stuck on "file".
+    if (url && url.value) selectUrl(n);
+    else if (file && file.files && file.files.length) selectFile(n);
 }
 
 // Open the (hidden) file picker for a row.

--- a/htdocs/stc/editicons.css
+++ b/htdocs/stc/editicons.css
@@ -1,49 +1,170 @@
 hr {
     clear: left;
 }
-	
+
 #uploadBox-inner {
     padding: 0.5em 0.75em;
 }
 
-#submit_wrapper {
-    text-align: center;
+/* --- upload row: tighten spacing between the fields --- */
+#uploadBox .pkg {
+    margin-bottom: 0.4rem;
 }
+#uploadBox p.detail {
+    margin-bottom: 0.3rem;
+}
+.helper {
+    margin: 0.15rem 0 0 0;
+    font-size: smaller;
+}
+
+/* upload rows: single aligned grid -- right-aligned label | input | help.
+   Labels sit on a shared left edge and hug the inputs; help is aligned to the
+   top of the input. On small screens everything stacks and labels go left. */
+.upload_row {
+    margin-bottom: 0.5rem;
+}
+.upload_row > label {
+    text-align: right;
+    padding-top: 0.4rem;
+    font-weight: normal;
+}
+.upload_row .helper {
+    padding-top: 0.4rem;
+    margin-top: 0;
+}
+#submit_wrapper {
+    margin-top: 0.5rem;
+}
+#uploadBox input.upload_url {
+    display: inline-block;
+    width: 22rem;
+    max-width: 100%;
+    vertical-align: middle;
+    margin-bottom: 0;
+}
+
+/* "?" help toggle next to the "Upload a new icon" heading */
+.upload_heading {
+    margin-bottom: 0.5rem;
+}
+.upload_help_toggle {
+    display: inline-block;
+    width: 1.25em;
+    height: 1.25em;
+    line-height: 1.2em;
+    margin-left: 0.4rem;
+    border: 1px solid currentColor;
+    border-radius: 50%;
+    font-size: 0.6em;
+    font-weight: bold;
+    text-align: center;
+    vertical-align: middle;
+    text-decoration: none;
+}
+
+/* source row: file-picker button + "or enter URL" + field, all on one line.
+   The URL box has margin-bottom:0, so add row spacing here to match the default
+   bottom margin the keyword/comment/description inputs carry. */
+#upload_wrapper .upload_source {
+    margin-bottom: 1rem;
+}
+.upload_source .upload_file_btn {
+    margin: 0 0.5rem 0 0;
+    vertical-align: middle;
+}
+.upload_file_input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+}
+.upload_filename {
+    font-size: smaller;
+    margin-right: 0.5rem;
+}
+.upload_or {
+    display: inline-block;
+    margin: 0 0.4rem;
+    vertical-align: middle;
+}
+
+/* extra upload slots added via "Add another" */
+.additional_upload .upload_source {
+    margin-bottom: 0.4rem;
+}
+.additional_upload .additional_field label.inline,
+.additional_upload .additional_default label.inline {
+    display: inline-block;
+    min-width: 6rem;
+}
+.additional_remove {
+    margin-left: 0.5rem;
+}
+
+@media screen and (max-width: 39.9375em) {
+    .upload_row > label {
+        text-align: left;
+        padding-top: 0;
+    }
+    .upload_row .helper {
+        padding-top: 0.15rem;
+    }
+}
+
+/* --- current icons: responsive grid, two-up on wider screens --- */
+#list_userpics {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+}
+@media screen and (min-width: 40em) {
+    #list_userpics {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
 .userpic_wrapper {
-    margin: 0.5rem 0 0.25rem 0;
+    margin: 0;
+    padding: 0.5rem;
+    border: 1px solid #e5e5e5;
+    border-radius: 3px;
+    overflow: hidden; /* contain the floated icon + controls */
 }
 .EditIconsUserpic {
-    margin-right: 10px;
+    margin: 0 10px 10px 0;
     display: block;
     text-align: center;
     width: 100px;
     height: 100px;
     float: left;
-    clear: left;
-    margin-bottom: 10px;
 }
 
-@media all and (min-width: 0px){ .userpic_controls { 
-    width: 400px;
-}}
+/* fields fill the space beside the icon instead of a fixed width */
+.userpic_controls {
+    overflow: hidden;
+    width: auto;
+}
 .userpic_controls input.text {
-    width: 220px;
+    width: 100%;
 }
-* html .userpic_controls input.text {
-    width: 180px;
+.userpic_controls .row {
+    margin-bottom: 0.3rem;
 }
-*:first-child+html .userpic_controls input.text {
-    width: 180px;
-}
-
+.userpic_keywords,
+.userpic_comments,
+.userpic_descriptions,
 .userpic_defaultdelete {
-    width: 200px;
+    margin-bottom: 0;
 }
 .userpic_rename {
-    width: 200px;
-    margin-bottom: 4px;
-    margin-top: 4px;
+    margin: 0.25rem 0;
 }
+
 #no_default_userpic {
     text-align: center;
 }
@@ -52,9 +173,4 @@ hr {
 #no_default_userpic label {
     float: none;
     display: inline;
-}
-
-.helper {
-    margin-top: 0.5rem;
-    font-size: smaller;
 }

--- a/htdocs/stc/editicons.css
+++ b/htdocs/stc/editicons.css
@@ -24,7 +24,8 @@ hr {
 .upload_row {
     margin-bottom: 0.5rem;
 }
-.upload_row > label {
+.upload_row > label,
+.upload_row > .upload_row_label {
     text-align: right;
     padding-top: 0.4rem;
     font-weight: normal;
@@ -106,7 +107,8 @@ hr {
 }
 
 @media screen and (max-width: 39.9375em) {
-    .upload_row > label {
+    .upload_row > label,
+    .upload_row > .upload_row_label {
         text-align: left;
         padding-top: 0;
     }

--- a/views/edit/icons.tt
+++ b/views/edit/icons.tt
@@ -27,131 +27,122 @@
   [%- END -%]
 [%- END -%]
 
-<div class="row">
 [%- IF num_icons >= max_icons -%]
-  <div id='limit' class="columns large-4">[% '.error.icon.quota' | ml( num = max_icons ) %]</div>
+  <div id='limit'>[% '.error.icon.quota' | ml( num = max_icons ) %]</div>
 [%- ELSE -%]
-  <div id='uploadBox' class='highlight-box box pkg columns large-4'>
+  <div id='uploadBox' class='highlight-box box pkg'>
   <div id='uploadBox-inner' class="small-left">
   <form enctype="multipart/form-data" action="[% selflink() %]" method='post'
         id='uploadPic'>
 
-    <h2>[% '.upload.header' | ml %]</h2>
-    <p class='detail'>
-      <a href='javascript:void(0)' onclick='toggleElement("upload_desc")'
-         id='upload_desc_link'>[% '.upload.about' | ml %]</a>
-    </p>
+    <h2 class='upload_heading'>[% '.upload.header' | ml %]<a href='javascript:void(0)'
+        onclick='toggleElement("upload_desc")' id='upload_desc_link' class='upload_help_toggle'
+        title="[% '.upload.about' | ml %]" aria-label="[% '.upload.about' | ml %]">?</a></h2>
     <div id='upload_desc'><p>[% '.upload.desc' | ml %]</p></div>
-    <div id='upload_wrapper' class='pkg'>
-      <p class='pkg' style='margin-bottom: 0;'>
-        [%# can't use auto-label with ml strings that contain HTML formats -%]
-        [% form.radio( name = "src", id = "radio_file", value = "file",
-                       class = "radio", accesskey = dw.ml( '.fromfile.key' ),
-                       selected = 1 ) %]
-        <label for="radio_file">[% '.fromfile' | ml %]</label>
-      </p>
-      <div style="overflow: hidden; margin: 0em 0em 0.5em 2em;">
-        <input type='file' class='file' name='userpic_0' id='userpic_0'
-               size='18' />
+
+    <div id='upload_wrapper' class='row upload_row'>
+      <label class='columns small-12 medium-2'>[% '.upload.label.source' | ml %]</label>
+      <div class='columns small-12 medium-10 upload_source'>
+        <button type='button' class='button secondary upload_file_btn'
+                onclick='chooseFile(0)'>[% '.upload.btn.file' | ml %]</button>
+        <input type='file' class='upload_file_input' name='userpic_0' id='userpic_0' />
+        <span class='upload_filename' id='filename_0'></span>
+        <label class='upload_or' for='urlpic_0'>[% '.upload.or.url' | ml %]</label>
+        [% form.textbox( name = "urlpic_0", id = "urlpic_0", class = "text upload_url" ) %]
+        <input type='hidden' name='src_0' id='src_0' value='file' />
       </div>
-      <p class='pkg'>
-        [%# can't use auto-label with ml strings that contain HTML formats -%]
-        [% form.radio( name = "src", id = "radio_url", value = "url",
-                       class = "radio", accesskey = dw.ml( '.fromurl.key' ),
-                       selected = formdata.urlpic_0.length ) %]
-        <label for="radio_url">[% '.fromurl' | ml %]</label>
-        <br />
-        [% form.textbox( name = "urlpic_0", id = "urlpic_0", class = "text inline",
-                         style = 'margin: 0em 0em 0.5em 2em;' ) %]
-      </p>
-      <p class='helper'>[% '.upload.formats.desc' | ml %]</p>
     </div>
 
-    <hr class='hr' />
-
-    <p class='pkg'>
-      <label for='keywords_0'>[% '.upload.label.keywords' | ml %]</label>
+    <div class='row upload_row'>
+      <label class='columns small-12 medium-2' for='keywords_0'>[% '.upload.label.keywords' | ml %]</label>
+      <div class='columns small-12 medium-4'>
         [% form.textbox( name = "keywords_0", id = "keywords_0", class = "text" ) %]
         [% help_icon( 'upic_keywords' ) %]
-      <div class='helper'>[% '.upload.label.keywords.desc' | ml %]</div>
-    </p>
+      </div>
+      <div class='columns small-12 medium-6 helper'>[% '.upload.label.keywords.desc' | ml %]</div>
+    </div>
 
-    <p class='pkg'>
-      <label for='comments_0'>[% '.upload.label.comment' | ml %]</label>
+    <div class='row upload_row'>
+      <label class='columns small-12 medium-2' for='comments_0'>[% '.upload.label.comment' | ml %]</label>
+      <div class='columns small-12 medium-4'>
         [% form.textbox( name = "comments_0", id = "comments_0", class = "text",
                          maxlength = maxlength.comment ) %]
         [% help_icon( 'upic_comments' ) %]
-        <div class='helper'>[% '.upload.label.comment.desc' | ml %]</div>
-    </p>
+      </div>
+      <div class='columns small-12 medium-6 helper'>[% '.upload.label.comment.desc' | ml %]</div>
+    </div>
 
-
-    <p class='pkg'>
-      <label for='descriptions_0'>[% '.upload.label.description' | ml %]</label>
+    <div class='row upload_row'>
+      <label class='columns small-12 medium-2' for='descriptions_0'>[% '.upload.label.description' | ml %]</label>
+      <div class='columns small-12 medium-4'>
         [% form.textbox( name = "descriptions_0", id = "descriptions_0", class = "text",
                          maxlength = maxlength.description ) %]
         [% help_icon( 'upic_descriptions' ) %]
-        <div class='helper'>
-          [% '.upload.label.description.desc' | ml %]
-          [% alttext_faq( dw.ml( '.upload.label.description.faq' ) ) %]
-        </div>
-    </p>
+      </div>
+      <div class='columns small-12 medium-6 helper'>
+        [% '.upload.label.description.desc' | ml %]
+        [% alttext_faq( dw.ml( '.upload.label.description.faq' ) ) %]
+      </div>
+    </div>
 
+    <div class='row'>
+      <div class='columns small-12 medium-10 medium-offset-2'>
+        <p class='pkg' style='margin-bottom: 0.4rem;'>
+          <span id='main_make_default'>
+            [%# can't use auto-label with ml strings that contain HTML formats -%]
+            [% form.checkbox( name = 'make_default', id = 'make_default_0',
+                              accesskey = dw.ml( '.makedefault.key' ), value = 0,
+                              selected = num_icons ? 0 : 1 ) %]
+            <label for="make_default_0">[% '.makedefault' | ml %]</label>
+          </span>
+        </p>
 
-    <p class='pkg'>
-      <span id='main_make_default'>
-        [%# can't use auto-label with ml strings that contain HTML formats -%]
-        [% form.checkbox( name = 'make_default', id = 'make_default_0',
-                          accesskey = dw.ml( '.makedefault.key' ), value = 0,
-                          selected = num_icons ? 0 : 1 ) %]
-        <label for="make_default_0">[% '.makedefault' | ml %]</label>
-      </span>
-    </p>
+        [%- num_remaining = max_icons - num_icons -%]
+        [%- IF num_remaining >= 2 -%]
+          <div id='multi_insert'></div>
+          <div id='no_default_insert'></div>
+        [%- END -%]
 
-    [%- num_remaining = max_icons - num_icons -%]
-    [%- IF num_remaining >= 2 -%]
-      <div id='multi_insert'></div>
-      <div id='no_default_insert'></div>
-      <p class='pkg small-center' id='multi_insert_buttons'>
-        <input class="button" type='button secondary' value="[% '.upload.btn.addfile' | ml %]"
-               onclick='javascript:addNewUpload("file");' />
-        <input class="button" type='button secondary' value="[% '.upload.btn.addurl' | ml %]"
-               onclick='javascript:addNewUpload("url");' />
-        <script type='text/javascript'>
-            window.editiconsConfig = {
-                maxcounter: [% num_remaining %],
-                allowComments: true,
-                allowDescriptions: true,
-                labels: {
-                    comment: [% '.upload.label.comment' | ml | js %],
-                    description: [% '.upload.label.description' | ml | js %],
-                    fromfile: [% '.fromfile' | ml | js %],
-                    fromurl: [% '.fromurl' | ml | js %],
-                    keepdefault: [% '.keepdefault' | ml | js %],
-                    keywords: [% '.upload.label.keywords' | ml | js %],
-                    makedefault: [% '.makedefault' | ml | js %],
-                    makedefaultkey: [% '.makedefault.key' | ml | js %],
-                    remove: [% '.upload.btn.remove' | ml | js %]
-                }
-            };
-        </script>
-      </p>
-    [%- END -%]
+        <p class='pkg' id='submit_wrapper'>
+          [% form.submit( class="large", value = dw.ml( ".upload.btn.proceed" ),
+                          disabled = uploads_disabled ) %]
+          [%- IF num_remaining >= 2 -%]
+            <button type='button' class='button secondary' id='multi_insert_buttons'
+                    onclick='addNewUpload()'>[% '.upload.btn.addanother' | ml %]</button>
+          [%- END -%]
+        </p>
 
-    <p class='pkg' id='submit_wrapper'>
-      [% form.submit( class="large", value = dw.ml( ".upload.btn.proceed" ),
-                      disabled = uploads_disabled ) %]
-    </p>
+        [%- IF num_remaining >= 2 -%]
+          <script type='text/javascript'>
+              window.editiconsConfig = {
+                  maxcounter: [% num_remaining %],
+                  allowComments: true,
+                  allowDescriptions: true,
+                  labels: {
+                      comment: [% '.upload.label.comment' | ml | js %],
+                      description: [% '.upload.label.description' | ml | js %],
+                      file: [% '.upload.btn.file' | ml | js %],
+                      orurl: [% '.upload.or.url' | ml | js %],
+                      keepdefault: [% '.keepdefault' | ml | js %],
+                      keywords: [% '.upload.label.keywords' | ml | js %],
+                      makedefault: [% '.makedefault' | ml | js %],
+                      makedefaultkey: [% '.makedefault.key' | ml | js %],
+                      remove: [% '.upload.btn.remove' | ml | js %]
+                  }
+              };
+          </script>
+        [%- END -%]
+      </div>
+    </div>
   </form>
   </div></div><!-- end #uploadBox -->
 [%- END -%]
 
 [%- IF ! num_icons -%]
-  <div class="columns large-8">
   <h2>[% '.edit.nopics.header' | ml %]</h2>
   <p>[% '.edit.nopics.desc' | ml %]</p>
-  </div>
 [%- ELSE -%]
-  <div id='current_userpics' class="columns large-8">
+  <div id='current_userpics'>
   <form method='post' action='[% selflink() %]'>
     [% dw.form_auth %]
     <h2>[% '.edit.icons.header' | ml %]</h2>
@@ -266,7 +257,6 @@
 
           </div><!-- userpic_controls -->
         </div><!-- userpic_wrapper -->
-        <hr class='hr' />
       [%- END -%]
     </div><!-- end #list_userpics -->
 
@@ -281,4 +271,3 @@
   </form>
   </div><!-- end #current_userpics -->
 [%- END -%]
-</div><!-- end .row -->

--- a/views/edit/icons.tt
+++ b/views/edit/icons.tt
@@ -41,7 +41,8 @@
     <div id='upload_desc'><p>[% '.upload.desc' | ml %]</p></div>
 
     <div id='upload_wrapper' class='row upload_row'>
-      <label class='columns small-12 medium-2'>[% '.upload.label.source' | ml %]</label>
+      [%# not a <label>: this heads a file-or-URL group, not one control -%]
+      <span class='columns small-12 medium-2 upload_row_label'>[% '.upload.label.source' | ml %]</span>
       <div class='columns small-12 medium-10 upload_source'>
         <button type='button' class='button secondary upload_file_btn'
                 onclick='chooseFile(0)'>[% '.upload.btn.file' | ml %]</button>
@@ -49,7 +50,8 @@
         <span class='upload_filename' id='filename_0'></span>
         <label class='upload_or' for='urlpic_0'>[% '.upload.or.url' | ml %]</label>
         [% form.textbox( name = "urlpic_0", id = "urlpic_0", class = "text upload_url" ) %]
-        <input type='hidden' name='src_0' id='src_0' value='file' />
+        [%# default the source to whichever input the last (failed) submit used -%]
+        <input type='hidden' name='src_0' id='src_0' value='[% formdata.urlpic_0 ? "url" : "file" %]' />
       </div>
     </div>
 

--- a/views/edit/icons.tt.text
+++ b/views/edit/icons.tt.text
@@ -1,7 +1,7 @@
 ;; -*- coding: utf-8 -*-
 .edit.btn.save=Save
 
-.edit.icons.desc=These are your current icons. You can choose which icon to use as your default, add new icons, and delete icons you no longer want. If you assign keywords to your icons, you can select them by keyword for entries and comments. You can also assign a description to each icon. To upload a new icon, use the form at the left.
+.edit.icons.desc=These are your current icons. You can choose which icon to use as your default, add new icons, and delete icons you no longer want. If you assign keywords to your icons, you can select them by keyword for entries and comments. You can also assign a description to each icon. To upload a new icon, use the form above.
 
 .edit.icons.header=Current Icons
 
@@ -20,16 +20,6 @@
 .edit.nopics.header=No Icons
 
 .error.icon.quota=You're at your limit of [[num]] [[?num|icon|icons]]. You can't upload any more icons until you delete one of your existing ones.
-
-.fromfile=From <u>F</u>ile:
-
-.fromfile.key|notes=Enter here a <b>lower-case</b> version of the letter you underlined in ".fromfile". This is the shortcut key for the fromfile option.
-.fromfile.key=f
-
-.fromurl=From U<u>R</u>L:
-
-.fromurl.key|notes=Enter here a <b>lower-case</b> version of the letter you underlined in ".fromurl". This is the shortcut key for the fromurl option.
-.fromurl.key=r
 
 .icon.countstatus=Currently uploaded: [[current]] out of [[max]].
 
@@ -52,17 +42,17 @@
 
 .upload.about=About Icons
 
-.upload.btn.addfile=Add another from file
+.upload.btn.proceed=Upload
 
-.upload.btn.addurl=Add another from URL
+.upload.btn.addanother=Add another
 
-.upload.btn.proceed=Proceed
+.upload.btn.file=Upload file
+
+.upload.or.url=or enter URL:
 
 .upload.btn.remove=Remove
 
 .upload.desc=Use the form below to upload a new icon.
-
-.upload.formats.desc=Acceptable formats are GIF, JPG, and PNG.
 
 .upload.header=Upload a new icon
 
@@ -77,6 +67,8 @@
 .upload.label.description.faq=Read more about good descriptions.
 
 .upload.label.keywords=Keywords:
+
+.upload.label.source=Source:
 
 .upload.label.keywords.desc=Comma-separated list of up to 10 terms you'll use to select this icon. Keywords over 40 characters will be truncated.
 


### PR DESCRIPTION
The upload form and icon list were two side-by-side columns (`large-4`/`large-8`) that **stacked below 1024px**, pushing the icon list far down under a tall full-width upload box. This reworks the page into a full-width upload row above a **responsive icon grid** (two-up ≥640px, one-up on mobile) and tightens the upload form.

**Upload form**
- Source is now an **"Upload file"** button + an **"or enter URL"** field instead of two radios with separate labels/inputs. Each upload row carries a hidden `src_N` field the JS sets from the chosen source; `DW::Controller::EditIcons` now gates *every* row by its own `src_N` (previously only the first row was gated, by a single `src`), so an unused file/URL input never trips an empty-input error.
- One **"Add another"** button beside the primary action (now **"Upload"**) replaces the separate add-from-file / add-from-URL buttons; `editicons.js` builds a combined-source extra-upload row.
- Fields sit on one aligned grid (right-aligned labels · input · help to the right); **"About Icons"** becomes a **"?"** toggle by the heading; the "acceptable formats" line is dropped (upload already errors on bad types).
- Removed strings retired via `deadphrases.dat`.

Verified end-to-end on the dev server: file upload, URL upload, and multi-row upload all succeed with no empty-input errors, and "Add another" builds working rows in a real browser with no JS errors. `t/02-tidy.t` and `t/00-compile.t` pass.

### Before / after

| | Before | After |
|---|---|---|
| **Desktop (1200px)** | ![before desktop](https://raw.githubusercontent.com/zorkian/dreamwidth/90bdce8eb78dad2c8deeb83280164ad3370d8129/before-desktop.png) | ![after desktop](https://raw.githubusercontent.com/zorkian/dreamwidth/90bdce8eb78dad2c8deeb83280164ad3370d8129/after-desktop.png) |
| **Tablet (800px)** | ![before tablet](https://raw.githubusercontent.com/zorkian/dreamwidth/90bdce8eb78dad2c8deeb83280164ad3370d8129/before-tablet.png) | ![after tablet](https://raw.githubusercontent.com/zorkian/dreamwidth/90bdce8eb78dad2c8deeb83280164ad3370d8129/after-tablet.png) |
| **Mobile (430px)** | — | ![after mobile](https://raw.githubusercontent.com/zorkian/dreamwidth/90bdce8eb78dad2c8deeb83280164ad3370d8129/after-mobile.png) |

CODE TOUR: The "Manage Icons" page got a cleanup. The box for adding a new icon is now a single tidy row across the top — pick a file or paste a URL, no more duplicated radio buttons — and your existing icons show in two columns on a normal screen (one column on a phone) instead of one long list you had to scroll past a giant upload box to reach. Same features, less scrolling, and it finally works well on mobile.