### PR TITLE
Load LJ::Location where it's used so entry locations render again

### DIFF
--- a/cgi-bin/LJ/Entry.pm
+++ b/cgi-bin/LJ/Entry.pm
@@ -1407,6 +1407,7 @@ package LJ;
 use Carp qw(confess);
 use LJ::Poll;
 use LJ::EmbedModule;
+use LJ::Location;
 use DW::External::Account;
 
 # <LJFUNC>

--- a/cgi-bin/LJ/Hooks/Setters.pm
+++ b/cgi-bin/LJ/Hooks/Setters.pm
@@ -15,6 +15,7 @@ package LJ;
 
 use strict;
 use LJ::Hooks;
+use LJ::Location;
 
 LJ::Hooks::register_setter(
     'synlevel',

--- a/cgi-bin/LJ/Protocol.pm
+++ b/cgi-bin/LJ/Protocol.pm
@@ -25,6 +25,7 @@ use LJ::Console;
 use LJ::Event::JournalNewEntry;
 use LJ::Event::AddedToCircle;
 use LJ::Entry;
+use LJ::Location;
 use LJ::Poll;
 use LJ::Config;
 use LJ::Comment;

--- a/t/currents.t
+++ b/t/currents.t
@@ -1,0 +1,47 @@
+# t/currents.t
+#
+# Test LJ::currents, which assembles the mood/music/location metadata shown on
+# an entry. Regression guard: LJ::currents renders the location through
+# LJ::Location, but nothing on the render path used to load that module, so the
+# eval-wrapped call died silently and the location vanished from every entry.
+# This test deliberately does NOT `use LJ::Location` itself -- it must exercise
+# the same dependency the render path relies on.
+#
+# This code was forked from the LiveJournal project owned and operated
+# by Live Journal, Inc. The code has been modified and expanded by
+# Dreamwidth Studios, LLC. These files were originally licensed under
+# the terms of the license supplied by Live Journal, Inc, which can
+# currently be found at:
+#
+# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+#
+# In accordance with the original license, this code and all its
+# modifications are provided under the GNU General Public License.
+# A copy of that license can be found in the LICENSE file included as
+# part of this distribution.
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+use LJ::Entry;
+
+my %current = LJ::currents(
+    {
+        current_location => "Testville",
+        current_music    => "a song",
+        current_mood     => "happy",
+    },
+    undef
+);
+
+is( $current{Location}, "Testville",
+    "location renders (LJ::Location is loaded on the render path)" );
+is( $current{Music}, "a song", "music renders" );
+is( $current{Mood},  "happy",  "mood renders" );
+
+# Coordinates-only entries fall back to the numeric location.
+my %coords = LJ::currents( { current_coords => "45.2345,-123.1234" }, undef );
+is( $coords{Location}, "45.2345,-123.1234", "coords-only location renders" );

--- a/t/currents.t
+++ b/t/currents.t
@@ -1,3 +1,5 @@
+#!/usr/bin/perl
+#
 # t/currents.t
 #
 # Test LJ::currents, which assembles the mood/music/location metadata shown on
@@ -7,18 +9,14 @@
 # This test deliberately does NOT `use LJ::Location` itself -- it must exercise
 # the same dependency the render path relies on.
 #
-# This code was forked from the LiveJournal project owned and operated
-# by Live Journal, Inc. The code has been modified and expanded by
-# Dreamwidth Studios, LLC. These files were originally licensed under
-# the terms of the license supplied by Live Journal, Inc, which can
-# currently be found at:
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
 #
-# http://code.livejournal.org/trac/livejournal/browser/trunk/LICENSE-LiveJournal.txt
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
 #
-# In accordance with the original license, this code and all its
-# modifications are provided under the GNU General Public License.
-# A copy of that license can be found in the LICENSE file included as
-# part of this distribution.
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
 
 use strict;
 use warnings;


### PR DESCRIPTION
`LJ::currents` renders an entry's current location by calling `LJ::Location->new` inside an `eval`, but nothing on the render path ever loaded `LJ::Location` — it was only ever *called*, never `use`d/`require`d. Once Apache/mod_perl (which broadly preloaded modules at startup) was retired in favor of Starman-only, the module stopped being resident, so the `eval` died silently, `$loc` came back undef, and the location was dropped from every entry. Mood and music don't go through `LJ::Location`, which is why they kept working.

Adds `use LJ::Location` to the three files that call it: `LJ::Entry` (the user-visible display path), `LJ::Protocol` (`current_coords` validation), and `LJ::Hooks::Setters` (the icbm/location setter). Adds `t/currents.t`, which exercises `LJ::currents` *without* loading `LJ::Location` itself and asserts the location renders — it fails against the pre-fix tree and passes now.

CODE TOUR: If you set a "current location" on a post, it recently stopped showing up on the entry even though mood and music still did. The value was being saved correctly — the site just wasn't displaying it. This restores the current location on entries.