### PR TITLE
Clean up the control strip HTML/CSS some

### DIFF
--- a/htdocs/stc/controlstrip-dark.css
+++ b/htdocs/stc/controlstrip-dark.css
@@ -5,7 +5,8 @@
     color: #989898;
 }
 
-#lj_controlstrip a
+#lj_controlstrip a, #lj_controlstrip_switch ul a,
+#lj_controlstrip_switch .switch-account-btn
 {
     color: #f5f5f5;
 }
@@ -20,4 +21,10 @@
 #lj_controlstrip_statustext
 {
     color: #f5f5f5;
+}
+
+#lj_controlstrip_switch ul {
+    background-color: #2e2c2c;
+    border-color:#878080;
+    color:#f5f5f5;
 }

--- a/htdocs/stc/controlstrip-light.css
+++ b/htdocs/stc/controlstrip-light.css
@@ -1,5 +1,4 @@
-#lj_controlstrip, #lj_controlstrip_switch ul
-{
+#lj_controlstrip {
     background-color: #c7c6c6;
     background-image: url(/img/controlstrip/bg-light.gif);
     color: #7c7c7c;

--- a/htdocs/stc/controlstrip-light.css
+++ b/htdocs/stc/controlstrip-light.css
@@ -1,11 +1,17 @@
-#lj_controlstrip
+#lj_controlstrip, #lj_controlstrip_switch ul
 {
     background-color: #c7c6c6;
     background-image: url(/img/controlstrip/bg-light.gif);
     color: #7c7c7c;
 }
 
-#lj_controlstrip a
+#lj_controlstrip_switch ul {
+    background-color: #c7c6c6;
+    border-color:#fbfbfb;
+}
+
+#lj_controlstrip a, #lj_controlstrip_switch ul a,
+#lj_controlstrip_switch .switch-account-btn
 {
     color: #505050;
 }

--- a/htdocs/stc/controlstrip.css
+++ b/htdocs/stc/controlstrip.css
@@ -85,6 +85,10 @@ html body
     border: 0;
 }
 
+#Greeting form {
+    display:inline-block;
+}
+
 /* Account switcher in the control strip: a bare caret (native <details>) sitting
    next to the username, whose open panel overlays the page rather than pushing
    the strip's layout. The panel has its own light background, so its links must
@@ -95,14 +99,7 @@ html body
     vertical-align: middle;
 }
 
-/* Keep the username, switcher caret, and Log out button on one line. */
-#lj_controlstrip_user #Greeting,
-#lj_controlstrip_user #Greeting > div {
-    display: inline;
-}
-
 #lj_controlstrip_switch > summary {
-    font-family: Arial, sans-serif;
     cursor: pointer;
     list-style: none;
 }
@@ -128,9 +125,9 @@ html body
     min-width: 12em;
     list-style: none;
     white-space: nowrap;
-    background: #f7f7f7;
-    color: #333333;
-    border: 1px solid #cccccc;
+    background: inherit;
+    color: inherit;
+    border: 1px solid;
     box-shadow: 0 2px 6px rgba(0, 0, 0, .3);
 }
 
@@ -159,7 +156,6 @@ html body
     margin: 0;
     cursor: pointer;
     text-decoration: none;
-    color: #2172a8;
     width: auto;
 }
 

--- a/htdocs/stc/controlstrip.css
+++ b/htdocs/stc/controlstrip.css
@@ -124,9 +124,6 @@ html body
     padding: 4px 8px;
     min-width: 12em;
     list-style: none;
-    white-space: nowrap;
-    background: inherit;
-    color: inherit;
     border: 1px solid;
     box-shadow: 0 2px 6px rgba(0, 0, 0, .3);
 }

--- a/views/journal/controlstrip.tt
+++ b/views/journal/controlstrip.tt
@@ -18,31 +18,32 @@ the same terms as Perl itself.  For a copy of the license, please reference
 
 [%- IF remote -%]
   <div id='lj_controlstrip_user'>
-    [% remote.display %]
-    [%- IF switch_accounts.size -%]
-    <details id='lj_controlstrip_switch' class='account-switcher'>
-      <summary aria-label="[% 'web.controlstrip.switch.label' | ml %]"></summary>
-      <ul>
-        [%- FOREACH acct IN switch_accounts -%]
-          <li>
-            <span class='switch-account-name'>[% acct.display %]</span>
-          [%- IF acct.valid -%]
-            <form class='switch-account' action='[% site.root %]/switchaccount' method='post'>
-              [%- dw.form_auth -%]
-              [%- form.hidden( name = "userid", value = acct.userid ) -%]
-              [%- form.hidden( name = "returnto", value = returnto ) -%]
-              <button type="submit" class="switch-account-btn">[% 'web.controlstrip.switch.go' | ml %]</button>
-            </form>
-          [%- ELSE -%]
-            <a class='switch-account-signedout' href='[% site.root %]/login?switch=1&amp;user=[% acct.user | uri %]&amp;returnto=[% returnto | uri %]'>[% 'web.controlstrip.switch.signedout' | ml %]</a>
-          [%- END -%]
-          </li>
+    
+      <div id='Greeting' class='nopic' >
+        [%- IF switch_accounts.size -%]
+        <details id='lj_controlstrip_switch' class='account-switcher'>
+          <summary aria-label="[% 'web.controlstrip.switch.label' | ml %]"></summary>
+          <ul>
+            [%- FOREACH acct IN switch_accounts -%]
+              <li>
+                <span class='switch-account-name'>[% acct.display %]</span>
+              [%- IF acct.valid -%]
+                <form class='switch-account' action='[% site.root %]/switchaccount' method='post'>
+                  [%- dw.form_auth -%]
+                  [%- form.hidden( name = "userid", value = acct.userid ) -%]
+                  [%- form.hidden( name = "returnto", value = returnto ) -%]
+                  <button type="submit" class="switch-account-btn">[% 'web.controlstrip.switch.go' | ml %]</button>
+                </form>
+              [%- ELSE -%]
+                <a class='switch-account-signedout' href='[% site.root %]/login?switch=1&amp;user=[% acct.user | uri %]&amp;returnto=[% returnto | uri %]'>[% 'web.controlstrip.switch.signedout' | ml %]</a>
+              [%- END -%]
+              </li>
+            [%- END -%]
+          </ul>
+        </details>
         [%- END -%]
-      </ul>
-    </details>
-    [%- END -%]
-    <form id='Greeting' class='nopic' action='[%- site.root -%]/logout' method='post'>
-      <div>
+        [% remote.display %]
+        <form action='[%- site.root -%]/logout' method='post'>
         [%- dw.form_auth -%]
         [%- form.hidden( name = "user", value = remote.user ) -%]
         [%- form.hidden( name = "returnto", value = returnto ) -%]
@@ -59,8 +60,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
         [%- UNLESS remote.is_validated -%]
           &nbsp;&nbsp; [% links.confirm %]
         [%- END -%]
-      </div>
+
     </form>
+          </div>
     [%- UNLESS remote.is_identity -%]
       [%- links.home -%]&nbsp;&nbsp; [%- links.post_journal -%]&nbsp;&nbsp;
     [%- END -%]


### PR DESCRIPTION
CODE TOUR: Cleans up some of the code for the account switcher so it matches the existing navstrip styling better.
<!--
Above, please explain how these changes affect users. This summary must be a single line that starts with the text `CODE TOUR:`.

The rest of your PR description is for other developers, but the CODE TOUR line is for whoever writes the next code tour post. See https://dw-dev.dreamwidth.org/tag/code+tour for examples.

If this PR has no direct effect on users, write a summary anyway, but include the text `no-impact` as a hint for sorting.
-->
