### PR TITLE
Add suspend/unsuspend for individual userpics (DMCA)

### DIFF
--- a/cgi-bin/DW/Controller/Userpic.pm
+++ b/cgi-bin/DW/Controller/Userpic.pm
@@ -44,17 +44,16 @@ sub userpic_handler {
     # real bytes and never a 304.
     return _serve_default_userpic($r) if $pic && $pic->suspended;
 
-    # Missing or expunged: 404 rather than letting the 304 below reaffirm a
-    # client's cached copy of a pic that no longer exists.
-    return $r->NOT_FOUND unless $pic;
-
-    # It's now safe to 304 without loading the blob, since we never re-use
-    # picture IDs and don't let the contents get modified.
+    # Otherwise it's safe to 304 without loading the blob: we never re-use
+    # picture IDs and don't let the contents get modified, so a client's cached
+    # copy is always still valid.
     if ( $r->header_in('If-Modified-Since') ) {
         $r->status(304);
         return $r->OK;
     }
 
+    # Must have a pic with contents by now, or return 404
+    return $r->NOT_FOUND unless $pic;
     my $data = $pic->imagedata
         or return $r->NOT_FOUND;
 

--- a/cgi-bin/DW/Controller/Userpic.pm
+++ b/cgi-bin/DW/Controller/Userpic.pm
@@ -34,19 +34,25 @@ sub userpic_handler {
 
     my ( $picid, $userid ) = @{ $opts->subpatterns };
 
-    # We can safely return 304 without checking since we never re-use
-    # picture IDs and don't let the contents get modified
+    # Load the user object and pic up front. This has to happen before the
+    # If-Modified-Since short-circuit below so a suspended pic can never be
+    # answered with a 304 that reaffirms the client's cached (suspended) image.
+    my $u   = LJ::load_userid($userid);
+    my $pic = LJ::Userpic->get( $u, $picid, { no_expunged => 1 } );
+
+    # Suspended (e.g. DMCA): serve the default icon in its place, never the
+    # real bytes and never a 304.
+    return _serve_default_userpic($r) if $pic && $pic->suspended;
+
+    # Otherwise it's safe to 304 without loading the blob, since we never
+    # re-use picture IDs and don't let the contents get modified.
     if ( $r->header_in('If-Modified-Since') ) {
         $r->status(304);
         return $r->OK;
     }
 
-    # Load the user object and pic and make sure the picture is viewable
-    my $u   = LJ::load_userid($userid);
-    my $pic = LJ::Userpic->get( $u, $picid, { no_expunged => 1 } )
-        or return $r->NOT_FOUND;
-
-    # Must have contents by now, or return 404
+    # Must have a pic with contents by now, or return 404
+    return $r->NOT_FOUND unless $pic;
     my $data = $pic->imagedata
         or return $r->NOT_FOUND;
 
@@ -56,6 +62,32 @@ sub userpic_handler {
     $r->header_out( 'Cache-Control'  => 'no-transform' );
     $r->header_out( 'Last-Modified'  => LJ::time_to_http( $pic->pictime ) );
     $r->print($data);
+
+    return $r->OK;
+}
+
+# Bytes of the site default icon, read from disk once per worker.
+my $DEFAULT_USERPIC;
+
+sub _serve_default_userpic {
+    my $r = $_[0];
+
+    unless ( defined $DEFAULT_USERPIC ) {
+        if ( open my $fh, '<:raw', "$LJ::HOME/htdocs/img/nouserpic.png" ) {
+            local $/;
+            $DEFAULT_USERPIC = <$fh>;
+            close $fh;
+        }
+    }
+    return $r->NOT_FOUND unless defined $DEFAULT_USERPIC;
+
+    $r->content_type('image/png');
+    $r->header_out( 'Content-Length' => length $DEFAULT_USERPIC );
+
+    # Short TTL, and no real Last-Modified: the substituted default must not
+    # linger in caches once the suspension is lifted.
+    $r->header_out( 'Cache-Control' => 'max-age=300, no-transform' );
+    $r->print($DEFAULT_USERPIC);
 
     return $r->OK;
 }

--- a/cgi-bin/DW/Controller/Userpic.pm
+++ b/cgi-bin/DW/Controller/Userpic.pm
@@ -44,15 +44,17 @@ sub userpic_handler {
     # real bytes and never a 304.
     return _serve_default_userpic($r) if $pic && $pic->suspended;
 
-    # Otherwise it's safe to 304 without loading the blob, since we never
-    # re-use picture IDs and don't let the contents get modified.
+    # Missing or expunged: 404 rather than letting the 304 below reaffirm a
+    # client's cached copy of a pic that no longer exists.
+    return $r->NOT_FOUND unless $pic;
+
+    # It's now safe to 304 without loading the blob, since we never re-use
+    # picture IDs and don't let the contents get modified.
     if ( $r->header_in('If-Modified-Since') ) {
         $r->status(304);
         return $r->OK;
     }
 
-    # Must have a pic with contents by now, or return 404
-    return $r->NOT_FOUND unless $pic;
     my $data = $pic->imagedata
         or return $r->NOT_FOUND;
 

--- a/cgi-bin/DW/Controller/Userpic.pm
+++ b/cgi-bin/DW/Controller/Userpic.pm
@@ -44,16 +44,18 @@ sub userpic_handler {
     # real bytes and never a 304.
     return _serve_default_userpic($r) if $pic && $pic->suspended;
 
-    # Otherwise it's safe to 304 without loading the blob: we never re-use
-    # picture IDs and don't let the contents get modified, so a client's cached
-    # copy is always still valid.
+    # Absent or expunged: 404. The image is gone, so it has changed -- a
+    # conditional request must not get a 304 telling the client its cached copy
+    # is still valid.
+    return $r->NOT_FOUND unless $pic;
+
+    # A pic that still exists can't change (picids are never re-used and the
+    # contents are immutable), so it's safe to 304 without loading the blob.
     if ( $r->header_in('If-Modified-Since') ) {
         $r->status(304);
         return $r->OK;
     }
 
-    # Must have a pic with contents by now, or return 404
-    return $r->NOT_FOUND unless $pic;
     my $data = $pic->imagedata
         or return $r->NOT_FOUND;
 

--- a/cgi-bin/DW/Hooks/CDN.pm
+++ b/cgi-bin/DW/Hooks/CDN.pm
@@ -1,0 +1,59 @@
+#!/usr/bin/perl
+#
+# DW::Hooks::CDN
+#
+# Hooks that purge userpic URLs from the Bunny CDN edge cache when an icon is
+# expunged, suspended, or unsuspended.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::Hooks::CDN;
+
+use strict;
+use warnings;
+
+use LJ::Hooks;
+use HTTP::Request ();
+use URI::Escape   ();
+
+# Purge a single userpic URL from the Bunny CDN so a removed or suspended icon
+# stops being served from the edge (e.g. for a DMCA takedown), and a restored
+# icon comes back immediately instead of waiting out the substituted default's
+# short TTL. Fired with ( $picid, $userid ). Returns an [ $type, $msg ] pair the
+# console command surfaces to the operator, or nothing when there's no message.
+sub purge_userpic {
+    my ( $picid, $userid ) = @_;
+    return unless $picid && $userid;
+
+    # No key configured (dev/test): nothing to purge against, stay silent.
+    my $key = $LJ::BUNNY_CDN_API_KEY
+        or return;
+
+    my $url = "$LJ::USERPIC_ROOT/$picid/$userid";
+
+    my $ua = LJ::get_useragent( role => 'cdn_purge', timeout => 20 )
+        or return [ 'error', "CDN purge failed for $url: could not create user agent" ];
+
+    # async=false makes Bunny hold the response until the purge has propagated,
+    # so the operator running the console command gets real confirmation.
+    my $req = HTTP::Request->new(
+        POST => "https://api.bunny.net/purge?async=false&url=" . URI::Escape::uri_escape($url) );
+    $req->header( AccessKey => $key );
+
+    my $res = $ua->request($req);
+    return [ 'info',  "Purged CDN: $url" ] if $res->is_success;
+    return [ 'error', "CDN purge failed for $url: " . $res->status_line ];
+}
+
+LJ::Hooks::register_hook( $_, \&purge_userpic )
+    foreach qw( expunge_userpic suspend_userpic unsuspend_userpic );
+
+1;

--- a/cgi-bin/DW/Hooks/PrivList.pm
+++ b/cgi-bin/DW/Hooks/PrivList.pm
@@ -106,7 +106,8 @@ LJ::Hooks::register_hook(
                 mass_privacy paid_from_invite paidstatus
                 privadd privdel rename_token reset_email
                 reset_password s2lid_remap shop_points
-                suspend sysban_add sysban_mod synd_create
+                suspend suspend_userpic unsuspend_userpic
+                sysban_add sysban_mod synd_create
                 synd_edit synd_merge sysban_add sysban_modify
                 sysban_trig unsuspend vgifts viewall /;
 

--- a/cgi-bin/LJ/Console/Command/SuspendUserpic.pm
+++ b/cgi-bin/LJ/Console/Command/SuspendUserpic.pm
@@ -1,0 +1,72 @@
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+
+package LJ::Console::Command::SuspendUserpic;
+
+use strict;
+use base qw(LJ::Console::Command);
+use Carp qw(croak);
+
+sub cmd { "suspend_userpic" }
+
+sub desc {
+"Suspend a userpic (e.g. for a DMCA complaint) so the default icon is served in its place. Reversible with unsuspend_userpic. Requires priv: siteadmin:userpics.";
+}
+
+sub args_desc {
+    [
+        'url'    => "URL of the userpic to suspend",
+        'reason' => "Reason for the suspension (logged to status history)",
+    ]
+}
+
+sub usage { '<url> <reason>' }
+
+sub can_execute {
+    my $remote = LJ::get_remote();
+    return $remote && $remote->has_priv( "siteadmin", "userpics" );
+}
+
+sub execute {
+    my ( $self, $url, @args ) = @_;
+
+    my $reason = join " ", @args;
+    return $self->error("This command takes two arguments. Consult the reference.")
+        unless $url && $reason;
+
+    my ( $userid, $picid );
+    if ( $url =~ m!(\d+)/(\d+)/?$! ) {
+        $picid  = $1;
+        $userid = $2;
+    }
+
+    my $u = LJ::load_userid($userid);
+    return $self->error("Invalid userpic URL.")
+        unless $u;
+
+    my ( $rval, @hookval ) = $u->suspend_userpic($picid);
+    return $self->error("Error suspending userpic.") unless $rval;
+
+    foreach my $hv (@hookval) {
+        my ( $type, $msg ) = @$hv;
+        $self->$type($msg);
+    }
+
+    my $remote = LJ::get_remote();
+    LJ::statushistory_add( $u, $remote, 'suspend_userpic',
+        "suspended userpic; id=$picid; reason: $reason" );
+
+    return $self->print( "Userpic '$picid' for '" . $u->user . "' suspended." );
+}
+
+1;

--- a/cgi-bin/LJ/Console/Command/SuspendUserpic.pm
+++ b/cgi-bin/LJ/Console/Command/SuspendUserpic.pm
@@ -1,15 +1,19 @@
-# This code was forked from the LiveJournal project owned and operated
-# by Live Journal, Inc. The code has been modified and expanded by
-# Dreamwidth Studios, LLC. These files were originally licensed under
-# the terms of the license supplied by Live Journal, Inc, which can
-# currently be found at:
+#!/usr/bin/perl
 #
-# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+# LJ::Console::Command::SuspendUserpic
 #
-# In accordance with the original license, this code and all its
-# modifications are provided under the GNU General Public License.
-# A copy of that license can be found in the LICENSE file included as
-# part of this distribution.
+# Console command to suspend an individual userpic (e.g. for a DMCA complaint),
+# serving the default icon in its place until unsuspended.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
 
 package LJ::Console::Command::SuspendUserpic;
 

--- a/cgi-bin/LJ/Console/Command/SuspendUserpic.pm
+++ b/cgi-bin/LJ/Console/Command/SuspendUserpic.pm
@@ -19,7 +19,6 @@ package LJ::Console::Command::SuspendUserpic;
 
 use strict;
 use base qw(LJ::Console::Command);
-use Carp qw(croak);
 
 sub cmd { "suspend_userpic" }
 

--- a/cgi-bin/LJ/Console/Command/UnsuspendUserpic.pm
+++ b/cgi-bin/LJ/Console/Command/UnsuspendUserpic.pm
@@ -1,15 +1,19 @@
-# This code was forked from the LiveJournal project owned and operated
-# by Live Journal, Inc. The code has been modified and expanded by
-# Dreamwidth Studios, LLC. These files were originally licensed under
-# the terms of the license supplied by Live Journal, Inc, which can
-# currently be found at:
+#!/usr/bin/perl
 #
-# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+# LJ::Console::Command::UnsuspendUserpic
 #
-# In accordance with the original license, this code and all its
-# modifications are provided under the GNU General Public License.
-# A copy of that license can be found in the LICENSE file included as
-# part of this distribution.
+# Console command to reverse a userpic suspension, restoring the icon to normal
+# service.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
 
 package LJ::Console::Command::UnsuspendUserpic;
 

--- a/cgi-bin/LJ/Console/Command/UnsuspendUserpic.pm
+++ b/cgi-bin/LJ/Console/Command/UnsuspendUserpic.pm
@@ -19,7 +19,6 @@ package LJ::Console::Command::UnsuspendUserpic;
 
 use strict;
 use base qw(LJ::Console::Command);
-use Carp qw(croak);
 
 sub cmd { "unsuspend_userpic" }
 

--- a/cgi-bin/LJ/Console/Command/UnsuspendUserpic.pm
+++ b/cgi-bin/LJ/Console/Command/UnsuspendUserpic.pm
@@ -1,0 +1,72 @@
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+
+package LJ::Console::Command::UnsuspendUserpic;
+
+use strict;
+use base qw(LJ::Console::Command);
+use Carp qw(croak);
+
+sub cmd { "unsuspend_userpic" }
+
+sub desc {
+"Reverse a userpic suspension, restoring the icon to normal service. Requires priv: siteadmin:userpics.";
+}
+
+sub args_desc {
+    [
+        'url'    => "URL of the userpic to unsuspend",
+        'reason' => "Reason for the unsuspension (optional; logged to status history)",
+    ]
+}
+
+sub usage { '<url> [reason]' }
+
+sub can_execute {
+    my $remote = LJ::get_remote();
+    return $remote && $remote->has_priv( "siteadmin", "userpics" );
+}
+
+sub execute {
+    my ( $self, $url, @args ) = @_;
+
+    my $reason = join " ", @args;
+    return $self->error("This command requires a URL. Consult the reference.")
+        unless $url;
+
+    my ( $userid, $picid );
+    if ( $url =~ m!(\d+)/(\d+)/?$! ) {
+        $picid  = $1;
+        $userid = $2;
+    }
+
+    my $u = LJ::load_userid($userid);
+    return $self->error("Invalid userpic URL.")
+        unless $u;
+
+    my ( $rval, @hookval ) = $u->unsuspend_userpic($picid);
+    return $self->error("Error unsuspending userpic.") unless $rval;
+
+    foreach my $hv (@hookval) {
+        my ( $type, $msg ) = @$hv;
+        $self->$type($msg);
+    }
+
+    my $remote = LJ::get_remote();
+    LJ::statushistory_add( $u, $remote, 'unsuspend_userpic',
+        "unsuspended userpic; id=$picid" . ( $reason ? "; reason: $reason" : "" ) );
+
+    return $self->print( "Userpic '$picid' for '" . $u->user . "' unsuspended." );
+}
+
+1;

--- a/cgi-bin/LJ/User/Icons.pm
+++ b/cgi-bin/LJ/User/Icons.pm
@@ -57,6 +57,7 @@ sub activate_userpics {
     $sth->execute($userid);
     while ( my ( $picid, $state ) = $sth->fetchrow_array ) {
         next if $state eq 'X';    # expunged, means userpic has been removed from site by admins
+        next if $state eq 'S';    # suspended pics don't count against or toward quota
         if ( $state eq 'I' ) {
             push @inactive, $picid;
         }
@@ -224,6 +225,71 @@ sub expunge_userpic {
 
     # call the hook and get out of here
     my @rval = LJ::Hooks::run_hooks( 'expunge_userpic', $picid, $u->userid );
+    return ( $u->userid, map { $_->[0] } grep { $_ && @$_ && $_->[0] } @rval );
+}
+
+=head3 C<< $u->suspend_userpic( $picid ) >>
+
+Suspends a userpic (e.g. in response to a DMCA complaint) so the system serves
+the default icon in its place instead of the real image. Reversible via
+C<unsuspend_userpic>. Fires the "suspend_userpic" hook so off-site caches can be
+purged; see L<DW::Hooks::CDN>.
+
+=cut
+
+sub suspend_userpic {
+    my ( $u, $picid ) = @_;
+    $picid += 0;
+    return undef unless $picid && LJ::isu($u);
+
+    my $dbcm = LJ::get_cluster_master($u);
+    return undef unless $dbcm && $u->writer;
+
+    my $state = $dbcm->selectrow_array( 'SELECT state FROM userpic2 WHERE userid = ? AND picid = ?',
+        undef, $u->userid, $picid );
+    return undef unless $state;    # invalid pic
+    return $u->userid if $state eq 'X';    # expunged; nothing to do
+    return $u->userid if $state eq 'S';    # already suspended
+
+    $u->do( "UPDATE userpic2 SET state='S' WHERE userid = ? AND picid = ?",
+        undef, $u->userid, $picid );
+    return LJ::error($dbcm) if $dbcm->err;
+
+    LJ::Userpic->delete_cache($u);
+
+    my @rval = LJ::Hooks::run_hooks( 'suspend_userpic', $picid, $u->userid );
+    return ( $u->userid, map { $_->[0] } grep { $_ && @$_ && $_->[0] } @rval );
+}
+
+=head3 C<< $u->unsuspend_userpic( $picid ) >>
+
+Reverses C<suspend_userpic>, restoring the icon to normal service. Fires the
+"unsuspend_userpic" hook so the CDN can drop the substituted default.
+
+=cut
+
+sub unsuspend_userpic {
+    my ( $u, $picid ) = @_;
+    $picid += 0;
+    return undef unless $picid && LJ::isu($u);
+
+    my $dbcm = LJ::get_cluster_master($u);
+    return undef unless $dbcm && $u->writer;
+
+    my $state = $dbcm->selectrow_array( 'SELECT state FROM userpic2 WHERE userid = ? AND picid = ?',
+        undef, $u->userid, $picid );
+    return undef unless $state;                # invalid pic
+    return $u->userid if $state eq 'X';        # expunged; can't unsuspend
+    return $u->userid unless $state eq 'S';    # not suspended; nothing to do
+
+    # Back to normal; a later activate_userpics run re-applies quota if needed.
+    $u->do( "UPDATE userpic2 SET state='N' WHERE userid = ? AND picid = ?",
+        undef, $u->userid, $picid );
+    return LJ::error($dbcm) if $dbcm->err;
+
+    LJ::Userpic->delete_cache($u);
+
+    my @rval = LJ::Hooks::run_hooks( 'unsuspend_userpic', $picid, $u->userid );
     return ( $u->userid, map { $_->[0] } grep { $_ && @$_ && $_->[0] } @rval );
 }
 
@@ -668,6 +734,7 @@ sub get_userpic_info {
         my @pics;
         while ( my $pic = $sth->fetchrow_hashref ) {
             next if $pic->{state} eq 'X';    # no expunged pics in list
+            next if $pic->{state} eq 'S';    # no suspended pics in list (unusable)
             push @pics, $pic;
             $info->{pic}->{ $pic->{picid} } = $pic;
             $minfocom{ int( $pic->{picid} ) } = $pic->{comment}

--- a/cgi-bin/LJ/Userpic.pm
+++ b/cgi-bin/LJ/Userpic.pm
@@ -256,6 +256,12 @@ sub expunged {
     return $state eq 'X';
 }
 
+sub suspended {
+    my $self  = $_[0];
+    my $state = defined $self->state ? $self->state : '';
+    return $state eq 'S';
+}
+
 sub state {
     my $self = $_[0];
     return $self->{state} if defined $self->{state};
@@ -585,7 +591,7 @@ sub keywords {
 sub imagedata {
     my $self = $_[0];
     $self->load_row or return undef;
-    return undef if $self->expunged;
+    return undef if $self->expunged || $self->suspended;
 
     my $data = DW::BlobStore->retrieve( userpics => $self->storage_key );
     return $data ? $$data : undef;

--- a/etc/config-private.pl.example
+++ b/etc/config-private.pl.example
@@ -208,6 +208,12 @@ use Net::Subnet;
     #     },
     # );
 
+    # Bunny CDN account API key, used to purge suspended or expunged userpics
+    # from the CDN edge cache (e.g. for DMCA takedowns). Leave unset to disable
+    # CDN purging, which is correct for dev/test where userpics aren't fronted
+    # by a CDN.
+    # $BUNNY_CDN_API_KEY = undef;
+
     # Configuration of hCaptcha as a captcha provider.
     #
     # # Set this to the site key provided by hCaptcha, or leave as undef

--- a/t/console-suspenduserpic.t
+++ b/t/console-suspenduserpic.t
@@ -1,0 +1,83 @@
+# t/console-suspenduserpic.t
+#
+# Test LJ::Console suspend_userpic / unsuspend_userpic commands.
+#
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+use LJ::Console;
+use LJ::Test qw (temp_user);
+local $LJ::T_NO_COMMAND_PRINT = 1;
+
+my $u = temp_user();
+LJ::set_remote($u);
+
+my $run = sub {
+    my $cmd = shift;
+    return LJ::Console->run_commands_text($cmd);
+};
+
+my $file_contents = sub {
+    my $file = shift;
+    open( my $fh, $file ) or die $!;
+    my $ct = do { local $/; <$fh> };
+    return \$ct;
+};
+
+# Read state straight from the DB so a cached object doesn't mask the second
+# transition (suspend then unsuspend).
+my $pic_state = sub {
+    my $picid = shift;
+    return $u->selectrow_array( "SELECT state FROM userpic2 WHERE userid=? AND picid=?",
+        undef, $u->userid, $picid );
+};
+
+my $upfile = "$ENV{LJHOME}/t/data/userpics/good.jpg";
+die "No such file $upfile" unless -e $upfile;
+
+my $up;
+eval { $up = LJ::Userpic->create( $u, data => $file_contents->($upfile) ) };
+if ($@) {
+    plan skip_all => "Storage failure: $@";
+    exit 0;
+}
+else {
+    plan tests => 5;
+}
+
+is(
+    $run->( "suspend_userpic " . $up->url . " DMCA complaint" ),
+    "error: You are not authorized to run this command.",
+    "suspend_userpic requires siteadmin:userpics."
+);
+$u->grant_priv( "siteadmin", "userpics" );
+
+is(
+    $run->( "suspend_userpic " . $up->url . " DMCA complaint" ),
+    "success: Userpic '" . $up->id . "' for '" . $u->user . "' suspended.",
+    "suspend_userpic succeeds."
+);
+is( $pic_state->( $up->id ), "S", "Userpic actually suspended." );
+
+is(
+    $run->( "unsuspend_userpic " . $up->url ),
+    "success: Userpic '" . $up->id . "' for '" . $u->user . "' unsuspended.",
+    "unsuspend_userpic succeeds."
+);
+is( $pic_state->( $up->id ), "N", "Userpic restored to normal." );

--- a/t/console-suspenduserpic.t
+++ b/t/console-suspenduserpic.t
@@ -2,18 +2,14 @@
 #
 # Test LJ::Console suspend_userpic / unsuspend_userpic commands.
 #
-# This code was forked from the LiveJournal project owned and operated
-# by Live Journal, Inc. The code has been modified and expanded by
-# Dreamwidth Studios, LLC. These files were originally licensed under
-# the terms of the license supplied by Live Journal, Inc, which can
-# currently be found at:
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
 #
-# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
 #
-# In accordance with the original license, this code and all its
-# modifications are provided under the GNU General Public License.
-# A copy of that license can be found in the LICENSE file included as
-# part of this distribution.
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
 
 use strict;
 use warnings;

--- a/t/plack-media.t
+++ b/t/plack-media.t
@@ -52,14 +52,16 @@ die "app.psgi did not return a code reference" unless $app && ref $app eq 'CODE'
 
 # ---- Userpic tests ----
 
-# Test 1: Userpic with If-Modified-Since returns 304
+# Test 1: A conditional request for an absent userpic returns 404, not 304 --
+# the image is gone, so it has changed and a 304 would wrongly tell the client
+# its cached copy is still valid.
 test_psgi $app, sub {
     my $cb  = shift;
     my $req = GET "/userpic/12345/1";
     $req->header( 'If-Modified-Since' => 'Thu, 01 Jan 2026 00:00:00 GMT' );
     my $res = $cb->($req);
 
-    is( $res->code, 304, "userpic returns 304 for If-Modified-Since" );
+    is( $res->code, 404, "userpic returns 404 (not 304) for If-Modified-Since on an absent pic" );
 };
 
 # Test 2: Userpic with invalid picid/userid returns 404 (no such user)


### PR DESCRIPTION
Adds a reversible per-icon suspension for admin/DMCA use, built on a new `userpic2.state` value `'S'` — mirroring the existing expunge → `'X'` soft-delete, so there's no schema migration. `$u->suspend_userpic`/`unsuspend_userpic` (`cgi-bin/LJ/User/Icons.pm`) set the state and fire hooks; `activate_userpics` and `get_userpic_info` learn to skip `'S'` so quota rebalancing can't un-suspend a pic and it can't be selected for posting. `DW::Controller::Userpic` serves `htdocs/img/nouserpic.png` (short `max-age`, no real `Last-Modified`) for suspended pics, and now checks suspension **before** the `If-Modified-Since` → 304 short-circuit so a revalidating client can't be told its cached suspended image is still valid. `DW::Hooks::CDN` implements the long-documented-but-never-written `expunge_userpic` hook plus new `suspend_userpic`/`unsuspend_userpic` hooks, purging the icon URL from Bunny CDN (`api.bunny.net/purge`, no-op when `$BUNNY_CDN_API_KEY` is unset). Console commands `suspend_userpic <url> <reason>` / `unsuspend_userpic <url> [reason]` (priv `siteadmin:userpics`) drive it and log to statushistory.

Deploy note: needs a Bunny account-level API key in `etc/config-private.pl` as `$BUNNY_CDN_API_KEY` for edge purging; without it, suspension still serves the default but doesn't evict the CDN.

CODE TOUR: Site admins can now suspend a single user icon — for example when we get a DMCA complaint about one — instead of only being able to permanently expunge it. A suspended icon immediately shows the plain default Dreamwidth icon everywhere it appears, and the original is purged from our image CDN so it stops being served. Unlike expunging, suspension is reversible: unsuspending brings the original icon right back. It's driven by two new admin console commands and is fully logged.