### PR TITLE
Update makertube embed filter

### DIFF
--- a/cgi-bin/DW/Hooks/EmbedWhitelist.pm
+++ b/cgi-bin/DW/Hooks/EmbedWhitelist.pm
@@ -101,14 +101,16 @@ my %host_path_match = (
 
     "www.kickstarter.com" => [ qr!/widget/[a-zA-Z]+\.html$!, 1 ],
 
-    "lichess.org" => [ qr!/study/embed/!,     1 ],
-    "www.loc.gov" => [ qr!/item/[a-z0-9]+/$!, 1 ],
+    "html5-player.libsyn.com" => [ qr!^/embed/!,          1 ],
+    "lichess.org"             => [ qr!/study/embed/!,     1 ],
+    "www.loc.gov"             => [ qr!/item/[a-z0-9]+/$!, 1 ],
 
-    "mega.nz"          => [ qr!^/embed/!,                   1 ],
-    "www.mixcloud.com" => [ qr!^/widget/iframe/$!,          1 ],
-    "mixstep.co"       => [ qr!^/embed/!,                   1 ],
-    "www.msnbc.com"    => [ qr!^/msnbc/embedded-video/\w+!, 1 ],
-    "my.mail.ru"       => [ qr!^/video/embed/\d+!,          1 ],
+    "makertube.net"    => [ qr!^/videos/embed/[0-9a-fA-F\-]{36}!, 1 ],
+    "mega.nz"          => [ qr!^/embed/!,                         1 ],
+    "www.mixcloud.com" => [ qr!^/widget/iframe/$!,                1 ],
+    "mixstep.co"       => [ qr!^/embed/!,                         1 ],
+    "www.msnbc.com"    => [ qr!^/msnbc/embedded-video/\w+!,       1 ],
+    "my.mail.ru"       => [ qr!^/video/embed/\d+!,                1 ],
 
     "nekocap.com"      => [ qr!^/view/[a-zA-Z0-9]+$!,                 1 ],
     "ext.nicovideo.jp" => [ qr!^/thumb/!,                             0 ],
@@ -117,10 +119,11 @@ my %host_path_match = (
 
     "onedrive.live.com" => [ qr!^/embed$!, 1 ],
 
-    "playmoss.com"  => [ qr!^/embed/!,                  1 ],
-    "www.plurk.com" => [ qr!^/getWidget$!,              1 ],
-    "pastebin.com"  => [ qr!^/embed_iframe/\w+$!,       1 ],
-    "podomatic.com" => [ qr!^/embed/html5/episode/\d*!, 1 ],
+    "player.pbs.org" => [ qr!^/viralplayer/[0-9]+!,      1 ],
+    "playmoss.com"   => [ qr!^/embed/!,                  1 ],
+    "www.plurk.com"  => [ qr!^/getWidget$!,              1 ],
+    "pastebin.com"   => [ qr!^/embed_iframe/\w+$!,       1 ],
+    "podomatic.com"  => [ qr!^/embed/html5/episode/\d*!, 1 ],
 
     "www.random.org"       => [ qr!^/widgets/integers/iframe.php$!,        1 ],
     "www.redditmedia.com"  => [ qr!^/r/\w+/comments/\w+/\w+/$!,            1 ],

--- a/t/embed-whitelist.t
+++ b/t/embed-whitelist.t
@@ -15,7 +15,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 116;
+use Test::More tests => 119;
 
 BEGIN { $LJ::_T_CONFIG = 1; require "$ENV{LJHOME}/cgi-bin/ljlib.pl"; }
 
@@ -172,6 +172,9 @@ note("misc");
     );
 
     # L
+    test_good_url(
+"//html5-player.libsyn.com/embed/episode/id/16608338/height/360/theme/standard-mini/thumbnail/yes/direction/backward/"
+    );
     test_good_url("https://lichess.org/study/embed/JYjprYmJ/CeyjnPCj");
     test_good_url("https://www.loc.gov/item/mbrs01991430/?embed=resources");
 
@@ -181,6 +184,7 @@ note("misc");
     test_bad_url( "https://shad_tkhom.livejournal.com/1244sd088.html?embed", "bad username" );
 
     # M
+    test_good_url("https://makertube.net/videos/embed/52a10666-3a18-4e73-93da-e8d3c12c305a");
     test_good_url("https://mega.nz/embed/yr5VEDDZ#6vvZAnbmADkNc6KX5fKUB9GXYYrYGOhkgsx-xw9_SMw");
     test_good_url(
 "https://www.mixcloud.com/widget/iframe/?feed=https%3A%2F%2Fwww.mixcloud.com%2Fvladmradio%2F25-podcast-from-august-24-2016%2F&hide_cover=1&light=1"
@@ -209,6 +213,7 @@ note("misc");
     );
 
     # P
+    test_good_url("https://player.pbs.org/viralplayer/2318689287/");
     test_good_url("https://playmoss.com/embed/wingedbeastie/the-swamp-witch-nix-s-playlist");
     test_good_url(
         "http://www.plurk.com/getWidget?uid=123123123&h=375&w=200&u_info=2&bg=cf682f&tl=cae7fd");


### PR DESCRIPTION
CODE TOUR: Updates the embed filter for makertube.net (with tests);

makertube.net (a peertube instance) has changed how new videos are identified. Old videos retain the old naming scheme. Have changed the filter to allow the new naming scheme, as well as making sure still works for the old naming scheme.

I added the functionality in this PR: https://github.com/dreamwidth/dreamwidth/pull/3361, just keeping up with the maintenance.

Note: don't know if this will apply to all peertube instances, but happy to update those if needed.