### PR TITLE
Skip captchas for logged-out browsers that recently held a good session

### DIFF
--- a/cgi-bin/DW/Captcha.pm
+++ b/cgi-bin/DW/Captcha.pm
@@ -207,10 +207,14 @@ sub form_fields { qw() }
 
 sub site_enabled { return LJ::is_enabled('captcha') && $_[0]->_implementation_enabled ? 1 : 0 }
 
-# Subclasses override this; the abstract base is never a usable captcha, so it
-# reports disabled -- a base instance (only reachable as a last-resort fallback)
-# then cleanly no-ops instead of rendering nothing while failing validation.
-sub _implementation_enabled { return 0; }
+# Subclasses override this. On the abstract base -- the class-method call
+# callers use to ask "is captcha configured at all?" (e.g. the comment captcha
+# logic in LJ::Talk), or a base instance (only reachable as a last-resort
+# fallback) -- it reports whether ANY implementation is enabled, so a fallback
+# base instance still cleanly no-ops when nothing is configured.
+sub _implementation_enabled {
+    return ( grep { $_->_implementation_enabled } values %impl2class ) ? 1 : 0;
+}
 
 sub print {
     my ( $self, %opts ) = @_;

--- a/cgi-bin/DW/Captcha.pm
+++ b/cgi-bin/DW/Captcha.pm
@@ -452,11 +452,13 @@ sub record_success {
 
 # Called when a captcha that would have been shown was skipped because the
 # browser holds a valid trust cookie (LJ::Session->trusted_anon_user). Tags
-# mirror dw.captcha.shown so the two can be compared directly; only anonymous
+# mirror dw.captcha.shown so the two can be compared directly -- including
+# type:<impl>, the implementation that would have been used; only anonymous
 # viewers can bypass, so logged_in is always 0.
 sub record_bypass {
     my ( $class, @tags ) = @_;
-    DW::Stats::increment( 'dw.captcha.bypassed', 1, _stat_tags( undef, @tags ) );
+    DW::Stats::increment( 'dw.captcha.bypassed', 1,
+        _stat_tags( undef, 'type:' . $class->new->name, @tags ) );
 }
 
 # Reset the captcha counter, so the user starts getting them

--- a/cgi-bin/DW/Captcha.pm
+++ b/cgi-bin/DW/Captcha.pm
@@ -342,10 +342,22 @@ sub should_captcha_view {
         : $LJ::SHOULD_CAPTCHA_IP ? 'ip'
         :                          'all';
 
+    # A browser recently logged in to an account in good standing gets the
+    # logged-in treatment. Checked lazily, only where we'd otherwise show a
+    # captcha, so the common allow path pays nothing and trusted browsers
+    # never feed the fraud counter below (which tempbans IPs).
+    my $trusted_bypass = sub {
+        my ($reason) = @_;
+        return 0 unless LJ::Session->trusted_anon_user;
+        $class->record_bypass( 'kind:interstitial', "reason:$reason", "source:$source" );
+        return 1;
+    };
+
     # Get our captcha information -- no information means that the user has not
     # passed a captcha. If we have information, then they *have* at some point.
     my $info_raw = LJ::MemCache::get($mckey);
     unless ($info_raw) {
+        return 0 if $trusted_bypass->('no_record');
 
         # Let's see if this is a repeat offender who is spamming requests at us
         # and hitting a bunch of 302s -- in which case, temp ban
@@ -391,6 +403,7 @@ sub should_captcha_view {
 
     # If the first request is too long ago, then re-captcha
     if ( ( time() - $first_req_ts ) > $LJ::CAPTCHA_RETEST_INTERVAL_SECS ) {
+        return 0 if $trusted_bypass->('retest_interval');
         $log->info( $mckey, ' has exceeded the retest interval, issuing captcha.' );
         DW::Stats::increment( 'dw.captcha.shown', 1,
             _stat_tags( $remote, 'kind:interstitial', 'reason:retest_interval', "source:$source" )
@@ -411,6 +424,7 @@ sub should_captcha_view {
 
     # If we are out of requests, retest
     if ( $remaining <= 0 ) {
+        return 0 if $trusted_bypass->('out_of_requests');
         $log->info( $mckey, ' is out of requests by usage, retesting.' );
         DW::Stats::increment( 'dw.captcha.shown', 1,
             _stat_tags( $remote, 'kind:interstitial', 'reason:out_of_requests', "source:$source" )
@@ -434,6 +448,15 @@ sub record_success {
     $log->debug( 'Captcha success for: ', $mckey );
     LJ::MemCache::set( $mckey, join( ':', time(), time(), $LJ::CAPTCHA_INITIAL_REMAINING ) );
     DW::Stats::increment( 'dw.captcha.solved', 1, _stat_tags($remote) );
+}
+
+# Called when a captcha that would have been shown was skipped because the
+# browser holds a valid trust cookie (LJ::Session->trusted_anon_user). Tags
+# mirror dw.captcha.shown so the two can be compared directly; only anonymous
+# viewers can bypass, so logged_in is always 0.
+sub record_bypass {
+    my ( $class, @tags ) = @_;
+    DW::Stats::increment( 'dw.captcha.bypassed', 1, _stat_tags( undef, @tags ) );
 }
 
 # Reset the captcha counter, so the user starts getting them

--- a/cgi-bin/LJ/Session.pm
+++ b/cgi-bin/LJ/Session.pm
@@ -19,10 +19,11 @@ use LJ::Utils;
 
 use constant VERSION => 1;
 
-# how long a trust cookie vouches for a browser after it was last signed
-# (matches the "long" session length, so the bypass never outlives the
-# session that could have produced it)
-use constant TRUST_COOKIE_MAX_AGE => 60 * 86400;
+# how long a trust cookie vouches for a browser after it was last signed:
+# the "long" session length, so the bypass never outlives the session that
+# could have produced it (a sub, not a constant, since session_length isn't
+# compiled yet at this point)
+sub TRUST_COOKIE_MAX_AGE { return LJ::Session->session_length('long') }
 
 # NOTES
 #

--- a/cgi-bin/LJ/Session.pm
+++ b/cgi-bin/LJ/Session.pm
@@ -19,6 +19,11 @@ use LJ::Utils;
 
 use constant VERSION => 1;
 
+# how long a trust cookie vouches for a browser after it was last signed
+# (matches the "long" session length, so the bypass never outlives the
+# session that could have produced it)
+use constant TRUST_COOKIE_MAX_AGE => 60 * 86400;
+
 # NOTES
 #
 # * fields in this object:
@@ -301,6 +306,44 @@ sub update_master_cookie {
             domain        => $LJ::DOMAIN,
             path          => '/',
             delete        => 1
+        );
+    }
+
+    $sess->update_trust_cookie;
+
+    return;
+}
+
+# Sets/refreshes the "ljtrust" cookie: a long-lived, HMAC-signed marker that
+# this browser held a valid session for this user. It's bound to the browser's
+# ljuniq ident so it can't be presented under a different uniq, and it is
+# deliberately NOT cleared on logout -- its whole purpose is to vouch for a
+# logged-out browser (see trusted_anon_user), e.g. to skip anti-bot captchas.
+# It makes no authentication claims.
+sub update_trust_cookie {
+    my ($sess) = @_;
+
+    my $uniq = LJ::UniqCookie->current_uniq
+        or return;
+
+    my ( $time, $secret ) = LJ::get_secret();
+    return unless $secret;
+
+    my $sig = trust_cookie_signature( $time, $sess->{userid}, $uniq )
+        or return;
+
+    my $ver   = VERSION;
+    my $value = "v$ver:u$sess->{userid}:t$time:g$sig//" . LJ::eurl( $LJ::COOKIE_GEN || "" );
+
+    # all cookie domains, like ljuniq itself, so journal subdomains see it
+    my @domains = ref $LJ::COOKIE_DOMAIN ? @$LJ::COOKIE_DOMAIN : ($LJ::COOKIE_DOMAIN);
+    foreach my $dom (@domains) {
+        set_cookie(
+            ljtrust   => $value,
+            domain    => $dom,
+            path      => '/',
+            http_only => 1,
+            expires   => TRUST_COOKIE_MAX_AGE,
         );
     }
 
@@ -783,6 +826,82 @@ sub domsess_signature {
     my $data = join( "-", $sess->{auth}, $domcook, $u->{userid}, $sess->{sessid}, $time );
     my $sig  = hmac_sha1_hex( $data, $secret );
     return $sig;
+}
+
+sub trust_cookie_signature {
+    my ( $time, $userid, $uniq ) = @_;
+
+    my $secret = LJ::get_secret($time)
+        or return undef;
+
+    # leading literal domain-separates this from other get_secret signatures
+    return hmac_sha1_hex( join( "-", "trust", $userid, $uniq, $time ), $secret );
+}
+
+# CLASS method. Returns the LJ::User this browser was previously logged in as,
+# iff the ljtrust cookie is present, correctly signed, bound to the *current*
+# ljuniq ident, fresh enough, and the account is still in good standing --
+# otherwise undef. Standing is re-checked live on every use, so suspending or
+# deleting the account revokes the trust immediately. This identifies a
+# browser, not a person: never treat it as authentication.
+sub trusted_anon_user {
+    my ($class) = @_;
+
+    # cache per-request; wrapped in an arrayref so a negative result caches too
+    my $cached = $LJ::REQ_CACHE{trusted_anon_user};
+    return $cached->[0] if $cached;
+
+    my $u = $class->_trusted_anon_user_uncached;
+    $LJ::REQ_CACHE{trusted_anon_user} = [$u];
+    return $u;
+}
+
+sub _trusted_anon_user_uncached {
+    my ($class) = @_;
+
+    my $r = DW::Request->get
+        or return undef;
+    my $val = $r->cookie('ljtrust')
+        or return undef;
+    my $uniq = LJ::UniqCookie->current_uniq
+        or return undef;
+
+    my ( $cookie, $gen ) = split m!//!, $val;
+    return undef unless defined $cookie;
+
+    my ( $version, $uid, $time, $sig );
+    my $dest = {
+        v => \$version,
+        u => \$uid,
+        t => \$time,
+        g => \$sig,
+    };
+
+    foreach my $var ( split /:/, $cookie ) {
+        return undef unless $var =~ /^(\w)(.+)$/ && $dest->{$1};
+        ${ $dest->{$1} } = $2;
+    }
+
+    return undef unless valid_cookie_generation($gen);
+    return undef unless defined $version && $version == VERSION;
+    return undef unless $uid && $uid =~ /^\d+$/;
+    return undef unless $time && $time =~ /^\d+$/;
+
+    # too old (or from the future, which no honest clock produces)
+    my $now = time();
+    return undef if $time > $now || $now - $time > TRUST_COOKIE_MAX_AGE;
+
+    my $correct_sig = trust_cookie_signature( $time, $uid, $uniq )
+        or return undef;
+    return undef unless $sig && $correct_sig eq $sig;
+
+    my $u = LJ::load_userid($uid)
+        or return undef;
+
+    # in good standing: live account, validated email, an actual individual
+    return undef unless $u->is_visible && $u->is_validated && $u->is_individual;
+
+    return $u;
 }
 
 # function or instance method.

--- a/cgi-bin/LJ/Talk.pm
+++ b/cgi-bin/LJ/Talk.pm
@@ -2954,6 +2954,15 @@ sub require_captcha_test {
     my $anon_commenter = !LJ::isu($commenter)
         || ( $commenter->identity && !$commenter->is_validated );
 
+    # A logged-out browser holding a valid trust cookie (recently logged in to
+    # an account in good standing) gets the same treatment as a generic
+    # logged-in commenter: skip the anonymous-only checks below, keep every
+    # check a logged-in user would still face. $bypassed records the first
+    # check trust exempted, for the metric at the bottom -- emitted only if no
+    # later check requires a captcha anyway.
+    my $trusted_anon = $anon_commenter && LJ::Session->trusted_anon_user ? 1 : 0;
+    my $bypassed;
+
     ##
     ## 1. Check rate by remote user and by IP (for anonymous user)
     ##
@@ -2995,7 +3004,10 @@ sub require_captcha_test {
     }
     elsif ( $show_captcha_to eq 'R' ) {
         ## anonymous
-        return 'journal_setting' if $anon_commenter;
+        if ($anon_commenter) {
+            return 'journal_setting' unless $trusted_anon;
+            $bypassed //= 'journal_setting';
+        }
     }
     elsif ( $show_captcha_to eq 'F' ) {
         ## not friends
@@ -3010,33 +3022,56 @@ sub require_captcha_test {
     ## 4. Global (site) settings
     ## See if they have any tags or URLs in the comment's body
     ##
-    if ( $captcha->enabled('comment_html_auth')
-        || ( $captcha->enabled('comment_html_anon') && $anon_commenter ) )
+    if (
+        $body
+        && ( $captcha->enabled('comment_html_auth')
+            || ( $captcha->enabled('comment_html_anon') && $anon_commenter ) )
+        && _comment_html_is_suspicious($body)
+        )
     {
-        return '' unless $body;    # Before we bother matching against it.
-
-        if ( $body =~ /<[a-z]/i ) {
-
-            # strip white-listed bare tags w/o attributes,
-            # then see if they still have HTML.  if so, it's
-            # questionable.  (can do evil spammy-like stuff w/
-            # attributes and other elements)
-            my $body_copy = $body;
-            $body_copy =~ s/<(?:q|blockquote|b|strong|i|em|cite|sub|sup|var|del|tt|code|pre|p)>//ig;
-            return 'comment_html' if $body_copy =~ /<[a-z]/i;
+        # trusted anon is exempt only when the anonymous-commenter HTML check
+        # alone applies; comment_html_auth covers logged-in users too, so it
+        # still fires
+        if ( $trusted_anon && !$captcha->enabled('comment_html_auth') ) {
+            $bypassed //= 'comment_html';
         }
-
-        # multiple URLs is questionable too
-        return 'comment_html' if $body =~ /\b(?:http|ftp|www)\b.+\b(?:http|ftp|www)\b/s;
-
-        # or if they're not even using HTML
-        return 'comment_html' if $body =~ /\[url/is;
-
-        # or if it's obviously spam
-        return 'comment_html' if $body =~ /\s*message\s*/is;
+        else {
+            return 'comment_html';
+        }
     }
 
+    DW::Captcha->record_bypass( 'kind:form', 'page:comment', "reason:$bypassed" )
+        if $bypassed;
+
     return '';
+}
+
+# The suspicious-content heuristics behind the comment_html captcha pages:
+# non-whitelisted HTML, multiple URLs, BBCode-style [url, or classic spam text.
+sub _comment_html_is_suspicious {
+    my ($body) = @_;
+
+    if ( $body =~ /<[a-z]/i ) {
+
+        # strip white-listed bare tags w/o attributes,
+        # then see if they still have HTML.  if so, it's
+        # questionable.  (can do evil spammy-like stuff w/
+        # attributes and other elements)
+        my $body_copy = $body;
+        $body_copy =~ s/<(?:q|blockquote|b|strong|i|em|cite|sub|sup|var|del|tt|code|pre|p)>//ig;
+        return 1 if $body_copy =~ /<[a-z]/i;
+    }
+
+    # multiple URLs is questionable too
+    return 1 if $body =~ /\b(?:http|ftp|www)\b.+\b(?:http|ftp|www)\b/s;
+
+    # or if they're not even using HTML
+    return 1 if $body =~ /\[url/is;
+
+    # or if it's obviously spam
+    return 1 if $body =~ /\s*message\s*/is;
+
+    return 0;
 }
 
 # Does what it says on the tin.

--- a/cgi-bin/LJ/UniqCookie.pm
+++ b/cgi-bin/LJ/UniqCookie.pm
@@ -432,7 +432,14 @@ sub ensure_cookie_value {
 
     if ( $setting_new && !$hook_saved_mapping && !$class->is_disabled ) {
         my $remote = LJ::get_remote();
-        $class->save_mapping( $uniq => $remote ) if $remote;
+        if ($remote) {
+            $class->save_mapping( $uniq => $remote );
+
+            # the trust cookie is signed over the uniq ident, so a fresh
+            # ident invalidates it; re-sign while we still have a session
+            my $sess = $remote->session;
+            $sess->update_trust_cookie if $sess;
+        }
     }
 
     # set uniq cookies for all cookie_domains

--- a/t/captcha-request.t
+++ b/t/captcha-request.t
@@ -31,6 +31,7 @@ sub new { my ( $class, %a ) = @_; bless {%a}, $class }
 sub uri           { $_[0]->{uri} }
 sub query_string  { $_[0]->{query_string} }
 sub get_remote_ip { $_[0]->{ip} }
+sub cookie        { undef }                   # no ljtrust cookie -> no trusted-anon bypass
 
 package main;
 

--- a/t/captcha-trusted-anon.t
+++ b/t/captcha-trusted-anon.t
@@ -1,0 +1,242 @@
+# t/captcha-trusted-anon.t
+#
+# Tests the trusted-anon captcha bypass: a logged-out browser vouched for by
+# LJ::Session->trusted_anon_user gets the logged-in treatment from both captcha
+# gates. Covers DW::Captcha::should_captcha_view (bypass at each would-show
+# point, no fraud-counter side effects, dw.captcha.bypassed metric) and
+# LJ::Talk::Post::require_captcha_test (anon-only checks bypassed, checks that
+# also apply to logged-in users still enforced).
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+use LJ::Test qw(temp_user);
+use DW::Captcha;
+use LJ::Talk;
+
+# Minimal fake request so we can drive the gates without a live stack.
+package FakeRequest;
+sub new { my ( $class, %a ) = @_; bless {%a}, $class }
+sub uri           { $_[0]->{uri} }
+sub query_string  { $_[0]->{query_string} }
+sub get_remote_ip { $_[0]->{ip} }
+sub host          { "www.example.com" }
+sub header_in     { "" }
+sub cookie        { undef }
+
+package main;
+
+my $req;
+my $trusted = 0;
+my @metrics;
+
+# create test users before we mock DW::Request; user creation touches more of
+# the request object than the gates under test do
+my $journal = temp_user();
+$journal->update_self( { status => 'A' } );
+my $poster = temp_user();
+$poster->update_self( { status => 'A' } );
+
+no warnings 'redefine';
+local *DW::Request::get             = sub { $req };
+local *LJ::UniqCookie::current_uniq = sub { "testuniq" };
+local *DW::Stats::increment         = sub { push @metrics, [@_] };
+
+# The session side of trust is covered by t/session-trust.t; here we only care
+# how the gates react, so stub the verdict.
+local *LJ::Session::trusted_anon_user = sub { $trusted ? bless {}, 'LJ::User' : undef };
+
+sub metric_count {
+    my ( $name, $tag ) = @_;
+    return scalar grep {
+        $_->[0] eq $name
+            && ( !$tag || grep { $_ eq $tag } @{ $_->[2] } )
+    } @metrics;
+}
+
+# Force the captcha machinery on regardless of test config.
+local %LJ::DISABLED                 = ( captcha => 0 );
+local $LJ::CAPTCHA_HCAPTCHA_SITEKEY = "test-sitekey";
+local $LJ::CAPTCHA_HCAPTCHA_SECRET  = "test-secret";
+
+# regression: class-method site_enabled on the abstract base must reflect the
+# configured implementation (broken by #3594, which made it always 0 and
+# thereby disabled all comment captchas)
+ok( DW::Captcha->site_enabled, "DW::Captcha->site_enabled true when hCaptcha is configured" );
+{
+    local $LJ::CAPTCHA_HCAPTCHA_SITEKEY = "";
+    ok( !DW::Captcha->site_enabled, "and false when it is not" );
+}
+
+# Gate everyone (no IP matcher), deterministic fraud/refill config.
+local $LJ::CAPTCHA_BYPASS_REGEX             = undef;
+local $LJ::CAPTCHA_BYPASS_IP                = undef;
+local $LJ::SHOULD_CAPTCHA_IP                = undef;
+local $LJ::SHOULD_CAPTCHA_REQUEST           = undef;
+local $LJ::CAPTCHA_FRAUD_INTERVAL_SECS      = 60;
+local $LJ::CAPTCHA_FRAUD_LIMIT              = 1000;
+local $LJ::CAPTCHA_FRAUD_FORGIVENESS_AMOUNT = 1;
+local $LJ::CAPTCHA_FRAUD_SYSBAN_SECS        = 60;
+local $LJ::CAPTCHA_RETEST_INTERVAL_SECS     = 3600;
+local $LJ::CAPTCHA_REFILL_INTERVAL_SECS     = 60;
+local $LJ::CAPTCHA_REFILL_AMOUNT            = 1;
+local $LJ::CAPTCHA_MAX_REMAINING            = 10;
+
+note("--- should_captcha_view ---");
+
+LJ::Test::with_fake_memcache {
+
+    # mckey is "uniq:ip/24"
+    my $ip    = "198.51.100.7";
+    my $mckey = "testuniq:198.51.100.0";
+    $req = FakeRequest->new( uri => "/x", query_string => "", ip => $ip );
+
+    note("no captcha record (first visit)");
+    {
+        $trusted = 0;
+        @metrics = ();
+        ok( DW::Captcha->should_captcha_view(undef), "untrusted anon, no record -> captcha" );
+        ok( LJ::MemCache::get("cct:$ip"),            "untrusted visit feeds the fraud counter" );
+    }
+
+    LJ::MemCache::delete("cct:$ip");
+
+    {
+        $trusted = 1;
+        @metrics = ();
+        ok( !DW::Captcha->should_captcha_view(undef), "trusted anon, no record -> no captcha" );
+        is( metric_count( 'dw.captcha.bypassed', 'reason:no_record' ),
+            1, "bypass metric emitted with reason:no_record" );
+        is( metric_count('dw.captcha.shown'), 0, "no shown metric" );
+        ok( !LJ::MemCache::get("cct:$ip"), "trusted bypass does not feed the fraud counter" );
+    }
+
+    note("retest interval exceeded");
+    {
+        my $old = time() - $LJ::CAPTCHA_RETEST_INTERVAL_SECS - 10;
+        LJ::MemCache::set( $mckey, join( ':', $old, $old, 5 ) );
+
+        $trusted = 0;
+        ok( DW::Captcha->should_captcha_view(undef), "untrusted -> captcha on retest" );
+
+        $trusted = 1;
+        @metrics = ();
+        ok( !DW::Captcha->should_captcha_view(undef), "trusted -> no captcha on retest" );
+        is( metric_count( 'dw.captcha.bypassed', 'reason:retest_interval' ),
+            1, "bypass metric emitted with reason:retest_interval" );
+    }
+
+    note("out of requests");
+    {
+        LJ::MemCache::set( $mckey, join( ':', time(), time(), 0 ) );
+
+        $trusted = 0;
+        ok( DW::Captcha->should_captcha_view(undef), "untrusted -> captcha when out of requests" );
+
+        $trusted = 1;
+        @metrics = ();
+        ok( !DW::Captcha->should_captcha_view(undef),
+            "trusted -> no captcha when out of requests" );
+        is( metric_count( 'dw.captcha.bypassed', 'reason:out_of_requests' ),
+            1, "bypass metric emitted with reason:out_of_requests" );
+    }
+
+    note("logged-in short-circuits before the trust check");
+    {
+        $trusted = 1;
+        @metrics = ();
+        my $remote = bless { userid => 1 }, "LJ::User";
+        ok( !DW::Captcha->should_captcha_view($remote), "logged-in -> no captcha" );
+        is( metric_count('dw.captcha.bypassed'), 0, "and no bypass metric" );
+    }
+};
+
+note("--- require_captcha_test ---");
+
+# require_captcha_test only asks the entry for these two things
+package FakeEntry;
+sub ditemid      { 257 }
+sub logtime_unix { time() }
+
+package main;
+
+my $entry = bless {}, 'FakeEntry';
+
+# anonpost/authpost off: skip the rate/sysban DB paths, which are orthogonal
+local %LJ::CAPTCHA_FOR = ();
+
+my $check = sub {
+    my (%opts) = @_;
+    $trusted = $opts{trusted} ? 1 : 0;
+    @metrics = ();
+    return LJ::Talk::Post::require_captcha_test( $opts{commenter}, $journal, $opts{body} // "",
+        $entry );
+};
+
+note("journal setting R (anonymous only)");
+{
+    $journal->set_prop( opt_show_captcha_to => 'R' );
+
+    is( $check->( trusted => 0 ), 'journal_setting', "untrusted anon -> captcha" );
+
+    is( $check->( trusted => 1 ), '', "trusted anon -> no captcha" );
+    is( metric_count( 'dw.captcha.bypassed', 'reason:journal_setting' ),
+        1, "bypass metric emitted with reason:journal_setting" );
+
+    is( $check->( trusted => 0, commenter => $poster ), '', "logged-in user -> no captcha" );
+}
+
+note("journal setting F (non-friends): trusted anon is still a non-friend");
+{
+    $journal->set_prop( opt_show_captcha_to => 'F' );
+    is( $check->( trusted => 1 ), 'journal_setting', "trusted anon -> captcha" );
+    is( metric_count('dw.captcha.bypassed'), 0, "no bypass metric" );
+}
+
+note("journal setting A (all): applies to logged-in users, so also to trusted anon");
+{
+    $journal->set_prop( opt_show_captcha_to => 'A' );
+    is( $check->( trusted => 1 ), 'journal_setting', "trusted anon -> captcha" );
+    is( $check->( trusted => 0, commenter => $poster ),
+        'journal_setting', "logged-in user -> captcha too" );
+}
+
+my $spammy = "check out http://spam.example/ and also www.spam.example please";
+
+note("comment_html_anon: anon-only content heuristics");
+{
+    $journal->set_prop( opt_show_captcha_to => 'N' );
+    local %LJ::CAPTCHA_FOR = ( comment_html_anon => 1 );
+
+    is( $check->( trusted => 0, body => $spammy ), 'comment_html', "untrusted anon -> captcha" );
+
+    is( $check->( trusted => 1, body => $spammy ), '', "trusted anon -> no captcha" );
+    is( metric_count( 'dw.captcha.bypassed', 'reason:comment_html' ),
+        1, "bypass metric emitted with reason:comment_html" );
+
+    is( $check->( trusted => 1, body => "hi, lovely post!" ),
+        '', "clean body -> no captcha either way" );
+    is( metric_count('dw.captcha.bypassed'), 0, "clean body records no bypass" );
+}
+
+note("comment_html_auth: applies to logged-in users, so also to trusted anon");
+{
+    local %LJ::CAPTCHA_FOR = ( comment_html_anon => 1, comment_html_auth => 1 );
+    is( $check->( trusted => 1, body => $spammy ), 'comment_html', "trusted anon -> captcha" );
+    is( metric_count('dw.captcha.bypassed'), 0, "no bypass metric" );
+}
+
+done_testing();

--- a/t/captcha-trusted-anon.t
+++ b/t/captcha-trusted-anon.t
@@ -195,6 +195,8 @@ note("journal setting R (anonymous only)");
     is( $check->( trusted => 1 ), '', "trusted anon -> no captcha" );
     is( metric_count( 'dw.captcha.bypassed', 'reason:journal_setting' ),
         1, "bypass metric emitted with reason:journal_setting" );
+    is( metric_count( 'dw.captcha.bypassed', 'type:hcaptcha' ),
+        1, "bypass metric carries the implementation type tag" );
 
     is( $check->( trusted => 0, commenter => $poster ), '', "logged-in user -> no captcha" );
 }

--- a/t/session-trust.t
+++ b/t/session-trust.t
@@ -1,0 +1,199 @@
+# t/session-trust.t
+#
+# Tests the "ljtrust" trust cookie in LJ::Session: a long-lived, HMAC-signed
+# marker that a browser recently held a valid session, bound to the browser's
+# ljuniq ident. Covers issuance (update_trust_cookie / update_master_cookie),
+# validation (trusted_anon_user), the uniq binding, tampering, staleness,
+# cookie-generation rotation, live standing re-checks, and that logout leaves
+# the cookie alone.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+use LJ::Test qw(temp_user);
+use LJ::Session;
+use LJ::UniqCookie;
+
+# Minimal fake request: a readable cookie jar plus capture of everything the
+# code under test sets via add_cookie.
+package FakeRequest;
+
+sub new { my ( $class, %a ) = @_; bless { jar => {}, set => [], %a }, $class }
+sub cookie        { $_[0]->{jar}{ $_[1] } }
+sub get_remote_ip { "127.0.0.1" }
+sub header_in     { "" }
+
+sub add_cookie {
+    my ( $self, %args ) = @_;
+    push @{ $self->{set} }, \%args;
+}
+
+# cookies set with a given name, in order
+sub set_cookies {
+    my ( $self, $name ) = @_;
+    return grep { $_->{name} eq $name } @{ $self->{set} };
+}
+
+package main;
+
+my $req;
+no warnings 'redefine';
+local *DW::Request::get = sub { $req };
+
+my $uniq = "abcdefghij12345";
+local $LJ::_T_UNIQCOOKIE_CURRENT_UNIQ = $uniq;
+
+my $u = temp_user();
+$u->update_self( { status => 'A' } );    # validated email
+
+# checks the current jar with a fresh per-request cache
+sub trusted {
+    delete $LJ::REQ_CACHE{trusted_anon_user};
+    return LJ::Session->trusted_anon_user;
+}
+
+note("issuance via update_trust_cookie");
+my $cookie_value;
+{
+    $req = FakeRequest->new;
+    my $sess = bless { userid => $u->id }, 'LJ::Session';
+    $sess->update_trust_cookie;
+
+    my @set = $req->set_cookies('ljtrust');
+    ok( scalar @set, "update_trust_cookie set an ljtrust cookie" );
+    $cookie_value = $set[0]->{value};
+    like( $cookie_value, qr/^v1:u\d+:t\d+:g[0-9a-f]{40}\/\//, "cookie has expected format" );
+    ok( $set[0]->{httponly}, "cookie is httponly" );
+}
+
+note("valid cookie resolves to the user");
+{
+    $req = FakeRequest->new;
+    $req->{jar}{ljtrust} = $cookie_value;
+    my $got = trusted();
+    ok( $got && $got->equals($u), "trusted_anon_user returns the issuing user" );
+}
+
+note("no cookie, no trust");
+{
+    $req = FakeRequest->new;
+    ok( !trusted(), "no ljtrust cookie -> undef" );
+}
+
+note("bound to the uniq ident");
+{
+    $req = FakeRequest->new;
+    $req->{jar}{ljtrust} = $cookie_value;
+    local $LJ::_T_UNIQCOOKIE_CURRENT_UNIQ = "zzzzzzzzzz54321";
+    ok( !trusted(), "same cookie under a different uniq -> undef" );
+}
+
+note("tampered signature");
+{
+    $req = FakeRequest->new;
+    ( my $tampered = $cookie_value ) =~ tr/0-9/1-90/;
+    $req->{jar}{ljtrust} = $tampered;
+    ok( !trusted(), "tampered cookie -> undef" );
+}
+
+note("tampered userid");
+{
+    my $other = temp_user();
+    $other->update_self( { status => 'A' } );
+
+    $req = FakeRequest->new;
+    ( my $tampered = $cookie_value ) =~ s/^v1:u\d+:/"v1:u" . $other->id . ":"/e;
+    $req->{jar}{ljtrust} = $tampered;
+    ok( !trusted(), "resigned to a different userid -> undef (signature covers userid)" );
+}
+
+note("garbage cookie");
+{
+    $req = FakeRequest->new;
+    $req->{jar}{ljtrust} = "total nonsense";
+    ok( !trusted(), "garbage cookie -> undef" );
+}
+
+note("stale cookie is rejected even with a valid signature");
+{
+    # get_secret generates for old hour-aligned buckets in list context, so we
+    # can forge a correctly-signed cookie from beyond the trust window
+    my $old = time() - LJ::Session::TRUST_COOKIE_MAX_AGE() - 7200;
+    $old -= $old % 3600;
+    my ( $time, $secret ) = LJ::get_secret($old);
+    ok( $secret, "generated a secret for an old time bucket" );
+
+    my $sig = LJ::Session::trust_cookie_signature( $old, $u->id, $uniq );
+    $req = FakeRequest->new;
+    $req->{jar}{ljtrust} =
+        "v1:u" . $u->id . ":t$old:g$sig//" . LJ::eurl( $LJ::COOKIE_GEN || "" );
+    ok( !trusted(), "correctly-signed but stale cookie -> undef" );
+}
+
+note("cookie generation rotation revokes trust");
+{
+    $req = FakeRequest->new;
+    $req->{jar}{ljtrust} = $cookie_value;
+    local $LJ::COOKIE_GEN      = "newgen";
+    local @LJ::COOKIE_GEN_OKAY = ();
+    ok( !trusted(), "rotated \$LJ::COOKIE_GEN -> undef" );
+}
+
+note("standing is re-checked live");
+{
+    $req = FakeRequest->new;
+    $req->{jar}{ljtrust} = $cookie_value;
+
+    $u->set_statusvis('S');
+    ok( !trusted(), "suspended account -> undef" );
+
+    $u->set_statusvis('V');
+    ok( trusted(), "restored account -> trusted again" );
+
+    $u->update_self( { status => 'N' } );
+    ok( !trusted(), "unvalidated email -> undef" );
+
+    $u->update_self( { status => 'A' } );
+    ok( trusted(), "revalidated email -> trusted again" );
+}
+
+note("update_master_cookie issues the trust cookie (login path)");
+{
+    $req = FakeRequest->new;
+    my $sess = LJ::Session->create( $u, exptype => 'long' );
+    ok( $sess, "created a real session" );
+    $sess->update_master_cookie;
+
+    my @set = $req->set_cookies('ljtrust');
+    ok( scalar @set, "update_master_cookie also set ljtrust" );
+
+    $req = FakeRequest->new;
+    $req->{jar}{ljtrust} = $set[0]->{value};
+    my $got = trusted();
+    ok( $got && $got->equals($u), "login-issued cookie validates" );
+
+    $sess->destroy;
+}
+
+note("logout leaves the trust cookie alone");
+{
+    $req = FakeRequest->new;
+    LJ::Session->clear_master_cookie;
+    ok( !$req->set_cookies('ljtrust'),               "clear_master_cookie does not touch ljtrust" );
+    ok( scalar $req->set_cookies('ljmastersession'), "but it did clear the master session" );
+}
+
+done_testing();


### PR DESCRIPTION
Adds a signed `ljtrust` cookie issued with the session cookies at login (`LJ::Session::update_trust_cookie`) and deliberately left behind on logout. On logged-out requests, `LJ::Session->trusted_anon_user` validates it (HMAC via the rotating `LJ::get_secret` pool, bound to the browser's `ljuniq` ident, 60-day window) and re-checks the account's standing live. A valid holder then gets the logged-in treatment from both captcha gates: the interstitial gate in `DW::Captcha::should_captcha_view` (checked lazily so trusted browsers never feed the fraud tempban counter) and the anon-only comment checks in `LJ::Talk::Post::require_captcha_test` (journal setting R, `comment_html_anon`); checks that also apply to logged-in users still fire. Skips are counted as `dw.captcha.bypassed` with tags mirroring `dw.captcha.shown`.

Also fixes a #3594 regression (first commit): class-method `DW::Captcha->site_enabled` always returned false, which had silently disabled all comment captchas and hidden the per-journal comment captcha setting.

CODE TOUR: If you browse or comment while logged out, but you'd logged in on that browser recently, Dreamwidth now remembers (via a tamper-proof cookie) that you're an established user in good standing and stops making you solve CAPTCHAs that exist to keep out anonymous bots. Journal owners' stricter settings, rate limits, and bans still apply exactly as they would to a logged-in user, and the free pass vanishes if the account is suspended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)