### PR TITLE
Hoist per-viewer trustmask lookup out of the tag loop (#3646)

### DIFF
--- a/cgi-bin/DW/User/Edges/WatchTrust.pm
+++ b/cgi-bin/DW/User/Edges/WatchTrust.pm
@@ -141,6 +141,7 @@ sub _add_wt_edge {
     # delete friend-of memcache keys for anyone who was added
     my ( $from_userid, $to_userid ) = ( $from_u->id, $to_u->id );
     LJ::MemCache::delete( [ $from_userid, "trustmask:$from_userid:$to_userid" ] );
+    delete $LJ::REQ_CACHE_TRUSTMASK{"$from_userid:$to_userid"};
     LJ::memcache_kill( $to_userid,   'wt_edges_rev' );
     LJ::memcache_kill( $from_userid, 'wt_edges' );
     LJ::memcache_kill( $from_userid, 'wt_list' );
@@ -230,6 +231,7 @@ sub _del_wt_edge {
     LJ::memcache_kill( $to_u,   'watched_by' );
     LJ::memcache_kill( $to_u,   'trusted_by' );
     LJ::MemCache::delete( [ $from_u->id, "trustmask:" . $from_u->id . ":" . $to_u->id ] );
+    delete $LJ::REQ_CACHE_TRUSTMASK{ $from_u->id . ":" . $to_u->id };
 
     # fire notifications if we have theschwartz
     my $notify =
@@ -887,6 +889,7 @@ q{UPDATE wt_edges SET groupmask = groupmask & ~(1 << ?) WHERE from_userid = ? AN
 
         # don't forget memcache
         LJ::MemCache::delete( [ $userid, "trustmask:$userid:$tid" ] );
+        delete $LJ::REQ_CACHE_TRUSTMASK{"$userid:$tid"};
     }
 
     # finally remove the trust group, huzzah

--- a/cgi-bin/DW/User/Edges/WatchTrust/Loader.pm
+++ b/cgi-bin/DW/User/Edges/WatchTrust/Loader.pm
@@ -27,12 +27,9 @@ use Carp qw/ confess /;
 sub _trustmask {
     my ( $from_userid, $to_userid ) = @_;
 
-    # Per-request memoization: the mask depends only on ($from, $to), so a page
-    # that asks for the same pair many times (e.g. a tag list) needn't repeat
-    # the memcache round-trip. %LJ::REQ_CACHE_TRUSTMASK is cleared in
-    # LJ::start_request and invalidated on edge changes, so it never outlives a
-    # request. (Do NOT use the bare %LJ::REQ_CACHE here: that hash is never
-    # cleared between requests and would serve stale masks.)
+    # Memoize per request. %LJ::REQ_CACHE_TRUSTMASK is cleared in
+    # LJ::start_request and invalidated on edge changes; do NOT use the bare
+    # %LJ::REQ_CACHE, which is never cleared and would serve stale masks.
     my $reqkey = "$from_userid:$to_userid";
     return $LJ::REQ_CACHE_TRUSTMASK{$reqkey}
         if defined $LJ::REQ_CACHE_TRUSTMASK{$reqkey};

--- a/cgi-bin/DW/User/Edges/WatchTrust/Loader.pm
+++ b/cgi-bin/DW/User/Edges/WatchTrust/Loader.pm
@@ -27,9 +27,8 @@ use Carp qw/ confess /;
 sub _trustmask {
     my ( $from_userid, $to_userid ) = @_;
 
-    # Memoize per request. %LJ::REQ_CACHE_TRUSTMASK is cleared in
-    # LJ::start_request and invalidated on edge changes; do NOT use the bare
-    # %LJ::REQ_CACHE, which is never cleared and would serve stale masks.
+    # Memoize per request; %LJ::REQ_CACHE_TRUSTMASK is cleared in
+    # LJ::start_request and invalidated on edge changes.
     my $reqkey = "$from_userid:$to_userid";
     return $LJ::REQ_CACHE_TRUSTMASK{$reqkey}
         if defined $LJ::REQ_CACHE_TRUSTMASK{$reqkey};

--- a/cgi-bin/DW/User/Edges/WatchTrust/Loader.pm
+++ b/cgi-bin/DW/User/Edges/WatchTrust/Loader.pm
@@ -27,6 +27,16 @@ use Carp qw/ confess /;
 sub _trustmask {
     my ( $from_userid, $to_userid ) = @_;
 
+    # Per-request memoization: the mask depends only on ($from, $to), so a page
+    # that asks for the same pair many times (e.g. a tag list) needn't repeat
+    # the memcache round-trip. %LJ::REQ_CACHE_TRUSTMASK is cleared in
+    # LJ::start_request and invalidated on edge changes, so it never outlives a
+    # request. (Do NOT use the bare %LJ::REQ_CACHE here: that hash is never
+    # cleared between requests and would serve stale masks.)
+    my $reqkey = "$from_userid:$to_userid";
+    return $LJ::REQ_CACHE_TRUSTMASK{$reqkey}
+        if defined $LJ::REQ_CACHE_TRUSTMASK{$reqkey};
+
     my $memkey = [ $from_userid, "trustmask:$from_userid:$to_userid" ];
     my $mask   = LJ::MemCache::get($memkey);
     unless ( defined $mask ) {
@@ -36,13 +46,13 @@ sub _trustmask {
         $mask = $dbr->selectrow_array(
             'SELECT groupmask FROM wt_edges WHERE from_userid = ? AND to_userid = ?',
             undef, $from_userid, $to_userid );
-        return 0 if $dbr->err;
+        return 0 if $dbr->err;    # transient error: don't cache
         $mask = $mask ? $mask + 0 : 0;    # force numeric
 
         LJ::MemCache::set( $memkey, $mask, 3600 );
     }
 
-    return $mask;
+    return $LJ::REQ_CACHE_TRUSTMASK{$reqkey} = $mask;
 }
 
 # actually get friend/friendof uids, should not be called directly

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -1962,8 +1962,28 @@ sub Tag {
     return $t;
 }
 
+# Compute the viewer's relationship to journal $u for tag-count purposes.
+# This depends only on ($u, remote) and so is identical for every tag on a
+# page; callers rendering a whole tag list should compute it once and pass it
+# into TagDetail, rather than paying a per-tag trustmask/memcache lookup for a
+# journal with many tags (see #3646).
+sub tag_viewer_context {
+    my ($u) = @_;
+    my $remote = LJ::get_remote();
+
+    my %ctx = ( remote => $remote );
+    if ( defined $remote && $remote->can_manage($u) ) {    # own journal
+        $ctx{can_manage} = 1;
+    }
+    elsif ( defined $remote ) {                            # logged in, not own journal
+        $ctx{trusted} = $u->trusts_or_has_member($remote);
+        $ctx{grpmask} = $u->trustmask($remote);
+    }
+    return \%ctx;
+}
+
 sub TagDetail {
-    my ( $u, $kwid, $tag ) = @_;
+    my ( $u, $kwid, $tag, $viewer ) = @_;
     return undef unless $u && $kwid && ref $tag eq 'HASH';
 
     my $t = {
@@ -1980,10 +2000,13 @@ sub TagDetail {
     # be visible to >1 of them. Instead of working it out accurately
     # every time, we give an approximation that will either be accurate
     # or an underestimate.
-    my $count  = 0;
-    my $remote = LJ::get_remote();
+    my $count = 0;
 
-    if ( defined $remote && $remote->can_manage($u) ) {    #own journal
+    # viewer relationship is identical across every tag; list callers pass it
+    # in, otherwise compute it for this single tag.
+    $viewer ||= tag_viewer_context($u);
+
+    if ( $viewer->{can_manage} ) {    # own journal
         $count = $tag->{uses};
         my $groupcount = $tag->{uses};
         foreach (qw(public private protected)) {
@@ -1993,9 +2016,9 @@ sub TagDetail {
         $t->{security_counts}->{group} = $groupcount;
 
     }
-    elsif ( defined $remote ) {                            #logged in, not own journal
-        my $trusted = $u->trusts_or_has_member($remote);
-        my $grpmask = $u->trustmask($remote);
+    elsif ( $viewer->{remote} ) {     # logged in, not own journal
+        my $trusted = $viewer->{trusted};
+        my $grpmask = $viewer->{grpmask};
 
         $count = $tag->{security}->{public};
         $t->{security_counts}->{public} = $tag->{security}->{public};
@@ -4610,13 +4633,16 @@ sub Page__visible_tag_list {
         my $tags = LJ::Tags::get_usertags( $u, { remote => $remote } );
         return [] unless $tags;
 
+        # compute the viewer relationship once for the whole list (see #3646)
+        my $viewer = LJ::S2::tag_viewer_context($u);
+
         foreach my $kwid ( keys %{$tags} ) {
 
             # only show tags for display
             next unless $tags->{$kwid}->{display};
 
             # create tag object
-            push @taglist, LJ::S2::TagDetail( $u, $kwid => $tags->{$kwid} );
+            push @taglist, LJ::S2::TagDetail( $u, $kwid => $tags->{$kwid}, $viewer );
         }
     }
 

--- a/cgi-bin/LJ/S2.pm
+++ b/cgi-bin/LJ/S2.pm
@@ -1962,11 +1962,9 @@ sub Tag {
     return $t;
 }
 
-# Compute the viewer's relationship to journal $u for tag-count purposes.
-# This depends only on ($u, remote) and so is identical for every tag on a
-# page; callers rendering a whole tag list should compute it once and pass it
-# into TagDetail, rather than paying a per-tag trustmask/memcache lookup for a
-# journal with many tags (see #3646).
+# The viewer's tag-count relationship to $u is identical for every tag, so
+# callers rendering a whole list compute it once and pass it into TagDetail
+# rather than paying a per-tag trustmask lookup (see #3646).
 sub tag_viewer_context {
     my ($u) = @_;
     my $remote = LJ::get_remote();
@@ -2002,8 +2000,7 @@ sub TagDetail {
     # or an underestimate.
     my $count = 0;
 
-    # viewer relationship is identical across every tag; list callers pass it
-    # in, otherwise compute it for this single tag.
+    # list callers pass this in; a lone tag computes it here.
     $viewer ||= tag_viewer_context($u);
 
     if ( $viewer->{can_manage} ) {    # own journal
@@ -4633,7 +4630,7 @@ sub Page__visible_tag_list {
         my $tags = LJ::Tags::get_usertags( $u, { remote => $remote } );
         return [] unless $tags;
 
-        # compute the viewer relationship once for the whole list (see #3646)
+        # compute the viewer relationship once for the whole list
         my $viewer = LJ::S2::tag_viewer_context($u);
 
         foreach my $kwid ( keys %{$tags} ) {

--- a/cgi-bin/LJ/S2/TagsPage.pm
+++ b/cgi-bin/LJ/S2/TagsPage.pm
@@ -40,11 +40,15 @@ sub TagsPage {
     # get tags for the page to display
     my @taglist;
     my $tags = LJ::Tags::get_usertags( $u, { remote => $remote } );
+
+    # compute the viewer relationship once for the whole list (see #3646)
+    my $viewer = LJ::S2::tag_viewer_context($u);
+
     foreach my $kwid ( keys %{$tags} ) {
 
         # only show tags for display
         next unless $tags->{$kwid}->{display};
-        push @taglist, LJ::S2::TagDetail( $u, $kwid => $tags->{$kwid} );
+        push @taglist, LJ::S2::TagDetail( $u, $kwid => $tags->{$kwid}, $viewer );
     }
     @taglist = sort { $a->{name} cmp $b->{name} } @taglist;
     $p->{'_visible_tag_list'} = $p->{'tags'} = \@taglist;

--- a/cgi-bin/LJ/S2/TagsPage.pm
+++ b/cgi-bin/LJ/S2/TagsPage.pm
@@ -41,7 +41,7 @@ sub TagsPage {
     my @taglist;
     my $tags = LJ::Tags::get_usertags( $u, { remote => $remote } );
 
-    # compute the viewer relationship once for the whole list (see #3646)
+    # compute the viewer relationship once for the whole list
     my $viewer = LJ::S2::tag_viewer_context($u);
 
     foreach my $kwid ( keys %{$tags} ) {

--- a/cgi-bin/ljlib.pl
+++ b/cgi-bin/ljlib.pl
@@ -490,6 +490,7 @@ sub start_request {
     %LJ::REQ_CACHE_USER_NAME    = ();       # users by name
     %LJ::REQ_CACHE_USER_ID      = ();       # users by id
     %LJ::REQ_CACHE_REL          = ();       # relations from LJ::check_rel()
+    %LJ::REQ_CACHE_TRUSTMASK    = ();       # ("$from:$to") -> trustmask from _trustmask()
     %LJ::REQ_LANGDATFILE        = ();       # caches language files
     %LJ::S2::REQ_CACHE_STYLE_ID = ();       # styleid -> hashref of s2 layers for style
     %LJ::S2::REQ_CACHE_LAYER_ID =

--- a/t/tags-trustmask-count.t
+++ b/t/tags-trustmask-count.t
@@ -1,0 +1,85 @@
+# t/tags-trustmask-count.t
+#
+# Regression test for #3646: rendering a tag-heavy journal for a logged-in,
+# non-owner viewer must perform a bounded (constant) number of trustmask
+# lookups, regardless of how many tags the journal has. The viewer's trust
+# relationship to the journal is identical for every tag, so it is computed
+# once (LJ::S2::tag_viewer_context) and passed into each TagDetail call, and
+# _trustmask memoizes per-request as defense-in-depth.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+use LJ::Test qw( temp_user );
+
+my $owner  = temp_user();
+my $viewer = temp_user();
+
+# owner trusts viewer (mask bit 0 = the plain trust bit); this also flushes
+# both the memcache and the per-request trustmask caches for the pair.
+$owner->add_edge( $viewer, trust => { mask => 1, nonotify => 1 } );
+
+# view the owner's journal as the (logged-in, non-owner) viewer
+LJ::set_remote($viewer);
+
+# count actual _trustmask invocations and the trustmask memcache gets they make
+my $tm_calls = 0;
+my $mc_gets  = 0;
+
+my $orig_tm = \&DW::User::Edges::WatchTrust::Loader::_trustmask;
+my $orig_mc = \&LJ::MemCache::get;
+
+no warnings 'redefine';
+local *DW::User::Edges::WatchTrust::Loader::_trustmask = sub {
+    $tm_calls++;
+    return $orig_tm->(@_);
+};
+local *LJ::MemCache::get = sub {
+    my $key  = $_[0];
+    my $name = ref $key eq 'ARRAY' ? $key->[1] : $key;
+    $mc_gets++ if defined $name && $name =~ /^trustmask:/;
+    return $orig_mc->(@_);
+};
+use warnings 'redefine';
+
+# a journal with many tags
+my $N = 200;
+my %tags;
+for my $i ( 1 .. $N ) {
+    $tags{$i} = {
+        name           => "tag$i",
+        display        => 1,
+        security_level => 'public',
+        uses           => 3,
+        security       => { public => 3, private => 0, protected => 0, groups => {} },
+    };
+}
+
+# render the tag list the way the S2 page code does: compute the viewer
+# relationship once, then build every TagDetail with it.
+%LJ::REQ_CACHE_TRUSTMASK = ();    # start from a clean per-request slate
+my $viewer_ctx = LJ::S2::tag_viewer_context($owner);
+my @list       = map { LJ::S2::TagDetail( $owner, $_, $tags{$_}, $viewer_ctx ) } sort keys %tags;
+
+is( scalar @list, $N, "rendered all $N tags" );
+
+# the count reflects the viewer's trust, so the fix must be behavior-preserving:
+# public(3) + protected(0) + best group(0) == 3 for a trusted viewer.
+is( $list[0]->{use_count}, 3, "use_count is correct for a trusted viewer" );
+
+# the whole point of #3646: work is constant, not O(tags).
+is( $tm_calls, 2, "_trustmask called a constant number of times (trusts + trustmask)" );
+cmp_ok( $mc_gets, '<=', 1, "trustmask memcache gets bounded regardless of tag count" );


### PR DESCRIPTION
Logged-in views of a tag-heavy journal were ~20s slow because `LJ::S2::TagDetail` recomputed the viewer's trust relationship (`trusts_or_has_member` + `trustmask`, both resolving to the unmemoized `_trustmask`) once per tag. Since that relationship is identical for every tag, `LJ::S2::tag_viewer_context` now computes it once and each `TagDetail` call receives it (single-tag callers like the REST API still compute it lazily, unchanged). As defense-in-depth, `_trustmask` memoizes per request in a dedicated `%LJ::REQ_CACHE_TRUSTMASK` — cleared in `start_request` and invalidated at the edge-change sites in `WatchTrust.pm` — rather than the bare `%LJ::REQ_CACHE`, which is never cleared between requests and would leak stale masks across viewers. Key files: `cgi-bin/LJ/S2.pm`, `cgi-bin/LJ/S2/TagsPage.pm`, `cgi-bin/DW/User/Edges/WatchTrust/Loader.pm`, `cgi-bin/DW/User/Edges/WatchTrust.pm`, `cgi-bin/ljlib.pl`. New test `t/tags-trustmask-count.t` asserts a constant number of trustmask lookups regardless of tag count.

CODE TOUR: If you were logged in and looked at a journal that has a huge number of tags, the page could take around 20 seconds to load, while logged-out visitors saw it in a second or two. The site was needlessly re-checking your relationship to that journal once for every single tag. Now it checks once and reuses the answer, so those pages load quickly for everyone.

Fixes #3646