### PR TITLE
Finish the web->web22 migration in the tooling

### DIFF
--- a/.github/workflows/tasks/web-canary-service.json
+++ b/.github/workflows/tasks/web-canary-service.json
@@ -2,7 +2,7 @@
     "containerDefinitions": [
         {
             "name": "web",
-            "image": "ghcr.io/dreamwidth/web:latest",
+            "image": "ghcr.io/dreamwidth/web22:latest",
             "cpu": 0,
             "portMappings": [
                 {

--- a/.github/workflows/tasks/web-shop-service.json
+++ b/.github/workflows/tasks/web-shop-service.json
@@ -2,7 +2,7 @@
     "containerDefinitions": [
         {
             "name": "web",
-            "image": "ghcr.io/dreamwidth/web:latest",
+            "image": "ghcr.io/dreamwidth/web22:latest",
             "cpu": 0,
             "portMappings": [
                 {

--- a/.github/workflows/tasks/web-stable-service.json
+++ b/.github/workflows/tasks/web-stable-service.json
@@ -2,7 +2,7 @@
     "containerDefinitions": [
         {
             "name": "web",
-            "image": "ghcr.io/dreamwidth/web:latest",
+            "image": "ghcr.io/dreamwidth/web22:latest",
             "cpu": 0,
             "portMappings": [
                 {

--- a/.github/workflows/tasks/web-unauthenticated-service.json
+++ b/.github/workflows/tasks/web-unauthenticated-service.json
@@ -2,7 +2,7 @@
     "containerDefinitions": [
         {
             "name": "web",
-            "image": "ghcr.io/dreamwidth/web:latest",
+            "image": "ghcr.io/dreamwidth/web22:latest",
             "cpu": 0,
             "portMappings": [
                 {

--- a/src/dwtool/internal/aws/ecs.go
+++ b/src/dwtool/internal/aws/ecs.go
@@ -256,8 +256,8 @@ func classifyService(name string) (group, workflow, workflowSvc, imageBase strin
 			{Label: "web22", Workflow: config.WorkflowWeb22, WorkflowSvc: "web-canary", ImageBase: config.ImageBaseWeb22},
 		}
 	case "web-stable":
-		return "web", config.WorkflowWeb, "web-stable", config.ImageBaseWeb, []model.DeployTarget{
-			{Label: "web", Workflow: config.WorkflowWeb, WorkflowSvc: "web-stable", ImageBase: config.ImageBaseWeb},
+		return "web", config.WorkflowWeb22, "web-stable", config.ImageBaseWeb22, []model.DeployTarget{
+			{Label: "web22", Workflow: config.WorkflowWeb22, WorkflowSvc: "web-stable", ImageBase: config.ImageBaseWeb22},
 		}
 	case "web-unauthenticated":
 		return "web", config.WorkflowWeb22, "web-unauthenticated", config.ImageBaseWeb22, []model.DeployTarget{
@@ -309,7 +309,7 @@ func (c *Client) FetchServiceImages(ctx context.Context, services []model.Servic
 		}
 
 		// Prefer Container.Image which has the task definition's image reference
-		// (e.g. "ghcr.io/dreamwidth/web@sha256:DIGEST") — this is the GHCR
+		// (e.g. "ghcr.io/dreamwidth/web22@sha256:DIGEST") — this is the GHCR
 		// manifest digest and will match GHCR package versions.
 		// Container.ImageDigest is the platform-specific runtime digest and
 		// won't match GHCR for multi-arch images.

--- a/src/dwtool/internal/config/config.go
+++ b/src/dwtool/internal/config/config.go
@@ -6,12 +6,11 @@ const (
 	DefaultRepo      = "dreamwidth/dreamwidth"
 	DefaultSQSPrefix = "dw-prod-"
 
-	ImageBaseWeb      = "ghcr.io/dreamwidth/web"
+	// All web services run on web22; the old "web" build/deploy was retired.
 	ImageBaseWeb22    = "ghcr.io/dreamwidth/web22"
 	ImageBaseWorker   = "ghcr.io/dreamwidth/worker"
 	ImageBaseWorker22 = "ghcr.io/dreamwidth/worker22"
 
-	WorkflowWeb      = "web-deploy.yml"
 	WorkflowWeb22    = "web22-deploy.yml"
 	WorkflowWorker   = "worker-deploy.yml"
 	WorkflowWorker22 = "worker22-deploy.yml"
@@ -41,10 +40,10 @@ func WebServices() []struct {
 		WorkflowSvc string
 		ImageBase   string
 	}{
-		{"web-canary", WorkflowWeb, "web-canary", ImageBaseWeb},
+		{"web-canary", WorkflowWeb22, "web-canary", ImageBaseWeb22},
 		{"web-shop", WorkflowWeb22, "web-shop", ImageBaseWeb22},
-		{"web-unauthenticated", WorkflowWeb, "web-unauthenticated", ImageBaseWeb},
-		{"web-stable", WorkflowWeb, "web-stable", ImageBaseWeb},
+		{"web-unauthenticated", WorkflowWeb22, "web-unauthenticated", ImageBaseWeb22},
+		{"web-stable", WorkflowWeb22, "web-stable", ImageBaseWeb22},
 	}
 }
 

--- a/src/dwtool/internal/config/config.go
+++ b/src/dwtool/internal/config/config.go
@@ -6,7 +6,6 @@ const (
 	DefaultRepo      = "dreamwidth/dreamwidth"
 	DefaultSQSPrefix = "dw-prod-"
 
-	// All web services run on web22; the old "web" build/deploy was retired.
 	ImageBaseWeb22    = "ghcr.io/dreamwidth/web22"
 	ImageBaseWorker   = "ghcr.io/dreamwidth/worker"
 	ImageBaseWorker22 = "ghcr.io/dreamwidth/worker22"

--- a/src/dwtool/internal/github/github.go
+++ b/src/dwtool/internal/github/github.go
@@ -36,7 +36,7 @@ type ghRunView struct {
 }
 
 // FetchImages lists recent GHCR package versions for the given image base.
-// imageBase is like "ghcr.io/dreamwidth/web22" — we extract "web" as the package name.
+// imageBase is like "ghcr.io/dreamwidth/web22" — we extract "web22" as the package name.
 func FetchImages(repo, imageBase string, limit int) ([]model.Image, error) {
 	// Extract package name from imageBase (e.g. "ghcr.io/dreamwidth/web22" -> "web22")
 	parts := strings.Split(imageBase, "/")

--- a/src/dwtool/internal/github/github.go
+++ b/src/dwtool/internal/github/github.go
@@ -36,9 +36,9 @@ type ghRunView struct {
 }
 
 // FetchImages lists recent GHCR package versions for the given image base.
-// imageBase is like "ghcr.io/dreamwidth/web" — we extract "web" as the package name.
+// imageBase is like "ghcr.io/dreamwidth/web22" — we extract "web" as the package name.
 func FetchImages(repo, imageBase string, limit int) ([]model.Image, error) {
-	// Extract package name from imageBase (e.g. "ghcr.io/dreamwidth/web" -> "web")
+	// Extract package name from imageBase (e.g. "ghcr.io/dreamwidth/web22" -> "web22")
 	parts := strings.Split(imageBase, "/")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("invalid image base: %s", imageBase)

--- a/src/dwtool/internal/model/types.go
+++ b/src/dwtool/internal/model/types.go
@@ -13,7 +13,7 @@ type DeployTarget struct {
 	Label       string // display name: "web", "web22", "worker", "worker22"
 	Workflow    string // GitHub Actions workflow filename
 	WorkflowSvc string // the "service" input value for the workflow
-	ImageBase   string // GHCR image base (e.g., ghcr.io/dreamwidth/web)
+	ImageBase   string // GHCR image base (e.g., ghcr.io/dreamwidth/web22)
 }
 
 // Service represents an ECS service with its current state.
@@ -29,7 +29,7 @@ type Service struct {
 	Group        string // "web", worker category, or "proxy"
 	Workflow     string // GitHub Actions workflow filename (primary)
 	WorkflowSvc  string // the "service" input value for the workflow
-	ImageBase    string // GHCR image base (e.g., ghcr.io/dreamwidth/web)
+	ImageBase    string // GHCR image base (e.g., ghcr.io/dreamwidth/web22)
 	DeployTargets []DeployTarget // all available deploy sources (len > 1 means choice)
 	Deployments   []Deployment  // active deployments (PRIMARY + any in-progress)
 }


### PR DESCRIPTION
The old `web` build/deploy was retired (commit `12730963b`, "Migrate web-stable deploy to web22; retire old-web build/deploy"), but the tooling still pointed several web services at the dead pipeline. As a result `dwtool deploy web-stable-service <digest>` resolved to `web-deploy.yml` / `ghcr.io/dreamwidth/web` and failed with "digest not found" — `web-canary`, `web-unauthenticated`, and `web-shop` had been moved to web22 but `web-stable` was missed.

- **dwtool**: map `web-canary` / `web-unauthenticated` / `web-stable` to `WorkflowWeb22` + `ImageBaseWeb22` (the `config.go` service table and the `ecs.go` `classifyService` switch that `deploy` uses), and drop the now-unused `WorkflowWeb` / `ImageBaseWeb` constants. `web-shop` was already correct. Stale `ghcr.io/dreamwidth/web` example comments updated.
- **task defs**: point the `web` container image base at `ghcr.io/dreamwidth/web22` in `web-{canary,shop,stable,unauthenticated}-service.json`. The deploy workflow overrides `image` at render time so this was inert, but it was misleading.

Left intentionally: the CloudWatch log-group names under `/dreamwidth/web` — a logging namespace, not the image repo or deploy pipeline.

Verified: `docker run golang:1.24 go build ./...` passes, and `dwtool deploy web-stable-service <digest>` (dry run) now shows `workflow: web22-deploy.yml`, `source: ghcr.io/dreamwidth/web22`.

CODE TOUR: Internal deploy-tooling cleanup — no user-facing change. When we moved the web servers to the new "web22" build, one service ("web-stable") got left pointing at the old, now-deleted build in our deploy helper, so deploying it failed. This finishes that move so the tool works for every web service.

Note: `dwtool` is built from source (the checked-in binary is gitignored), so anyone using it should rebuild after this merges.