### PR TITLE
Stop eagerly populating talk2row in get_talk_data

### DIFF
--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -758,6 +758,9 @@ sub get_talk_data {
             . "t.parenttalkid, t.state "
             . "FROM talk2 t "
             . "WHERE t.journalid=? AND t.nodetype=? AND t.nodeid=?" );
+
+    # hook for tests to count DB reads (the regen path, on a memcache miss)
+    $LJ::_T_GET_TALK_DATA_DB->() if $LJ::_T_GET_TALK_DATA_DB;
     $sth->execute( $u->{'userid'}, $nodetype, $nodeid );
     die $dbcr->errstr if $dbcr->err;
     while ( my $r = $sth->fetchrow_hashref ) {
@@ -2147,6 +2150,9 @@ CLUSTER:
 
         # is there anything to actually query for this cluster?
         next CLUSTER unless @vals;
+
+        # hook for tests to count DB reads (per-cluster fallback for cache misses)
+        $LJ::_T_GET_TALK2_ROW_DB->() if $LJ::_T_GET_TALK2_ROW_DB;
 
         my $dbcr = LJ::get_cluster_reader($cid)
             or die "unable to get cluster reader: $cid";

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -763,17 +763,9 @@ sub get_talk_data {
     while ( my $r = $sth->fetchrow_hashref ) {
         $ret->{ $r->{'talkid'} } = $r;
 
-        {
-            # make a new $r-type hash which also contains nodetype and nodeid
-            # -- they're not in $r because they were known and specified in the query
-            my %row_arg = %$r;
-            $row_arg{nodeid}   = $nodeid;
-            $row_arg{nodetype} = $nodetype;
-
-            # set talk2row memcache key for this bit of data
-            LJ::Talk::add_talk2row_memcache( $u->id, $r->{talkid}, \%row_arg );
-        }
-
+        # per-comment talk2row entries are populated lazily by get_talk2_row_multi,
+        # not here: eagerly writing one per comment held this lock for thousands of
+        # sequential memcache round-trips on large threads.
         $memval .= pack( $PACK_FORMAT,
             $r->{'talkid'},        $r->{'parenttalkid'}, $r->{'posterid'},
             $r->{'datepost_unix'}, ord( $r->{'state'} ) );

--- a/t/comment-talk2-rowcache.t
+++ b/t/comment-talk2-rowcache.t
@@ -60,6 +60,7 @@ LJ::Talk::invalidate_talk2row_memcache( $jid, $c1id, $c2id );
 # cold: one DB read, blob cached, per-comment rows NOT eagerly cached
 %db = ( data => 0, row => 0 );
 my $data = LJ::Talk::get_talk_data( $u, 'L', $jitemid );
+ok( $data, "get_talk_data returned data" );
 is( $db{data}, 1, "cold get_talk_data does one DB read" );
 ok( LJ::MemCache::get($blobkey), "get_talk_data caches the talk2 blob" );
 ok( !LJ::MemCache::get( $rowkey->($c2id) ),
@@ -72,15 +73,16 @@ is( $data->{$c2id}->{parenttalkid}, $c1id, "threading is correct" );
 my $warm = LJ::Talk::get_talk_data( $u, 'L', $jitemid );
 is( $db{data}, 0, "warm get_talk_data serves from memcache (no DB)" );
 is_deeply(
-    [ sort { $a <=> $b } keys %$warm ],
-    [ sort { $a <=> $b } keys %$data ],
+    [ sort { $a <=> $b } keys %{ $warm || {} } ],
+    [ sort { $a <=> $b } keys %{ $data || {} } ],
     "warm read returns the same comment set"
 );
 
 # per-comment rows: DB on the cold miss (batched), memcache on the warm hit
 %db = ( data => 0, row => 0 );
 my @rows = LJ::Talk::get_talk2_row_multi( [ $u, $c1id ], [ $u, $c2id ] );
-is( $db{row}, 1, "cold get_talk2_row_multi does one batched DB read" );
+is( scalar @rows, 2, "get_talk2_row_multi returned both rows" );
+is( $db{row},     1, "cold get_talk2_row_multi does one batched DB read" );
 ok( LJ::MemCache::get( $rowkey->($c2id) ), "rows are cached after the lazy load" );
 is( $rows[1]->{parenttalkid}, $c1id, "loaded row threading is correct" );
 

--- a/t/comment-talk2-rowcache.t
+++ b/t/comment-talk2-rowcache.t
@@ -1,0 +1,69 @@
+# t/comment-talk2-rowcache.t
+#
+# get_talk_data no longer eagerly populates the per-comment talk2row cache;
+# that is done lazily by get_talk2_row_multi. Verify comments still load
+# correctly and consistently from a cold cache through both paths.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+use LJ::Comment;
+use LJ::Talk;
+use LJ::Test qw( memcache_stress temp_user );
+
+my $u = temp_user();
+
+my $run = sub {
+    my $entry = $u->t_post_fake_entry;
+    my $c1    = $entry->t_enter_comment;    # top-level
+    my $c2    = $c1->t_reply;               # reply to c1
+
+    my $jid     = $u->userid;
+    my $jitemid = $entry->jitemid;
+
+    # cold: drop the packed blob and both per-comment rows, so get_talk_data has
+    # to regenerate (the path that no longer pre-warms talk2row) and the rows
+    # have to load lazily.
+    LJ::MemCache::delete( [ $jid, "talk2:$jid:L:$jitemid" ] );
+    LJ::Talk::invalidate_talk2row_memcache( $jid, $c1->jtalkid, $c2->jtalkid );
+
+    # get_talk_data returns the correct comment set from a cold cache
+    my $data = LJ::Talk::get_talk_data( $u, 'L', $jitemid );
+    ok(
+        $data->{ $c1->jtalkid } && $data->{ $c2->jtalkid },
+        "both comments present in get_talk_data"
+    );
+    is( $data->{ $c1->jtalkid }->{parenttalkid}, 0,            "top-level comment has parent 0" );
+    is( $data->{ $c2->jtalkid }->{parenttalkid}, $c1->jtalkid, "reply points at its parent" );
+    is( $data->{ $c2->jtalkid }->{posterid}, $c2->posterid,
+        "get_talk_data poster matches comment" );
+    is( $data->{ $c2->jtalkid }->{state}, "A", "reply state is approved" );
+
+    # the rows load correctly and consistently through the lazy path (from the
+    # per-row cache if warm, otherwise the batched DB fallback)
+    my @rows = LJ::Talk::get_talk2_row_multi( [ $u, $c1->jtalkid ], [ $u, $c2->jtalkid ] );
+    is( $rows[0]->{parenttalkid}, 0,            "row: top-level parent is 0" );
+    is( $rows[1]->{parenttalkid}, $c1->jtalkid, "row: reply parent is correct" );
+    is(
+        $rows[1]->{posterid},
+        $data->{ $c2->jtalkid }->{posterid},
+        "row poster agrees with get_talk_data"
+    );
+    is( $rows[1]->{state}, "A", "row: reply state is correct" );
+};
+
+memcache_stress { $run->() };
+
+done_testing();

--- a/t/comment-talk2-rowcache.t
+++ b/t/comment-talk2-rowcache.t
@@ -1,8 +1,12 @@
 # t/comment-talk2-rowcache.t
 #
-# get_talk_data no longer eagerly populates the per-comment talk2row cache;
-# that is done lazily by get_talk2_row_multi. Verify comments still load
-# correctly and consistently from a cold cache through both paths.
+# Exercise the comment-data caches (the packed talk2 blob from get_talk_data and
+# the per-comment talk2row entries from get_talk2_row_multi) across a full
+# read/write lifecycle, asserting that the database is only read on a cache miss,
+# that memcache serves warm reads, and that writes clear the right keys.
+#
+# Also guards the change that get_talk_data no longer eagerly populates talk2row
+# (that is done lazily by get_talk2_row_multi).
 #
 # Authors:
 #      Mark Smith <mark@dreamwidth.org>
@@ -21,49 +25,90 @@ use Test::More;
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 use LJ::Comment;
 use LJ::Talk;
-use LJ::Test qw( memcache_stress temp_user );
+use LJ::Test qw( temp_user );
 
-my $u = temp_user();
+# We need memcache ON to tell cache hits from DB reads, so install the in-memory
+# fake client directly (rather than memcache_stress, which also runs cache-off).
+my $fake = LJ::Test::FakeMemCache->new;
+@LJ::MEMCACHE_SERVERS = ("fake");
+LJ::MemCache::set_memcache($fake);
 
-my $run = sub {
-    my $entry = $u->t_post_fake_entry;
-    my $c1    = $entry->t_enter_comment;    # top-level
-    my $c2    = $c1->t_reply;               # reply to c1
+# count DB reads on each comment-loading path (hooks live in LJ::Talk)
+# reset before each measured step; explicit 0s so "no read" reads as 0, not undef
+my %db = ( data => 0, row => 0 );
+$LJ::_T_GET_TALK_DATA_DB = sub { $db{data}++ };
+$LJ::_T_GET_TALK2_ROW_DB = sub { $db{row}++ };
 
-    my $jid     = $u->userid;
-    my $jitemid = $entry->jitemid;
+my $u       = temp_user();
+my $entry   = $u->t_post_fake_entry;
+my $c1      = $entry->t_enter_comment;    # top-level
+my $c2      = $c1->t_reply;               # reply to c1
+my $c1id    = $c1->jtalkid;
+my $c2id    = $c2->jtalkid;
+my $jid     = $u->userid;
+my $jitemid = $entry->jitemid;
 
-    # cold: drop the packed blob and both per-comment rows, so get_talk_data has
-    # to regenerate (the path that no longer pre-warms talk2row) and the rows
-    # have to load lazily.
-    LJ::MemCache::delete( [ $jid, "talk2:$jid:L:$jitemid" ] );
-    LJ::Talk::invalidate_talk2row_memcache( $jid, $c1->jtalkid, $c2->jtalkid );
+my $blobkey = [ $jid, "talk2:$jid:L:$jitemid" ];
+my $rowkey  = sub { [ $jid, "talk2row:$jid:$_[0]" ] };
 
-    # get_talk_data returns the correct comment set from a cold cache
-    my $data = LJ::Talk::get_talk_data( $u, 'L', $jitemid );
-    ok(
-        $data->{ $c1->jtalkid } && $data->{ $c2->jtalkid },
-        "both comments present in get_talk_data"
-    );
-    is( $data->{ $c1->jtalkid }->{parenttalkid}, 0,            "top-level comment has parent 0" );
-    is( $data->{ $c2->jtalkid }->{parenttalkid}, $c1->jtalkid, "reply points at its parent" );
-    is( $data->{ $c2->jtalkid }->{posterid}, $c2->posterid,
-        "get_talk_data poster matches comment" );
-    is( $data->{ $c2->jtalkid }->{state}, "A", "reply state is approved" );
+# start from a clean cache
+LJ::MemCache::delete($blobkey);
+LJ::Talk::invalidate_talk2row_memcache( $jid, $c1id, $c2id );
 
-    # the rows load correctly and consistently through the lazy path (from the
-    # per-row cache if warm, otherwise the batched DB fallback)
-    my @rows = LJ::Talk::get_talk2_row_multi( [ $u, $c1->jtalkid ], [ $u, $c2->jtalkid ] );
-    is( $rows[0]->{parenttalkid}, 0,            "row: top-level parent is 0" );
-    is( $rows[1]->{parenttalkid}, $c1->jtalkid, "row: reply parent is correct" );
-    is(
-        $rows[1]->{posterid},
-        $data->{ $c2->jtalkid }->{posterid},
-        "row poster agrees with get_talk_data"
-    );
-    is( $rows[1]->{state}, "A", "row: reply state is correct" );
-};
+# --- reads: DB on the cold miss, memcache on the warm hit ---
 
-memcache_stress { $run->() };
+# cold: one DB read, blob cached, per-comment rows NOT eagerly cached
+%db = ( data => 0, row => 0 );
+my $data = LJ::Talk::get_talk_data( $u, 'L', $jitemid );
+is( $db{data}, 1, "cold get_talk_data does one DB read" );
+ok( LJ::MemCache::get($blobkey), "get_talk_data caches the talk2 blob" );
+ok( !LJ::MemCache::get( $rowkey->($c2id) ),
+    "get_talk_data does not eagerly cache per-comment rows" );
+ok( $data->{$c1id} && $data->{$c2id}, "both comments present" );
+is( $data->{$c2id}->{parenttalkid}, $c1id, "threading is correct" );
+
+# warm: no DB, identical comment set
+%db = ( data => 0, row => 0 );
+my $warm = LJ::Talk::get_talk_data( $u, 'L', $jitemid );
+is( $db{data}, 0, "warm get_talk_data serves from memcache (no DB)" );
+is_deeply(
+    [ sort { $a <=> $b } keys %$warm ],
+    [ sort { $a <=> $b } keys %$data ],
+    "warm read returns the same comment set"
+);
+
+# per-comment rows: DB on the cold miss (batched), memcache on the warm hit
+%db = ( data => 0, row => 0 );
+my @rows = LJ::Talk::get_talk2_row_multi( [ $u, $c1id ], [ $u, $c2id ] );
+is( $db{row}, 1, "cold get_talk2_row_multi does one batched DB read" );
+ok( LJ::MemCache::get( $rowkey->($c2id) ), "rows are cached after the lazy load" );
+is( $rows[1]->{parenttalkid}, $c1id, "loaded row threading is correct" );
+
+%db   = ( data => 0, row => 0 );
+@rows = LJ::Talk::get_talk2_row_multi( [ $u, $c1id ], [ $u, $c2id ] );
+is( $db{row}, 0, "warm get_talk2_row_multi serves from memcache (no DB)" );
+
+# --- writes: the right things get cleared ---
+
+# posting a comment clears the blob but leaves unrelated per-comment rows
+my $c3   = $entry->t_enter_comment;
+my $c3id = $c3->jtalkid;
+ok( !LJ::MemCache::get($blobkey),          "posting a comment clears the talk2 blob" );
+ok( LJ::MemCache::get( $rowkey->($c2id) ), "posting a comment leaves other comments' rows intact" );
+
+%db = ( data => 0, row => 0 );
+my $after_post = LJ::Talk::get_talk_data( $u, 'L', $jitemid );
+is( $db{data}, 1, "read after a post regenerates from DB" );
+ok( $after_post->{$c3id}, "regenerated data includes the new comment" );
+
+# deleting a comment clears the blob and that comment's own row
+$c2->delete;
+ok( !LJ::MemCache::get($blobkey),           "deleting a comment clears the talk2 blob" );
+ok( !LJ::MemCache::get( $rowkey->($c2id) ), "deleting a comment clears its own row" );
+
+%db = ( data => 0, row => 0 );
+my $after_del = LJ::Talk::get_talk_data( $u, 'L', $jitemid );
+is( $db{data},                    1,   "read after a delete regenerates from DB" );
+is( $after_del->{$c2id}->{state}, 'D', "deleted comment is marked deleted after regen" );
 
 done_testing();


### PR DESCRIPTION
Follow-up to #3639, which confirmed via production logs that comments vanish on large threads because `get_talk_data` returns `undef` after waiting the full 10s for its per-entry lock (`lock_taken, waited 10.0s`). This removes the reason the lock is held that long.

While rebuilding the packed `talk2` blob under the lock, `get_talk_data` also wrote a per-comment `talk2row` cache entry for **every** comment — one `LJ::MemCache::add` each, sequentially, inside the fetch loop. On a thousands-of-comments thread that's thousands of memcache round-trips holding the lock, so concurrent readers time out and drop the whole comment set.

That eager write is redundant: the `talk2row` cache is already populated **lazily and in batch** by `get_talk2_row_multi` (`get_multi` read → a single `IN()` DB fallback → populate-on-miss), which is the actual consumer path for per-comment rows. And it pre-warmed all N rows when a page renders ~25. Both paths write the identical `talk2row` schema fields (`nodetype, nodeid, parenttalkid, posterid, datepost, state`), so the cached value is unchanged — only the timing moves from eager to lazy. The lock hold drops to just the `SELECT` + pack.

**Testing.** `t/comment-talk2-rowcache.t` exercises the comment caches across a full read/write lifecycle and asserts the database is read only on a cache miss (memcache serves warm reads) and that writes clear the right keys: cold read hits the DB once and caches the blob without eagerly caching per-comment rows; the warm read serves from memcache; `get_talk2_row_multi` hits the DB once then serves warm; posting a comment clears the blob but leaves unrelated rows intact; deleting a comment clears the blob and that comment's own row; and reads after each write regenerate correctly. To count DB reads on each path it adds two test-only hooks (`$LJ::_T_GET_TALK_DATA_DB`, `$LJ::_T_GET_TALK2_ROW_DB`), guarded exactly like the existing `$LJ::_T_GET_TALK_DATA_MEMCACHE` hook.

CODE TOUR: On entries with thousands of comments, the comments sometimes vanished on reload and came back. The cause was that rebuilding the comment cache did thousands of tiny cache writes while holding a lock, long enough that other page loads gave up. This removes those redundant writes (the same data is still cached, just when it's actually needed), so rebuilding the cache is fast and the comments stop disappearing.