### PR TITLE
Batch the profile page's viewer-relationship lookups (#3648)

### DIFF
--- a/cgi-bin/DW/Controller/Profile.pm
+++ b/cgi-bin/DW/Controller/Profile.pm
@@ -139,24 +139,21 @@ sub profile_handler {
 
     $vars->{load_userids} = sub { LJ::load_userids( @{ $_[0] } ) };
 
-    # Precompute the viewer's circle as membership hashes so the template can
-    # highlight shared relationships with an O(1) check per listed user, instead
-    # of a per-user trustmask lookup that made big profiles ~8s (see #3648).
-    # Each accessor here is a single bulk load. Only needed when highlighting
-    # someone else's profile; format_userlink skips it otherwise.
+    # The viewer's circle as membership hashes, so format_userlink can highlight
+    # shared relationships with an O(1) check per listed user (see #3648). Each
+    # accessor is a single bulk load; only built when highlighting someone
+    # else's profile, since format_userlink skips the check otherwise.
     if ( $remote && !$remote->equals($u) ) {
         $vars->{remote_watches}   = { map { $_ => 1 } $remote->watched_userids };
         $vars->{remote_trusts}    = { map { $_ => 1 } $remote->trusted_userids };
         $vars->{remote_member_of} = { map { $_ => 1 } $remote->member_of_userids };
 
-        # trusts() reports self as trusted; mirror that so the viewer's own
-        # entry in a list highlights the same as before.
+        # trusts() reports self as trusted; mirror that for the viewer's own entry.
         $vars->{remote_trusts}{ $remote->id } = 1;
     }
 
     # Sort by display_name via a Schwartzian transform so each name is computed
-    # once, not on every O(n log n) comparison (see #3648). $list holds user
-    # objects, or userids to key into $us when that is given.
+    # once. $list holds user objects, or userids to key into $us when given.
     $vars->{sort_by_username} = sub {
         my ( $list, $us ) = @_;
         my $name = $us ? sub { $us->{ $_[0] }->display_name } : sub { $_[0]->display_name };

--- a/cgi-bin/DW/Controller/Profile.pm
+++ b/cgi-bin/DW/Controller/Profile.pm
@@ -139,12 +139,32 @@ sub profile_handler {
 
     $vars->{load_userids} = sub { LJ::load_userids( @{ $_[0] } ) };
 
+    # Precompute the viewer's circle as membership hashes so the template can
+    # highlight shared relationships with an O(1) check per listed user, instead
+    # of a per-user trustmask lookup that made big profiles ~8s (see #3648).
+    # Each accessor here is a single bulk load. Only needed when highlighting
+    # someone else's profile; format_userlink skips it otherwise.
+    if ( $remote && !$remote->equals($u) ) {
+        $vars->{remote_watches}   = { map { $_ => 1 } $remote->watched_userids };
+        $vars->{remote_trusts}    = { map { $_ => 1 } $remote->trusted_userids };
+        $vars->{remote_member_of} = { map { $_ => 1 } $remote->member_of_userids };
+
+        # trusts() reports self as trusted; mirror that so the viewer's own
+        # entry in a list highlights the same as before.
+        $vars->{remote_trusts}{ $remote->id } = 1;
+    }
+
+    # Sort by display_name via a Schwartzian transform so each name is computed
+    # once, not on every O(n log n) comparison (see #3648). $list holds user
+    # objects, or userids to key into $us when that is given.
     $vars->{sort_by_username} = sub {
         my ( $list, $us ) = @_;
-        my $sort = sub { $a->display_name cmp $b->display_name };
-        $sort = sub { $us->{$a}->display_name cmp $us->{$b}->display_name }
-            if $us;
-        return [ sort $sort @$list ];
+        my $name = $us ? sub { $us->{ $_[0] }->display_name } : sub { $_[0]->display_name };
+        return [
+            map  { $_->[1] }
+            sort { $a->[0] cmp $b->[0] }
+            map  { [ $name->($_), $_ ] } @$list
+        ];
     };
 
     $vars->{createdate} = LJ::mysql_time( $u->timecreate );

--- a/t/profile-userlink-lookups.t
+++ b/t/profile-userlink-lookups.t
@@ -1,0 +1,90 @@
+# t/profile-userlink-lookups.t
+#
+# Regression test for #3648 (Problem 1): the profile page highlights shared
+# relationships for a logged-in viewer by rendering format_userlink once per
+# listed user. That highlighting must NOT do a per-user trust/watch lookup
+# (which resolved to _trustmask / check_rel and made big profiles ~8s); the
+# viewer's circle is precomputed into lookup hashes in the controller and the
+# template does an O(1) membership check. Here we render the real _blocks.tt
+# listusers/format_userlink over N users and assert zero relationship lookups
+# happen during the render, regardless of N, while the highlighting output is
+# still correct.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+use LJ::Test qw( temp_user );
+use Template;
+
+my $u      = temp_user();    # profile owner
+my $remote = temp_user();    # logged-in viewer, not the owner
+
+# a list of users displayed on the profile
+my $N       = 20;
+my @targets = map { temp_user() } 1 .. $N;
+
+# the viewer's circle, precomputed the way the controller does: id => 1 hashes.
+# targets[0] trusted, [1] watched, [2] both, the rest unrelated.
+my %trusts  = ( $targets[0]->id => 1, $targets[2]->id => 1 );
+my %watches = ( $targets[1]->id => 1, $targets[2]->id => 1 );
+
+# count the per-user relationship lookups the render must NOT make
+my $tm_calls = 0;
+my $cr_calls = 0;
+my $orig_tm  = \&DW::User::Edges::WatchTrust::Loader::_trustmask;
+my $orig_cr  = \&LJ::check_rel;
+no warnings 'redefine';
+local *DW::User::Edges::WatchTrust::Loader::_trustmask = sub { $tm_calls++; return $orig_tm->(@_) };
+local *LJ::check_rel                                   = sub { $cr_calls++; return $orig_cr->(@_) };
+use warnings 'redefine';
+
+my %vars = (
+    remote           => $remote,
+    u                => $u,
+    users            => \@targets,
+    remote_watches   => \%watches,
+    remote_trusts    => \%trusts,
+    remote_member_of => {},
+
+    # the controller passes these subs in; stub the parts listusers touches
+    linkify       => sub { my $l = $_[0]; return ref $l eq 'HASH' ? $l->{text} : $l },
+    parse_openids => sub { return { sites => {}, shortnames => {} } },
+);
+
+my $tt = Template->new(
+    { INCLUDE_PATH => join( ':', LJ::get_all_directories('views') ), RECURSION => 1 } )
+    or die $Template::ERROR;
+
+my $src =
+    "[% PROCESS 'profile/_blocks.tt' -%]\n[%- PROCESS listusers users = users, openids = [] -%]";
+
+# measure only the render; setup above may have touched these
+$tm_calls = 0;
+$cr_calls = 0;
+
+my $out = '';
+$tt->process( \$src, \%vars, \$out ) or die $tt->error;
+
+is( $tm_calls, 0, "no _trustmask lookups while rendering $N user links" );
+is( $cr_calls, 0, "no check_rel lookups while rendering $N user links" );
+
+my $trusted_name = $targets[0]->display_name;
+my $watched_name = $targets[1]->display_name;
+my $neither_name = $targets[3]->display_name;
+
+like( $out, qr{<strong>\Q$trusted_name\E</strong>}, "trusted user rendered bold" );
+like( $out, qr{<em>\Q$watched_name\E</em>},         "watched user rendered italic" );
+unlike( $out, qr{<(?:strong|em)>\Q$neither_name\E</}, "unrelated user left unstyled" );

--- a/views/profile/_blocks.tt
+++ b/views/profile/_blocks.tt
@@ -81,13 +81,15 @@
         linked_u = "<strike>$linked_u</strike>";
       END;
   # if user is logged in and not looking at own profile, use
-  # appropriate highlighting for users they have in common
+  # appropriate highlighting for users they have in common. the lookup hashes
+  # are built once in the controller, so this is O(1) per user (see #3648).
       IF remote && ! remote.equals( u );
-        IF remote.watches( user );
+        IF remote_watches.${user.userid};
           linked_u = "<em>$linked_u</em>";
         END;
-        trust_method = user.is_community ? 'member_of' : 'trusts';
-        IF remote.$trust_method( user );
+        in_circle = user.is_community ? remote_member_of.${user.userid}
+                                      : remote_trusts.${user.userid};
+        IF in_circle;
           linked_u = "<strong>$linked_u</strong>";
         END;
       END;

--- a/views/profile/_blocks.tt
+++ b/views/profile/_blocks.tt
@@ -82,7 +82,7 @@
       END;
   # if user is logged in and not looking at own profile, use
   # appropriate highlighting for users they have in common. the lookup hashes
-  # are built once in the controller, so this is O(1) per user (see #3648).
+  # are built once in the controller, so this is O(1) per user.
       IF remote && ! remote.equals( u );
         IF remote_watches.${user.userid};
           linked_u = "<em>$linked_u</em>";


### PR DESCRIPTION
The profile page (`/profile`, `/info`) was slow in two independent ways, both CPU/memcache-bound rather than SQL-bound. `format_userlink` in `views/profile/_blocks.tt` ran once per listed user and called `remote.watches` / `remote.trusts` (or `member_of`) for each — every one an uncached `_trustmask` / `check_rel` memcache round-trip, ~3,000 gets for a ~1,500-relationship profile (~6s logged in). Unlike #3646 the keys are all distinct, so memoizing `_trustmask` doesn't help; instead `DW::Controller::Profile` now loads the viewer's circle once via `watched_userids` / `trusted_userids` / `member_of_userids` into `{id => 1}` hashes and the template does an O(1) membership check. Separately, `sort_by_username` recomputed `display_name` on every O(n log n) comparison (~31k calls, ~1s even logged out); it now uses a Schwartzian transform so each name is computed once. New test `t/profile-userlink-lookups.t` renders the real block over N users and asserts a bounded (zero) number of relationship lookups regardless of N, with highlighting output unchanged.

CODE TOUR: Profile pages for accounts with a lot of trusted/subscribed users were painfully slow to load, especially when you were logged in — around eight seconds for a big one — because the page re-checked your relationship to every single listed user one at a time. Now it looks up your circle once up front and reuses it, and it also stops redundantly recomputing display names while sorting the lists. Same page, same bolding/italics for people you know, just fast.

Fixes #3648