### PR TITLE
Don't memoize the trusted-anon verdict in %LJ::REQ_CACHE

### DIFF
--- a/cgi-bin/LJ/Session.pm
+++ b/cgi-bin/LJ/Session.pm
@@ -845,19 +845,12 @@ sub trust_cookie_signature {
 # otherwise undef. Standing is re-checked live on every use, so suspending or
 # deleting the account revokes the trust immediately. This identifies a
 # browser, not a person: never treat it as authentication.
+#
+# Deliberately uncached: %LJ::REQ_CACHE is NOT cleared between requests, so a
+# memoized verdict would leak across requests (and thus across visitors) on a
+# persistent worker. Validation is one HMAC plus a load_userid, and callers
+# only hit it where a captcha would otherwise be shown.
 sub trusted_anon_user {
-    my ($class) = @_;
-
-    # cache per-request; wrapped in an arrayref so a negative result caches too
-    my $cached = $LJ::REQ_CACHE{trusted_anon_user};
-    return $cached->[0] if $cached;
-
-    my $u = $class->_trusted_anon_user_uncached;
-    $LJ::REQ_CACHE{trusted_anon_user} = [$u];
-    return $u;
-}
-
-sub _trusted_anon_user_uncached {
     my ($class) = @_;
 
     my $r = DW::Request->get

--- a/t/session-trust.t
+++ b/t/session-trust.t
@@ -59,11 +59,7 @@ local $LJ::_T_UNIQCOOKIE_CURRENT_UNIQ = $uniq;
 my $u = temp_user();
 $u->update_self( { status => 'A' } );    # validated email
 
-# checks the current jar with a fresh per-request cache
-sub trusted {
-    delete $LJ::REQ_CACHE{trusted_anon_user};
-    return LJ::Session->trusted_anon_user;
-}
+sub trusted { return LJ::Session->trusted_anon_user }
 
 note("issuance via update_trust_cookie");
 my $cookie_value;
@@ -91,6 +87,23 @@ note("no cookie, no trust");
 {
     $req = FakeRequest->new;
     ok( !trusted(), "no ljtrust cookie -> undef" );
+}
+
+note("verdict is not memoized across requests");
+{
+    # %LJ::REQ_CACHE persists across requests on a worker, so a cached verdict
+    # would leak between visitors; simulate back-to-back requests from
+    # different browsers on one worker and check each gets its own answer
+    $req = FakeRequest->new;
+    $req->{jar}{ljtrust} = $cookie_value;
+    ok( trusted(), "request with a valid cookie -> trusted" );
+
+    $req = FakeRequest->new;
+    ok( !trusted(), "next request without the cookie -> not trusted" );
+
+    $req = FakeRequest->new;
+    $req->{jar}{ljtrust} = $cookie_value;
+    ok( trusted(), "and trust returns with the cookie" );
 }
 
 note("bound to the uniq ident");


### PR DESCRIPTION
Follow-up to #3643. `LJ::Session->trusted_anon_user` cached its verdict in `%LJ::REQ_CACHE` on the assumption that it's request-scoped — it isn't (nothing ever clears it), so on a persistent Starman worker one request's verdict leaked into subsequent requests from other visitors: a browser could inherit someone else's captcha bypass, or lose its own. The fix drops the memoization entirely; validation is one HMAC-SHA1 plus a `load_userid` that's already request-cached, and it only runs where a captcha would otherwise render. A new test in `t/session-trust.t` simulates back-to-back requests from different browsers on one worker and fails on the old code.

CODE TOUR: We found a bug in the just-released "skip CAPTCHAs if you were recently logged in" feature: on a busy server, one visitor's "yes, trusted" or "no, not trusted" answer could accidentally get reused for the next visitor. Nobody gained the ability to act as anyone else — this only affected whether a CAPTCHA was shown — but it's now fixed so every request is checked fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)