### PR TITLE
Add startup-cron.sh: run-once entrypoint for scheduled ECS tasks

### DIFF
--- a/etc/docker/worker22/scripts/startup-cron.sh
+++ b/etc/docker/worker22/scripts/startup-cron.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Entry point for scheduled (EventBridge -> ECS RunTask) cron tasks.
+#
+# Unlike startup-prod.sh, which loops forever to keep a resident queue worker
+# running, a scheduled task must run its command exactly once and exit so the
+# next scheduled run starts a fresh task. We validate config first, then exec
+# the command so its exit code becomes the task's (a non-zero exit is what the
+# task-failure alarm keys on). Overlap between runs is guarded in the app layer
+# (e.g. ljmaint via DW::Locker's global GET_LOCK), not here.
+
+set -xe
+
+fail () {
+    echo "-- failure detected --"
+    sleep 30
+    exit 1
+}
+
+perl -I$LJHOME/extlib/ $LJHOME/bin/checkconfig.pl || fail
+
+COMMAND="$1"
+shift
+exec "$LJHOME/$COMMAND" "$@"

--- a/etc/docker/worker22/scripts/startup-cron.sh
+++ b/etc/docker/worker22/scripts/startup-cron.sh
@@ -19,6 +19,11 @@ fail () {
 
 perl -I$LJHOME/extlib/ $LJHOME/bin/checkconfig.pl || fail
 
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <command-relative-to-LJHOME> [args...]" >&2
+    exit 2
+fi
+
 COMMAND="$1"
 shift
 exec "$LJHOME/$COMMAND" "$@"


### PR DESCRIPTION
`startup-prod.sh` runs its command in an infinite `while true` loop to keep a resident queue worker alive. That's exactly wrong for a scheduled (cron) task, which must run once and exit so EventBridge Scheduler can launch a fresh task on the next tick. This adds `etc/docker/worker22/scripts/startup-cron.sh`, which validates config (`checkconfig.pl`) and then `exec`s the given command so its exit code becomes the task's — which is what the task-failure alarm keys on.

Overlap between runs is deliberately **not** handled here: it belongs in the app layer, and `bin/ljmaint.pl` already guards every task with `DW::Locker`'s global `GET_LOCK` (a concurrent run exits 0 with "already running"). A bash-level lock can't cleanly hold a MySQL session lock across the child anyway.

The image already does `ADD scripts/ /opt/`, so the new script lands at `/opt/startup-cron.sh` with no Dockerfile change. It's used by the companion `dw-terraform` change that moves the ljmaint/stats crons to EventBridge Scheduler → ECS RunTask; nothing calls it until that lands.

CODE TOUR: Groundwork for moving our nightly maintenance jobs (statistics generation, cache cleanup, etc.) off a cron machine and onto scheduled, self-contained cloud tasks that spin up, do their one job, and shut down. This adds the small startup script those scheduled tasks use to run exactly once and exit — no user-facing change.