### PR TITLE
Add on-site multi-account switcher

### DIFF
--- a/bin/upgrading/en.dat
+++ b/bin/upgrading/en.dat
@@ -2097,6 +2097,8 @@ menunav.organize.customizejournalstyle=Customize Journal Style
 
 menunav.organize.importcontent=Import Content
 
+menunav.organize.manageaccounts=Account Switcher
+
 menunav.organize.managecommunities=Manage Communities
 
 menunav.organize.managefilters=Manage Filters
@@ -4000,6 +4002,12 @@ sitescheme.accountlinks.post=Post
 
 sitescheme.accountlinks.readinglist=Reading Page
 
+sitescheme.accountlinks.switch.go=Switch
+
+sitescheme.accountlinks.switch.label=Switch account
+
+sitescheme.accountlinks.switch.signedout=Signed out — log in
+
 sitescheme.accountlinks.userpic.alt=Upload Icons
 
 sitescheme.footer.info=Copyright &copy; 2009-2011 Dreamwidth Studios, LLC. All rights reserved.
@@ -4672,6 +4680,12 @@ web.controlstrip.status.yourjournal=You're viewing your journal
 web.controlstrip.status.yournetworkpage=You're viewing your Network Page.
 
 web.controlstrip.status.yourreadingpage=You're viewing your Reading Page.
+
+web.controlstrip.switch.go=Switch
+
+web.controlstrip.switch.label=Switch account
+
+web.controlstrip.switch.signedout=Signed out — log in
 
 web.controlstrip.userpic.alt=Icon
 

--- a/cgi-bin/DW/AccountSwitcher.pm
+++ b/cgi-bin/DW/AccountSwitcher.pm
@@ -1,0 +1,315 @@
+#!/usr/bin/perl
+#
+# DW::AccountSwitcher
+#
+# On-site multi-account session switching, in the spirit of GitHub's and
+# Google's account switchers. A browser may hold sessions for several accounts
+# at once and flip between them without re-entering a password.
+#
+# The model deliberately leaves the core auth path alone: the *active* account
+# is still ljmastersession/ljloggedin, validated exactly as before. This module
+# only tracks the *other* signed-in accounts, in a separate "ljsessions" cookie.
+# Each stored account is a (userid, sessid, auth) handle -- the same secret
+# ljmastersession already carries -- so the cookie is written http_only (and
+# secure on HTTPS, via LJ::Session::set_cookie) and treated as credential
+# material. Nothing is ever trusted from the cookie without re-validating the
+# session against the database, the same way session_from_master_cookie does.
+#
+# Invariant: ljsessions never contains the active account; switching promotes a
+# stored account to active and demotes the old active into the stored list.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself. For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+#
+
+package DW::AccountSwitcher;
+
+use strict;
+use v5.10;
+
+use DW::Cache;
+use DW::Request;
+use LJ::Session;
+
+use constant COOKIE_NAME => 'ljsessions';
+use constant COOKIE_VER  => 1;
+
+# Cap the number of stored (non-active) accounts so the cookie stays small;
+# each entry is a live credential, so a runaway list is also a liability.
+use constant MAX_ACCOUNTS => 9;
+
+################################################################################
+# Cookie serialization
+#
+# Value: "v<ver>|<entry>|<entry>...//<cookie-gen>" where each entry is
+# "u<userid>:s<sessid>:a<auth>". auth is alphanumeric (LJ::rand_chars) and the
+# ids are integers, so "|" and ":" are unambiguous separators.
+################################################################################
+
+# Returns an arrayref of { userid, sessid, auth } hashes, unvalidated. Reads a
+# write made earlier in this request first (the incoming cookie is stale once we
+# have set a new one), then the incoming cookie.
+sub _entries {
+    my $class = shift;
+
+    my $req = DW::Cache->request;
+    return $req->get( 'account_switcher', 'entries' )
+        if $req->has( 'account_switcher', 'entries' );
+
+    my $entries = $class->_parse_cookie;
+    $req->set( 'account_switcher', 'entries', $entries );
+    return $entries;
+}
+
+sub _parse_cookie {
+    my $class = shift;
+
+    my $r = DW::Request->get or return [];
+    my $val = $r->cookie(COOKIE_NAME) || '' or return [];
+
+    my ( $body, $gen ) = split m!//!, $val, 2;
+    return [] unless LJ::Session::valid_cookie_generation($gen);
+
+    my ( $ver, @raw ) = split /\|/, $body;
+    return [] unless defined $ver && $ver eq 'v' . COOKIE_VER;
+
+    my @entries;
+    foreach my $chunk (@raw) {
+        my ( $userid, $sessid, $auth );
+        my $dest = { u => \$userid, s => \$sessid, a => \$auth };
+
+        my $bogus = 0;
+        foreach my $field ( split /:/, $chunk ) {
+            if ( $field =~ /^(\w)(.+)$/ && $dest->{$1} ) {
+                ${ $dest->{$1} } = $2;
+            }
+            else {
+                $bogus = 1;
+            }
+        }
+        next if $bogus;
+        next unless $userid && $userid =~ /^\d+$/ && $sessid && $sessid =~ /^\d+$/ && $auth;
+
+        push @entries, { userid => $userid + 0, sessid => $sessid + 0, auth => $auth };
+    }
+
+    return \@entries;
+}
+
+# Persist the stored-account list. Empty list deletes the cookie. Also stashes
+# the list in the request cache so later reads this request see it.
+sub _write {
+    my ( $class, $entries ) = @_;
+
+    # keep only the most recently added accounts if we somehow overflow
+    @$entries = @$entries[ -MAX_ACCOUNTS() .. -1 ] if @$entries > MAX_ACCOUNTS;
+
+    DW::Cache->request->set( 'account_switcher', 'entries', $entries );
+
+    my $domain = $LJ::DOMAIN_WEB || $LJ::DOMAIN;
+
+    unless (@$entries) {
+        LJ::Session::set_cookie(
+            COOKIE_NAME() => "",
+            domain        => $domain,
+            path          => '/',
+            delete        => 1,
+        );
+        return;
+    }
+
+    my $body = join '|', 'v' . COOKIE_VER,
+        map { "u$_->{userid}:s$_->{sessid}:a$_->{auth}" } @$entries;
+    my $value = $body . "//" . LJ::eurl( $LJ::COOKIE_GEN || "" );
+
+    LJ::Session::set_cookie(
+        COOKIE_NAME() => $value,
+        domain        => $domain,
+        path          => '/',
+        http_only     => 1,
+        expires       => LJ::Session->session_length('long'),
+    );
+
+    return;
+}
+
+# Delete the cookie entirely.
+sub clear {
+    my $class = shift;
+    return $class->_write( [] );
+}
+
+################################################################################
+# Validation / display
+################################################################################
+
+# Turn one raw entry into a display record, re-validating the session against
+# the DB. Returns undef only if the user can't be loaded at all. An expired or
+# otherwise unusable session still returns a record flagged not-valid, so the UI
+# can list the account and route a click to a pre-filled login (Google-style).
+sub _resolve {
+    my ( $class, $entry ) = @_;
+
+    my $u = LJ::load_userid( $entry->{userid} ) or return undef;
+
+    my $valid = 0;
+    my $sess;
+    unless ( $u->is_expunged || $u->is_locked ) {
+        $sess  = LJ::Session->instance( $u, $entry->{sessid} );
+        $valid = 1
+            if $sess && $sess->{auth} eq $entry->{auth} && $sess->valid;
+    }
+
+    return {
+        u      => $u,
+        userid => $u->userid,
+        user   => $u->user,
+        sess   => ( $valid ? $sess : undef ),
+        valid  => $valid,
+    };
+}
+
+# The other signed-in accounts, resolved for display. Skips the active remote
+# defensively (the invariant already excludes it).
+sub accounts {
+    my $class = shift;
+
+    my $remote    = LJ::get_remote();
+    my $remote_id = $remote ? $remote->userid : 0;
+
+    my @out;
+    my %seen;
+    foreach my $entry ( @{ $class->_entries } ) {
+        next if $entry->{userid} == $remote_id;
+        next if $seen{ $entry->{userid} }++;
+
+        my $rec = $class->_resolve($entry) or next;
+        push @out, $rec;
+    }
+
+    # sorted by username so the lists have a stable order and don't reshuffle as
+    # accounts are added or switched (the cookie order changes; this doesn't).
+    # Sort into an array first so scalar context still yields the count -- a bare
+    # `return sort ...` is undef in scalar context.
+    my @sorted = sort { $a->{user} cmp $b->{user} } @out;
+    return @sorted;
+}
+
+################################################################################
+# Mutations
+################################################################################
+
+# Make ($u, $sess) the active account: rewrite ljmastersession/ljloggedin/scheme
+# and set the request remote. The session must already be validated.
+sub _activate {
+    my ( $class, $u, $sess ) = @_;
+    $sess->update_master_cookie;
+    LJ::set_remote($u);
+    $u->{_session} = $sess;
+    return;
+}
+
+# The (userid, sessid, auth) handle for the current active remote, or undef.
+sub _current_handle {
+    my $class  = shift;
+    my $remote = LJ::get_remote() or return undef;
+    my $sess   = $remote->session or return undef;
+    return {
+        userid => $remote->userid,
+        sessid => $sess->id,
+        auth   => $sess->auth,
+    };
+}
+
+# Add a freshly-authenticated account and make it active, demoting the current
+# active into the stored list. $u must already be password-verified by the
+# caller. Returns 1.
+sub add_account {
+    my ( $class, $u, $exptype, $ipfixed ) = @_;
+
+    my @list = grep { $_->{userid} != $u->userid } @{ $class->_entries };
+
+    # demote the account we're currently logged in as
+    if ( my $cur = $class->_current_handle ) {
+        push @list, $cur unless $cur->{userid} == $u->userid;
+    }
+    $class->_write( \@list );
+
+    # make_login_session creates a new session for $u, writes the master cookie,
+    # and sets the remote -- exactly like a normal login.
+    $u->make_login_session( $exptype, $ipfixed );
+
+    return 1;
+}
+
+# Switch the active account to a stored one. Returns:
+#   1          -- switched
+#   'expired'  -- account is stored but its session is no longer usable
+#   0          -- not a stored account
+sub switch_to {
+    my ( $class, $userid ) = @_;
+    $userid += 0;
+
+    my @entries = @{ $class->_entries };
+    my ($target) = grep { $_->{userid} == $userid } @entries;
+    return 0 unless $target;
+
+    my $rec = $class->_resolve($target);
+    return 'expired' unless $rec && $rec->{valid};
+
+    # demote current active, drop the target from the stored list
+    my @list = grep { $_->{userid} != $userid } @entries;
+    if ( my $cur = $class->_current_handle ) {
+        push @list, $cur unless $cur->{userid} == $userid;
+    }
+    $class->_write( \@list );
+
+    $class->_activate( $rec->{u}, $rec->{sess} );
+    return 1;
+}
+
+# After the active account has logged out, promote the first usable stored
+# account to active. Returns the promoted LJ::User, or undef if none is usable
+# (in which case the caller finishes a normal logout). Does NOT demote the old
+# active -- it is already gone.
+sub promote_next {
+    my $class = shift;
+
+    my @entries = @{ $class->_entries };
+    foreach my $entry (@entries) {
+        my $rec = $class->_resolve($entry);
+        next unless $rec && $rec->{valid};
+
+        my @list = grep { $_->{userid} != $entry->{userid} } @entries;
+        $class->_write( \@list );
+        $class->_activate( $rec->{u}, $rec->{sess} );
+        return $rec->{u};
+    }
+
+    return undef;
+}
+
+# Remove one stored account from this browser without touching the active one:
+# destroy its session and drop it from the list. Returns 1 if it was present.
+sub remove_account {
+    my ( $class, $userid ) = @_;
+    $userid += 0;
+
+    my @entries = @{ $class->_entries };
+    my ($target) = grep { $_->{userid} == $userid } @entries;
+    return 0 unless $target;
+
+    my $rec = $class->_resolve($target);
+    $rec->{sess}->destroy if $rec && $rec->{sess};
+
+    $class->_write( [ grep { $_->{userid} != $userid } @entries ] );
+    return 1;
+}
+
+1;

--- a/cgi-bin/DW/Controller/Auth.pm
+++ b/cgi-bin/DW/Controller/Auth.pm
@@ -22,14 +22,17 @@ use v5.10;
 use Log::Log4perl;
 my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
+use DW::AccountSwitcher;
 use DW::Captcha;
 use DW::Controller;
 use DW::FormErrors;
 use DW::Routing;
 use DW::Template;
 
-DW::Routing->register_string( "/captcha", \&captcha_handler, app => 1 );
-DW::Routing->register_string( "/logout",  \&logout_handler,  app => 1 );
+DW::Routing->register_string( "/captcha",         \&captcha_handler,         app => 1 );
+DW::Routing->register_string( "/logout",          \&logout_handler,          app => 1 );
+DW::Routing->register_string( "/switchaccount",   \&switch_handler,          app => 1 );
+DW::Routing->register_string( "/manage/accounts", \&manage_accounts_handler, app => 1 );
 
 sub captcha_handler {
     my ( $ok, $rv ) = controller( anonymous => 1, form_auth => 1, skip_captcha => 1 );
@@ -82,13 +85,32 @@ sub logout_handler {
 
     if ( $remote && $r->did_post ) {
         my $post_args = $r->post_args;
+
+        # After ending the active account's session(s), hand off to another
+        # account signed in to this browser if there is one; otherwise finish a
+        # normal logout and forget the switcher's stored accounts.
+        my $finish_logout = sub {
+            my $default_success = shift;
+            if ( my $next = DW::AccountSwitcher->promote_next ) {
+                $vars->{success}     = 'switched';
+                $vars->{switched_to} = $next->ljuser_display;
+            }
+            else {
+                $remote->_logout_common;
+                DW::AccountSwitcher->clear;
+                $vars->{success} = $default_success;
+            }
+        };
+
         if ( exists $post_args->{logout_one} ) {
-            $remote->logout;
-            $vars->{success} = 'one';
+            if ( my $sess = $remote->session ) {
+                $sess->destroy;
+            }
+            $finish_logout->('one');
         }
         elsif ( exists $post_args->{logout_all} ) {
-            $remote->logout_all;
-            $vars->{success} = 'all';
+            LJ::Session->destroy_all_sessions($remote);
+            $finish_logout->('all');
         }
 
         # If the logout form asked to be sent back to the original page (with a
@@ -103,6 +125,81 @@ sub logout_handler {
 
     # GET case or the logout success case
     return DW::Template->render_template( 'auth/logout.tt', $vars );
+}
+
+# Switch the active account to another one signed in to this browser, or remove
+# one from the switcher. POST-only and CSRF-protected. Always redirects.
+sub switch_handler {
+    my ( $ok, $rv ) = controller( anonymous => 1, form_auth => 1 );
+    return $rv unless $ok;
+
+    my $r = DW::Request->get;
+    return $r->redirect("$LJ::SITEROOT/login") unless $r->did_post;
+
+    my $post     = $r->post_args;
+    my $returnto = $post->{returnto};
+
+    my $back = sub {
+        if ($returnto) {
+
+            # a local absolute path (our own manage page, etc.) is safe to honor
+            # directly; the leading "/" without a second one rules out
+            # protocol-relative "//evil.com" redirects
+            return $r->redirect($returnto) if $returnto =~ m{^/(?!/)};
+
+            # otherwise only honor a full same-site URL
+            return $r->redirect($returnto) if LJ::check_referer( '', $returnto );
+        }
+        return $r->redirect("$LJ::SITEROOT/");
+    };
+
+    # remove a stored account from this browser, leaving the active one alone
+    if ( my $rm = $post->{remove_userid} ) {
+        DW::AccountSwitcher->remove_account($rm);
+        return $back->();
+    }
+
+    my $userid = $post->{userid} + 0;
+    my $result = DW::AccountSwitcher->switch_to($userid);
+
+    # session gone or unknown: send to a pre-filled login (Google-style)
+    if ( $result ne '1' ) {
+        my $u   = LJ::load_userid($userid);
+        my $url = "$LJ::SITEROOT/login?switch=1";
+        $url .= "&user=" . LJ::eurl( $u->user )    if $u;
+        $url .= "&returnto=" . LJ::eurl($returnto) if $returnto;
+        return $r->redirect($url);
+    }
+
+    return $back->();
+}
+
+# Management page for the account switcher: list the accounts signed in to this
+# browser, switch to or remove any of them, or add another. The switch/remove
+# actions post to /switchaccount; adding goes through /login?switch=1.
+sub manage_accounts_handler {
+    my ( $ok, $rv ) = controller();
+    return $rv unless $ok;
+
+    my $remote = $rv->{remote};
+
+    # Every account signed in to this browser (current + switchable) in one
+    # alphabetical list, the current one flagged inline so that switching moves
+    # only the flag and never reorders the rows.
+    my @accounts = sort { $a->{user} cmp $b->{user} } (
+        { u => $remote, user => $remote->user, current => 1, valid => 1 },
+        map {
+            { %$_, current => 0 }
+        } DW::AccountSwitcher->accounts,
+    );
+
+    return DW::Template->render_template(
+        'manage/accounts.tt',
+        {
+            accounts => \@accounts,
+            returnto => "$LJ::SITEROOT/manage/accounts",
+        }
+    );
 }
 
 1;

--- a/cgi-bin/DW/Controller/Auth.pm
+++ b/cgi-bin/DW/Controller/Auth.pm
@@ -139,6 +139,10 @@ sub switch_handler {
     my $post     = $r->post_args;
     my $returnto = $post->{returnto};
 
+    # strip CR/LF so a crafted returnto can't inject headers when it later
+    # becomes a Location header on redirect
+    $returnto =~ tr/\r\n//d if defined $returnto;
+
     my $back = sub {
         if ($returnto) {
 

--- a/cgi-bin/DW/Controller/Login.pm
+++ b/cgi-bin/DW/Controller/Login.pm
@@ -23,6 +23,7 @@ use DW::Routing;
 use DW::Template;
 use DW::Controller;
 use DW::FormErrors;
+use DW::AccountSwitcher;
 
 # no_cache: the login form embeds a form_auth (CSRF) token that, for logged-out
 # users, is bound to their per-browser ljuniq cookie. If a shared proxy caches
@@ -52,6 +53,10 @@ sub login_handler {
     my $returnto = $post->{returnto} // $get->{returnto};
     $returnto =~ tr/\r\n//d if defined $returnto;
 
+    # "add another account" intent: a login submitted while already logged in
+    # should add a session rather than change the current one's options.
+    my $adding = ( $post->{switch} || $get->{switch} ) ? 1 : 0;
+
     my $vars = {
         continue_to => $get->{continue_to},
 
@@ -59,6 +64,13 @@ sub login_handler {
         # so that, after a successful login, we send the user back to the page
         # they were trying to reach when they got bounced here by needlogin().
         returnto => $returnto,
+
+        # render the login form (not the change-options form) even when logged
+        # in, so the user can sign in to an additional account.
+        add_account => $adding,
+
+        # canonicalized so a reflected ?user= can't inject markup into the form
+        prefill_user => LJ::canonical_username( $get->{user} // '' ),
     };
 
     my @errors = ();
@@ -110,8 +122,9 @@ sub login_handler {
             $do_login = 1;
         }
 
-        # if they're already logged in, change opts
-        if ( $do_login && $remote ) {
+        # if they're already logged in, change opts -- unless they're adding
+        # another account, in which case treat it as a fresh login
+        if ( $do_login && $remote && !$adding ) {
             $do_login  = 0;
             $do_change = 1;
         }
@@ -214,7 +227,14 @@ sub login_handler {
                     : "short";
                 my $bindip = ( ( $post->{'bindip'} // '' ) eq "yes" ) ? $r->get_remote_ip : "";
 
-                $u->make_login_session( $exptype, $bindip );
+                # when adding a second account, keep the current one signed in
+                # and demote it into the switcher's stored list
+                if ( $adding && $old_remote && !$old_remote->equals($u) ) {
+                    DW::AccountSwitcher->add_account( $u, $exptype, $bindip );
+                }
+                else {
+                    $u->make_login_session( $exptype, $bindip );
+                }
                 LJ::Hooks::run_hook( 'user_login', $u );
                 $cursess = $u->session;
 

--- a/cgi-bin/DW/Controller/Settings.pm
+++ b/cgi-bin/DW/Controller/Settings.pm
@@ -30,6 +30,7 @@ my $log = Log::Log4perl->get_logger(__PACKAGE__);
 
 use Imager::QRCode;
 
+use DW::AccountSwitcher;
 use DW::Auth::TOTP;
 use DW::Controller;
 use DW::Routing;
@@ -433,8 +434,27 @@ sub changepassword_handler {
             # if we used an authcode, we'll need to expire it now
             LJ::mark_authaction_used($aa) if $authu;
 
-            # Kill all sessions, forcing user to relogin
-            $u->kill_all_sessions;
+            # End this account's sessions. Normally that logs the user out
+            # everywhere and they re-login. But if they have other accounts
+            # signed in to this browser through the switcher and are changing
+            # their own password from here, keep THIS browser's session alive so
+            # they stay signed in and don't lose those other accounts. Every
+            # other session (including on other devices) is still ended, and the
+            # switcher list itself is never touched.
+            my $stayed = 0;
+            if (   $remote
+                && $remote->equals($u)
+                && ( my $cur = $remote->session )
+                && scalar( DW::AccountSwitcher->accounts ) )
+            {
+                my @others = grep { $_->id != $cur->id } $u->sessions;
+                LJ::Session->destroy_sessions( $u, map { $_->id } @others )
+                    if @others;
+                $stayed = 1;
+            }
+            else {
+                $u->kill_all_sessions;
+            }
 
             LJ::send_mail(
                 {
@@ -453,6 +473,10 @@ sub changepassword_handler {
                     ),
                 }
             );
+
+            if ($stayed) {
+                return DW::Controller->render_success("settings/changepassword.tt.stayed");
+            }
 
             my $success_ml =
                 $remote

--- a/cgi-bin/DW/Logic/MenuNav.pm
+++ b/cgi-bin/DW/Logic/MenuNav.pm
@@ -120,6 +120,11 @@ sub get_menu_navigation {
                     display => $loggedin,
                 },
                 {
+                    url     => "$LJ::SITEROOT/manage/accounts",
+                    text    => "menunav.organize.manageaccounts",
+                    display => $loggedin,
+                },
+                {
                     url     => "$LJ::SITEROOT/manage/circle/edit",
                     text    => "menunav.organize.managerelationships",
                     display => $loggedin,

--- a/cgi-bin/DW/Template/Plugin/SiteScheme.pm
+++ b/cgi-bin/DW/Template/Plugin/SiteScheme.pm
@@ -17,6 +17,7 @@ package DW::Template::Plugin::SiteScheme;
 use base 'Template::Plugin';
 use strict;
 
+use DW::AccountSwitcher;
 use DW::Auth::Challenge;
 use DW::Logic::MenuNav;
 
@@ -88,6 +89,12 @@ sub challenge_generate {
 
 sub show_invite_link {
     return $LJ::USE_ACCT_CODES ? 1 : 0;
+}
+
+# The other accounts signed in to this browser (for the account switcher), as a
+# list of records: { u => LJ::User, user, userid, valid }.
+sub switch_accounts {
+    return [ DW::AccountSwitcher->accounts ];
 }
 
 =head1 AUTHOR

--- a/cgi-bin/LJ/Web.pm
+++ b/cgi-bin/LJ/Web.pm
@@ -21,6 +21,7 @@ use POSIX;
 use Digest::MD5;
 use Digest::SHA1;
 
+use DW::AccountSwitcher;
 use DW::Auth::Challenge;
 use DW::External::Site;
 use DW::Request;
@@ -2891,6 +2892,18 @@ sub control_strip {
             'is_validated' => $remote->is_validated,
             'is_identity'  => $remote->is_identity,
         };
+
+        # other accounts signed in to this browser, for the switcher
+        $template_args->{'switch_accounts'} = [
+            map {
+                {
+                    userid  => $_->{userid},
+                    user    => $_->{user},
+                    display => $_->{u}->ljuser_display,
+                    valid   => $_->{valid},
+                }
+            } DW::AccountSwitcher->accounts
+        ];
         if ($userpic) {
             my $wh = $userpic->img_fixedsize( width => 43, height => 43 );
             $template_args->{'userpic_html'} =

--- a/htdocs/scss/components/account-switcher.scss
+++ b/htdocs/scss/components/account-switcher.scss
@@ -1,0 +1,34 @@
+@charset "UTF-8";
+
+/* Compact layout for the /manage/accounts switcher table: tight rows, and the
+   Switch/Remove actions sitting horizontally next to each other. */
+.account-switcher-manage {
+    max-width: 34em;
+    border-collapse: collapse;
+
+    td {
+        vertical-align: middle;
+        padding: .25em .75em .25em 0;
+    }
+
+    .status {
+        font-size: .9em;
+        opacity: .8;
+    }
+
+    .actions {
+        white-space: nowrap;
+        text-align: right;
+    }
+
+    /* keep each single-button form inline so the two buttons share a row */
+    .inline-form {
+        display: inline-block;
+        margin: 0;
+    }
+
+    .actions .button,
+    .actions .inline-form .button {
+        margin: 0 0 0 .4em;
+    }
+}

--- a/htdocs/scss/skins/_nav.scss
+++ b/htdocs/scss/skins/_nav.scss
@@ -16,6 +16,71 @@ $nav-small-screen-header-height: 3em;
 
     }
 
+    /* Keep the username, the switcher caret, and the Log out button on one line. */
+    #account-links .account-links-active { display: inline; }
+
+    #account-links .account-links-logout {
+        display: inline-block;
+        margin: 0 0 0 .5em;
+
+        .button { margin: 0; }
+    }
+
+    /* Account switcher: a native <details> fold-out. The open list is absolutely
+       positioned so it overlays rather than pushing the masthead nav links. */
+    #account-links .account-switcher {
+        position: relative;
+        display: inline-block;
+
+        > summary {
+            cursor: pointer;
+            list-style: none;               /* hide the default disclosure marker */
+            &::-webkit-details-marker { display: none; }
+            &::after { content: " \25BE"; } /* down triangle */
+        }
+        &[open] > summary::after { content: " \25B4"; } /* up triangle */
+
+        > ul {
+            position: absolute;
+            z-index: 100;
+            margin: .2em 0 0;
+            padding: .4em .6em;
+            min-width: 12em;
+            list-style: none;
+            white-space: nowrap;
+            text-align: left;
+            background: #fff;
+            border: 1px solid #ccc;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, .2);
+        }
+
+        li {
+            float: none;
+            display: block;
+            margin: .2em 0;
+            white-space: nowrap;
+
+            &:after { content: ""; margin: 0; }
+        }
+
+        /* account name on the left, the Switch action on the right */
+        .switch-account-form { display: inline-block; margin-left: .75em; }
+
+        .switch-account-btn {
+            background: none;
+            border: 0;
+            padding: 0;
+            margin: 0;
+            font: inherit;
+            color: $link-color;
+            cursor: pointer;
+
+            &:hover { text-decoration: underline; }
+        }
+
+        .switch-account-signedout { margin-left: .75em; font-style: italic; }
+    }
+
     .top-bar {
         &.expanded {
             z-index: 99;

--- a/htdocs/stc/controlstrip.css
+++ b/htdocs/stc/controlstrip.css
@@ -85,6 +85,89 @@ html body
     border: 0;
 }
 
+/* Account switcher in the control strip: a bare caret (native <details>) sitting
+   next to the username, whose open panel overlays the page rather than pushing
+   the strip's layout. The panel has its own light background, so its links must
+   be forced to a dark color -- the strip's own link color may be light. */
+#lj_controlstrip_switch {
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+/* Keep the username, switcher caret, and Log out button on one line. */
+#lj_controlstrip_user #Greeting,
+#lj_controlstrip_user #Greeting > div {
+    display: inline;
+}
+
+#lj_controlstrip_switch > summary {
+    font-family: Arial, sans-serif;
+    cursor: pointer;
+    list-style: none;
+}
+
+#lj_controlstrip_switch > summary::-webkit-details-marker {
+    display: none;
+}
+
+#lj_controlstrip_switch > summary::after {
+    content: "\25BE";
+}
+
+#lj_controlstrip_switch[open] > summary::after {
+    content: "\25B4";
+}
+
+#lj_controlstrip_switch ul {
+    position: absolute;
+    left: 0;
+    z-index: 1000;
+    margin: 2px 0 0;
+    padding: 4px 8px;
+    min-width: 12em;
+    list-style: none;
+    white-space: nowrap;
+    background: #f7f7f7;
+    color: #333333;
+    border: 1px solid #cccccc;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, .3);
+}
+
+#lj_controlstrip_switch li {
+    display: block;
+    margin: 2px 0;
+    white-space: nowrap;
+}
+
+#lj_controlstrip_switch form.switch-account {
+    display: inline-block;
+    margin-left: .5em;
+}
+
+#lj_controlstrip_switch .switch-account-signedout {
+    margin-left: .5em;
+    font-style: italic;
+}
+
+#lj_controlstrip_switch ul a,
+#lj_controlstrip_switch .switch-account-btn {
+    font-family: Arial, sans-serif;
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    text-decoration: none;
+    color: #2172a8;
+    width: auto;
+}
+
+#lj_controlstrip_switch ul a:hover,
+#lj_controlstrip_switch .switch-account-btn:hover {
+    text-decoration: underline;
+}
+
 /* Make sure all form elements use default colors and control strip fonts */
 #lj_controlstrip input
 {

--- a/htdocs/stc/lj_base-app.css
+++ b/htdocs/stc/lj_base-app.css
@@ -242,3 +242,80 @@ div.columns-2-r300 .columns-2-right {
 
 /* clearing element at the foot of Support index */
 .clear-floats { clear: both; }
+
+/* Account switcher caret + fold-out for the non-Foundation sitescheme variant.
+   (The Foundation masthead/control strip style this via their own stylesheets;
+   these baseline rules are more general and are overridden there.) */
+.account-links-active { display: inline; }
+
+.account-links-logout {
+    display: inline-block;
+    margin-left: .5em;
+}
+
+.account-switcher {
+    position: relative;
+    display: inline-block;
+}
+
+.account-switcher > summary {
+    cursor: pointer;
+    list-style: none;
+}
+
+.account-switcher > summary::-webkit-details-marker {
+    display: none;
+}
+
+.account-switcher > summary::after {
+    content: "\25BE";
+}
+
+.account-switcher[open] > summary::after {
+    content: "\25B4";
+}
+
+.account-switcher > ul {
+    position: absolute;
+    z-index: 100;
+    left: 0;
+    margin: .2em 0 0;
+    padding: .4em .6em;
+    min-width: 12em;
+    list-style: none;
+    white-space: nowrap;
+    text-align: left;
+    background: #fff;
+    border: 1px solid #ccc;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, .2);
+}
+
+.account-switcher li {
+    display: block;
+    margin: .2em 0;
+    white-space: nowrap;
+}
+
+.account-switcher .switch-account-form {
+    display: inline-block;
+    margin-left: .75em;
+}
+
+.account-switcher .switch-account-btn {
+    background: none;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: #00539b;
+    cursor: pointer;
+}
+
+.account-switcher .switch-account-btn:hover {
+    text-decoration: underline;
+}
+
+.account-switcher .switch-account-signedout {
+    margin-left: .75em;
+    font-style: italic;
+}

--- a/schemes/common.tt
+++ b/schemes/common.tt
@@ -102,9 +102,34 @@ the table based way can be removed when the entire site is Foundation-based.
 
 <div id='account-links-text' role="navigation" aria-label="[% 'sitescheme.navigation.accountlinks' | ml %]" data-reveal>
 <div class='row'><div class='columns'>
-    <form action='[% site.root %]/logout' method='post'>
-        [%- dw.form_auth -%]
+    [%- switch_accounts = dw_scheme.switch_accounts -%]
+    <span class='account-links-active'>
         [%- remote.ljuser_display -%]
+        [%- IF switch_accounts.size -%]
+        <details class='account-switcher'>
+        <summary aria-label="[% 'sitescheme.accountlinks.switch.label' | ml %]"></summary>
+        <ul>
+        [%- FOREACH acct IN switch_accounts -%]
+            <li class='switch-account'>
+                <span class='switch-account-name'>[% acct.u.ljuser_display %]</span>
+            [%- IF acct.valid -%]
+                <form action='[% site.root %]/switchaccount' method='post' class='switch-account-form'>
+                    [%- dw.form_auth -%]
+                    [%- form.hidden( name = "userid", value = acct.userid ) -%]
+                    [%- form.hidden( name = "returnto", value = returnto ) -%]
+                    <button type="submit" class="switch-account-btn">[% 'sitescheme.accountlinks.switch.go' | ml %]</button>
+                </form>
+            [%- ELSE -%]
+                <a class='switch-account-signedout' href='[% site.root %]/login?switch=1&amp;user=[% acct.user | uri %]&amp;returnto=[% returnto | uri %]'>[% 'sitescheme.accountlinks.switch.signedout' | ml %]</a>
+            [%- END -%]
+            </li>
+        [%- END -%]
+        </ul>
+        </details>
+        [%- END -%]
+    </span>
+    <form class='account-links-logout' action='[% site.root %]/logout' method='post'>
+        [%- dw.form_auth -%]
         <input type="hidden" name="returnto" value="[% returnto | html %]" />
         <input type="hidden" name="ret" value="1" />
         <input class="logout button secondary" type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />
@@ -159,10 +184,35 @@ the table based way can be removed when the entire site is Foundation-based.
     [%- inbox = remote.notification_inbox -%]
     [%- unread = inbox.unread_count -%]
     [%- identity = remote.is_identity -%]
+    [%- switch_accounts = dw_scheme.switch_accounts -%]
     [%- -%]<div id='account-links-text'>
-    <form action='[% site.root %]/logout' method='post'>
-        [%- dw.form_auth -%]
+    <span class='account-links-active'>
         [%- remote.ljuser_display -%]
+        [%- IF switch_accounts.size -%]
+        <details class='account-switcher'>
+        <summary aria-label="[% 'sitescheme.accountlinks.switch.label' | ml %]"></summary>
+        <ul>
+        [%- FOREACH acct IN switch_accounts -%]
+            <li class='switch-account'>
+                <span class='switch-account-name'>[% acct.u.ljuser_display %]</span>
+            [%- IF acct.valid -%]
+                <form action='[% site.root %]/switchaccount' method='post' class='switch-account-form'>
+                    [%- dw.form_auth -%]
+                    [%- form.hidden( name = "userid", value = acct.userid ) -%]
+                    [%- form.hidden( name = "returnto", value = returnto ) -%]
+                    <button type="submit" class="switch-account-btn">[% 'sitescheme.accountlinks.switch.go' | ml %]</button>
+                </form>
+            [%- ELSE -%]
+                <a class='switch-account-signedout' href='[% site.root %]/login?switch=1&amp;user=[% acct.user | uri %]&amp;returnto=[% returnto | uri %]'>[% 'sitescheme.accountlinks.switch.signedout' | ml %]</a>
+            [%- END -%]
+            </li>
+        [%- END -%]
+        </ul>
+        </details>
+        [%- END -%]
+    </span>
+    <form action='[% site.root %]/logout' method='post' class='account-links-logout'>
+        [%- dw.form_auth -%]
         <input type="hidden" name="returnto" value="[% returnto | html %]" />
         <input type="hidden" name="ret" value="1" />
         <input type="submit" name="logout_one" value="[% 'sitescheme.accountlinks.btn.logout' | ml %]" />

--- a/t/account-switcher.t
+++ b/t/account-switcher.t
@@ -1,0 +1,262 @@
+# t/account-switcher.t
+#
+# Tests DW::AccountSwitcher: the on-site multi-account switcher. The active
+# account stays in ljmastersession; the other signed-in accounts live in a
+# separate "ljsessions" cookie as (userid, sessid, auth) handles. Covers cookie
+# parsing, listing/validating stored accounts, switching (which re-validates
+# against the DB and demotes the old active), promotion on logout, removal, and
+# rejection of tampered / stale / rotated cookies.
+#
+# Authors:
+#      Mark Smith <mark@dreamwidth.org>
+#
+# Copyright (c) 2026 by Dreamwidth Studios, LLC.
+#
+# This program is free software; you may redistribute it and/or modify it under
+# the same terms as Perl itself.  For a copy of the license, please reference
+# 'perldoc perlartistic' or 'perldoc perlgpl'.
+
+use strict;
+use warnings;
+
+use Test::More;
+
+BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
+
+use LJ::Test qw(temp_user);
+use LJ::Session;
+use DW::AccountSwitcher;
+use DW::Cache;
+
+# Minimal fake request: a readable cookie jar plus a capture of everything the
+# code under test sets via add_cookie.
+package FakeRequest;
+
+sub new { my ( $class, %a ) = @_; bless { jar => {}, set => [], %a }, $class }
+
+sub cookie {
+    my ( $self, $name ) = @_;
+    return $self->{jar}{$name};
+}
+sub get_remote_ip { "127.0.0.1" }
+sub header_in     { "" }
+
+sub add_cookie {
+    my ( $self, %args ) = @_;
+    $self->{jar}{ $args{name} } = $args{delete} ? undef : $args{value};
+    push @{ $self->{set} }, \%args;
+}
+
+sub set_cookies {
+    my ( $self, $name ) = @_;
+    return grep { $_->{name} eq $name } @{ $self->{set} };
+}
+
+sub last_cookie {
+    my ( $self, $name ) = @_;
+    my @set = $self->set_cookies($name);
+    return @set ? $set[-1] : undef;
+}
+
+package main;
+
+my $req;
+no warnings 'redefine';
+local *DW::Request::get = sub { $req };
+
+local $LJ::_T_UNIQCOOKIE_CURRENT_UNIQ = "abcdefghij12345";
+
+# Start a fresh simulated request: new jar, cleared per-request cache, optional
+# incoming ljsessions cookie value.
+sub new_request {
+    my ($ljsessions) = @_;
+    $req = FakeRequest->new;
+    DW::Cache->request->clear_ns('account_switcher');
+    $req->{jar}{ljsessions} = $ljsessions if defined $ljsessions;
+    return $req;
+}
+
+# The active-account handle held by ljmastersession after a mutation.
+sub master_userid {
+    my $set = $req->last_cookie('ljmastersession') or return undef;
+    return $1 if $set->{value} =~ /:u(\d+):/;
+    return undef;
+}
+
+# Build an ljsessions cookie value from (u, sess) pairs, exactly as the module
+# serializes it, so we can seed an incoming request.
+sub build_cookie {
+    my @pairs = @_;
+    my $body  = join '|', 'v' . DW::AccountSwitcher::COOKIE_VER,
+        map { "u$_->[0]->{userid}:s$_->[1]->{sessid}:a$_->[1]->{auth}" } @pairs;
+    return $body . "//" . LJ::eurl( $LJ::COOKIE_GEN || "" );
+}
+
+# Make $u the active remote with a fresh long session.
+sub login_active {
+    my $u    = shift;
+    my $sess = LJ::Session->create( $u, exptype => 'long' );
+    $u->{_session} = $sess;
+    LJ::set_remote($u);
+    return $sess;
+}
+
+my $ua = temp_user();
+my $ub = temp_user();
+my $uc = temp_user();
+$_->update_self( { status => 'A' } ) for ( $ua, $ub, $uc );
+
+# ---------------------------------------------------------------------------
+note("parsing: valid cookie lists the stored accounts");
+{
+    new_request();
+    my $sb = LJ::Session->create( $ub, exptype => 'long' );
+    my $sc = LJ::Session->create( $uc, exptype => 'long' );
+
+    new_request( build_cookie( [ $ub, $sb ], [ $uc, $sc ] ) );
+    login_active($ua);
+
+    my @accts = DW::AccountSwitcher->accounts;
+    is( scalar @accts, 2, "two stored accounts listed" );
+    ok( ( grep  { $_->{userid} == $ub->id } @accts ), "account B present" );
+    ok( ( grep  { $_->{userid} == $uc->id } @accts ), "account C present" );
+    ok( ( !grep { $_->{userid} == $ua->id } @accts ), "active account A not listed" );
+    ok( ( grep  { $_->{valid} } @accts ) == 2,        "both stored accounts validate" );
+}
+
+# ---------------------------------------------------------------------------
+note("switch_to: promotes a stored account and demotes the old active");
+{
+    my $sb = LJ::Session->create( $ub, exptype => 'long' );
+    my $sc = LJ::Session->create( $uc, exptype => 'long' );
+
+    new_request( build_cookie( [ $ub, $sb ], [ $uc, $sc ] ) );
+    login_active($ua);
+
+    my $rv = DW::AccountSwitcher->switch_to( $ub->id );
+    is( $rv,             1,       "switch_to returns 1 on success" );
+    is( master_userid(), $ub->id, "ljmastersession now points at B" );
+    ok( LJ::get_remote()->equals($ub), "remote is now B" );
+
+    # ljsessions should now hold C (untouched) and A (demoted), but not B
+    my @accts = DW::AccountSwitcher->accounts;      # dedupes active (B)
+    my %ids   = map { $_->{userid} => 1 } @accts;
+    ok( $ids{ $uc->id },  "C still stored" );
+    ok( $ids{ $ua->id },  "old active A demoted into the list" );
+    ok( !$ids{ $ub->id }, "B no longer in the stored list" );
+}
+
+# ---------------------------------------------------------------------------
+note("switch_to: expired stored session is reported, not switched");
+{
+    my $sb     = LJ::Session->create( $ub, exptype => 'long' );
+    my $cookie = build_cookie( [ $ub, $sb ] );
+    $sb->destroy;                                   # session gone from the DB
+
+    new_request($cookie);
+    login_active($ua);
+
+    my $rv = DW::AccountSwitcher->switch_to( $ub->id );
+    is( $rv, 'expired', "switch_to reports 'expired' for a dead session" );
+    ok( LJ::get_remote()->equals($ua), "active account unchanged" );
+
+    # the account is still listed (for a pre-filled re-login) but flagged invalid
+    my ($rec) = grep { $_->{userid} == $ub->id } DW::AccountSwitcher->accounts;
+    ok( $rec && !$rec->{valid}, "expired account listed but not valid" );
+}
+
+# ---------------------------------------------------------------------------
+note("switch_to: unknown account id is refused");
+{
+    new_request( build_cookie() );
+    login_active($ua);
+    is( DW::AccountSwitcher->switch_to( $ub->id ), 0, "not-stored account -> 0" );
+}
+
+# ---------------------------------------------------------------------------
+note("promote_next: hands off to the first usable stored account");
+{
+    my $sb = LJ::Session->create( $ub, exptype => 'long' );
+    my $sc = LJ::Session->create( $uc, exptype => 'long' );
+
+    # simulate the active account having just been destroyed on logout
+    new_request( build_cookie( [ $ub, $sb ], [ $uc, $sc ] ) );
+    LJ::set_remote(undef);
+
+    my $next = DW::AccountSwitcher->promote_next;
+    ok( $next && $next->equals($ub), "promote_next returns B (first stored)" );
+    is( master_userid(), $ub->id, "master cookie switched to B" );
+
+    my %ids = map { $_->{userid} => 1 } DW::AccountSwitcher->accounts;
+    ok( $ids{ $uc->id } && !$ids{ $ub->id }, "B removed from list, C remains" );
+}
+
+# ---------------------------------------------------------------------------
+note("promote_next: nothing usable -> undef");
+{
+    my $sb     = LJ::Session->create( $ub, exptype => 'long' );
+    my $cookie = build_cookie( [ $ub, $sb ] );
+    $sb->destroy;
+
+    new_request($cookie);
+    LJ::set_remote(undef);
+    ok( !defined DW::AccountSwitcher->promote_next, "no usable account -> undef" );
+}
+
+# ---------------------------------------------------------------------------
+note("remove_account: destroys the session and drops it from the list");
+{
+    my $sb = LJ::Session->create( $ub, exptype => 'long' );
+    my $sc = LJ::Session->create( $uc, exptype => 'long' );
+
+    new_request( build_cookie( [ $ub, $sb ], [ $uc, $sc ] ) );
+    login_active($ua);
+
+    ok( DW::AccountSwitcher->remove_account( $uc->id ), "remove_account returns true" );
+    ok( !LJ::Session->instance( $uc, $sc->{sessid} ), "C's session was destroyed" );
+
+    my %ids = map { $_->{userid} => 1 } DW::AccountSwitcher->accounts;
+    ok( $ids{ $ub->id } && !$ids{ $uc->id }, "C dropped, B remains" );
+    ok( LJ::get_remote()->equals($ua),       "active account untouched" );
+}
+
+# ---------------------------------------------------------------------------
+note("tampered auth token invalidates just that entry");
+{
+    my $sb = LJ::Session->create( $ub, exptype => 'long' );
+    ( my $bad = build_cookie( [ $ub, $sb ] ) ) =~ s/(:a)(\w)/$1 . ($2 eq 'x' ? 'y' : 'x')/e;
+
+    new_request($bad);
+    login_active($ua);
+
+    my ($rec) = grep { $_->{userid} == $ub->id } DW::AccountSwitcher->accounts;
+    ok( $rec && !$rec->{valid}, "tampered auth -> account listed but invalid" );
+    is(
+        DW::AccountSwitcher->switch_to( $ub->id ),
+        'expired',
+        "cannot switch into a tampered entry"
+    );
+}
+
+# ---------------------------------------------------------------------------
+note("garbage cookie yields no accounts");
+{
+    new_request("total nonsense");
+    login_active($ua);
+    is( scalar DW::AccountSwitcher->accounts, 0, "garbage cookie -> empty list" );
+}
+
+# ---------------------------------------------------------------------------
+note("cookie-generation rotation drops the stored accounts");
+{
+    my $sb = LJ::Session->create( $ub, exptype => 'long' );
+    new_request( build_cookie( [ $ub, $sb ] ) );
+    login_active($ua);
+
+    local $LJ::COOKIE_GEN      = "newgen";
+    local @LJ::COOKIE_GEN_OKAY = ();
+    DW::Cache->request->clear_ns('account_switcher');    # re-read under the new gen
+    is( scalar DW::AccountSwitcher->accounts, 0, "rotated cookie gen -> empty list" );
+}
+
+done_testing();

--- a/views/auth/logout.tt
+++ b/views/auth/logout.tt
@@ -17,7 +17,13 @@
 [%- sections.title = "Log Out" -%]
 [%- CALL dw.active_resource_group( "foundation" ) -%]
 
-[% IF success == 'one' %]
+[% IF success == 'switched' %]
+
+    <p>
+    You have been logged out, and are now signed in as [% switched_to %].
+    </p>
+
+[% ELSIF success == 'one' %]
 
     <p>
     You have successfully logged out of [% site.nameshort %] in this browser.

--- a/views/components/login.tt
+++ b/views/components/login.tt
@@ -23,9 +23,11 @@
     <div id="login-form">
     [%- dw.form_auth() -%]
     [%- form.hidden( name = "returnto", value = returnto ) IF returnto -%]
+    [%- form.hidden( name = "switch", value = 1 ) IF switch -%]
     [%- form.textbox(
         label => dw.ml('sitescheme.accountlinks.login.username')
         name => "user",
+        value => default_user,
         labelclass => (short ? "invisible" : ""),
         placeholder => (short ? dw.ml('/components/login.tt.login.username' ): ""),
         id => "login_user",

--- a/views/components/login.tt
+++ b/views/components/login.tt
@@ -27,7 +27,7 @@
     [%- form.textbox(
         label => dw.ml('sitescheme.accountlinks.login.username')
         name => "user",
-        value => default_user,
+        default => default_user,
         labelclass => (short ? "invisible" : ""),
         placeholder => (short ? dw.ml('/components/login.tt.login.username' ): ""),
         id => "login_user",

--- a/views/journal/controlstrip.tt
+++ b/views/journal/controlstrip.tt
@@ -18,6 +18,29 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- IF remote -%]
   <div id='lj_controlstrip_user'>
+    [% remote.display %]
+    [%- IF switch_accounts.size -%]
+    <details id='lj_controlstrip_switch' class='account-switcher'>
+      <summary aria-label="[% 'web.controlstrip.switch.label' | ml %]"></summary>
+      <ul>
+        [%- FOREACH acct IN switch_accounts -%]
+          <li>
+            <span class='switch-account-name'>[% acct.display %]</span>
+          [%- IF acct.valid -%]
+            <form class='switch-account' action='[% site.root %]/switchaccount' method='post'>
+              [%- dw.form_auth -%]
+              [%- form.hidden( name = "userid", value = acct.userid ) -%]
+              [%- form.hidden( name = "returnto", value = returnto ) -%]
+              <button type="submit" class="switch-account-btn">[% 'web.controlstrip.switch.go' | ml %]</button>
+            </form>
+          [%- ELSE -%]
+            <a class='switch-account-signedout' href='[% site.root %]/login?switch=1&amp;user=[% acct.user | uri %]&amp;returnto=[% returnto | uri %]'>[% 'web.controlstrip.switch.signedout' | ml %]</a>
+          [%- END -%]
+          </li>
+        [%- END -%]
+      </ul>
+    </details>
+    [%- END -%]
     <form id='Greeting' class='nopic' action='[%- site.root -%]/logout' method='post'>
       <div>
         [%- dw.form_auth -%]
@@ -28,7 +51,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- END -%]
         [%- form.hidden( name = "ret", value = 1 ) -%]
 
-        [% remote.display %]
         [% form.submit(
             id = "Logout",
             name = "logout_one",

--- a/views/login.tt
+++ b/views/login.tt
@@ -13,7 +13,7 @@ under the same terms as Perl itself.  For a copy of the license, please
 reference 'perldoc perlartistic' or 'perldoc perlgpl'.
 %]
 [%- CALL dw.active_resource_group( "foundation" ) -%]
-[% IF remote %]
+[% IF remote && !add_account %]
     [% sections.title = dw.ml(".loggedin.head2", { 'sitename' => site.nameshort}) %]
 
     <p> [% dw.ml(".loggedin.text2", { 'username' => remote.user} ) %]</p>
@@ -92,6 +92,19 @@ reference 'perldoc perlartistic' or 'perldoc perlgpl'.
       </div>
     </div>
     </form>
+[% ELSIF add_account && remote %]
+[% sections.title = dw.ml(".addaccount.title", { 'sitename' => site.nameshort} ) %]
+[% IF errors.size %]
+    [% FOREACH err = errors %]
+        <div class="alert-box alert radius">[% err.1 %]</div>
+    [% END %]
+[% END %]
+<p>[% dw.ml('.addaccount.text', { 'username' => remote.ljuser_display }) %]</p>
+<div class="row" id="protected_login">
+  <div class="columns medium-6">
+    [% PROCESS "components/login.tt" switch = 1 default_user = prefill_user %]
+  </div>
+</div>
 [% ELSE %]
 [% sections.title = dw.ml(".login.title", { 'sitename' => site.nameshort} ) %]
 [% IF errors.size %]

--- a/views/login.tt.text
+++ b/views/login.tt.text
@@ -1,4 +1,8 @@
 ;; -*- coding: utf-8 -*-
+.addaccount.text=You're signed in as [[username]]. Sign in to another account to switch between them without logging out.
+
+.addaccount.title=Sign in to another account
+
 .createaccount.button=Create an Account
 
 .createaccount.header=Not a [[sitename]] member?

--- a/views/manage/accounts.tt
+++ b/views/manage/accounts.tt
@@ -1,0 +1,65 @@
+[%# manage/accounts.tt
+
+Manage the accounts signed in to the on-site account switcher on this browser:
+switch to one, drop one from the list, or add another.
+
+Authors:
+    Mark Smith <mark@dreamwidth.org>
+
+Copyright (c) 2026 by Dreamwidth Studios, LLC.
+
+This program is free software; you may redistribute it and/or modify it under
+the same terms as Perl itself.  For a copy of the license, please reference
+'perldoc perlartistic' or 'perldoc perlgpl'.
+%]
+
+[%- sections.title = ".title" | ml -%]
+
+[%- CALL dw.active_resource_group( "foundation" ) -%]
+
+[%- dw.need_res( { group => "foundation" }
+    "stc/css/components/account-switcher.css"
+) -%]
+
+<p>[% '.intro' | ml %]</p>
+
+<table class="account-switcher-manage">
+    <tbody>
+        [%- FOREACH acct IN accounts -%]
+        <tr>
+            <td class="acct">[% acct.u.ljuser_display %]</td>
+            <td class="status">
+            [%- IF acct.current -%][% '.status.current' | ml %]
+            [%- ELSIF acct.valid -%][% '.status.active' | ml %]
+            [%- ELSE -%][% '.status.signedout' | ml %][%- END -%]
+            </td>
+            <td class="actions">
+                [%- IF acct.current -%]
+                [%# no actions for the account you're currently using %]
+                [%- ELSE -%]
+                    [%- IF acct.valid -%]
+                    <form action="[% site.root %]/switchaccount" method="post" class="inline-form">
+                        [%- dw.form_auth -%]
+                        [%- form.hidden( name = "userid", value = acct.userid ) -%]
+                        [%- form.hidden( name = "returnto", value = returnto ) -%]
+                        [% form.submit( name = "switch", value = dw.ml('.btn.switch'), class = "button tiny secondary" ) %]
+                    </form>
+                    [%- ELSE -%]
+                    <a class="button tiny secondary" href="[% site.root %]/login?switch=1&amp;user=[% acct.user | uri %]&amp;returnto=[% returnto | uri %]">[% '.btn.login' | ml %]</a>
+                    [%- END -%]
+                    <form action="[% site.root %]/switchaccount" method="post" class="inline-form">
+                        [%- dw.form_auth -%]
+                        [%- form.hidden( name = "remove_userid", value = acct.userid ) -%]
+                        [%- form.hidden( name = "returnto", value = returnto ) -%]
+                        [% form.submit( name = "remove", value = dw.ml('.btn.remove'), class = "button tiny alert" ) %]
+                    </form>
+                [%- END -%]
+            </td>
+        </tr>
+        [%- END -%]
+    </tbody>
+</table>
+
+<p>
+    <a class="button tiny" href="[% site.root %]/login?switch=1&amp;returnto=[% returnto | uri %]">[% '.btn.add' | ml %]</a>
+</p>

--- a/views/manage/accounts.tt.text
+++ b/views/manage/accounts.tt.text
@@ -1,0 +1,18 @@
+;; -*- coding: utf-8 -*-
+.btn.add=Add another account
+
+.btn.login=Log in
+
+.btn.remove=Remove
+
+.btn.switch=Switch
+
+.intro=These accounts are signed in on this browser. You can switch between them without re-entering your password, remove ones you no longer want listed here, or add another. Removing an account here only affects this browser.
+
+.status.active=Available
+
+.status.current=Current
+
+.status.signedout=Signed out
+
+.title=Account switcher

--- a/views/settings/changepassword.tt.text
+++ b/views/settings/changepassword.tt.text
@@ -55,6 +55,10 @@ Regards,
 
 .success.message=Your password has been changed and an email has been sent to you saying that your password has been changed.
 
+.stayed.success.title=Success
+
+.stayed.success.message=Your password has been changed and an email has been sent to you saying so. Your other sessions (including on other devices) have been logged out, but you're still signed in here, so your other switchable accounts are unaffected.
+
 .withremote.success.title=Success
 
 .withremote.success.message=Your password has been changed and an email has been sent to you saying that your password has been changed. You've also been logged out from all your existing sessions. You should <a href="[[url]]">log in again</a> before continuing.


### PR DESCRIPTION
Lets a browser hold several accounts signed in at once and switch between them without re-entering a password (GitHub/Google-style). The active account stays in `ljmastersession`/`ljloggedin` and is validated exactly as before; a new http_only `ljsessions` cookie carries the other signed-in accounts as `(userid, sessid, auth)` handles, and every switch re-validates against the DB the same way `session_from_master_cookie` does. `DW::AccountSwitcher` owns the cookie and the add/switch/promote/remove logic; wiring lives in `DW::Controller::{Login,Auth,Settings}`, and the caret/fold-out UI is in the Foundation masthead (`schemes/common.tt`), the journal control strip (`views/journal/controlstrip.tt`), and the legacy sitescheme, with an "Account Switcher" management page at `/manage/accounts` linked from the Organize menu.

## Screenshots

A bare caret next to your username opens a switch-only fold-out.

**Masthead (Foundation)**

![masthead](https://github.com/zorkian/dreamwidth/blob/pr-3654-screenshots/screenshots/masthead.png?raw=true)

**Journal control strip**

![control strip](https://github.com/zorkian/dreamwidth/blob/pr-3654-screenshots/screenshots/navstrip.png?raw=true)

**Legacy (non-Foundation) sitescheme**

![legacy](https://github.com/zorkian/dreamwidth/blob/pr-3654-screenshots/screenshots/legacy.png?raw=true)

**Manage page (`/manage/accounts`, under the Organize menu)** — one alphabetical list, current account flagged inline, switch/remove per row:

![manage](https://github.com/zorkian/dreamwidth/blob/pr-3654-screenshots/screenshots/manage.png?raw=true)

**Adding another account**

![add account](https://github.com/zorkian/dreamwidth/blob/pr-3654-screenshots/screenshots/addaccount.png?raw=true)

CODE TOUR: You can now be logged in to more than one Dreamwidth account in the same browser and flip between them without typing your password each time. Next to your username there's a small arrow that drops down your other accounts; click one to switch. There's also an "Account Switcher" page (under the Organize menu) where you can add, switch, or remove accounts, and changing your password no longer boots you out of the others.

Fixes #3302

🤖 Generated with [Claude Code](https://claude.com/claude-code)