### PR TITLE
get_talk_data: convert lock to DW::Locker + diagnostics for vanishing comments

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -802,15 +802,11 @@ sub fixup_logitem_replycount {
     my $rp_count  = LJ::MemCache::get($rp_memkey) || 0;
     my $fix_key   = "rp_fixed:$u->{userid}:$nodetype:$jitemid:$rp_count";
 
-    my $db_key   = "rp:fix:$u->{userid}:$nodetype:$jitemid";
-    my $got_lock = $u->selectrow_array( "SELECT GET_LOCK(?, 1)", undef, $db_key );
-    return unless $got_lock;
+    my $db_key = "rp:fix:$u->{userid}:$nodetype:$jitemid";
+    my $lock   = DW::Locker->new->trylock( $db_key, class => 'replycount_fixup', wait => 1 );
+    return unless $lock;
 
-    # setup an unlock handler
-    my $unlock = sub {
-        $u->do( "SELECT RELEASE_LOCK(?)", undef, $db_key );
-        return undef;
-    };
+    my $unlock = sub { $lock->release; return undef; };
 
     # check memcache to see if someone has previously fixed this entry in this journal
     # with this reply count

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -28,6 +28,8 @@ use DW::Search;
 use DW::Captcha;
 use DW::EmailPost::Comment;
 use DW::Formats;
+use DW::Locker;
+use Time::HiRes ();
 use LJ::Utils;
 use LJ::Comment;
 use LJ::Event::JournalNewComment;
@@ -716,23 +718,27 @@ sub get_talk_data {
 
     my $dbcr = LJ::get_cluster_def_reader($u);
     unless ($dbcr) {
-
-        # DIAGNOSTIC: returning undef here drops the whole comment set for the
-        # request. Track how often, and why, so we can confirm the failure mode
-        # behind intermittently-vanishing comments on large/busy threads.
         DW::Stats::increment( 'dw.talk.get_talk_data.undef', 1, ["reason:no_reader"] );
         $log->warn( "get_talk_data undef (no_reader): "
                 . "journalid=$u->{userid} nodetype=$nodetype nodeid=$nodeid" );
         return undef;
     }
 
-    # GET_LOCK returns 1 on success, 0 on the 10s timeout, NULL on error.
-    my $lock = $dbcr->selectrow_array( "SELECT GET_LOCK(?,10)", undef, $lockkey );
+    # Serialize the DB read + repopulate so a cache miss on a popular post
+    # doesn't stampede the database.
+    my $lock_t0 = Time::HiRes::time();
+    my $lock    = DW::Locker->new->trylock( $lockkey, class => 'get_talk_data', wait => 10 );
     unless ($lock) {
-        my $reason = defined $lock ? "lock_timeout" : "lock_error";
+        my $waited = Time::HiRes::time() - $lock_t0;
+        my $reason = ( $DW::Locker::Error // '' ) =~ /taken/ ? "lock_taken" : "lock_error";
         DW::Stats::increment( 'dw.talk.get_talk_data.undef', 1, ["reason:$reason"] );
-        $log->warn( "get_talk_data undef ($reason) on $lockkey: "
-                . "journalid=$u->{userid} nodetype=$nodetype nodeid=$nodeid" );
+        $log->warn(
+            sprintf(
+                "get_talk_data undef (%s, waited %.3fs) on %s: "
+                    . "journalid=%d nodetype=%s nodeid=%s",
+                $reason, $waited, $lockkey, $u->{userid}, $nodetype, $nodeid
+            )
+        );
         return undef;
     }
 
@@ -740,7 +746,7 @@ sub get_talk_data {
     # already populated while we were waiting for the lock
     $packed = LJ::MemCache::get($memkey);
     if ( $memcache_good->() ) {
-        $dbcr->selectrow_array( "SELECT RELEASE_LOCK(?)", undef, $lockkey );
+        $lock->release;    # release before the separately-locked replycount fixup
         $memcache_decode->();
         return $ret;
     }
@@ -775,7 +781,7 @@ sub get_talk_data {
         $rp_ourcount++ if $r->{'state'} eq "A";
     }
     LJ::MemCache::set( $memkey, $memval );
-    $dbcr->selectrow_array( "SELECT RELEASE_LOCK(?)", undef, $lockkey );
+    $lock->release;    # release before the separately-locked replycount fixup
 
     $fixup_rp->();
 

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -715,10 +715,26 @@ sub get_talk_data {
     return $memcache_decode->() if $memcache_good->();
 
     my $dbcr = LJ::get_cluster_def_reader($u);
-    return undef unless $dbcr;
+    unless ($dbcr) {
 
+        # DIAGNOSTIC: returning undef here drops the whole comment set for the
+        # request. Track how often, and why, so we can confirm the failure mode
+        # behind intermittently-vanishing comments on large/busy threads.
+        DW::Stats::increment( 'dw.talk.get_talk_data.undef', 1, ["reason:no_reader"] );
+        $log->warn( "get_talk_data undef (no_reader): "
+                . "journalid=$u->{userid} nodetype=$nodetype nodeid=$nodeid" );
+        return undef;
+    }
+
+    # GET_LOCK returns 1 on success, 0 on the 10s timeout, NULL on error.
     my $lock = $dbcr->selectrow_array( "SELECT GET_LOCK(?,10)", undef, $lockkey );
-    return undef unless $lock;
+    unless ($lock) {
+        my $reason = defined $lock ? "lock_timeout" : "lock_error";
+        DW::Stats::increment( 'dw.talk.get_talk_data.undef', 1, ["reason:$reason"] );
+        $log->warn( "get_talk_data undef ($reason) on $lockkey: "
+                . "journalid=$u->{userid} nodetype=$nodetype nodeid=$nodeid" );
+        return undef;
+    }
 
     # it's quite likely (for a popular post) that the memcache was
     # already populated while we were waiting for the lock

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -730,7 +730,7 @@ sub get_talk_data {
     my $lock    = DW::Locker->new->trylock( $lockkey, class => 'get_talk_data', wait => 10 );
     unless ($lock) {
         my $waited = Time::HiRes::time() - $lock_t0;
-        my $reason = ( $DW::Locker::Error // '' ) =~ /taken/ ? "lock_taken" : "lock_error";
+        my $reason = ( $DW::Locker::Error // '' ) eq "lock taken" ? "lock_taken" : "lock_error";
         DW::Stats::increment( 'dw.talk.get_talk_data.undef', 1, ["reason:$reason"] );
         $log->warn(
             sprintf(

--- a/cgi-bin/LJ/User/Data.pm
+++ b/cgi-bin/LJ/User/Data.pm
@@ -118,9 +118,11 @@ sub log2_do {
     my $lock = DW::Locker->new->trylock( $lockkey, class => 'log2_do', wait => 10 );
     my $ret  = $u->do( $sql, undef, @args );
     $$errref = $u->errstr if ref $errref && $u->err;
+
+    # invalidate before releasing, to keep the stale-read window small
+    LJ::MemCache::delete( $memkey, 0 ) if int($ret);
     $lock->release if $lock;
 
-    LJ::MemCache::delete( $memkey, 0 ) if int($ret);
     return $ret;
 }
 
@@ -367,9 +369,11 @@ sub talk2_do {
     my $lock = DW::Locker->new->trylock( $lockkey, class => 'talk2_do', wait => 10 );
     my $ret  = $u->do( $sql, undef, @args );
     $$errref = $u->errstr if ref $errref && $u->err;
+
+    # invalidate before releasing, to keep the stale-read window small
+    LJ::MemCache::delete( $memkey, 0 ) if int($ret);
     $lock->release if $lock;
 
-    LJ::MemCache::delete( $memkey, 0 ) if int($ret);
     return $ret;
 }
 

--- a/cgi-bin/LJ/User/Data.pm
+++ b/cgi-bin/LJ/User/Data.pm
@@ -16,6 +16,7 @@ use strict;
 no warnings 'uninitialized';
 
 use Carp;
+use DW::Locker;
 
 ########################################################################
 ### 5. Database and Memcache Functions
@@ -111,15 +112,13 @@ sub log2_do {
     my ( $u, $errref, $sql, @args ) = @_;
     return undef unless $u->writer;
 
-    my $dbcm = $u->{_dbcm};
-
     my $memkey  = [ $u->userid, "log2lt:" . $u->userid ];
     my $lockkey = $memkey->[1];
 
-    $dbcm->selectrow_array( "SELECT GET_LOCK(?,10)", undef, $lockkey );
-    my $ret = $u->do( $sql, undef, @args );
+    my $lock = DW::Locker->new->trylock( $lockkey, class => 'log2_do', wait => 10 );
+    my $ret  = $u->do( $sql, undef, @args );
     $$errref = $u->errstr if ref $errref && $u->err;
-    $dbcm->selectrow_array( "SELECT RELEASE_LOCK(?)", undef, $lockkey );
+    $lock->release if $lock;
 
     LJ::MemCache::delete( $memkey, 0 ) if int($ret);
     return $ret;
@@ -358,16 +357,17 @@ sub talk2_do {
     return undef unless $nodeid =~ /^\d+$/;
     return undef unless $u->writer;
 
-    my $dbcm   = $u->{_dbcm};
     my $userid = $u->userid;
 
     my $memkey  = [ $userid, "talk2:$userid:$nodetype:$nodeid" ];
     my $lockkey = $memkey->[1];
 
-    $dbcm->selectrow_array( "SELECT GET_LOCK(?,10)", undef, $lockkey );
-    my $ret = $u->do( $sql, undef, @args );
+    # Same lock name as get_talk_data's read path, so a write and a
+    # read-repopulate don't run at once.
+    my $lock = DW::Locker->new->trylock( $lockkey, class => 'talk2_do', wait => 10 );
+    my $ret  = $u->do( $sql, undef, @args );
     $$errref = $u->errstr if ref $errref && $u->err;
-    $dbcm->selectrow_array( "SELECT RELEASE_LOCK(?)", undef, $lockkey );
+    $lock->release if $lock;
 
     LJ::MemCache::delete( $memkey, 0 ) if int($ret);
     return $ret;


### PR DESCRIPTION
`LJ::Talk::get_talk_data` returns `undef` when it can't get a cluster reader or its per-entry lock fails; that `undef` makes `load_comments` bail with `out_error=nodb`, dropping the whole comment set for the request. This is the suspected mechanism behind comments intermittently vanishing on large, busy entries: the `talk2:` memcache blob is deleted on every comment, so hot threads are constantly cache-cold and concurrent reloads stampede the single per-entry lock; when it times out, the comment section (and reply-count link) fails to render, then works once the cache warms.

**Convert the comment/log write locks to `DW::Locker`** (the site lock primitive), replacing raw `GET_LOCK`/`RELEASE_LOCK`:
- `get_talk_data` (the read/repopulate lock)
- `talk2_do` — reuses `get_talk_data`'s lock name, so a write and a read-repopulate stay mutually exclusive
- `log2_do` — `talk2_do`'s twin, same pattern
- `fixup_logitem_replycount` — the comment-path replycount fixup

All of these now get `dw.locker.acquire` outcome + `dw.locker.acquire_duration_seconds` metrics for free and auto-release the lock.

**Diagnostics** on `get_talk_data`: a `dw.talk.get_talk_data.undef` counter tagged `reason:no_reader` / `lock_taken` / `lock_error` (the comment-drop signal), and a warn line that includes how long we waited for the lock — so a fast error is distinguishable from a full 10s timeout, and correlatable against reported entries.

The remaining raw `GET_LOCK` sites are separate features with their own semantics (`LJ::Entry`, `LJ::Protocol`, `DW::Auth::Challenge`, `bin/moveucluster.pl`) and are left for a separate sweep.

CODE TOUR: On entries with thousands of comments, people have seen the comments — and even the comment count — vanish on a reload and then come back. This moves comment loading (and the matching comment/entry write locks) onto our standard locking system, which comes with metrics, and adds logging (including how long we wait for the lock) so we can confirm exactly why it's happening before the actual fix. No user-facing behavior change yet.